### PR TITLE
Add support to Giles for messages from files

### DIFF
--- a/giles/README.md
+++ b/giles/README.md
@@ -30,7 +30,7 @@ Giles as follows:
 
 ```
 ./giles/receiver 127.0.0.1:8082
-./giles/sender 127.0.0.1:8081
+./giles/sender 127.0.0.1:8081 100
 ```
 
 The receiver should be started before the sender otherwise data will be lost. By
@@ -40,3 +40,14 @@ sending data.
 
 To shutdown a Giles process, be it sender or receiver, send a TERM signal to the
 process. This will cause it to write out its data and shutdown.
+
+Currently the Giles sender sends messages in one of two way:
+- With no other commandline options given, it will send string
+  representations of integers, starting with `0` and increasing by `1`
+  with each new message. For example, `./giles/sender 127.0.0.1:8081
+  100` will send messages containing string representations of the
+  numbers `0` through `99`.
+- With a file name given as the last argument it will send each line
+  of the given file as a message. For example, `./giles/sender
+  127.0.0.1:8081 100 war-and-peace.txt` will send messages containing
+  each of the first 100 lines of the file `war-and-peace.txt`.


### PR DESCRIPTION
Giles can now send messages based on the contents of a file. Each line
of the input file is sent as a message. The file is given as an
optional final command line argument.
