### PR TITLE
Use periodic ack requests to ensure we don't deadlock

### DIFF
--- a/apps/arizona-jr-app/arizona-jr-app/main.pony
+++ b/apps/arizona-jr-app/arizona-jr-app/main.pony
@@ -1,0 +1,106 @@
+"""
+Setting up a complex app run (in order):
+1) reports sink:
+nc -l 127.0.0.1 7002 >> /dev/null
+
+2) metrics sink:
+nc -l 127.0.0.1 7003 >> /dev/null
+
+3a) single worker
+./arizona-jr -i 127.0.0.1:7010 -o 127.0.0.1:7002 -m 127.0.0.1:8000 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -e 10000000 -n worker-name
+
+3b) multi-worker
+./arizona-jr -i 127.0.0.1:7010 -o 127.0.0.1:7002 -m 127.0.0.1:8000 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -e 10000000 -w 3 -t -n worker1
+./arizona-jr -i 127.0.0.1:7010 -o 127.0.0.1:7002 -m 127.0.0.1:8000 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -e 10000000 -w 3 -n worker2
+./arizona-jr -i 127.0.0.1:7010 -o 127.0.0.1:7002 -m 127.0.0.1:8000 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -e 10000000 -w 3 -n worker3
+
+"""
+
+use "lib:wallaroo"
+use "lib:arizona-jr-app"
+use "lib:c++" if osx
+use "lib:stdc++" if linux
+
+use "collections"
+
+use "wallaroo"
+use "wallaroo/topology"
+use "wallaroo/tcp-source"
+use "wallaroo/cpp-api/pony"
+use "debug"
+
+use @get_partition_key[KeyP](client_id: U64)
+use @get_partition_function[PartitionFunctionP]()
+use @get_source_decoder[SourceDecoderP]()
+use @get_sink_encoder[SinkEncoderP]()
+use @get_state_computation[ComputationP]()
+use @get_default_state_computation[ComputationP]()
+use @get_state[StateP]()
+use @get_default_state[StateP]()
+
+primitive ArizonaStateBuilder
+  fun name(): String => "state builder"
+  fun apply(): CPPState =>
+    // Debug("Building state")
+    CPPState(@get_state())
+
+primitive ArizonaDefaultStateBuilder
+  fun name(): String => "default state builder"
+  fun apply(): CPPState =>
+    // Debug("Building state")
+    CPPState(@get_default_state())
+
+actor Main
+  new create(env: Env) =>
+    try
+      let partition_function = recover val CPPPartitionFunctionU64(@get_partition_function()) end
+      let partition_keys: Array[U64] val = partition_factory(10001, 11001)
+      let data_partition = Partition[CPPData val, U64](partition_function, partition_keys)
+
+      let application = recover val
+        Application("Passthrough Topology")
+          .new_pipeline[CPPData val, CPPData val]("source-decoder", recover CPPSourceDecoder(@get_source_decoder()) end)
+          // NO PARTITION
+          // .to_stateful[CPPData val, CPPState](
+          //   computation_factory(),
+          //   ArizonaStateBuilder, "state-builder")
+
+          // PARTITIONED
+          // .to_state_partition[CPPData val, CPPKey val, CPPData val, CPPState](
+          //     computation_factory(),
+          //     ArizonaStateBuilder, "state-builder", data_partition where multi_worker = true)
+
+          // PARITIONED WITH DEFAULT (A)
+          .to_state_partition[CPPData val, U64, CPPData val, CPPState](
+              computation_factory(),
+              ArizonaStateBuilder, "state-builder", data_partition
+              where
+              multi_worker = true)//, default_state_name = "default-state")
+          .to_sink(recover CPPSinkEncoder(recover @get_sink_encoder() end) end, recover [0] end)
+
+          // PARITIONED WITH DEFAULT (B)
+//          .partition_default_target[CPPData val, CPPData val, CPPState](
+//              "Arizona Default Test", "default-state", default_computation_factory(),
+//             ArizonaDefaultStateBuilder)
+
+      end
+      Startup(env, application, None)
+    else
+      env.out.print("Could not build topology")
+    end
+
+  fun computation_factory(): CPPStateComputation val =>
+    recover CPPStateComputation(recover @get_state_computation() end) end
+
+  fun default_computation_factory(): CPPStateComputation val =>
+    recover CPPStateComputation(recover @get_default_state_computation() end) end
+
+  fun partition_factory(partition_start: USize, partition_end: USize): Array[U64] val =>
+    let partition_count = partition_end - partition_start
+    recover val
+      let partitions = Array[U64 val](partition_count)
+      for i in Range(partition_start, partition_end) do
+        partitions.push(i.u64())
+      end
+      consume partitions
+    end

--- a/apps/arizona-source-app/arizona-source-app/main.pony
+++ b/apps/arizona-source-app/arizona-source-app/main.pony
@@ -98,7 +98,7 @@ actor Main
     @printf[I32]("Application has %u clients".cstring(), _clients)
     try
       let partition_function = recover val CPPPartitionFunctionU64(@get_partition_function()) end
-      let partition_keys: Array[U64] val = partition_factory(10000, 10000 + _clients)
+      let partition_keys: Array[U64] val = partition_factory(10001, 10001 + _clients)
       let data_partition = Partition[CPPData val, U64](partition_function, partition_keys)
 
       let application = recover val
@@ -131,7 +131,7 @@ actor Main
     let partition_count = partition_end - partition_start
     recover val
       let partitions = Array[U64 val](partition_count)
-      for i in Range(partition_start, partition_end + 1) do
+      for i in Range(partition_start, partition_end) do
         partitions.push(i.u64())
       end
       consume partitions

--- a/apps/arizona-source-app/cpp/Arizona.cpp
+++ b/apps/arizona-source-app/cpp/Arizona.cpp
@@ -271,6 +271,7 @@ void OrderMessage::serialize(char* bytes_, size_t nsz_)
   Writer writer((unsigned char *)bytes_);
 
   writer.u16_be(SerializationType::Message);
+  writer.u32_be(0);
   writer.u16_be(MessageType::Order);
 
   writer.u64_be(_message_id);
@@ -287,6 +288,7 @@ void OrderMessage::serialize(char* bytes_, size_t nsz_)
 size_t OrderMessage::serialize_get_size()
 {
   size_t sz = 2 + // object type
+    4 + // client id
     2 + // message type
     8 + // message id
     2 + _client->size() +
@@ -343,6 +345,7 @@ void CancelMessage::serialize(char* bytes_, size_t nsz_)
   Writer writer((unsigned char *)bytes_);
 
   writer.u16_be(SerializationType::Message);
+  writer.u32_be(0);
   writer.u16_be(MessageType::Cancel);
 
   writer.u64_be(_message_id);
@@ -355,6 +358,7 @@ void CancelMessage::serialize(char* bytes_, size_t nsz_)
 size_t CancelMessage::serialize_get_size()
 {
   size_t sz = 2 + // object type
+    4 + // client id
     2 + // message type
     8 + // message id
     2 + _client->size() +
@@ -406,6 +410,7 @@ void ExecuteMessage::serialize(char* bytes_, size_t nsz_)
   Writer writer((unsigned char *)bytes_);
 
   writer.u16_be(SerializationType::Message);
+  writer.u32_be(0);
   writer.u16_be(MessageType::Execute);
 
   writer.u64_be(_message_id);
@@ -420,6 +425,7 @@ void ExecuteMessage::serialize(char* bytes_, size_t nsz_)
 size_t ExecuteMessage::serialize_get_size()
 {
   size_t sz = 2 + // object type
+    4 + // client id
     2 + // message type
     8 + // message id
     2 + _client->size() +
@@ -470,6 +476,7 @@ void AdminMessage::serialize(char* bytes_, size_t nsz_)
   Writer writer((unsigned char *)bytes_);
 
   writer.u16_be(SerializationType::Message);
+  writer.u32_be(0);
   writer.u16_be(MessageType::Admin);
 
   writer.u64_be(_message_id);
@@ -482,11 +489,13 @@ void AdminMessage::serialize(char* bytes_, size_t nsz_)
 size_t AdminMessage::serialize_get_size()
 {
   size_t sz = 2 + // object type
+    4 + // client id
     2 + // message type
     8 + // message id
     2 + // request type
     2 + _client->size() +
-    2 + _account->size();
+    2 + _account->size() +
+    2 + _aggunit->size();
   return sz;
 }
 

--- a/apps/one-stream-market/one-stream-market.pony
+++ b/apps/one-stream-market/one-stream-market.pony
@@ -83,8 +83,7 @@ actor Main
       let application = recover val
         Application("One Steam NBBO Updater App")
           .new_pipeline[FixNbboMessage val, NbboResult val](
-            "Nbbo", FixNbboFrameHandler
-              where init_file = init_file)
+            "Nbbo", FixNbboFrameHandler)
             .to_state_partition[Symboly val, String,
               (NbboResult val | None), SymbolData](ProcessNbbo,
                 SymbolDataBuilder, "symbol-data",

--- a/lib/wallaroo/messages/channel-messages.pony
+++ b/lib/wallaroo/messages/channel-messages.pony
@@ -252,18 +252,17 @@ trait DeliveryMsg is ChannelMsg
   fun target_id(): U128
   fun sender_name(): String
   fun deliver(pipeline_time_spent: U64, target_step: RunnableStep tag,
-    origin: Producer, seq_id: SeqId, latest_ts: U64, metrics_id: U16,
-    worker_ingress_ts: U64): Bool
+    origin: Producer, seq_id: SeqId, route_id: RouteId, latest_ts: U64,
+    metrics_id: U16, worker_ingress_ts: U64): Bool
 
 trait ReplayableDeliveryMsg is DeliveryMsg
   fun replay_deliver(pipeline_time_spent: U64, target_step: RunnableStep tag,
-    origin: Producer, seq_id: SeqId, latest_ts: U64, metrics_id: U16,
-    worker_ingress_ts: U64): Bool
+    origin: Producer, seq_id: SeqId, route_id: RouteId, latest_ts: U64,
+    metrics_id: U16, worker_ingress_ts: U64): Bool
   fun input(): Any val
   fun metric_name(): String
   fun msg_uid(): U128
   fun frac_ids(): None => None
-
 
 class ForwardMsg[D: Any val] is ReplayableDeliveryMsg
   let _target_id: U128
@@ -294,19 +293,21 @@ class ForwardMsg[D: Any val] is ReplayableDeliveryMsg
   fun sender_name(): String => _sender_name
 
   fun deliver(pipeline_time_spent: U64, target_step: RunnableStep tag,
-    origin: Producer, seq_id: SeqId, latest_ts: U64, metrics_id: U16,
-    worker_ingress_ts: U64): Bool
+    origin: Producer, seq_id: SeqId, route_id: RouteId, latest_ts: U64,
+    metrics_id: U16, worker_ingress_ts: U64): Bool
   =>
     target_step.run[D](_metric_name, pipeline_time_spent, _data, origin,
-      _msg_uid, _frac_ids, seq_id, 0, latest_ts, metrics_id, worker_ingress_ts)
+      _msg_uid, _frac_ids, seq_id, route_id, latest_ts, metrics_id,
+      worker_ingress_ts)
     false
 
   fun replay_deliver(pipeline_time_spent: U64, target_step: RunnableStep tag,
-    origin: Producer, seq_id: SeqId, latest_ts: U64, metrics_id: U16,
-    worker_ingress_ts: U64): Bool
+    origin: Producer, seq_id: SeqId, route_id: RouteId, latest_ts: U64,
+    metrics_id: U16, worker_ingress_ts: U64): Bool
   =>
     target_step.replay_run[D](_metric_name, pipeline_time_spent, _data, origin,
-      _msg_uid, _frac_ids, seq_id, 0, latest_ts, metrics_id, worker_ingress_ts)
+      _msg_uid, _frac_ids, seq_id, route_id, latest_ts, metrics_id,
+      worker_ingress_ts)
     false
 
 class RequestReplayMsg is DeliveryMsg
@@ -321,7 +322,8 @@ class RequestReplayMsg is DeliveryMsg
   fun sender_name(): String => _sender_name
 
   fun deliver(pipeline_time_spent: U64, target_step: RunnableStep tag, origin: Producer,
-    seq_id: SeqId = 0, latest_ts: U64 = 0, metrics_id: U16 = 0, worker_ingress_ts: U64): Bool
+    seq_id: SeqId = 0, route_id: RouteId = 0, latest_ts: U64 = 0,
+    metrics_id: U16 = 0, worker_ingress_ts: U64): Bool
   =>
     match target_step
     | let ob: OutgoingBoundary =>

--- a/lib/wallaroo/routing/_outgoing-to-incoming.pony
+++ b/lib/wallaroo/routing/_outgoing-to-incoming.pony
@@ -53,20 +53,18 @@ class _OutgoingToIncoming
     exists in within the mapping.
     """
     try
-      let index = (id - _seq_id_to_incoming(0)._1).usize()
-      ifdef "trace" then
-        @printf[I32]("id: %llu o: %llu\n".cstring(),
-          id, _seq_id_to_incoming(index)._1)
+      let low_id = _seq_id_to_incoming(0)._1
+      if id >= low_id then
+        let index = (id - low_id).usize()
+        ifdef debug then
+          LazyInvariant({
+            ()(_seq_id_to_incoming, index, id): Bool ? =>
+            _seq_id_to_incoming(index)._1 == id})
+        end
+        index
+      else
+        error
       end
-      ifdef debug then
-        LazyInvariant({
-          ()(_seq_id_to_incoming, index, id): Bool ? =>
-          _seq_id_to_incoming(index)._1 <= id})
-        LazyInvariant({
-          ()(_seq_id_to_incoming, index, id): Bool ? =>
-          _seq_id_to_incoming(index)._1 == id})
-      end
-      index
     else
       error
     end

--- a/lib/wallaroo/routing/boundary-route.pony
+++ b/lib/wallaroo/routing/boundary-route.pony
@@ -130,3 +130,7 @@ class BoundaryRoute is Route
     ifdef "backpressure" then
       _route.use_credit()
     end
+
+  fun ref request_ack() =>
+    _consumer.request_ack()
+

--- a/lib/wallaroo/routing/data-receiver-routes.pony
+++ b/lib/wallaroo/routing/data-receiver-routes.pony
@@ -1,0 +1,42 @@
+use "collections"
+use "wallaroo/fail"
+use "wallaroo/invariant"
+
+class DataReceiverRoutes
+  let _filter_route: _FilterRoute ref = recover ref _FilterRoute end
+  let _routes: Map[RouteId, _Route] = _routes.create()
+
+  fun ref add_route(route_id: RouteId) =>
+    ifdef debug then
+      Invariant(not _routes.contains(route_id))
+    end
+
+    _routes(route_id) = _Route
+
+  fun ref send(route_id: RouteId, seq_id: SeqId)
+  =>
+    ifdef debug then
+      Invariant(_routes.contains(route_id))
+    end
+
+    try
+      _routes(route_id).send(seq_id)
+    else
+      Fail()
+    end
+
+  fun ref receive_ack(route_id: RouteId, seq_id: SeqId) =>
+    ifdef debug then
+      Invariant(_routes.contains(route_id))
+      LazyInvariant({()(_routes, route_id, seq_id): Bool ? =>
+          _routes(route_id).highest_seq_id_sent() >= seq_id})
+    end
+
+    try
+      _routes(route_id).receive_ack(seq_id)
+    else
+      Fail()
+    end
+
+  fun ref propose_new_watermark(): SeqId =>
+    _ProposeWatermark(_filter_route, _routes)

--- a/lib/wallaroo/routing/producer.pony
+++ b/lib/wallaroo/routing/producer.pony
@@ -52,7 +52,7 @@ trait tag Producer
       "\tseq_id: " + seq_id.string() + "\n\n").cstring())
     end
 
-    _x_resilience_routes().receive_ack(route_id, seq_id)
+    _x_resilience_routes().receive_ack(this, route_id, seq_id)
 
 primitive HashProducer
   fun hash(o: Producer): U64 =>

--- a/lib/wallaroo/routing/route.pony
+++ b/lib/wallaroo/routing/route.pony
@@ -23,6 +23,7 @@ trait Route
     i_origin: Producer, msg_uid: U128, i_frac_ids: None, i_seq_id: SeqId,
     i_route_id: RouteId, latest_ts: U64, metrics_id: U16, metric_name: String,
     worker_ingress_ts: U64): Bool
+  fun ref request_ack()
 
 trait RouteLogic
   fun ref application_initialized(new_max_credits: ISize, step_type: String)
@@ -199,6 +200,7 @@ class EmptyRoute is Route
   fun ref dispose() => None
   fun ref request_credits() => None
   fun ref receive_credits(number: ISize) => None
+  fun ref request_ack() => None
 
   fun ref run[D](metric_name: String, pipeline_time_spent: U64, data: D,
     cfp: Producer ref,

--- a/lib/wallaroo/routing/typed-route.pony
+++ b/lib/wallaroo/routing/typed-route.pony
@@ -145,3 +145,6 @@ class TypedRoute[In: Any val] is Route
     ifdef "backpressure" then
       _route.use_credit()
     end
+
+  fun ref request_ack() =>
+    _consumer.request_ack()

--- a/lib/wallaroo/tcp-sink/empty-sink.pony
+++ b/lib/wallaroo/tcp-sink/empty-sink.pony
@@ -47,3 +47,6 @@ actor EmptySink is CreditFlowConsumerStep
 
   be return_credits(credits: ISize) =>
     None
+
+  be request_ack() =>
+    None

--- a/lib/wallaroo/tcp-sink/tcp-sink.pony
+++ b/lib/wallaroo/tcp-sink/tcp-sink.pony
@@ -242,6 +242,9 @@ actor TCPSink is (CreditFlowConsumer & RunnableStep & Initializable)
       end
     end
 
+  be request_ack() =>
+    _terminus_route.request_ack()
+
   //
   // CREDIT FLOW
   be register_producer(producer: Producer) =>
@@ -927,3 +930,10 @@ class EmptyNotify is _TCPSinkNotify
   Called when we have successfully connected to the server.
   """
   None
+
+fun ref closed(conn: TCPSink ref) =>
+  """
+  Called when the connection is closed.
+  """
+  @printf[I32]("TCPSink connection closed\n".cstring())
+

--- a/lib/wallaroo/topology/steps.pony
+++ b/lib/wallaroo/topology/steps.pony
@@ -29,6 +29,7 @@ trait tag RunnableStep
     frac_ids: None, incoming_seq_id: SeqId, route_id: RouteId,
     latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64)
 
+  be request_ack()
 
 interface Initializable
   be application_begin_reporting(initializer: LocalTopologyInitializer)
@@ -107,6 +108,9 @@ actor Step is (RunnableStep & Resilient & Producer &
   //
   // Application startup lifecycle event
   //
+
+  be print_flushing() =>
+    _resilience_routes.print_flushing()
 
   be application_begin_reporting(initializer: LocalTopologyInitializer) =>
     initializer.report_created(this)
@@ -313,8 +317,14 @@ actor Step is (RunnableStep & Resilient & Producer &
       end
     end
 
-  //////////////
+  //////////////////////
   // ORIGIN (resilience)
+  be request_ack() =>
+    _resilience_routes.request_ack(this)
+    for route in _routes.values() do
+      route.request_ack()
+    end
+
   fun ref _x_resilience_routes(): Routes =>
     _resilience_routes
 


### PR DESCRIPTION
We need to ensure that if some routes receive fewer messages
than others, we do not get stuck waiting for it to ack once
the boundary queue surpasses its heuristic max size. This algo
has each DataReceiver periodically send a request ack message
down all of its routes which are broadcast down the line until
they hit the sinks. If any step along the way can ack a watermark,
it will. Otherwise, if a sink can ack, that message will bubble
back up to the DataReceiver and then over to the corresponding
boundary on the sending worker.