### PR TITLE
Run lib/sendence tests as part of normal testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,4 +90,9 @@ install:
 script:
   - cd lib/wallaroo;
     stable env ponyc;
-    ./wallaroo
+    ./wallaroo;
+    cd -;
+  - cd lib/sendence/;
+    stable env ponyc;
+    ./sendence;
+    cd -;

--- a/lib/sendence/.gitignore
+++ b/lib/sendence/.gitignore
@@ -1,0 +1,1 @@
+sendence

--- a/lib/sendence/Makefile
+++ b/lib/sendence/Makefile
@@ -1,0 +1,37 @@
+rules_mk_path := ../../rules.mk
+
+# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
+#PONY_TARGET := false
+
+# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
+#EXS_TARGET := false
+
+# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
+#DOCKER_TARGET := false
+
+# uncomment to disable generate recursing into Makefiles of subdirectories
+#RECURSE_SUBMAKEFILES := false
+
+
+
+#########################################################################################
+#### don't change after this line unless to disable standard rules generation makefile
+MY_NAME := $(lastword $(MAKEFILE_LIST))
+$(MY_NAME)_PATH := $(dir $(MY_NAME))
+
+include $($(MY_NAME)_PATH:%/=%)/$(rules_mk_path)
+#### don't change before this line unless to disable standard rules generation makefile
+#########################################################################################
+
+
+# args to RUN_DAGON and RUN_DAGON_SPIKE: $1 = test name; $2 = ini file; $3 = timeout; $4 = wesley test command, $5 = include in CI
+# NOTE: all paths must be relative to buffy directory (use buffy_path variable)
+
+##<NAME OF TARGET>: #used as part of `make help` command ## <DESCRIPTION OF TARGET>
+#$(eval $(call RUN_DAGON\
+#,<NAME OF TARGET> \
+#,$(buffy_path)/<PATH TO INI FILE> \
+#,<TIMEOUT VALUE> \
+#,<WESLEY TEST COMMAND> \
+#,<INCLUDE IN CI>))
+

--- a/lib/sendence/_test.pony
+++ b/lib/sendence/_test.pony
@@ -1,0 +1,33 @@
+"""
+# Sendence Standard Library
+
+This package represents the unit test suite for Sendence's standard library.
+Classes herein are used across applications rather than being specific to
+just Wallaroo.
+
+All tests can be run by compiling and running this package.
+"""
+use "ponytest"
+use bytes = "bytes"
+use container_queue = "container-queue"
+use fix = "fix"
+use fixed_queue = "fixed-queue"
+use messages = "messages"
+use queue = "queue"
+use weighted = "weighted"
+
+actor Main is TestList
+  new create(env: Env) =>
+    PonyTest(env, this)
+
+  new make() =>
+    None
+
+  fun tag tests(test: PonyTest) =>
+    bytes.Main.make().tests(test)
+    container_queue.Main.make().tests(test)
+    fix.Main.make().tests(test)
+    fixed_queue.Main.make().tests(test)
+    messages.Main.make().tests(test)
+    queue.Main.make().tests(test)
+    weighted.Main.make().tests(test)

--- a/lib/sendence/messages/test.pony
+++ b/lib/sendence/messages/test.pony
@@ -4,7 +4,7 @@ actor Main is TestList
   new create(env: Env) =>
     PonyTest(env, this)
 
-  new make(env: Env) => None
+  new make() => None
 
   fun tag tests(test: PonyTest) =>
     test(_TestFallorMsgEncoder)
@@ -31,7 +31,7 @@ class iso _TestFallorMsgEncoder is UnitTest
           end
         end
       end
-    end 
+    end
     let msgs = FallorMsgDecoder(consume bytes)
 
     h.assert_eq[USize](msgs.size(), 4)


### PR DESCRIPTION
Adds the running of the tests for lib/sendence when:
  * Running in TravisCI
  * Running via `make test`