### PR TITLE
Allow dynamic updates to local topology

### DIFF
--- a/lib/sendence/equality/equality.pony
+++ b/lib/sendence/equality/equality.pony
@@ -1,0 +1,106 @@
+use "collections"
+
+primitive MapEquality[K: (Hashable #read & Equatable[K] #read),
+  V: Equatable[V] #read]
+  fun apply(m1: box->Map[K, V], m2: box->Map[K, V]): Bool =>
+    if m1.size() != m2.size() then return false end
+    try
+      for (k, v) in m1.pairs() do
+        if m2(k) != v then return false end
+      end
+      true
+    else
+      false
+    end
+
+primitive MapEquality2[K: (Hashable #read & Equatable[K] #read),
+  V1: Equatable[V1] #read, V2: Equatable[V2] #read]
+  fun apply(m1: box->Map[K, (V1 | V2)], m2: box->Map[K, (V1 | V2)]): Bool =>
+    if m1.size() != m2.size() then return false end
+    try
+      for (k, v) in m1.pairs() do
+        if not OrEq2[V1, V2](m2(k), v) then return false end
+      end
+      true
+    else
+      false
+    end
+
+primitive MapEquality3[K: (Hashable #read & Equatable[K] #read),
+  V1: Equatable[V1] #read, V2: Equatable[V2] #read, V3: Equatable[V3] #read]
+  fun apply(m1: box->Map[K, (V1 | V2 | V3)],
+    m2: box->Map[K, (V1 | V2 | V3)]): Bool
+  =>
+    if m1.size() != m2.size() then return false end
+    try
+      for (k, v) in m1.pairs() do
+        if not OrEq3[V1, V2, V3](m2(k), v) then return false end
+      end
+      true
+    else
+      false
+    end
+
+primitive ArrayEquality[V: Equatable[V] #read]
+  fun apply(a1: box->Array[V], a2: box->Array[V]): Bool =>
+    if a1.size() != a2.size() then return false end
+    try
+      for idx in Range(0, a1.size()) do
+        if a1(idx) != a2(idx) then return false end
+      end
+      true
+    else
+      false
+    end
+
+primitive OrEq2[A: Equatable[A] #read, B: Equatable[B] #read]
+  fun apply(v1: (box->A | box->B), v2: (box->A | box-> B)): Bool =>
+    match v1
+    | let v1a: box->A =>
+      match v2
+      | let v2a: box->A =>
+        v1a == v2a
+      else
+        false
+      end
+    | let v1b: box->B =>
+      match v2
+      | let v2b: box->B =>
+        v1b == v2b
+      else
+        false
+      end
+    else
+      false
+    end
+
+primitive OrEq3[A: Equatable[A] #read, B: Equatable[B] #read,
+  C: Equatable[C] #read]
+  fun apply(v1: (box->A | box->B | box->C),
+    v2: (box->A | box->B | box->C)): Bool
+  =>
+    match v1
+    | let v1a: box->A =>
+      match v2
+      | let v2a: box->A =>
+        v1a == v2a
+      else
+        false
+      end
+    | let v1b: box->B =>
+      match v2
+      | let v2b: box->B =>
+        v1b == v2b
+      else
+        false
+      end
+    | let v1c: box->C =>
+      match v2
+      | let v2c: box->C =>
+        v1c == v2c
+      else
+        false
+      end
+    else
+      false
+    end

--- a/lib/wallaroo/_test.pony
+++ b/lib/wallaroo/_test.pony
@@ -6,6 +6,7 @@ This package represents the unit test suite for Wallaroo.
 All tests can be run by compiling and running this package.
 """
 use "ponytest"
+use initialization = "initialization"
 use routing = "routing"
 use spike = "spike"
 
@@ -17,5 +18,6 @@ actor Main is TestList
     None
 
   fun tag tests(test: PonyTest) =>
+    initialization.Main.make().tests(test)
     routing.Main.make().tests(test)
     spike.Main.make().tests(test)

--- a/lib/wallaroo/initialization/_local_topology_test.pony
+++ b/lib/wallaroo/initialization/_local_topology_test.pony
@@ -1,0 +1,181 @@
+use "collections"
+use "ponytest"
+use "sendence/dag"
+use "wallaroo/routing"
+use "wallaroo/topology"
+
+actor TestLocalTopology is TestList
+  new make() =>
+    None
+
+  fun tag tests(test: PonyTest) =>
+    test(_TestLocalTopologyEquality)
+
+class iso _TestLocalTopologyEquality is UnitTest
+  """
+  Test that updating LocalTopology creates the expected changes
+  """
+  fun name(): String =>
+    "initialization/LocalTopologyEquality"
+
+  fun ref apply(h: TestHelper) ? =>
+    // These five are currently tested using identity checks (e.g. "x is y")
+    // since they cannot be changed. Thus, we need a reference to the same
+    // object in the base topology and target topology in order for our
+    // equality check to pass in this test. Once they become dynamic, this test
+    // will need to be updated.
+    let dag = _DagGenerator()
+    let default_target = _DefaultTargetGenerator()
+    let partition_function = _PartitionFunctionGenerator()
+    let runner_builder = _RunnerBuilderGenerator()
+    let pre_state_data = _PreStateDataArrayGenerator(runner_builder)
+
+    var base_topology = _BaseLocalTopologyGenerator(dag, pre_state_data,
+      default_target, partition_function, runner_builder)
+    let target_topology = _TargetLocalTopologyGenerator(dag, pre_state_data,
+      default_target, partition_function, runner_builder)
+    h.assert_eq[Bool](false, base_topology == target_topology)
+    base_topology = base_topology.update_proxy_address_for_state_key[String](
+      "state", "k1", ProxyAddress("w2", 10))
+    base_topology = base_topology.add_worker_name("w4")
+    h.assert_eq[Bool](true, base_topology == target_topology)
+
+primitive _BaseLocalTopologyGenerator
+  fun apply(dag: Dag[StepInitializer val] val,
+    psd: Array[PreStateData val] val,
+    default_target: (Array[StepBuilder val] val | ProxyAddress val | None),
+    pf: PartitionFunction[String, String] val,
+    rb: RunnerBuilder val): LocalTopology val
+  =>
+    LocalTopology("test", "w1", dag, _StepMapGenerator(),
+      _BaseStateBuildersGenerator(rb, pf), psd, _ProxyIdsGenerator(),
+      default_target, "test-default", 1, _BaseWorkerNamesGenerator())
+
+primitive _TargetLocalTopologyGenerator
+  fun apply(dag: Dag[StepInitializer val] val,
+    psd: Array[PreStateData val] val,
+    default_target: (Array[StepBuilder val] val | ProxyAddress val | None),
+    pf: PartitionFunction[String, String] val,
+    rb: RunnerBuilder val): LocalTopology val
+  =>
+    LocalTopology("test", "w1", dag, _StepMapGenerator(),
+      _TargetStateBuildersGenerator(rb, pf), psd, _ProxyIdsGenerator(),
+      default_target, "test-default", 1, _TargetWorkerNamesGenerator())
+
+primitive _DagGenerator
+  fun apply(): Dag[StepInitializer val] val =>
+    Dag[StepInitializer val]
+
+primitive _StepMapGenerator
+  fun apply(): Map[U128, (ProxyAddress val | U128)] val =>
+    let m: Map[U128, (ProxyAddress val | U128)] trn =
+      recover Map[U128, (ProxyAddress val | U128)] end
+    m(1) = ProxyAddress("w1", 10)
+    m(2) = ProxyAddress("w2", 20)
+    m(3) = ProxyAddress("w3", 30)
+    consume m
+
+primitive _BaseStateBuildersGenerator
+  fun apply(rb: RunnerBuilder val, pf: PartitionFunction[String, String] val):
+    Map[String, StateSubpartition val] val
+  =>
+    let m: Map[String, StateSubpartition val] trn =
+      recover Map[String, StateSubpartition val] end
+    m("state") = _BaseStateSubpartitionGenerator(rb, pf)
+    consume m
+
+primitive _TargetStateBuildersGenerator
+  fun apply(rb: RunnerBuilder val, pf: PartitionFunction[String, String] val):
+    Map[String, StateSubpartition val] val
+  =>
+    let m: Map[String, StateSubpartition val] trn =
+      recover Map[String, StateSubpartition val] end
+    m("state") = _TargetStateSubpartitionGenerator(rb, pf)
+    consume m
+
+primitive _BaseStateSubpartitionGenerator
+  fun apply(rb: RunnerBuilder val, pf: PartitionFunction[String, String] val):
+    StateSubpartition val
+  =>
+    KeyedStateSubpartition[String, String](
+      _BaseKeyedPartitionAddressesGenerator(), _IdMapGenerator(),
+      rb, pf, "pipeline")
+
+primitive _TargetStateSubpartitionGenerator
+  fun apply(rb: RunnerBuilder val, pf: PartitionFunction[String, String] val):
+    StateSubpartition val
+  =>
+    KeyedStateSubpartition[String, String](
+      _TargetKeyedPartitionAddressesGenerator(), _IdMapGenerator(),
+      rb, pf, "pipeline")
+
+primitive _BaseKeyedPartitionAddressesGenerator
+  fun apply(): KeyedPartitionAddresses[String] val =>
+    let m: Map[String, ProxyAddress val] trn =
+      recover Map[String, ProxyAddress val] end
+    m("k1") = ProxyAddress("w1", 10)
+    m("k2") = ProxyAddress("w2", 20)
+    m("k3") = ProxyAddress("w3", 30)
+    KeyedPartitionAddresses[String](consume m)
+
+primitive _TargetKeyedPartitionAddressesGenerator
+  fun apply(): KeyedPartitionAddresses[String] val =>
+    let m: Map[String, ProxyAddress val] trn =
+      recover Map[String, ProxyAddress val] end
+    m("k1") = ProxyAddress("w2", 10)
+    m("k2") = ProxyAddress("w2", 20)
+    m("k3") = ProxyAddress("w3", 30)
+    KeyedPartitionAddresses[String](consume m)
+
+primitive _IdMapGenerator
+  fun apply(): Map[String, U128] val =>
+    let m: Map[String, U128] trn = recover Map[String, U128] end
+    m("k1") = 10
+    m("k2") = 20
+    m("k3") = 30
+    consume m
+
+primitive _PartitionFunctionGenerator
+  fun apply(): PartitionFunction[String, String] val =>
+    {(s: String): String => s}
+
+primitive _PreStateDataArrayGenerator
+  fun apply(rb: RunnerBuilder val): Array[PreStateData val] val =>
+    recover [_PreStateDataGenerator(rb), _PreStateDataGenerator(rb),
+      _PreStateDataGenerator(rb)] end
+
+primitive _PreStateDataGenerator
+  fun apply(rb: RunnerBuilder val): PreStateData val =>
+    PreStateData(rb, 1000)
+
+primitive _RunnerBuilderGenerator
+  fun apply(): RunnerBuilder val =>
+    ComputationRunnerBuilder[U8, U8](_ComputationBuilderGenerator(),
+      EmptyRouteBuilder)
+
+primitive _ComputationBuilderGenerator
+  fun apply(): ComputationBuilder[U8, U8] val =>
+    {(): Computation[U8, U8] val => _IdentityComputation[U8]}
+
+class val _IdentityComputation[V]
+  fun name(): String => "id"
+  fun apply(v: V): V =>
+    v
+
+primitive _ProxyIdsGenerator
+  fun apply(): Map[String, U128] val =>
+    recover Map[String, U128] end
+
+primitive _DefaultTargetGenerator
+  fun apply(): (Array[StepBuilder val] val | ProxyAddress val | None) =>
+    None
+
+primitive _BaseWorkerNamesGenerator
+  fun apply(): Array[String] val =>
+    recover ["w1", "w2", "w3"] end
+
+primitive _TargetWorkerNamesGenerator
+  fun apply(): Array[String] val =>
+    recover ["w1", "w2", "w3", "w4"] end
+
+

--- a/lib/wallaroo/initialization/_test.pony
+++ b/lib/wallaroo/initialization/_test.pony
@@ -1,0 +1,12 @@
+use "ponytest"
+
+
+actor Main is TestList
+  new create(env: Env) =>
+    PonyTest(env, this)
+
+  new make() =>
+    None
+
+  fun tag tests(test: PonyTest) =>
+    TestLocalTopology.make().tests(test)

--- a/lib/wallaroo/topology/proxy.pony
+++ b/lib/wallaroo/topology/proxy.pony
@@ -7,4 +7,9 @@ class ProxyAddress
     step_id = s_id
 
   fun string(): String =>
-    "[[" + worker + ": " + step_id.string() + "]]" 
+    "[[" + worker + ": " + step_id.string() + "]]"
+
+  fun eq(that: box->ProxyAddress): Bool =>
+    (worker == that.worker) and (step_id == that.step_id)
+
+  fun ne(that: box->ProxyAddress): Bool => not eq(that)

--- a/lib/wallaroo/topology/step_initializer.pony
+++ b/lib/wallaroo/topology/step_initializer.pony
@@ -8,8 +8,7 @@ use "wallaroo/routing"
 use "wallaroo/tcp_source"
 use "wallaroo/tcp_sink"
 
-type StepInitializer is (StepBuilder | //PartitionedStateStepBuilder |
-  SourceData | EgressBuilder)
+type StepInitializer is (StepBuilder | SourceData | EgressBuilder)
 
 class StepBuilder
   let _app_name: String


### PR DESCRIPTION
We can now make two kinds of changes to local topology
information: 1) we can update information about where
a state step resides in the cluster of workers and
2) we have a hook to add a new worker name to our list when a
worker joins the cluster. Whenever one of these changes is
made, if we are running with resilience, we update data
in the relevant resilience files.
