### PR TITLE
Update boundary-related logic to improve performance

### DIFF
--- a/lib/wallaroo/network/connections.pony
+++ b/lib/wallaroo/network/connections.pony
@@ -198,11 +198,12 @@ actor Connections
     end
 
   be ack_watermark_to_boundary(receiver_name: String, seq_id: U64) =>
-    try
+    None
+/*    try
       _data_conns(receiver_name).ack(seq_id)
     else
       @printf[I32](("No outgoing boundary to worker " + receiver_name + "\n").cstring())
-    end
+    end*/
 
   be request_replay(receiver_name: String) =>
     try

--- a/lib/wallaroo/network/data-channel-tcp.pony
+++ b/lib/wallaroo/network/data-channel-tcp.pony
@@ -125,7 +125,7 @@ class DataChannelConnectNotifier is TCPConnectionNotify
         end
       | let dc: DataConnectMsg val =>
         try
-          _receivers(dc.sender_name).data_connect(dc.sender_step_id)
+          _receivers(dc.sender_name).data_connect(dc.sender_step_id, conn)
         else
           @printf[I32]("Missing DataReceiver!\n".cstring())
         end
@@ -170,6 +170,7 @@ class DataChannelConnectNotifier is TCPConnectionNotify
 
   fun ref accepted(conn: TCPConnection ref) =>
     _env.out.print("accepted data channel connection")
+    conn.set_nodelay(true)
     conn.expect(4)
 
   fun ref connected(sock: TCPConnection ref) =>

--- a/lib/wallaroo/routing/_test_watermarking.pony
+++ b/lib/wallaroo/routing/_test_watermarking.pony
@@ -442,6 +442,12 @@ actor _TestProducer is Producer
   be receive_credits(credits: ISize, from: CreditFlowConsumer) =>
     None
 
+  be mute(c: CreditFlowConsumer) =>
+    None
+
+  be unmute(c: CreditFlowConsumer) =>
+    None
+
   fun ref recoup_credits(credits: ISize) =>
     None
 

--- a/lib/wallaroo/routing/producer.pony
+++ b/lib/wallaroo/routing/producer.pony
@@ -1,6 +1,8 @@
 trait tag Producer
   // from CreditFlowProducer
   be receive_credits(credits: ISize, from: CreditFlowConsumer)
+  be mute(c: CreditFlowConsumer)
+  be unmute(c: CreditFlowConsumer)
   fun ref recoup_credits(credits: ISize)
   fun ref route_to(c: CreditFlowConsumer): (Route | None)
   fun ref next_sequence_id(): U64

--- a/lib/wallaroo/tcp-source/tcp-source.pony
+++ b/lib/wallaroo/tcp-source/tcp-source.pony
@@ -59,6 +59,7 @@ actor TCPSource is Producer
       false
     end
   var _expect_read_buf: Reader = Reader
+  let _muted_downstream: SetIs[Any tag] = _muted_downstream.create()
 
   // Origin (Resilience)
   var _seq_id: SeqId = 1 // 0 is reserved for "not seen yet"
@@ -462,8 +463,18 @@ actor TCPSource is Producer
       _pending_reads()
     end
 
-  be unmute() =>
-    _unmute()
+  be mute(c: CreditFlowConsumer) =>
+    @printf[I32]("MUTE\n".cstring())
+    _muted_downstream.set(c)
+    _mute()
+
+  be unmute(c: CreditFlowConsumer) =>
+    @printf[I32]("UNMUTE\n".cstring())
+    _muted_downstream.unset(c)
+
+    if _muted_downstream.size() == 0 then
+      _unmute()
+    end
 
   fun ref is_muted(): Bool =>
     _muted

--- a/lib/wallaroo/topology/router.pony
+++ b/lib/wallaroo/topology/router.pony
@@ -293,6 +293,16 @@ class DataRouter
       true
     end
 
+  fun register_producer(producer: Producer) =>
+    for step in _data_routes.values() do
+      step.register_producer(producer)
+    end
+
+  fun unregister_producer(producer: Producer, credits_returned: ISize) =>
+    for step in _data_routes.values() do
+      step.unregister_producer(producer, credits_returned)
+    end
+
   fun routes(): Array[CreditFlowConsumerStep] val =>
     // TODO: CREDITFLOW - real implmentation?
     recover val Array[CreditFlowConsumerStep] end

--- a/lib/wallaroo/topology/steps.pony
+++ b/lib/wallaroo/topology/steps.pony
@@ -472,6 +472,16 @@ actor Step is (RunnableStep & Resilient & Producer &
   fun _above_minimum_response_level(): Bool =>
     _distributable_credits >= _minimum_credit_response
 
+  be mute(c: CreditFlowConsumer) =>
+    for u in _upstreams.values() do
+      u.mute(c)
+    end
+
+  be unmute(c: CreditFlowConsumer) =>
+    for u in _upstreams.values() do
+      u.unmute(c)
+    end
+
 class StepRouteCallbackHandler is RouteCallbackHandler
   fun ref register(producer: Producer ref, r: RouteLogic tag) =>
     None


### PR DESCRIPTION
- Reply directly over TCPConnection when acking from
  DataReceiver

- Add ability to mute a source in response to external events

- Turn on TCP_NODELAY on both sides of a worker boundary
  Results in smoother, more consistent performance. Cuts
  down greatly on the boundary getting throttled.

- Print when muting/unmuting to standard out

- Set TCP_NODELAY when sending from a TCPSink
  We have seen indications that this helps our latency performance

- Only unmute source when all downstreams are ready

- DataReceiver is now muted/unmuted by downstream (though due to
  a bug with holding a TCPConnection reference, this mute/unmute
  does not currently make it back to the TCPConnection.