### PR TITLE
Handle regions with less then 4 availability zones correctly

### DIFF
--- a/orchestration/terraform/Makefile
+++ b/orchestration/terraform/Makefile
@@ -385,7 +385,7 @@ setup_az_arg: tmp_az_arg=$(if $(availability_zone),-var aws_subnet_id=$(shell \
                 aws ec2 --region $(region) describe-subnets --filters \
                 Name=availabilityZone,Values=$(availability_zone) \
                 Name=tag:Project,Values=buffy --query \
-                'Subnets[*].{SubnetId:SubnetId}' --output text),)
+                'Subnets[*].{SubnetId:SubnetId}' --output text | head -n 1),)
 setup_az_arg: # set up availability zone arg
 	$(if $(availability_zone),$(if $(subst -var \
           aws_subnet_id=,,$(tmp_az_arg)),,$(error Unable to look up\


### PR DESCRIPTION
- Currently, if a region has less than 4 availability zones
  some availability zones get repeated for different subnets
  because we create 4 subnets for each VPC (one for each
  availability zone for regions that have 4 availability zones).
  If we happen to select an availability zone that has been
  repeated, we get a runtime error. This commit fixes the
  runtime error.

To test:
- Run the following on `master` to confirm the issue and run it
  again on `another-aws-fix` to confirm the fix worked:
  `make plan mem_required=30 cpus_required=16 use_automagic_instances=true force_instance=c4.4xlarge num_followers=0 cluster_name=dh region=us-west-2 availability_zone=us-west-2b`
