### PR TITLE
Set TCP_NODELAY when Giles sender sends to remote machine

### DIFF
--- a/giles/sender/giles-sender.pony
+++ b/giles/sender/giles-sender.pony
@@ -198,6 +198,9 @@ class ToBuffyNotify is TCPConnectionNotify
     _coordinator.to_buffy_socket(sock, Failed)
 
   fun ref connected(sock: TCPConnection ref) =>
+    if sock.local_address() != sock.remote_address() then
+      sock.set_nodelay(true)
+    end
     _coordinator.to_buffy_socket(sock, Ready)
 
   fun ref throttled(sock: TCPConnection ref) =>
@@ -219,6 +222,9 @@ class ToDagonNotify is TCPConnectionNotify
     _coordinator.to_dagon_socket(sock, Failed)
 
   fun ref connected(sock: TCPConnection ref) =>
+    if sock.local_address() != sock.remote_address() then
+      sock.set_nodelay(true)
+    end
     _coordinator.to_dagon_socket(sock, Ready)
 
   fun ref received(conn: TCPConnection ref, data: Array[U8] iso,


### PR DESCRIPTION
Testing showed that using TCP_NODELAY when sending to a remote
machine helps performance, whereas, it hinders performance
when sending to the local machine.