### PR TITLE
Initial pass a "send computation to data"

### DIFF
--- a/apps/state-avg-of-avgs/.gitignore
+++ b/apps/state-avg-of-avgs/.gitignore
@@ -1,0 +1,1 @@
+state-avg-of-avgs

--- a/apps/state-avg-of-avgs/bundle.json
+++ b/apps/state-avg-of-avgs/bundle.json
@@ -1,0 +1,12 @@
+{
+  "deps": [
+    { "type": "local",
+      "local-path": "../../lib/"
+    },
+    { "type": "github",
+      "repo": "aturley/osc-pony",
+      "subdir": "src/",
+      "tag": "0.0.1"
+    }
+  ]
+}

--- a/apps/state-avg-of-avgs/state-avg-of-avgs.pony
+++ b/apps/state-avg-of-avgs/state-avg-of-avgs.pony
@@ -1,0 +1,85 @@
+"""
+Average of Averages app written using our "State" representation.
+Currently, until issue #807 against ponyc is fixed (couple weeks),
+we can't use the library version in steps.pony as it won't compile
+so we have to "handroll" for now. That basically means doing what
+a generic would do for us, by hand. At the end of this file, you
+will two types that accomplish that: AveragerStateComputation and
+AveragerState.
+"""
+use "collections"
+use "buffy"
+use "buffy/messages"
+
+actor Main
+  new create(env: Env) =>
+    let topology: Topology val =
+      Topology(recover val
+        ["double", "halve", "average", "average"]
+      end)
+    Startup(env, topology, SB, 1)
+
+primitive SB is StepBuilder
+  fun val apply(computation_type: String): Any tag ? =>
+    match computation_type
+    | "double" => Step[I32, I32](Double)
+    | "halve" => Step[I32, I32](Halve)
+    | "average" =>
+      let s = recover Averager end
+      AveragerState[I32, I32](consume s, Average)
+    else
+      error
+    end
+
+class Double is Computation[I32, I32]
+  fun apply(msg: Message[I32] val): Message[I32] val^ =>
+    let output = msg.data * 2
+    Message[I32](msg.id, output)
+
+class Halve is Computation[I32, I32]
+  fun apply(msg: Message[I32] val): Message[I32] val^ =>
+    let output = msg.data / 2
+    Message[I32](msg.id, output)
+
+class Average is AveragerStateComputation[I32, I32]
+  fun ref apply(state: Averager, msg: Message[I32] val) : Message[I32] val =>
+    let output = state(msg.data)
+    Message[I32](msg.id, output)
+
+class Averager
+  var count: I32 = 0
+  var total: I32 = 0
+
+  fun ref apply(value: I32): I32 =>
+    count = count + 1
+    total = total + value
+    total / count
+
+///
+///
+///
+
+interface AveragerStateComputation[In: OSCEncodable,
+  Out: OSCEncodable]
+
+  fun ref apply(state: Averager, input: Message[In] val)
+    : Message[Out] val^
+
+actor AveragerState[In: OSCEncodable val,
+  Out: OSCEncodable val] is ThroughStep[In, Out]
+  let _f: AveragerStateComputation[In, Out]
+  var _output: (ComputeStep[Out] tag | None) = None
+  let _state: Averager
+
+  new create(state: Averager iso, f: AveragerStateComputation[In, Out] iso) =>
+    _state = consume state
+    _f = consume f
+
+  be add_output(to: ComputeStep[Out] tag) =>
+    _output = to
+
+  be apply(input: Message[In] val) =>
+    let r = _f(_state, input)
+    match _output
+      | let c: ComputeStep[Out] tag => c(r)
+    end

--- a/lib/buffy/computations.pony
+++ b/lib/buffy/computations.pony
@@ -1,10 +1,17 @@
 use "buffy/messages"
+use "collections"
 
 interface Computation[In: OSCEncodable, Out: OSCEncodable]
-  fun ref apply(input: Message[In] val): Message[Out] val^
+  fun ref apply(input: Message[In] val)
+    : Message[Out] val^
 
 interface FinalComputation[In: OSCEncodable]
   fun ref apply(input: Message[In] val)
 
 interface PartitionFunction[In: OSCEncodable]
   fun apply(input: In): I32
+
+interface StateComputation[In: OSCEncodable,
+  Out: OSCEncodable, State: Any]
+
+  fun ref apply(state: State, input: Message[In] val) :Message[Out] val^

--- a/lib/buffy/steps.pony
+++ b/lib/buffy/steps.pony
@@ -84,3 +84,24 @@ actor Partition[In: OSCEncodable val, Out: OSCEncodable val] is ThroughStep[In, 
           @printf[String]("Couldn't find partition when trying to add output!".cstring())
       end
     end
+
+/*
+// commented out until ponylang/ponyc issue #807 is fixed
+actor State[In: OSCEncodable val, Out: OSCEncodable val, DataStructure: Any] is ThroughStep[In, Out]
+  let _f: StateComputation[In, Out, DataStructure]
+  var _output: (ComputeStep[Out] tag | None) = None
+  let _state: Map[I32, I32]
+
+  new create(state: DataStructure iso, f: StateComputation[In, Out, DataStructure] iso) =>
+    _state = consume state
+    _f = consume f
+
+  be add_output(to: ComputeStep[Out] tag) =>
+    _output = to
+
+  be apply(input: Message[In] val) =>
+    let r = _f(_state, input)
+    match _output
+      | let c: ComputeStep[Out] tag => c(r)
+    end
+*/


### PR DESCRIPTION
One of our big ideas with Buffy is to encapsulate state
and send computation to the state rather than the other
way around. The commit is the first step towards introducing
that.

It includes commented out final code in steps.pony that requires
ponyc issue #807 to be fixed. Once that done, we will have a
usable, generic first basic pass. In the meantime, a simple
version of an app that uses this was added "state-avg-of-avgs".

Once a couple other changes are done, the marketspread app will
use the functionality and be the best example of how it works.
