### PR TITLE
Add support for multifiles in Giles sender

### DIFF
--- a/giles/README.md
+++ b/giles/README.md
@@ -34,6 +34,12 @@ start Giles as follows:
 ./giles/sender -b 127.0.0.1:8081 -m 100
 ```
 
+The sender also takes the following parameters:
+```-f``` specifies a file path to read from (the number of lines is specified by `-m`).
+Use comma-separated file paths to send multiple files in sequence.  
+```--batch-size/-s``` specifies the number of messages sent every interval.  
+```--interval/-i``` specifies the length of the sending interval.  
+
 The receiver should be started before the sender otherwise data will be lost. By
 the same token, the sender should be shut down before the receiver to prevent
 data loss. Once you start running the sender, it will immediately start

--- a/giles/sender/giles-sender.pony
+++ b/giles/sender/giles-sender.pony
@@ -116,17 +116,12 @@ actor Main
             match f_arg
             | let mfn': String =>
               let fs: Array[String] iso = recover mfn'.split(",") end
-              if fs.size() == 1 then
-                let path = FilePath(env.root as AmbientAuth, mfn')
-                FileDataSource(path)
-              else
-                let paths: Array[FilePath] iso = 
-                  recover Array[FilePath] end
-                for str in (consume fs).values() do
-                  paths.push(FilePath(env.root as AmbientAuth, str))
-                end
-                MultiFileDataSource(consume paths)
+              let paths: Array[FilePath] iso = 
+                recover Array[FilePath] end
+              for str in (consume fs).values() do
+                paths.push(FilePath(env.root as AmbientAuth, str))
               end
+              MultiFileDataSource(consume paths)
             else
               IntegerDataSource
             end


### PR DESCRIPTION
You can now use comma separated file names to run multiple files through Giles sender
