### PR TITLE
Write all length encoded data in WindowEncoder

### DIFF
--- a/apps/sequence-window/main.pony
+++ b/apps/sequence-window/main.pony
@@ -195,9 +195,7 @@ primitive WindowEncoder
     ifdef debug then
       @printf[I32]("output: %s\n".cstring(), s.cstring())
     end
-    try
-      wb.write(Bytes.length_encode(s)(0))
-    end
+    wb.writev(Bytes.length_encode(s))
     wb.done()
 
 class Ring


### PR DESCRIPTION
Closes #588 

Fixes output encoding to write out the entire length encoded data.

Tested manually that this decodes correctly with fallor (from a giles' `received.txt`)

**Manual test instructions**: 
1. Build `sequence-window`, `receiver`, `sender`, and `fallor` as necessary
1. then in the `apps/sequence-window` directory, in order:  
   1. `../../giles/receiver/receiver --ponythreads=1 --ponynoblock --ponypinasio -l 127.0.0.1:5555`
   1. `./sequence-window -i 127.0.0.1:7000 -o 127.0.0.1:5555 -c 127.0.0.1:12500 -d 127.0.0.1:12501 -m 127.0.0.1:5001`
   1. `../../giles/sender/sender -b 127.0.0.1:7000 -i 50_000_000 -w -u -m 100 -s 1 -y -g 12`
   1. terminate `receiver` and `sequence-window`
   1. `../../fallor/fallor`
   1. open `fallor-readable.txt` and observe that it looks correct. The first three lines I get are 
   ```
   326933235793935, [0, 0, 0, 1]
   326933274910636, [0, 0, 0, 2]
   326933328287086, [0, 0, 1, 3]
   ```
