### PR TITLE
Use the step ids we assigned earlier for partitions

### DIFF
--- a/lib/wallaroo/topology/partition.pony
+++ b/lib/wallaroo/topology/partition.pony
@@ -1,7 +1,6 @@
 use "collections"
 use "files"
 use "net"
-use "sendence/guid"
 use "wallaroo/boundary"
 use "wallaroo/fail"
 use "wallaroo/initialization"
@@ -136,8 +135,6 @@ class KeyedStateSubpartition[PIn: Any val,
     default_router: (Router val | None) = None):
     LocalPartitionRouter[PIn, Key] val
   =>
-    let guid_gen = GuidGenerator
-
     let routes: Map[Key, (Step | ProxyRouter val)] trn =
       recover Map[Key, (Step | ProxyRouter val)] end
 
@@ -153,7 +150,7 @@ class KeyedStateSubpartition[PIn: Any val,
         if pa.worker == worker_name then
           let reporter = MetricsReporter(app_name, worker_name, metrics_conn)
           let next_state_step = Step(_runner_builder(where alfred = alfred),
-            consume reporter, guid_gen.u128(), _runner_builder.route_builder(),
+            consume reporter, id, _runner_builder.route_builder(),
               alfred)
 
           initializables.set(next_state_step)


### PR DESCRIPTION
Fix bug where instead of using pre-assigned partition step ids we were using a new randomly generated id.