### PR TITLE
No longer require -c and -d params for single worker

### DIFF
--- a/lib/wallaroo/initialization/application-initializer.pony
+++ b/lib/wallaroo/initialization/application-initializer.pony
@@ -34,8 +34,8 @@ actor ApplicationInitializer
   be update_application(app: Application val) =>
     _application = app
 
-  be initialize(worker_initializer: WorkerInitializer, worker_count: USize,
-    worker_names: Array[String] val)
+  be initialize(worker_initializer: (WorkerInitializer | None),
+    worker_count: USize, worker_names: Array[String] val)
   =>
     match _application
     | let a: Application val =>
@@ -61,7 +61,7 @@ actor ApplicationInitializer
     end
 
   fun ref _automate_initialization(application: Application val,
-    worker_initializer: WorkerInitializer, worker_count: USize,
+    worker_initializer: (WorkerInitializer | None), worker_count: USize,
     worker_names: Array[String] val, alfred: Alfred tag)
   =>
     @printf[I32]("---------------------------------------------------------\n".cstring())
@@ -800,13 +800,14 @@ actor ApplicationInitializer
       end
 
       // Distribute the LocalTopologies to the other (non-initializer) workers
-      match worker_initializer
-      | let wi: WorkerInitializer =>
-        wi.distribute_local_topologies(consume other_local_topologies)
-      else
-        @printf[I32]("Error distributing local topologies!\n".cstring())
+      if worker_count > 1 then
+        match worker_initializer
+        | let wi: WorkerInitializer =>
+          wi.distribute_local_topologies(consume other_local_topologies)
+        else
+          @printf[I32]("Error distributing local topologies!\n".cstring())
+        end
       end
-
       @printf[I32]("\n^^^^^^Finished Initializing Topologies for Workers^^^^^^^\n".cstring())
       @printf[I32]("---------------------------------------------------------\n".cstring())
     else

--- a/lib/wallaroo/initialization/local-topology.pony
+++ b/lib/wallaroo/initialization/local-topology.pony
@@ -64,8 +64,7 @@ class LocalTopology
   fun update_state_map(state_name: String,
     state_map: Map[String, Router val],
     metrics_conn: MetricsSink, alfred: Alfred,
-    connections: Connections, auth: AmbientAuth,
-    outgoing_boundaries: Map[String, OutgoingBoundary] val,
+    auth: AmbientAuth, outgoing_boundaries: Map[String, OutgoingBoundary] val,
     initializables: SetIs[Initializable tag],
     data_routes: Map[U128, CreditFlowConsumerStep tag],
     default_router: (Router val | None)) ?
@@ -81,7 +80,7 @@ class LocalTopology
     if not state_map.contains(state_name) then
       @printf[I32](("----Creating state steps for " + state_name + "----\n").cstring())
       state_map(state_name) = subpartition.build(_app_name, _worker_name,
-         metrics_conn, auth, connections, alfred, outgoing_boundaries,
+         metrics_conn, auth, alfred, outgoing_boundaries,
          initializables, data_routes, default_router)
     end
 
@@ -107,7 +106,7 @@ actor LocalTopologyInitializer
   let _worker_count: USize
   let _env: Env
   let _auth: AmbientAuth
-  let _connections: Connections
+  let _connections: (Connections | None)
   let _metrics_conn: MetricsSink
   let _alfred : Alfred tag
   var _is_initializer: Bool
@@ -135,7 +134,7 @@ actor LocalTopologyInitializer
     recover iso Array[TCPSourceListenerBuilder val] end
 
   new create(app: Application val, worker_name: String, worker_count: USize,
-    env: Env, auth: AmbientAuth, connections: Connections,
+    env: Env, auth: AmbientAuth, connections: (Connections | None),
     metrics_conn: MetricsSink, is_initializer: Bool, alfred: Alfred tag,
     input_addrs: Array[Array[String]] val, local_topology_file: String,
     data_channel_file: String, worker_names_file: String)
@@ -165,44 +164,51 @@ actor LocalTopologyInitializer
 
   be create_data_receivers(ws: Array[String] val,
     worker_initializer: (WorkerInitializer | None) = None) =>
-    let drs: Map[String, DataReceiver] trn =
-      recover Map[String, DataReceiver] end
+    if _worker_count == 1 then Fail() end
 
-    for w in ws.values() do
-      if w != _worker_name then
-        let data_receiver = DataReceiver(_auth, _worker_name, w, _connections,
-          _alfred)
-        drs(w) = data_receiver
-        _data_receivers(w) = data_receiver
+    match _connections
+    | let conns: Connections =>
+      let drs: Map[String, DataReceiver] trn =
+        recover Map[String, DataReceiver] end
+
+      for w in ws.values() do
+        if w != _worker_name then
+          let data_receiver = DataReceiver(_auth, _worker_name, w, conns,
+            _alfred)
+          drs(w) = data_receiver
+          _data_receivers(w) = data_receiver
+        end
       end
-    end
 
-    let data_receivers: Map[String, DataReceiver] val = consume drs
-    try
-      let data_channel_filepath = FilePath(_auth, _data_channel_file)
-      if not _is_initializer then
-        let data_notifier: TCPListenNotify iso =
-          DataChannelListenNotifier(_worker_name, _env, _auth, _connections,
-            _is_initializer, data_receivers,
-            MetricsReporter(_application.name(), _worker_name, _metrics_conn),
-            data_channel_filepath)
+      let data_receivers: Map[String, DataReceiver] val = consume drs
+      try
+        let data_channel_filepath = FilePath(_auth, _data_channel_file)
+        if not _is_initializer then
+          let data_notifier: TCPListenNotify iso =
+            DataChannelListenNotifier(_worker_name, _env, _auth, conns,
+              _is_initializer, data_receivers,
+              MetricsReporter(_application.name(), _worker_name, _metrics_conn),
+              data_channel_filepath)
 
-        ifdef "resilience" then
-          _connections.make_and_register_recoverable_listener(
-            _auth, consume data_notifier, data_channel_filepath)
+          ifdef "resilience" then
+            conns.make_and_register_recoverable_listener(
+              _auth, consume data_notifier, data_channel_filepath)
+          else
+            conns.register_listener(TCPListener(_auth,
+              consume data_notifier))
+          end
         else
-          _connections.register_listener(TCPListener(_auth,
-            consume data_notifier))
+          match worker_initializer
+            | let wi: WorkerInitializer =>
+              conns.create_initializer_data_channel(data_receivers, wi,
+              data_channel_filepath)
+          end
         end
       else
-        match worker_initializer
-          | let wi: WorkerInitializer =>
-            _connections.create_initializer_data_channel(data_receivers, wi,
-            data_channel_filepath)
-        end
+        @printf[I32]("FAIL: cannot create data channel\n".cstring())
       end
     else
-      @printf[I32]("FAIL: cannot create data channel\n".cstring())
+      Fail()
     end
 
   fun ref _save_worker_names(worker_names_filepath: FilePath,
@@ -303,7 +309,14 @@ actor LocalTopologyInitializer
         let tcp_sinks_trn: Array[TCPSink] trn = recover Array[TCPSink] end
 
         // Update the step ids for all OutgoingBoundaries
-        _connections.update_boundary_ids(t.proxy_ids())
+        if _worker_count > 1 then
+          match _connections
+          | let conns: Connections =>
+            conns.update_boundary_ids(t.proxy_ids())
+          else
+            Fail()
+          end
+        end
 
         // Keep track of routers to the steps we've built
         let built_routers = Map[U128, Router val]
@@ -482,7 +495,7 @@ actor LocalTopologyInitializer
                 // Create the state partition if it doesn't exist
                 if builder.state_name() != "" then
                   t.update_state_map(builder.state_name(), state_map,
-                    _metrics_conn, _alfred, _connections, _auth,
+                    _metrics_conn, _alfred, _auth,
                     _outgoing_boundaries, _initializables,
                     data_routes_ref, default_router)
                 end
@@ -725,7 +738,7 @@ actor LocalTopologyInitializer
               // Create the state partition if it doesn't exist
               if source_data.state_name() != "" then
                 t.update_state_map(source_data.state_name(), state_map,
-                  _metrics_conn, _alfred, _connections, _auth,
+                  _metrics_conn, _alfred, _auth,
                   _outgoing_boundaries, _initializables,
                   data_routes_ref, default_router)
               end
@@ -860,7 +873,7 @@ actor LocalTopologyInitializer
             else
               if psd.state_name() != "" then
                 t.update_state_map(psd.state_name(), state_map,
-                  _metrics_conn, _alfred, _connections, _auth,
+                  _metrics_conn, _alfred, _auth,
                   _outgoing_boundaries, _initializables,
                   data_routes_ref, None)
               end
@@ -906,10 +919,13 @@ actor LocalTopologyInitializer
               @printf[I32]("ChannelMsgEncoder failed\n".cstring())
               error
             end
-          _connections.send_control("initializer", topology_ready_msg)
+          match _connections
+          | let conns: Connections =>
+            conns.send_control("initializer", topology_ready_msg)
 
-          let ready_msg = ExternalMsgEncoder.ready(_worker_name)
-          _connections.send_phone_home(ready_msg)
+            let ready_msg = ExternalMsgEncoder.ready(_worker_name)
+            conns.send_phone_home(ready_msg)
+          end
         end
 
         let omni_router = StepIdRouter(_worker_name,

--- a/lib/wallaroo/startup.pony
+++ b/lib/wallaroo/startup.pony
@@ -35,7 +35,10 @@ actor Startup
       recover Array[Array[String]] end
     var worker_count: USize = 1
     var is_initializer = false
+    var is_multi_worker = true
+    var connections: (Connections | None) = None
     var worker_initializer: (WorkerInitializer | None) = None
+    var application_initializer: (ApplicationInitializer | None) = None
     var worker_name = ""
     var resilience_dir = "/tmp"
     var alfred_file_length: (USize | None) = None
@@ -96,6 +99,7 @@ actor Startup
       if worker_count == 1 then
         env.out.print("Single worker topology")
         is_initializer = true
+        is_multi_worker = false
       else
         env.out.print(worker_count.string() + " worker topology")
       end
@@ -104,24 +108,30 @@ actor Startup
 
       let input_addrs: Array[Array[String]] val = consume i_addrs_write
       let m_addr = m_arg as Array[String]
-      let c_addr = c_arg as Array[String]
-      let c_host = c_addr(0)
-      let c_service = c_addr(1)
+      (let c_addr, let c_host, let c_service) =
+        match c_arg
+        | let addr: Array[String] =>
+          (addr, addr(0), addr(1))
+        else
+          (Array[String], "", "")
+        end
+      (let d_addr: Array[String] val, let d_host, let d_service) =
+        match d_arg
+        | let addr: Array[String] =>
+          let d_addr_trn: Array[String] trn = recover Array[String] end
+          d_addr_trn.push(addr(0))
+          d_addr_trn.push(addr(1))
+          (consume d_addr_trn, addr(0), addr(1))
+        else
+          (recover Array[String] end, "", "")
+        end
+
 
       let o_addr_ref = o_arg as Array[String]
       let o_addr_trn: Array[String] trn = recover Array[String] end
       o_addr_trn.push(o_addr_ref(0))
       o_addr_trn.push(o_addr_ref(1))
       let o_addr: Array[String] val = consume o_addr_trn
-
-      let d_addr_ref = d_arg as Array[String]
-      let d_addr_trn: Array[String] trn = recover Array[String] end
-      d_addr_trn.push(d_addr_ref(0))
-      d_addr_trn.push(d_addr_ref(1))
-      let d_addr: Array[String] val = consume d_addr_trn
-
-      let d_host = d_addr(0)
-      let d_service = d_addr(1)
 
       if worker_name == "" then
         env.out.print("You must specify a worker name via --worker-name/-n.")
@@ -145,9 +155,11 @@ actor Startup
           ("", "")
         end
 
-      let connections = Connections(application.name(), worker_name, env, auth,
-        c_host, c_service, d_host, d_service, ph_host, ph_service,
-        metrics_conn, is_initializer)
+      if is_multi_worker then
+        connections = Connections(application.name(), worker_name, env, auth,
+          c_host, c_service, d_host, d_service, ph_host, ph_service,
+          metrics_conn, is_initializer)
+      end
 
       let name =  match app_name
         | let n: String => n
@@ -174,37 +186,52 @@ actor Startup
 
       if is_initializer then
         env.out.print("Running as Initializer...")
-        let application_initializer = ApplicationInitializer(auth,
+        application_initializer = ApplicationInitializer(auth,
           local_topology_initializer, input_addrs, o_addr, alfred)
-
-        worker_initializer = WorkerInitializer(auth, worker_count, connections,
-          application_initializer, local_topology_initializer, d_addr,
-          metrics_conn)
+        if is_multi_worker then
+          match connections
+          | let conns: Connections =>
+            match application_initializer
+            | let ai: ApplicationInitializer =>
+              worker_initializer = WorkerInitializer(auth, worker_count, conns,
+                ai, local_topology_initializer, d_addr, metrics_conn)
+            end
+          else
+            Fail()
+          end
+        end
         worker_name = "initializer"
       end
 
-      let control_channel_filepath: FilePath = FilePath(auth, control_channel_file)
-      let control_notifier: TCPListenNotify iso =
-        ControlChannelListenNotifier(worker_name, env, auth, connections,
-        is_initializer, worker_initializer, local_topology_initializer,
-        alfred, control_channel_filepath)
+      if is_multi_worker then
+        match connections
+        | let conns: Connections =>
+          let control_channel_filepath: FilePath = FilePath(auth, control_channel_file)
+          let control_notifier: TCPListenNotify iso =
+            ControlChannelListenNotifier(worker_name, env, auth, conns,
+            is_initializer, worker_initializer, local_topology_initializer,
+            alfred, control_channel_filepath)
 
-      ifdef "resilience" then
-        if is_initializer then
-          connections.make_and_register_recoverable_listener(
-            auth, consume control_notifier, control_channel_filepath,
-            c_host, c_service)
+          ifdef "resilience" then
+            if is_initializer then
+              conns.make_and_register_recoverable_listener(
+                auth, consume control_notifier, control_channel_filepath,
+                c_host, c_service)
+            else
+              conns.make_and_register_recoverable_listener(
+                auth, consume control_notifier, control_channel_filepath)
+            end
+          else
+            if is_initializer then
+              conns.register_listener(
+                TCPListener(auth, consume control_notifier, c_host, c_service))
+            else
+              conns.register_listener(
+                TCPListener(auth, consume control_notifier))
+            end
+          end
         else
-          connections.make_and_register_recoverable_listener(
-            auth, consume control_notifier, control_channel_filepath)
-        end
-      else
-        if is_initializer then
-          connections.register_listener(
-            TCPListener(auth, consume control_notifier, c_host, c_service))
-        else
-          connections.register_listener(
-            TCPListener(auth, consume control_notifier))
+          Fail()
         end
       end
 
@@ -214,16 +241,27 @@ actor Startup
         let worker_names_filepath: FilePath = FilePath(auth, worker_names_file)
         if worker_names_filepath.exists() then
           let recovered_workers = _recover_worker_names(worker_names_filepath)
-          local_topology_initializer.create_data_receivers(recovered_workers,
-            worker_initializer)
+          if is_multi_worker then
+            local_topology_initializer.create_data_receivers(recovered_workers,
+              worker_initializer)
+          end
         end
       end
 
       // TODO: We are not recreating the control channel connection from upstream!
-
-      match worker_initializer
-      | let w: WorkerInitializer =>
-        w.start(application)
+      if is_multi_worker then
+        match worker_initializer
+        | let w: WorkerInitializer =>
+          w.start(application)
+        end
+      else
+        match application_initializer
+        | let ai: ApplicationInitializer =>
+          ai.update_application(application)
+          ai.initialize(None, 1, recover Array[String] end)
+        else
+          Fail()
+        end
       end
 
     else

--- a/lib/wallaroo/topology/partition.pony
+++ b/lib/wallaroo/topology/partition.pony
@@ -102,7 +102,7 @@ class KeyedStateAddresses[Key: (Hashable val & Equatable[Key] val)]
 trait StateSubpartition
   fun build(app_name: String, worker_name: String,
     metrics_conn: MetricsSink,
-    auth: AmbientAuth, connections: Connections, alfred: Alfred,
+    auth: AmbientAuth, alfred: Alfred,
     outgoing_boundaries: Map[String, OutgoingBoundary] val,
     initializables: SetIs[Initializable tag],
     data_routes: Map[U128, CreditFlowConsumerStep tag],
@@ -129,7 +129,7 @@ class KeyedStateSubpartition[PIn: Any val,
 
   fun build(app_name: String, worker_name: String,
     metrics_conn: MetricsSink,
-    auth: AmbientAuth, connections: Connections, alfred: Alfred,
+    auth: AmbientAuth, alfred: Alfred,
     outgoing_boundaries: Map[String, OutgoingBoundary] val,
     initializables: SetIs[Initializable tag],
     data_routes: Map[U128, CreditFlowConsumerStep tag],


### PR DESCRIPTION
[NOTE: This change is both because those params are unused in single worker runs and because it will simplify documentation for Hello Wallaroo]

Control and data channels are only used for multi-worker
runs. This stops them being required for single worker
runs. We may need to bring back control channel if we
later use a Dagon-like tool, but that will be
straightforward if needed.

Make Connections optional in startup process

Single worker runs no longer require c and d params