### PR TITLE
Rename CreditFlowConsumer to Consumer

### DIFF
--- a/apps/backpressure-test/bpt.pony
+++ b/apps/backpressure-test/bpt.pony
@@ -32,9 +32,9 @@ actor Main
     // its a behind the scenes thing
     // maybe "MySourceBuilder" is a behind the scenes thing
     let builder = MySourceBuilder(MyHandler, runner)
-    let consumers: Array[CreditFlowConsumer] trn = recover trn Array[CreditFlowConsumer] end
+    let consumers: Array[Consumer] trn = recover trn Array[Consumer] end
     consumers.push(sink)
-    let c: Array[CreditFlowConsumer] val = consume consumers
+    let c: Array[Consumer] val = consume consumers
     let listener = TCPSourceListener(consume builder,
       c,
       "127.0.0.1", "7000")

--- a/lib/wallaroo/boundary/boundary.pony
+++ b/lib/wallaroo/boundary/boundary.pony
@@ -33,7 +33,7 @@ class OutgoingBoundaryBuilder
     OutgoingBoundary(auth, worker_name, consume reporter, host,
       service)
 
-actor OutgoingBoundary is (CreditFlowConsumer & RunnableStep & Initializable)
+actor OutgoingBoundary is (Consumer & RunnableStep & Initializable)
   // Steplike
   // let _encoder: EncoderWrapper val
   let _wb: Writer = Writer

--- a/lib/wallaroo/boundary/data-receiver.pony
+++ b/lib/wallaroo/boundary/data-receiver.pony
@@ -16,7 +16,7 @@ actor DataReceiver is Producer
   var _sender_step_id: U128 = 0
   let _connections: Connections
   var _router: DataRouter val =
-    DataRouter(recover Map[U128, CreditFlowConsumerStep tag] end)
+    DataRouter(recover Map[U128, ConsumerStep tag] end)
   var _last_id_seen: U64 = 0
   var _last_id_acked: U64 = 0
   var _connected: Bool = false
@@ -234,7 +234,7 @@ actor DataReceiver is Producer
   be dispose() =>
     _timers.dispose()
 
-  fun ref route_to(c: CreditFlowConsumer): (Route | None) =>
+  fun ref route_to(c: Consumer): (Route | None) =>
     None
 
   fun ref next_sequence_id(): U64 =>
@@ -243,13 +243,13 @@ actor DataReceiver is Producer
   fun ref current_sequence_id(): U64 =>
     0
 
-  be mute(c: CreditFlowConsumer) =>
+  be mute(c: Consumer) =>
     match _latest_conn
     | let conn: TCPConnection =>
       conn.mute(c)
     end
 
-  be unmute(c: CreditFlowConsumer) =>
+  be unmute(c: Consumer) =>
     match _latest_conn
     | let conn: TCPConnection =>
       conn.unmute(c)

--- a/lib/wallaroo/initialization/local-topology.pony
+++ b/lib/wallaroo/initialization/local-topology.pony
@@ -66,7 +66,7 @@ class LocalTopology
     metrics_conn: MetricsSink, alfred: Alfred,
     auth: AmbientAuth, outgoing_boundaries: Map[String, OutgoingBoundary] val,
     initializables: SetIs[Initializable tag],
-    data_routes: Map[U128, CreditFlowConsumerStep tag],
+    data_routes: Map[U128, ConsumerStep tag],
     default_router: (Router val | None)) ?
   =>
     let subpartition =
@@ -358,12 +358,12 @@ actor LocalTopologyInitializer
 
         // For passing into partition builders so they can add state steps
         // to our data routes
-        let data_routes_ref = Map[U128, CreditFlowConsumerStep tag]
+        let data_routes_ref = Map[U128, ConsumerStep tag]
 
-        // Keep track of all CreditFlowConsumerSteps by id so we can create a
+        // Keep track of all ConsumerSteps by id so we can create a
         // DataRouter for the data channel boundary
-        var data_routes: Map[U128, CreditFlowConsumerStep tag] trn =
-          recover Map[U128, CreditFlowConsumerStep tag] end
+        var data_routes: Map[U128, ConsumerStep tag] trn =
+          recover Map[U128, ConsumerStep tag] end
 
         let tcp_sinks_trn: Array[TCPSink] trn = recover Array[TCPSink] end
 
@@ -383,8 +383,8 @@ actor LocalTopologyInitializer
         // Keep track of steps we've built that we'll use for the OmniRouter.
         // Unlike data_routes, these will not include state steps, which will
         // never be direct targets for state computation outputs.
-        let built_stateless_steps: Map[U128, CreditFlowConsumerStep] trn =
-          recover Map[U128, CreditFlowConsumerStep] end
+        let built_stateless_steps: Map[U128, ConsumerStep] trn =
+          recover Map[U128, ConsumerStep] end
 
         // TODO: Replace this when we move past the temporary POC based default
         // target strategy. There can currently only be one partition default

--- a/lib/wallaroo/routing/_test_watermarking.pony
+++ b/lib/wallaroo/routing/_test_watermarking.pony
@@ -702,13 +702,13 @@ class iso _TestOutgoingToIncomingBadEviction is UnitTest
     end
 
 actor _TestProducer is Producer
-  be mute(c: CreditFlowConsumer) =>
+  be mute(c: Consumer) =>
     None
 
-  be unmute(c: CreditFlowConsumer) =>
+  be unmute(c: Consumer) =>
     None
 
-  fun ref route_to(c: CreditFlowConsumer): (Route | None) =>
+  fun ref route_to(c: Consumer): (Route | None) =>
     None
 
   fun ref next_sequence_id(): U64 =>

--- a/lib/wallaroo/routing/consumer.pony
+++ b/lib/wallaroo/routing/consumer.pony
@@ -1,7 +1,5 @@
-trait tag CreditFlowConsumer
+trait tag Consumer
   be register_producer(producer: Producer)
   be unregister_producer(producer: Producer)
 
-type CreditFlowProducerConsumer is (Producer & CreditFlowConsumer)
-
-type Consumer is CreditFlowConsumer
+type CreditFlowProducerConsumer is (Producer & Consumer)

--- a/lib/wallaroo/routing/producer.pony
+++ b/lib/wallaroo/routing/producer.pony
@@ -1,8 +1,8 @@
 trait tag Producer
   // from CreditFlowProducer
-  be mute(c: CreditFlowConsumer)
-  be unmute(c: CreditFlowConsumer)
-  fun ref route_to(c: CreditFlowConsumer): (Route | None)
+  be mute(c: Consumer)
+  be unmute(c: Consumer)
+  fun ref route_to(c: Consumer): (Route | None)
   fun ref next_sequence_id(): U64
   fun ref current_sequence_id(): U64
 

--- a/lib/wallaroo/routing/route-builder.pony
+++ b/lib/wallaroo/routing/route-builder.pony
@@ -3,11 +3,11 @@ use "wallaroo/metrics"
 use "wallaroo/topology"
 
 trait RouteBuilder
-  fun apply(step: Producer ref, consumer: CreditFlowConsumerStep,
+  fun apply(step: Producer ref, consumer: ConsumerStep,
     metrics_reporter: MetricsReporter ref): Route
 
 primitive TypedRouteBuilder[In: Any val] is RouteBuilder
-  fun apply(step: Producer ref, consumer: CreditFlowConsumerStep,
+  fun apply(step: Producer ref, consumer: ConsumerStep,
     metrics_reporter: MetricsReporter ref): Route
   =>
     match consumer
@@ -18,7 +18,7 @@ primitive TypedRouteBuilder[In: Any val] is RouteBuilder
     end
 
 primitive EmptyRouteBuilder is RouteBuilder
-  fun apply(step: Producer ref, consumer: CreditFlowConsumerStep,
+  fun apply(step: Producer ref, consumer: ConsumerStep,
     metrics_reporter: MetricsReporter ref): Route
   =>
     EmptyRoute

--- a/lib/wallaroo/routing/route.pony
+++ b/lib/wallaroo/routing/route.pony
@@ -30,13 +30,11 @@ trait RouteLogic
 
 class _RouteLogic is RouteLogic
   let _step: Producer ref
-  let _consumer: CreditFlowConsumer
+  let _consumer: Consumer
   var _step_type: String = ""
   var _route_type: String = ""
 
-  new create(step: Producer ref, consumer: CreditFlowConsumer,
-    r_type: String)
-  =>
+  new create(step: Producer ref, consumer: Consumer, r_type: String) =>
     _step = step
     _consumer = consumer
     _route_type = r_type

--- a/lib/wallaroo/routing/typed-route.pony
+++ b/lib/wallaroo/routing/typed-route.pony
@@ -14,11 +14,11 @@ class TypedRoute[In: Any val] is Route
   let _route_id: U64 = 1 + GuidGenerator.u64() // route 0 is used for filtered messages
   var _step_type: String = ""
   let _step: Producer ref
-  let _consumer: CreditFlowConsumerStep
+  let _consumer: ConsumerStep
   let _metrics_reporter: MetricsReporter
   var _route: RouteLogic = _EmptyRouteLogic
 
-  new create(step: Producer ref, consumer: CreditFlowConsumerStep,
+  new create(step: Producer ref, consumer: ConsumerStep,
     metrics_reporter: MetricsReporter ref)
   =>
     _step = step

--- a/lib/wallaroo/tcp-sink/empty-sink.pony
+++ b/lib/wallaroo/tcp-sink/empty-sink.pony
@@ -4,7 +4,7 @@ use "wallaroo/initialization"
 use "wallaroo/routing"
 use "wallaroo/topology"
 
-actor EmptySink is CreditFlowConsumerStep
+actor EmptySink is ConsumerStep
   be run[D: Any val](metric_name: String, pipeline_time_spent: U64, data: D,
     origin: Producer, msg_uid: U128,
     frac_ids: None, seq_id: SeqId, route_id: RouteId,

--- a/lib/wallaroo/tcp-sink/tcp-sink.pony
+++ b/lib/wallaroo/tcp-sink/tcp-sink.pony
@@ -20,7 +20,7 @@ use @pony_asio_event_resubscribe_read[None](event: AsioEventID)
 use @pony_asio_event_resubscribe_write[None](event: AsioEventID)
 use @pony_asio_event_destroy[None](event: AsioEventID)
 
-actor TCPSink is (CreditFlowConsumer & RunnableStep & Initializable)
+actor TCPSink is (Consumer & RunnableStep & Initializable)
   """
   # TCPSink
 

--- a/lib/wallaroo/tcp-source/framed-source-notify.pony
+++ b/lib/wallaroo/tcp-source/framed-source-notify.pony
@@ -41,7 +41,7 @@ class FramedSourceNotify[In: Any val] is TCPSourceNotify
     _metrics_reporter = consume metrics_reporter
     _header_size = _handler.header_length()
 
-  fun routes(): Array[CreditFlowConsumerStep] val =>
+  fun routes(): Array[ConsumerStep] val =>
     _router.routes()
 
   fun ref received(conn: TCPSource ref, data: Array[U8] iso): Bool =>

--- a/lib/wallaroo/tcp-source/tcp-source-notify.pony
+++ b/lib/wallaroo/tcp-source/tcp-source-notify.pony
@@ -8,7 +8,7 @@ interface TCPSourceNotify
   // on startup. It probably makes more sense to make this
   // available via the source builder that Listener gets
   // and it can then make routes available
-  fun ref routes(): Array[CreditFlowConsumerStep] val
+  fun ref routes(): Array[ConsumerStep] val
 
   fun ref accepted(conn: TCPSource ref) =>
     """

--- a/lib/wallaroo/tcp-source/tcp-source.pony
+++ b/lib/wallaroo/tcp-source/tcp-source.pony
@@ -26,7 +26,7 @@ actor TCPSource is Producer
   * Switch to requesting credits via promise
   """
   // Credit Flow
-  let _routes: MapIs[CreditFlowConsumer, Route] = _routes.create()
+  let _routes: MapIs[Consumer, Route] = _routes.create()
   let _route_builder: RouteBuilder val
   let _outgoing_boundaries: Map[String, OutgoingBoundary] val
   let _tcp_sinks: Array[TCPSink] val
@@ -59,10 +59,10 @@ actor TCPSource is Producer
   var _seq_id: SeqId = 1 // 0 is reserved for "not seen yet"
 
   new _accept(listen: TCPSourceListener, notify: TCPSourceNotify iso,
-    routes: Array[CreditFlowConsumerStep] val, route_builder: RouteBuilder val,
+    routes: Array[ConsumerStep] val, route_builder: RouteBuilder val,
     outgoing_boundaries: Map[String, OutgoingBoundary] val,
     tcp_sinks: Array[TCPSink] val,
-    fd: U32, default_target: (CreditFlowConsumerStep | None) = None,
+    fd: U32, default_target: (ConsumerStep | None) = None,
     forward_route_builder: (RouteBuilder val | None) = None,
     init_size: USize = 64, max_size: USize = 16384,
     metrics_reporter: MetricsReporter iso)
@@ -106,7 +106,7 @@ actor TCPSource is Producer
     end
 
     match default_target
-    | let r: CreditFlowConsumerStep =>
+    | let r: ConsumerStep =>
       match forward_route_builder
       | let frb: RouteBuilder val =>
         _routes(r) = frb(this, r, _metrics_reporter)
@@ -160,7 +160,7 @@ actor TCPSource is Producer
 
   //
   // CREDIT FLOW
-  fun ref route_to(c: CreditFlowConsumer): (Route | None) =>
+  fun ref route_to(c: Consumer): (Route | None) =>
     try
       _routes(c)
     else
@@ -444,12 +444,12 @@ actor TCPSource is Producer
       _pending_reads()
     end
 
-  be mute(c: CreditFlowConsumer) =>
+  be mute(c: Consumer) =>
     @printf[I32]("MUTE\n".cstring())
     _muted_downstream.set(c)
     _mute()
 
-  be unmute(c: CreditFlowConsumer) =>
+  be unmute(c: Consumer) =>
     @printf[I32]("UNMUTE\n".cstring())
     _muted_downstream.unset(c)
 

--- a/lib/wallaroo/topology/partition.pony
+++ b/lib/wallaroo/topology/partition.pony
@@ -58,7 +58,7 @@ class KeyedPartitionAddresses[Key: (Hashable val & Equatable[Key] val)]
 interface StateAddresses
   fun apply(key: Any val): (Step tag | ProxyRouter val | None)
   fun register_routes(router: Router val, route_builder: RouteBuilder val)
-  fun steps(): Array[CreditFlowConsumerStep] val
+  fun steps(): Array[ConsumerStep] val
 
 class KeyedStateAddresses[Key: (Hashable val & Equatable[Key] val)]
   let _addresses: Map[Key, (Step | ProxyRouter val)] val
@@ -86,12 +86,12 @@ class KeyedStateAddresses[Key: (Hashable val & Equatable[Key] val)]
       end
     end
 
-  fun steps(): Array[CreditFlowConsumerStep] val =>
-    let ss: Array[CreditFlowConsumerStep] trn =
-      recover Array[CreditFlowConsumerStep] end
+  fun steps(): Array[ConsumerStep] val =>
+    let ss: Array[ConsumerStep] trn =
+      recover Array[ConsumerStep] end
     for s in _addresses.values() do
       match s
-      | let cfcs: CreditFlowConsumerStep =>
+      | let cfcs: ConsumerStep =>
         ss.push(cfcs)
       end
     end
@@ -104,7 +104,7 @@ trait StateSubpartition
     auth: AmbientAuth, alfred: Alfred,
     outgoing_boundaries: Map[String, OutgoingBoundary] val,
     initializables: SetIs[Initializable tag],
-    data_routes: Map[U128, CreditFlowConsumerStep tag],
+    data_routes: Map[U128, ConsumerStep tag],
     default_router: (Router val | None) = None): PartitionRouter val
 
 class KeyedStateSubpartition[PIn: Any val,
@@ -131,7 +131,7 @@ class KeyedStateSubpartition[PIn: Any val,
     auth: AmbientAuth, alfred: Alfred,
     outgoing_boundaries: Map[String, OutgoingBoundary] val,
     initializables: SetIs[Initializable tag],
-    data_routes: Map[U128, CreditFlowConsumerStep tag],
+    data_routes: Map[U128, ConsumerStep tag],
     default_router: (Router val | None) = None):
     LocalPartitionRouter[PIn, Key] val
   =>

--- a/lib/wallaroo/topology/step-initializer.pony
+++ b/lib/wallaroo/topology/step-initializer.pony
@@ -175,7 +175,7 @@ class EgressBuilder
   fun apply(worker_name: String, reporter: MetricsReporter ref,
     auth: AmbientAuth,
     proxies: Map[String, OutgoingBoundary] val =
-      recover Map[String, OutgoingBoundary] end): CreditFlowConsumerStep tag ?
+      recover Map[String, OutgoingBoundary] end): ConsumerStep tag ?
   =>
     match _addr
     | let a: Array[String] val =>


### PR DESCRIPTION
We no longer have a Wallaroo level credit based back pressure system.
Various classes need to be renamed as a result. This is one such
renaming.