### PR TITLE
Change Slack channel that Drone posts to

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -201,7 +201,7 @@ build:
 notify:
   slack:
     webhook_url: $$SLACK_WEBHOOK
-    channel: b-drone-ci
+    channel: b-ci-status
     username: drone-ci
     template: >
       build `#{{ build.number }}` for {{repo.clone_url}} for commit


### PR DESCRIPTION
Instead of the Drone specific #b-drone-ci, we now have a more
general #b-ci-status