### PR TITLE
Don't pass failing tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,8 +91,8 @@ script:
   - cd lib/wallaroo;
     stable env ponyc;
     ./wallaroo;
-    cd -;
+  - cd -;
   - cd lib/sendence/;
     stable env ponyc;
     ./sendence;
-    cd -;
+  - cd -;


### PR DESCRIPTION
Currently, how I set up travis results in failing tests like
Wallaroo tests not compiling to be passed. This is because the
last executed command for the section of script would always return
a non-zero code.

This changes the travis yaml to have the running of test binaries
have it own return code.