### PR TITLE
Fix buffy startup binding

### DIFF
--- a/lib/buffy/startup.pony
+++ b/lib/buffy/startup.pony
@@ -123,12 +123,12 @@ actor Startup
         coordinator.add_listener(TCPListener(auth,
           WorkerControlNotifier(env, auth, node_name, leader_control_host,
             leader_control_service, coordinator, metrics_collector),
-            node_name
+            "0.0.0.0"
           ))
         coordinator.add_listener(TCPListener(auth,
           WorkerIntraclusterDataNotifier(env, auth, node_name, leader_control_host,
             leader_control_service, coordinator, spike_config),
-            node_name
+            "0.0.0.0"
           ))
       else
         if source_addrs.size() != source_count then


### PR DESCRIPTION
When booting Buffy components (leaders, workers) in a container the workers need to bind to
a specific host address. Currently none is specified when we create the TCPListener and we
end up with 127.0.0.1 which works for local processes but not for containers.

This patch fixes the issue for containers. It binds to the name of the node which for containers
corresponds with a resolvable address.

This breaks for processes now, but I'll resolve that in this PR.
