### PR TITLE
Nominal join (issue #496)

### DIFF
--- a/lib/wallaroo/messages/channel_messages.pony
+++ b/lib/wallaroo/messages/channel_messages.pony
@@ -107,6 +107,25 @@ primitive ChannelMsgEncoder
   =>
     _encode(ReplayMsg(delivery_bytes), auth)
 
+  fun join_cluster(worker_name: String, auth: AmbientAuth):
+    Array[ByteSeq] val ?
+  =>
+    """
+    This message is sent from a worker requesting to join a running cluster to
+    any existing worker in the cluster.
+    """
+    _encode(JoinClusterMsg(worker_name), auth)
+
+  // TODO: Update this once new workers become first class citizens
+  fun inform_joining_worker(metric_app_name: String, metric_host: String,
+    metric_service: String, auth: AmbientAuth): Array[ByteSeq] val ?
+  =>
+    """
+    This message is sent as a response to a JoinCluster message. Currently it
+    only informs the new worker of metrics-related info
+    """
+    _encode(InformJoiningWorkerMsg(metric_app_name, metric_host, metric_service), auth)
+
 primitive ChannelMsgDecoder
   fun apply(data: Array[U8] val, auth: AmbientAuth): ChannelMsg val =>
     try
@@ -346,3 +365,28 @@ class RequestReplayMsg is DeliveryMsg
       @printf[I32]("RequestReplayMsg was not directed to an OutgoingBoundary!\n".cstring())
     end
     false
+
+class JoinClusterMsg is ChannelMsg
+  """  
+  This message is sent from a worker requesting to join a running cluster to
+  any existing worker in the cluster.
+  """
+  let worker_name: String
+
+  new val create(w: String) =>
+    worker_name = w
+
+class InformJoiningWorkerMsg is ChannelMsg
+  """  
+  This message is sent as a response to a JoinCluster message. Currently it
+  only informs the new worker of metrics-related info
+  """
+  let metrics_app_name: String
+  let metrics_host: String
+  let metrics_service: String
+
+  new val create(app: String, host: String, service: String) =>
+    metrics_app_name = app
+    metrics_host = host
+    metrics_service = service
+

--- a/lib/wallaroo/startup.pony
+++ b/lib/wallaroo/startup.pony
@@ -7,6 +7,7 @@ use "time"
 use "sendence/hub"
 use "wallaroo/fail"
 use "wallaroo/initialization"
+use "wallaroo/messages"
 use "wallaroo/metrics"
 use "wallaroo/network"
 use "wallaroo/resilience"
@@ -28,12 +29,13 @@ actor Startup
     var c_arg: (Array[String] | None) = None
     var d_arg: (Array[String] | None) = None
     var p_arg: (Array[String] | None) = None
+    var j_arg: (Array[String] | None) = None
     var i_addrs_write: Array[Array[String]] trn =
       recover Array[Array[String]] end
     var worker_count: USize = 1
     var is_initializer = false
     var is_multi_worker = true
-    var connections: (Connections | None) = None
+    var is_joining = false
     var worker_initializer: (WorkerInitializer | None) = None
     var application_initializer: (ApplicationInitializer | None) = None
     var worker_name = ""
@@ -59,6 +61,12 @@ actor Startup
         .add("name", "n", StringArgument)
         .add("resilience-dir", "r", StringArgument)
         .add("alfred-file-length", "l", I64Argument)
+        // pass in control address of any worker as the value of this parameter
+        // to join a running cluster
+        // TODO: Actually make a joining worker a first class citizen.
+        // All this does is give the new worker metrics info so it can
+        // register with the UI (a "nominal join").
+        .add("join", "j", StringArgument)
 
       for option in options do
         match option
@@ -86,253 +94,247 @@ actor Startup
           end
         | ("alfred-file-length", let arg: I64) =>
           alfred_file_length = arg.usize()
+        | ("join", let arg: String) =>
+          j_arg = arg.split(":")
+          is_joining = true
         end
       end
 
-      ifdef "resilience" then
-        env.out.print("|||Resilience directory: " + resilience_dir + "|||")
-      end
-
-      if worker_count == 1 then
-        env.out.print("Single worker topology")
-        is_initializer = true
-        is_multi_worker = false
+      // TODO: When we add full cluster join functionality, we will probably
+      // need to break out initialization branches into primitives.
+      // Currently a joining worker only nominally becomes part of the cluster.
+      if is_joining then
+        let j_addr = j_arg as Array[String]
+        let control_notifier: TCPConnectionNotify iso =
+          ControlSenderConnectNotifier(env, auth)
+        let control_conn: TCPConnection =
+          TCPConnection(auth, consume control_notifier, j_addr(0), j_addr(1))
+        let cluster_join_msg = ChannelMsgEncoder.join_cluster(worker_name,
+          auth)
+        control_conn.writev(cluster_join_msg)
+        env.out.print("Attempting to join cluster...")
+        var x: USize = 0
+        while true do
+          x = x + 1
+          if x > 1000 then x = 0 end
+        end
       else
-        env.out.print(worker_count.string() + " worker topology")
-      end
-
-      if is_initializer then worker_name = "initializer" end
-
-      let input_addrs: Array[Array[String]] val = consume i_addrs_write
-      let m_addr = m_arg as Array[String]
-      (let c_addr, let c_host, let c_service) =
-        match c_arg
-        | let addr: Array[String] =>
-          (addr, addr(0), addr(1))
-        else
-          (Array[String], "", "")
-        end
-      (let d_addr: Array[String] val, let d_host, let d_service) =
-        match d_arg
-        | let addr: Array[String] =>
-          let d_addr_trn: Array[String] trn = recover Array[String] end
-          d_addr_trn.push(addr(0))
-          d_addr_trn.push(addr(1))
-          (consume d_addr_trn, addr(0), addr(1))
-        else
-          (recover Array[String] end, "", "")
+        ifdef "resilience" then
+          env.out.print("|||Resilience directory: " + resilience_dir + "|||")
         end
 
-
-      let o_addr_ref = o_arg as Array[String]
-      let o_addr_trn: Array[String] trn = recover Array[String] end
-      o_addr_trn.push(o_addr_ref(0))
-      o_addr_trn.push(o_addr_ref(1))
-      let o_addr: Array[String] val = consume o_addr_trn
-
-      if worker_name == "" then
-        env.out.print("You must specify a worker name via --worker-name/-n.")
-        error
-      end
-
-      let connect_auth = TCPConnectAuth(auth)
-      let metrics_conn = MetricsSink(m_addr(0),
-          m_addr(1))
-
-      let connect_msg = HubProtocol.connect()
-      let metrics_join_msg = HubProtocol.join("metrics:" + application.name())
-      metrics_conn.writev(connect_msg)
-      metrics_conn.writev(metrics_join_msg)
-
-      (let ph_host, let ph_service) =
-        match p_arg
-        | let addr: Array[String] =>
-          (addr(0), addr(1))
+        if worker_count == 1 then
+          env.out.print("Single worker topology")
+          is_initializer = true
+          is_multi_worker = false
         else
-          ("", "")
+          env.out.print(worker_count.string() + " worker topology")
         end
 
-      let name =  match app_name
-        | let n: String => n
-        else
-          ""
+        if is_initializer then worker_name = "initializer" end
+
+        let input_addrs: Array[Array[String]] val = consume i_addrs_write
+        let m_addr = m_arg as Array[String]
+        let c_addr = c_arg as Array[String]
+        let c_host = c_addr(0)
+        let c_service = c_addr(1)
+        let d_addr_ref = d_arg as Array[String]
+        let d_addr_trn: Array[String] trn = recover Array[String] end
+        d_addr_trn.push(d_addr_ref(0))
+        d_addr_trn.push(d_addr_ref(1))
+        let d_addr: Array[String] val = consume d_addr_trn
+        let d_host = d_addr(0)
+        let d_service = d_addr(1)
+
+        let o_addr_ref = o_arg as Array[String]
+        let o_addr_trn: Array[String] trn = recover Array[String] end
+        o_addr_trn.push(o_addr_ref(0))
+        o_addr_trn.push(o_addr_ref(1))
+        let o_addr: Array[String] val = consume o_addr_trn
+
+        if worker_name == "" then
+          env.out.print("You must specify a worker name via --worker-name/-n.")
+          error
         end
-      let event_log_file = resilience_dir + "/" + name + "-" +
-        worker_name + ".evlog"
-      let local_topology_file = resilience_dir + "/" + name + "-" +
-        worker_name + ".local-topology"
-      let data_channel_file = resilience_dir + "/" + name + "-" + worker_name +
-        ".tcp-data"
-      let control_channel_file = resilience_dir + "/" + name + "-" +
-        worker_name + ".tcp-control"
-      let worker_names_file = resilience_dir + "/" + name + "-" + worker_name +
-        ".workers"
-      let connection_addresses_file = resilience_dir + "/" + name + "-" +
-        worker_name + ".connection-addresses"
 
-      var recovering: Bool = false
+        let connect_auth = TCPConnectAuth(auth)
+        let metrics_conn = MetricsSink(m_addr(0),
+            m_addr(1))
 
-      // check to see if we can recover
-      ifdef "resilience" then
-        let event_log_filepath: FilePath = FilePath(auth, event_log_file)
-        let local_topology_filepath: FilePath = FilePath(auth,
-          local_topology_file)
-        let data_channel_filepath: FilePath = FilePath(auth, data_channel_file)
+        let connect_msg = HubProtocol.connect()
+        let metrics_join_msg = HubProtocol.join("metrics:" + application.name())
+        metrics_conn.writev(connect_msg)
+        metrics_conn.writev(metrics_join_msg)
+
+        (let ph_host, let ph_service) =
+          match p_arg
+          | let addr: Array[String] =>
+            (addr(0), addr(1))
+          else
+            ("", "")
+          end
+
+        let name =  match app_name
+          | let n: String => n
+          else
+            ""
+          end
+
+        let event_log_file = resilience_dir + "/" + name + "-" +
+          worker_name + ".evlog"
+        let local_topology_file = resilience_dir + "/" + name + "-" +
+          worker_name + ".local-topology"
+        let data_channel_file = resilience_dir + "/" + name + "-" +
+          worker_name + ".tcp-data"
+        let control_channel_file = resilience_dir + "/" + name + "-" +
+          worker_name + ".tcp-control"
+        let worker_names_file = resilience_dir + "/" + name + "-" +
+          worker_name + ".workers"
+        let connection_addresses_file = resilience_dir + "/" + name + "-" +
+          worker_name + ".connection-addresses"
+
+        var recovering: Bool = false
+
+        // check to see if we can recover
+        ifdef "resilience" then
+          let event_log_filepath: FilePath = FilePath(auth, event_log_file)
+          let local_topology_filepath: FilePath = FilePath(auth,
+            local_topology_file)
+          let data_channel_filepath: FilePath = FilePath(auth, data_channel_file)
+          let control_channel_filepath: FilePath = FilePath(auth,
+            control_channel_file)
+          let worker_names_filepath: FilePath = FilePath(auth, worker_names_file)
+          let connection_addresses_filepath: FilePath = FilePath(auth,
+            connection_addresses_file)
+          if not is_initializer then
+            if event_log_filepath.exists() or
+              local_topology_filepath.exists() or
+              data_channel_filepath.exists() or
+              control_channel_filepath.exists() or
+              worker_names_filepath.exists() or
+              connection_addresses_filepath.exists()
+            then
+
+              if not (event_log_filepath.exists() and
+                local_topology_filepath.exists() and
+                data_channel_filepath.exists() and
+                control_channel_filepath.exists() and
+                worker_names_filepath.exists() and
+                connection_addresses_filepath.exists())
+              then
+
+                @printf[I32](("Some of the resilience recovery files are" +
+                  " missing but others exist! Cannot continue!\n").cstring())
+                Fail()
+              else
+                @printf[I32]("Recovering from recovery files!!\n".cstring())
+                // we are recovering because all files exist
+                recovering = true
+              end
+            end
+          else
+            if event_log_filepath.exists() or
+              local_topology_filepath.exists() or
+              control_channel_filepath.exists() or
+              worker_names_filepath.exists()
+            then
+
+              if not (event_log_filepath.exists() and
+                local_topology_filepath.exists() and
+                control_channel_filepath.exists() and
+                worker_names_filepath.exists())
+              then
+
+                @printf[I32](("Some of the resilience recovery files are" +
+                  " missing but others exist! Cannot continue!\n").cstring())
+                Fail()
+              else
+                @printf[I32]("Recovering from recovery files!!\n".cstring())
+                // we are recovering because all files exist
+                recovering = true
+              end
+            end
+          end
+        end
+
+        let alfred = ifdef "resilience" then
+            Alfred(env, event_log_file
+              where backend_file_length = alfred_file_length)
+          else
+            Alfred(env, None)
+          end
+
+        let connections = Connections(application.name(), worker_name, env,
+          auth, c_host, c_service, d_host, d_service, ph_host, ph_service,
+          metrics_conn, m_addr(0), m_addr(1), is_initializer,
+          connection_addresses_file)
+
+        let local_topology_initializer = LocalTopologyInitializer(
+          application, worker_name, worker_count, env, auth, connections,
+          metrics_conn, is_initializer, alfred, input_addrs,
+          local_topology_file, data_channel_file, worker_names_file)
+
+        if is_initializer then
+          env.out.print("Running as Initializer...")
+          application_initializer = ApplicationInitializer(auth,
+            local_topology_initializer, input_addrs, o_addr, alfred)
+          match application_initializer
+          | let ai: ApplicationInitializer =>
+            worker_initializer = WorkerInitializer(auth, worker_count,
+              connections, ai, local_topology_initializer, d_addr,
+              metrics_conn)
+          end
+          worker_name = "initializer"
+        end
+
         let control_channel_filepath: FilePath = FilePath(auth,
           control_channel_file)
-        let worker_names_filepath: FilePath = FilePath(auth, worker_names_file)
-        let connection_addresses_filepath: FilePath = FilePath(auth,
-          connection_addresses_file)
-        if not is_initializer then
-          if event_log_filepath.exists() or
-            local_topology_filepath.exists() or
-            data_channel_filepath.exists() or
-            control_channel_filepath.exists() or
-            worker_names_filepath.exists() or
-            connection_addresses_filepath.exists()
-          then
+        let control_notifier: TCPListenNotify iso =
+          ControlChannelListenNotifier(worker_name, env, auth, connections,
+          is_initializer, worker_initializer, local_topology_initializer,
+          alfred, control_channel_filepath)
 
-            if not (event_log_filepath.exists() and
-              local_topology_filepath.exists() and
-              data_channel_filepath.exists() and
-              control_channel_filepath.exists() and
-              worker_names_filepath.exists() and
-              connection_addresses_filepath.exists())
-            then
-
-              @printf[I32](("Some of the resilience recovery files are" +
-                " missing but others exist! Cannot continue!\n").cstring())
-              Fail()
-            else
-              @printf[I32]("Recovering from recovery files!!\n".cstring())
-              // we are recovering because all files exist
-              recovering = true
-            end
-          end
-        else
-          if event_log_filepath.exists() or
-            local_topology_filepath.exists() or
-            control_channel_filepath.exists() or
-            worker_names_filepath.exists()
-          then
-
-            if not (event_log_filepath.exists() and
-              local_topology_filepath.exists() and
-              control_channel_filepath.exists() and
-              worker_names_filepath.exists())
-            then
-
-              @printf[I32](("Some of the resilience recovery files are" +
-                " missing but others exist! Cannot continue!\n").cstring())
-              Fail()
-            else
-              @printf[I32]("Recovering from recovery files!!\n".cstring())
-              // we are recovering because all files exist
-              recovering = true
-            end
-          end
-        end
-      end
-
-      let alfred = ifdef "resilience" then
-          Alfred(env, event_log_file
-            where backend_file_length = alfred_file_length)
-        else
-          Alfred(env, None)
-        end
-
-      if is_multi_worker then
-        connections = Connections(application.name(), worker_name, env, auth,
-          c_host, c_service, d_host, d_service, ph_host, ph_service,
-          metrics_conn, is_initializer, connection_addresses_file)
-      end
-
-      let local_topology_initializer = LocalTopologyInitializer(
-        application, worker_name, worker_count, env, auth, connections,
-        metrics_conn, is_initializer, alfred, input_addrs,
-        local_topology_file, data_channel_file, worker_names_file)
-
-      if is_initializer then
-        env.out.print("Running as Initializer...")
-        application_initializer = ApplicationInitializer(auth,
-          local_topology_initializer, input_addrs, o_addr, alfred)
-        if is_multi_worker then
-          match connections
-          | let conns: Connections =>
-            match application_initializer
-            | let ai: ApplicationInitializer =>
-              worker_initializer = WorkerInitializer(auth, worker_count, conns,
-                ai, local_topology_initializer, d_addr, metrics_conn)
-            end
+        ifdef "resilience" then
+          if is_initializer then
+            connections.make_and_register_recoverable_listener(
+              auth, consume control_notifier, control_channel_filepath,
+              c_host, c_service)
           else
-            Fail()
-          end
-        end
-        worker_name = "initializer"
-      end
-
-      if is_multi_worker then
-        match connections
-        | let conns: Connections =>
-          let control_channel_filepath: FilePath = FilePath(auth, control_channel_file)
-          let control_notifier: TCPListenNotify iso =
-            ControlChannelListenNotifier(worker_name, env, auth, conns,
-            is_initializer, worker_initializer, local_topology_initializer,
-            alfred, control_channel_filepath)
-
-          ifdef "resilience" then
-            if is_initializer then
-              conns.make_and_register_recoverable_listener(
-                auth, consume control_notifier, control_channel_filepath,
-                c_host, c_service)
-            else
-              conns.make_and_register_recoverable_listener(
-                auth, consume control_notifier, control_channel_filepath)
-            end
-          else
-            if is_initializer then
-              conns.register_listener(
-                TCPListener(auth, consume control_notifier, c_host, c_service))
-            else
-              conns.register_listener(
-                TCPListener(auth, consume control_notifier))
-            end
+            connections.make_and_register_recoverable_listener(
+              auth, consume control_notifier, control_channel_filepath)
           end
         else
-          Fail()
-        end
-      end
-
-      ifdef "resilience" then
-        if recovering then
-          // need to do this before recreating the data connection as at that point
-          // replay starts
-          let worker_names_filepath: FilePath = FilePath(auth, worker_names_file)
-          let recovered_workers = _recover_worker_names(worker_names_filepath)
-          if is_multi_worker then
-            local_topology_initializer.recover_and_initialize(recovered_workers,
-              worker_initializer)
+          if is_initializer then
+            connections.register_listener(
+              TCPListener(auth, consume control_notifier, c_host, c_service))
+          else
+            connections.register_listener(
+              TCPListener(auth, consume control_notifier))
           end
         end
-      end
 
-      if not recovering then
-        if is_multi_worker then
+        ifdef "resilience" then
+          if recovering then
+            // need to do this before recreating the data connection as at
+            // that point replay starts
+            let worker_names_filepath: FilePath = FilePath(auth,
+              worker_names_file)
+            let recovered_workers = _recover_worker_names(
+              worker_names_filepath)
+            if is_multi_worker then
+              local_topology_initializer.recover_and_initialize(
+                recovered_workers, worker_initializer)
+            end
+          end
+        end
+
+        if not recovering then
           match worker_initializer
           | let w: WorkerInitializer =>
             w.start(application)
           end
-        else
-          match application_initializer
-          | let ai: ApplicationInitializer =>
-            ai.update_application(application)
-            ai.initialize(None, 1, recover Array[String] end)
-          else
-            Fail()
-          end
         end
       end
-
     else
       StartupHelp(env)
     end

--- a/lib/wallaroo/startup_help.pony
+++ b/lib/wallaroo/startup_help.pony
@@ -20,6 +20,9 @@ primitive StartupHelp
         e.g. -r /tmp/data (no trailing slash)]
       --alfred-file-length/-l [Optionally sets initial file length for alfred
         backend file]
+      
+      --join/-j [When a new worker is joining a running cluster, pass the
+        control channel address of any worker as the value for this parameter]
       -----------------------------------------------------------------------------------
       """
     )


### PR DESCRIPTION
If a worker is run with the --join/-j  parameter and passed the control channel address of any worker in an existing cluster, then it will nominally join the cluster, which at the moment means that it will register with the monitoring hub but is otherwise unknown to the cluster and no part of the topology exists on it.  The contacted worker replies with metrics related info and the new worker contacts the monitoring hub using that information.