### PR TITLE
Revert to using "_final" in CPPData

### DIFF
--- a/apps/arizona-source-app/arizona-source-app/main.pony
+++ b/apps/arizona-source-app/arizona-source-app/main.pony
@@ -67,9 +67,6 @@ primitive StateFilter[In: Any val] is StateComputation[In, None, String]
     sc_repo: StateChangeRepository[String],
     state: String): (None, (StateChange[String] ref | None))
   =>
-    match msg
-    | let m: CPPData val => m.delete_obj()
-    end
     (None, None)
 
   fun state_change_builders(): Array[StateChangeBuilder[String] val] val =>

--- a/lib/wallaroo/cpp_api/pony/computations.pony
+++ b/lib/wallaroo/cpp_api/pony/computations.pony
@@ -37,8 +37,6 @@ class CPPComputation is Computation[CPPData val, CPPData val]
       @printf[I32]("result is not a DataP".cstring())
       None
     end
-    //SUPER-EVIL-DANGER-ZONE
-    input.delete_obj()
     ret
 
   fun name(): String =>
@@ -73,8 +71,6 @@ class CPPStateComputation is StateComputation[CPPData val, CPPData val, CPPState
         @printf[I32]("returning the same object is not allowed".cstring())
       end
     end
-    //SUPER-EVIL-DANGER-ZONE
-    input.delete_obj()
     result
 
   fun name(): String =>

--- a/lib/wallaroo/cpp_api/pony/data.pony
+++ b/lib/wallaroo/cpp_api/pony/data.pony
@@ -14,12 +14,10 @@ class CPPData
 
   fun _serialise(bytes: Pointer[U8] tag) =>
     let s = @w_serializable_serialize(_data, bytes, USize(0))
-    //SUPER-EVIL-DANGER-ZONE
-    delete_obj()
     s
 
   fun ref _deserialise(bytes: Pointer[U8] tag) =>
     _data = recover @w_user_serializable_deserialize(bytes, USize(0)) end
 
-  fun delete_obj() =>
+  fun _final() =>
     @w_managed_object_delete(_data)

--- a/lib/wallaroo/cpp_api/pony/sink_encoder.pony
+++ b/lib/wallaroo/cpp_api/pony/sink_encoder.pony
@@ -24,8 +24,6 @@ class CPPSinkEncoder is SinkEncoder[CPPData val]
           @w_sink_encoder_encode(_sink_encoder, data.obj(),
             bytes.cpointer(), size)
         end
-        //SUPER-EVIL-DANGER-ZONE
-        data.delete_obj()
         bytes
       end]
     end


### PR DESCRIPTION
As a workaround to pony_alloc_final being slow, we had inserted a workaround
that handled the CPP-allocated memory manually, given that we knew the exact
point where we would no longer need the objects created in CPP-land. These were
marked by a comment "SUPER-EVIL-DANGER-ZONE", just to remind everyone that we
were playing with fire. This commit removes those sections and restores the use
of pony_alloc_final now that pony_alloc_final is no longer slow.