### PR TITLE
Fix tests for new output format

### DIFF
--- a/buffy/functions/marketspread.py
+++ b/buffy/functions/marketspread.py
@@ -110,15 +110,16 @@ def test_func():
     input = ('8=FIX.4.2\x019=121\x0135=D\x011=CLIENT35\x0111=s0XCIa\x01'
              '21=3\x0138=4000\x0140=2\x0144=252.85366153511416\x0154=1\x01'
              '55=TSLA\x0160=20151204-14:30:00.000\x01107=Tesla Motors\x01'
-             '10=108\x01')
-    expected = ('New Order: (CLIENT35, TSLA, Rejected, 4000.0): Rejected: '
-                'Unknown symbol: TSLA')
+             '10=108\x01999=1234\x01')
+    expected = {'msg': ('New Order: (CLIENT35, TSLA, Rejected, 4000.0): '
+                        'Rejected: Unknown symbol: TSLA'),
+                'feed_time': 1234.0}
     output = func(input)
-    assert(output == expected)
+    assert(json.loads(output) == expected)
 
     input = ('8=FIX.4.2\x019=64\x0135=S\x0155=TSLA\x01'
              '60=20151204-14:30:00.000\x01117=S\x01132=16.40\x01133=16.60'
-             '\x0110=098\x01')
+             '\x0110=098\x01999=1234\x01')
     func(input)
 
     symbol = state.get_attribute('market', {}).get('TSLA')
@@ -126,7 +127,8 @@ def test_func():
     input = ('8=FIX.4.2\x019=121\x0135=D\x011=CLIENT35\x0111=s0XCIa\x01'
              '21=3\x0138=4000\x0140=2\x0144=252.85366153511416\x0154=1\x01'
              '55=TSLA\x0160=20151204-14:30:00.000\x01107=Tesla Motors\x01'
-             '10=108\x01')
-    expected = 'New Order: (CLIENT35, TSLA, Accepted, 4000.0): Accepted'
+             '10=108\x01999=1234\x01')
+    expected = {'msg': ('New Order: (CLIENT35, TSLA, Accepted, 4000.0): '
+                        'Accepted'), 'feed_time': 1234}
     output = func(input)
-    assert(output == expected)
+    assert(json.loads(output) == expected)


### PR DESCRIPTION
@dipin /cc @Sendence/buffy 
Fixes the tests in `buffy/functions/marketspread.py` to unbreak the build.
