### PR TITLE
Add support for building an entire Wallaroo application in C++

### DIFF
--- a/examples/counter-app/hpp/Counter.hpp
+++ b/examples/counter-app/hpp/Counter.hpp
@@ -12,7 +12,7 @@
 #include <vector>
 #include <iostream>
 
-class Numbers: public wallaroo::EncodableData
+class Numbers: public wallaroo::Data
 {
 private:
   std::vector<uint32_t> numbers;
@@ -25,13 +25,13 @@ public:
   uint32_t sum();
 
   virtual void deserialize (char* bytes);
-  virtual void serialize (char* bytes, size_t nsz_);
+  virtual void serialize (char* bytes);
   virtual size_t serialize_get_size ();
-  virtual size_t encode_get_size();
-  virtual void encode(char *bytes);
+  size_t encode_get_size();
+  void encode(char *bytes);
 };
 
-class Total: public wallaroo::EncodableData
+class Total: public wallaroo::Data
 {
 private:
   uint64_t _total;
@@ -39,7 +39,7 @@ public:
   Total(Total& t);
   Total(uint64_t total);
   virtual void deserialize (char* bytes);
-  virtual void serialize (char* bytes, size_t nsz_);
+  virtual void serialize (char* bytes);
   virtual size_t serialize_get_size () { return 10; }
   virtual size_t encode_get_size() { return 8; }
   virtual void encode(char *bytes);
@@ -51,17 +51,17 @@ class CounterSourceDecoder: public wallaroo::SourceDecoder
 public:
   virtual size_t header_length();
   virtual size_t payload_length(char *bytes);
-  virtual Numbers *decode(char *bytes, size_t sz_);
+  virtual Numbers *decode(char *bytes);
 };
 
 class CounterSinkEncoder: public wallaroo::SinkEncoder
 {
 public:
-  virtual size_t get_size(wallaroo::EncodableData *data);
-  virtual void encode(wallaroo::EncodableData *data, char *bytes);
+  virtual size_t get_size(wallaroo::Data *data);
+  virtual void encode(wallaroo::Data *data, char *bytes);
 
   virtual void deserialize (char* bytes) {};
-  virtual void serialize (char* bytes, size_t nsz_) { bytes[0] = 0; bytes[1] = 4; }
+  virtual void serialize (char* bytes) { bytes[0] = 0; bytes[1] = 4; }
   virtual size_t serialize_get_size () { return 2; }
 };
 
@@ -73,6 +73,13 @@ public:
   CounterState();
   void add(uint64_t value);
   uint64_t get_counter();
+};
+
+class CounterStateBuilder: public wallaroo::StateBuilder
+{
+public:
+  const char *name();
+  wallaroo::State *build();
 };
 
 class CounterAdd: public wallaroo::StateChange
@@ -98,7 +105,7 @@ class CounterAddBuilder: public wallaroo::StateChangeBuilder
 public:
   virtual wallaroo::StateChange *build(uint64_t idx_);
   virtual void deserialize (char* bytes);
-  virtual void serialize (char* bytes, size_t nsz_);
+  virtual void serialize (char* bytes);
   virtual size_t serialize_get_size ();
 };
 
@@ -117,7 +124,7 @@ public:
   virtual size_t get_number_of_state_change_builders();
   virtual wallaroo::StateChangeBuilder *get_state_change_builder(size_t idx_);
   virtual void deserialize (char* bytes) {};
-  virtual void serialize (char* bytes, size_t nsz_) { bytes[0] = 0; bytes[1] = 2; }
+  virtual void serialize (char* bytes) { bytes[0] = 0; bytes[1] = 2; }
   virtual size_t serialize_get_size () { return 2; }
 };
 
@@ -129,7 +136,7 @@ public:
   virtual size_t get_number_of_state_change_builders();
   virtual wallaroo::StateChangeBuilder *get_state_change_builder(size_t idx_);
   virtual void deserialize (char* bytes) {};
-  virtual void serialize (char* bytes, size_t nsz_) { bytes[0] = 0; bytes[1] = 1; }
+  virtual void serialize (char* bytes) { bytes[0] = 0; bytes[1] = 1; }
   virtual size_t serialize_get_size () { return 2; }
 };
 
@@ -144,7 +151,7 @@ public:
   virtual bool eq(wallaroo::Key *other_);
   size_t get_value();
   virtual void deserialize (char* bytes_);
-  virtual void serialize (char* bytes_, size_t nsz_);
+  virtual void serialize (char* bytes_);
   virtual size_t serialize_get_size () { return 6; }
 };
 

--- a/lib/wallaroo/cpp_api/cpp/cppapi/cpp/ApiHooks.cpp
+++ b/lib/wallaroo/cpp_api/cpp/cppapi/cpp/ApiHooks.cpp
@@ -1,4 +1,6 @@
 #include "ApiHooks.hpp"
+#include "Application.hpp"
+#include "ComputationBuilder.hpp"
 #include "Computation.hpp"
 #include "Data.hpp"
 #include "Key.hpp"
@@ -65,20 +67,19 @@ extern size_t w_serializable_serialize_get_size(Serializable* serializable_)
   return serializable_->serialize_get_size();
 }
 
-extern void w_serializable_serialize(Serializable* serializable_, char* bytes_,
-  size_t sz_)
+extern void w_serializable_serialize(Serializable* serializable_, char* bytes_)
 {
-  serializable_->serialize(bytes_, sz_);
+  serializable_->serialize(bytes_);
 }
 
 extern size_t w_sink_encoder_get_size(SinkEncoder *sink_encoder_,
-  EncodableData *data_)
+  Data *data_)
 {
   return sink_encoder_->get_size(data_);
 }
 
 extern void w_sink_encoder_encode(SinkEncoder *sink_encoder_,
-  EncodableData *data_, char *bytes_)
+  Data *data_, char *bytes_)
 {
   sink_encoder_->encode(data_, bytes_);
 }
@@ -95,9 +96,9 @@ extern size_t w_source_decoder_payload_length(SourceDecoder *source_decoder_,
 }
 
 extern Data *w_source_decoder_decode(SourceDecoder *source_decoder_,
-  char *bytes_, size_t sz_)
+  char *bytes_)
 {
-  return source_decoder_->decode(bytes_, sz_);
+  return source_decoder_->decode(bytes_);
 }
 
 extern const char *w_state_change_get_name(StateChange *state_change_)
@@ -202,4 +203,48 @@ extern void w_managed_object_delete(ManagedObject const *obj_)
   delete obj_;
 }
 
+  extern void *w_computation_builder_build_computation(ComputationBuilder *computation_builder_)
+  {
+    return computation_builder_->build();
+  }
+
+  extern void *w_partition_get_partition_function(wallaroo::Partition *partition_)
+  {
+    return partition_->get_partition_function();
+  }
+
+  extern size_t w_partition_get_number_of_keys(wallaroo::Partition *partition_)
+  {
+    return partition_->get_number_of_keys();
+  }
+
+  extern void *w_partition_get_key(wallaroo::Partition *partition_, size_t idx_)
+  {
+    return partition_->get_key(idx_);
+  }
+
+  extern void *w_partition_get_partition_function_u64(wallaroo::PartitionU64 *partition_)
+  {
+    return partition_->get_partition_function();
+  }
+
+  extern size_t w_partition_get_number_of_keys_u64(wallaroo::PartitionU64 *partition_)
+  {
+    return partition_->get_number_of_keys();
+  }
+
+  extern uint64_t w_partition_get_key_u64(wallaroo::PartitionU64 *partition_, size_t idx_)
+  {
+    return partition_->get_key(idx_);
+  }
+
+  const char *w_state_builder_get_name(StateBuilder *state_builder_)
+  {
+    return state_builder_->name();
+  }
+
+  extern void *w_state_builder_build_state(StateBuilder *state_builder_)
+  {
+    return state_builder_->build();
+  }
 }

--- a/lib/wallaroo/cpp_api/cpp/cppapi/cpp/Application.cpp
+++ b/lib/wallaroo/cpp_api/cpp/cppapi/cpp/Application.cpp
@@ -1,0 +1,136 @@
+#include "ApiHooks.hpp"
+#include "Application.hpp"
+#include "SourceDecoder.hpp"
+#include "SinkEncoder.hpp"
+#include "Computation.hpp"
+#include "ComputationBuilder.hpp"
+#include "State.hpp"
+#include "PartitionFunction.hpp"
+#include "Key.hpp"
+
+using namespace wallaroo;
+
+extern "C"
+{
+  void* pony_CPPApplicationBuilder_create_application(void* self, void* name_);
+  void* pony_CPPApplicationBuilder_new_pipeline(void* self, void* name_, void* source_decoder_);
+  void* pony_CPPApplicationBuilder_to(void* self, void *computation_builder);
+  void* pony_CPPApplicationBuilder_to_stateful(
+    void* self,
+    void *computation,
+    void *state_builder_,
+    void *state_name);
+  void* pony_CPPApplicationBuilder_to_state_partition(
+    void* self,
+    void *computation,
+    void *state_builder_,
+    void *state_name,
+    void *partition,
+    bool multi_worker);
+  void* pony_CPPApplicationBuilder_to_state_partition_u64(
+    void* self,
+    void *computation,
+    void *state_builder_,
+    void *state_name,
+    void *partition,
+    bool multi_worker);
+  void* pony_CPPApplicationBuilder_to_sink(void* self, void *sink_encoder);
+  void* pony_CPPApplicationBuilder_build(void* self);
+  void* pony_CPPApplicationBuilder_done(void* self);
+}
+
+Application::Application(void *application_builder_):
+  m_application_builder(application_builder_)
+{
+}
+
+Application::~Application()
+{
+}
+
+Application *Application::create_application(const char *name_)
+{
+  return this;
+}
+
+Application *Application::new_pipeline(
+  const char* pipeline_name_,
+  SourceDecoder *source_decoder_)
+{
+  pony_CPPApplicationBuilder_new_pipeline(
+    m_application_builder, (void *) pipeline_name_, (void *) source_decoder_);
+
+  return this;
+}
+
+Application *Application::to(ComputationBuilder *computation_builder_)
+{
+  pony_CPPApplicationBuilder_to(
+    m_application_builder, (void *) computation_builder_);
+  return this;
+}
+
+Application *Application::to_stateful(
+  StateComputation *state_computation_,
+  StateBuilder *state_builder_,
+  const char* state_name_)
+{
+  pony_CPPApplicationBuilder_to_stateful(
+    m_application_builder,
+    (void *) state_computation_,
+    (void *) state_builder_,
+    (void *) state_name_
+    );
+  return this;
+}
+
+Application *Application::to_state_partition(
+  StateComputation *state_computation_,
+  StateBuilder *state_builder_,
+  const char* state_name_,
+  Partition *partition_,
+  bool multi_worker_ = false)
+{
+  pony_CPPApplicationBuilder_to_state_partition(
+    m_application_builder,
+    (void *) state_computation_,
+    (void *) state_builder_,
+    (void *) state_name_,
+    (void *) partition_,
+    multi_worker_
+    );
+  return this;
+}
+
+Application *Application::to_state_partition_u64(
+  StateComputation *state_computation_,
+  StateBuilder *state_builder_,
+  const char* state_name_,
+  PartitionU64 *partition_,
+  bool multi_worker_ = false)
+{
+  pony_CPPApplicationBuilder_to_state_partition_u64(
+    m_application_builder,
+    (void *) state_computation_,
+    (void *) state_builder_,
+    (void *) state_name_,
+    (void *) partition_,
+    multi_worker_
+    );
+  return this;
+}
+
+Application *Application::to_sink(SinkEncoder *sink_encoder_)
+{
+  pony_CPPApplicationBuilder_to_sink(
+    m_application_builder,
+    sink_encoder_
+    );
+  return this;
+}
+
+Application *Application::done()
+{
+  pony_CPPApplicationBuilder_done(m_application_builder);
+  return this;
+}

--- a/lib/wallaroo/cpp_api/cpp/cppapi/hpp/ApiHooks.hpp
+++ b/lib/wallaroo/cpp_api/cpp/cppapi/hpp/ApiHooks.hpp
@@ -33,20 +33,18 @@ extern StateChangeBuilder *w_state_computation_get_state_change_builder(
   StateComputation *state_computation_, uint64_t idx_);
 
 extern size_t w_serializable_serialize_get_size(Serializable* serializable_);
-extern void w_serializable_serialize(Serializable* serializable_, char* bytes_,
-  size_t sz_);
-extern Serializable* w_serializable_deserialize (char* bytes_, size_t sz_);
+extern void w_serializable_serialize(Serializable* serializable_, char* bytes_);
+extern Serializable* w_serializable_deserialize (char* bytes_);
 
 extern size_t w_sink_encoder_get_size(SinkEncoder *sink_encoder_,
-  EncodableData *data_);
+  Data *data_);
 extern void w_sink_encoder_encode(SinkEncoder *sink_encoder_,
-  EncodableData *data_, char *bytes);
+  Data *data_, char *bytes);
 
 extern size_t w_source_decoder_header_length(SourceDecoder *source_decoder_);
 extern size_t w_source_decoder_payload_length(SourceDecoder *source_decoder_,
   char *bytes_);
-extern Data *w_source_decoder_decode(SourceDecoder *source_decoder_, char *bytes_,
-  size_t sz_);
+extern Data *w_source_decoder_decode(SourceDecoder *source_decoder_, char *bytes_);
 
 extern const char *w_state_change_get_name(StateChange *state_change_);
 extern uint64_t w_state_change_get_id(StateChange *state_change_);

--- a/lib/wallaroo/cpp_api/cpp/cppapi/hpp/Application.hpp
+++ b/lib/wallaroo/cpp_api/cpp/cppapi/hpp/Application.hpp
@@ -1,0 +1,47 @@
+#ifndef __APPLICATION_HPP__
+#define __APPLICATION_HPP__
+
+#include "SourceDecoder.hpp"
+#include "SinkEncoder.hpp"
+#include "Computation.hpp"
+#include "ComputationBuilder.hpp"
+#include "State.hpp"
+#include "StateBuilder.hpp"
+#include "Partition.hpp"
+
+namespace wallaroo {
+  class Application
+  {
+  private:
+    void *m_application_builder;
+    const char *m_name;
+  public:
+    Application(void *application_builder_);
+    ~Application();
+    Application *create_application(const char *name_);
+    Application *new_pipeline(
+      const char* pipeline_name_,
+      SourceDecoder *source_decoder_);
+    Application *to(ComputationBuilder *computation_builder_);
+    Application *to_stateful(
+      StateComputation *state_computation_,
+      StateBuilder *state_builder_,
+      const char* state_name_);
+    Application *to_state_partition(
+      StateComputation *state_computation_,
+      StateBuilder *state_builder_,
+      const char* state_name_,
+      Partition *partition_,
+      bool multi_worker_);
+    Application *to_state_partition_u64(
+      StateComputation *state_computation_,
+      StateBuilder *state_builder_,
+      const char* state_name_,
+      PartitionU64 *partition_,
+      bool multi_worker_);
+    Application *to_sink(SinkEncoder *sink_encoder_);
+    Application *done();
+  };
+}
+
+#endif // __LIBRARY_HPP__

--- a/lib/wallaroo/cpp_api/cpp/cppapi/hpp/ComputationBuilder.hpp
+++ b/lib/wallaroo/cpp_api/cpp/cppapi/hpp/ComputationBuilder.hpp
@@ -1,0 +1,15 @@
+#ifndef __COMPUTATIONBUILDER_HPP__
+#define __COMPUTATIONBUILDER_HPP__
+
+#include "Computation.hpp"
+
+namespace wallaroo
+{
+  class ComputationBuilder
+  {
+  public:
+    virtual Computation *build() = 0;
+  };
+}
+
+#endif

--- a/lib/wallaroo/cpp_api/cpp/cppapi/hpp/Data.hpp
+++ b/lib/wallaroo/cpp_api/cpp/cppapi/hpp/Data.hpp
@@ -11,14 +11,5 @@ class Data: public ManagedObject
 public:
   virtual ~Data();
 };
-
-class EncodableData: public Data
-{
-public:
-  virtual ~EncodableData() {};
-  virtual size_t encode_get_size() = 0;
-  virtual void encode(char *bytes_) = 0;
-};
-
 }
 #endif //__DATA_HPP__

--- a/lib/wallaroo/cpp_api/cpp/cppapi/hpp/Partition.hpp
+++ b/lib/wallaroo/cpp_api/cpp/cppapi/hpp/Partition.hpp
@@ -1,0 +1,26 @@
+#ifndef __PARTITION_HPP__
+#define __PARTITION_HPP__
+
+#include "PartitionFunction.hpp"
+#include "Key.hpp"
+
+namespace wallaroo {
+  class Partition
+  {
+  public:
+    virtual PartitionFunction *get_partition_function() = 0;
+    virtual size_t get_number_of_keys() = 0;
+    virtual Key *get_key(size_t idx_) = 0;
+  };
+
+  class PartitionU64
+  {
+  public:
+    virtual PartitionFunctionU64 *get_partition_function() = 0;
+    virtual size_t get_number_of_keys() = 0;
+    virtual uint64_t get_key(size_t idx_) = 0;
+  };
+}
+
+
+#endif // __PARTITION_HPP__

--- a/lib/wallaroo/cpp_api/cpp/cppapi/hpp/Serializable.hpp
+++ b/lib/wallaroo/cpp_api/cpp/cppapi/hpp/Serializable.hpp
@@ -9,7 +9,7 @@ class Serializable
 {
 public:
   virtual void deserialize (char* bytes_) {}
-  virtual void serialize (char* bytes_, size_t nsz_) {}
+  virtual void serialize (char* bytes_) {}
   virtual size_t serialize_get_size () { return 0; }
 };
 }

--- a/lib/wallaroo/cpp_api/cpp/cppapi/hpp/SinkEncoder.hpp
+++ b/lib/wallaroo/cpp_api/cpp/cppapi/hpp/SinkEncoder.hpp
@@ -9,8 +9,8 @@ namespace wallaroo
 {
 class SinkEncoder: public ManagedObject {
 public:
-  virtual size_t get_size(EncodableData *data_) = 0;
-  virtual void encode(EncodableData *data_, char *bytes_) = 0;
+  virtual size_t get_size(Data *data_) = 0;
+  virtual void encode(Data *data_, char *bytes_) = 0;
 };
 }
 

--- a/lib/wallaroo/cpp_api/cpp/cppapi/hpp/SourceDecoder.hpp
+++ b/lib/wallaroo/cpp_api/cpp/cppapi/hpp/SourceDecoder.hpp
@@ -11,7 +11,7 @@ class SourceDecoder: public ManagedObject
 public:
   virtual std::size_t header_length() = 0;
   virtual std::size_t payload_length(char *bytes_) = 0;
-  virtual Data *decode(char *bytes_, size_t sz_) = 0;
+  virtual Data *decode(char *bytes_) = 0;
 };
 }
 

--- a/lib/wallaroo/cpp_api/cpp/cppapi/hpp/StateBuilder.hpp
+++ b/lib/wallaroo/cpp_api/cpp/cppapi/hpp/StateBuilder.hpp
@@ -1,0 +1,16 @@
+#ifndef __STATEBUILDER_HPP__
+#define __STATEBUILDER_HPP__
+
+#include "State.hpp"
+
+namespace wallaroo
+{
+  class StateBuilder
+  {
+  public:
+    virtual const char *name() = 0;
+    virtual State *build() = 0;
+  };
+}
+
+#endif // __STATEBUILDER_HPP__

--- a/lib/wallaroo/cpp_api/cpp/cppapi/hpp/UserHooks.hpp
+++ b/lib/wallaroo/cpp_api/cpp/cppapi/hpp/UserHooks.hpp
@@ -4,7 +4,8 @@
 #include "Serializable.hpp"
 
 extern "C" {
-extern wallaroo::Serializable* w_user_data_deserialize (char* bytes_, size_t sz_);
+extern wallaroo::Serializable* w_user_data_deserialize (char* bytes_);
+extern bool w_main(int argc, char **argv, Application *application_builder_);
 }
 
 #endif //__USERHOOKS__HPP

--- a/lib/wallaroo/cpp_api/pony/application.pony
+++ b/lib/wallaroo/cpp_api/pony/application.pony
@@ -1,0 +1,171 @@
+use "collections"
+
+use "wallaroo"
+use "wallaroo/topology"
+
+use @w_computation_builder_build_computation[ComputationP](fn: ComputationBuilderP)
+use @w_state_builder_get_name[Pointer[U8]](sb: StateBuilderP)
+use @w_state_builder_build_state[StateP](sb: StateBuilderP)
+
+use @w_partition_get_partition_function[PartitionFunctionP](partition: PartitionP)
+use @w_partition_get_number_of_keys[USize](partition: PartitionP)
+use @w_partition_get_key[KeyP](partition: PartitionP, idx: USize)
+
+use @w_partition_get_partition_function_u64[PartitionFunctionP](partition: PartitionP)
+use @w_partition_get_number_of_keys_u64[USize](partition: PartitionP)
+use @w_partition_get_key_u64[U64](partition: PartitionP, idx: USize)
+
+export CPPApplicationBuilder
+
+type ApplicationP is Pointer[U8] val
+type ComputationBuilderP is Pointer[U8] val
+type StateBuilderP is Pointer[U8] val
+type PartitionP is Pointer[U8] val
+
+class CPPComputationBuilder
+  let _computation_builder: ComputationBuilderP
+
+  new create(computation_builder: ComputationBuilderP) =>
+    _computation_builder = computation_builder
+
+  fun apply(): CPPComputation val =>
+    recover CPPComputation(@w_computation_builder_build_computation(_computation_builder)) end
+
+class CPPStateBuilder
+  let _state_builder: StateBuilderP
+
+  new create(state_builder: StateBuilderP) =>
+    _state_builder = state_builder
+
+  fun name(): String =>
+    String.from_cstring(@w_state_builder_get_name(_state_builder)).clone()
+
+  fun apply(): CPPState =>
+    CPPState(@w_state_builder_build_state(_state_builder))
+
+class CPPApplicationBuilder
+  var _application: (None | Application) = None
+  var _pipeline_builder: (None | PipelineBuilder[CPPData val, CPPData val, CPPData val]) = None
+
+  fun ref create_application(application_name': Pointer[U8] ref) =>
+    let application_name: String = String.from_cstring(application_name').clone()
+    _application = recover Application(application_name) end
+
+  fun ref new_pipeline(name': Pointer[U8] ref,
+    source_decoder': Pointer[U8] val)
+  =>
+    match _application
+    | let app: Application =>
+      let name = String.from_cstring(name')
+      let source_decoder = recover val CPPSourceDecoder(source_decoder') end
+      _pipeline_builder = app.
+        new_pipeline[CPPData val, CPPData val](name.clone(), source_decoder)
+    end
+
+  fun ref to(computation_builder': ComputationBuilderP) =>
+    match _pipeline_builder
+    | let pb: PipelineBuilder[CPPData val, CPPData val, CPPData val] =>
+      let computation_builder: CPPComputationBuilder val =
+        recover CPPComputationBuilder(computation_builder') end
+      _pipeline_builder = pb.to[CPPData val](computation_builder)
+    end
+
+  fun ref to_stateful(state_computation: StateComputationP,
+    state_builder': StateBuilderP,
+    state_name': Pointer[U8] ref)
+  =>
+    match _pipeline_builder
+    | let pb: PipelineBuilder[CPPData val, CPPData val, CPPData val] =>
+      let state_name: String val = String.from_cstring(state_name').clone()
+      let state_builder = recover val CPPStateBuilder(state_builder') end
+      let stateful_computation_builder = recover val CPPStateComputation(state_computation) end
+      _pipeline_builder = pb.to_stateful[CPPData val, CPPState](
+        stateful_computation_builder, state_builder, state_name)
+    end
+
+  fun ref to_state_partition(state_computation': StateComputationP,
+    state_builder': StateBuilderP,
+    state_name': Pointer[U8],
+    partition': PartitionP,
+    multi_worker: Bool)
+  =>
+    match _pipeline_builder
+    | let pb: PipelineBuilder[CPPData val, CPPData val, CPPData val] =>
+      let state_name: String val = String.from_cstring(state_name').clone()
+      let state_builder = recover val CPPStateBuilder(state_builder') end
+      let state_computation = recover val CPPStateComputation(state_computation') end
+      let partition_function = recover val CPPPartitionFunction(
+        @w_partition_get_partition_function(partition')
+      ) end
+
+      let keys = recover iso Array[CPPKey val] end
+      for i in Range(0, @w_partition_get_number_of_keys(partition')) do
+        keys.push(recover val CPPKey(@w_partition_get_key(partition', i)) end)
+      end
+
+      let partition = Partition[CPPData val, CPPKey val](partition_function, consume keys)
+
+      _pipeline_builder = pb.to_state_partition[CPPData val, CPPKey val, CPPData val, CPPState](
+        state_computation,
+        state_builder,
+        state_name,
+        partition,
+        multi_worker)
+    end
+
+  fun ref to_state_partition_u64(state_computation': StateComputationP,
+    state_builder': StateBuilderP,
+    state_name': Pointer[U8],
+    partition': PartitionP,
+    multi_worker: Bool)
+  =>
+    match _pipeline_builder
+    | let pb: PipelineBuilder[CPPData val, CPPData val, CPPData val] =>
+      let state_name: String val = String.from_cstring(state_name').clone()
+      let state_builder = recover val CPPStateBuilder(state_builder') end
+      let state_computation = recover val CPPStateComputation(state_computation') end
+      let partition_function = recover val CPPPartitionFunctionU64(
+        @w_partition_get_partition_function_u64(partition')
+      ) end
+
+      let keys = recover iso Array[U64] end
+      for i in Range(0, @w_partition_get_number_of_keys_u64(partition')) do
+        keys.push(@w_partition_get_key_u64(partition', i))
+      end
+
+      let partition = Partition[CPPData val, U64](partition_function, consume keys)
+
+      _pipeline_builder = pb.to_state_partition[CPPData val, U64, CPPData val, CPPState](
+        state_computation,
+        state_builder,
+        state_name,
+        partition,
+        multi_worker)
+    end
+
+  fun ref to_sink(sink_encoder': SinkEncoderP): Bool =>
+    try
+      match _pipeline_builder
+      | let pb: PipelineBuilder[CPPData val, CPPData val, CPPData val] =>
+        let sink_encoder = recover val CPPSinkEncoder(sink_encoder') end
+        pb.to_sink(sink_encoder, recover [0] end)
+        _pipeline_builder = None
+      end
+      true
+    else
+      false
+    end
+
+  fun ref done(): Bool =>
+    try
+      match _pipeline_builder
+      | let pb: PipelineBuilder[CPPData val, CPPData val, CPPData val] =>
+        pb.done()
+      end
+      true
+    else
+      false
+    end
+
+  fun ref build(): Application ? =>
+    _application as Application

--- a/lib/wallaroo/cpp_api/pony/computations.pony
+++ b/lib/wallaroo/cpp_api/pony/computations.pony
@@ -102,10 +102,10 @@ class CPPStateComputation is StateComputation[CPPData val, CPPData val, CPPState
     @w_serializable_serialize_get_size(_computation)
 
   fun _serialise(bytes: Pointer[U8] tag) =>
-    @w_serializable_serialize(_computation, bytes, USize(0))
+    @w_serializable_serialize(_computation, bytes)
 
   fun ref _deserialise(bytes: Pointer[U8] tag) =>
-    _computation = recover @w_user_serializable_deserialize(bytes, USize(0)) end
+    _computation = recover @w_user_serializable_deserialize(bytes) end
 
   fun _final() =>
     @w_managed_object_delete(_computation)

--- a/lib/wallaroo/cpp_api/pony/data.pony
+++ b/lib/wallaroo/cpp_api/pony/data.pony
@@ -13,11 +13,11 @@ class CPPData
     @w_serializable_serialize_get_size(_data)
 
   fun _serialise(bytes: Pointer[U8] tag) =>
-    let s = @w_serializable_serialize(_data, bytes, USize(0))
+    let s = @w_serializable_serialize(_data, bytes)
     s
 
   fun ref _deserialise(bytes: Pointer[U8] tag) =>
-    _data = recover @w_user_serializable_deserialize(bytes, USize(0)) end
+    _data = recover @w_user_serializable_deserialize(bytes) end
 
   fun _final() =>
     @w_managed_object_delete(_data)

--- a/lib/wallaroo/cpp_api/pony/key.pony
+++ b/lib/wallaroo/cpp_api/pony/key.pony
@@ -24,10 +24,10 @@ class CPPKey is (Hashable & Equatable[CPPKey])
     @w_serializable_serialize_get_size(_key)
 
   fun _serialise(bytes: Pointer[U8] tag) =>
-    @w_serializable_serialize(_key, bytes, USize(0))
+    @w_serializable_serialize(_key, bytes)
 
   fun ref _deserialise(bytes: Pointer[U8] tag) =>
-    _key = recover @w_user_serializable_deserialize(bytes, USize(0)) end
+    _key = recover @w_user_serializable_deserialize(bytes) end
 
   fun _final() =>
     @w_managed_object_delete(_key)

--- a/lib/wallaroo/cpp_api/pony/partition_function.pony
+++ b/lib/wallaroo/cpp_api/pony/partition_function.pony
@@ -20,11 +20,11 @@ class CPPPartitionFunction
     @w_serializable_serialize_get_size(_partition_function)
 
   fun _serialise(bytes: Pointer[U8] tag) =>
-    @w_serializable_serialize(_partition_function, bytes, USize(0))
+    @w_serializable_serialize(_partition_function, bytes)
 
   fun ref _deserialise(bytes: Pointer[U8] tag) =>
     _partition_function = recover
-      @w_user_serializable_deserialize(bytes, USize(0))
+      @w_user_serializable_deserialize(bytes)
     end
 
   fun _final() =>
@@ -43,11 +43,11 @@ class CPPPartitionFunctionU64
     @w_serializable_serialize_get_size(_partition_function)
 
   fun _serialise(bytes: Pointer[U8] tag) =>
-    @w_serializable_serialize(_partition_function, bytes, USize(0))
+    @w_serializable_serialize(_partition_function, bytes)
 
   fun ref _deserialise(bytes: Pointer[U8] tag) =>
     _partition_function = recover
-      @w_user_serializable_deserialize(bytes, USize(0))
+      @w_user_serializable_deserialize(bytes)
     end
 
   fun _final() =>

--- a/lib/wallaroo/cpp_api/pony/serializable.pony
+++ b/lib/wallaroo/cpp_api/pony/serializable.pony
@@ -1,5 +1,4 @@
 use @w_serializable_serialize_get_size[USize](data: ManagedObjectP)
 use @w_serializable_serialize[None](data: ManagedObjectP,
-  bytes: Pointer[U8] tag, size: USize)
-use @w_user_serializable_deserialize[ManagedObjectP](bytes: Pointer[U8] tag,
-  size: USize)
+  bytes: Pointer[U8] tag)
+use @w_user_serializable_deserialize[ManagedObjectP](bytes: Pointer[U8] tag)

--- a/lib/wallaroo/cpp_api/pony/sink_encoder.pony
+++ b/lib/wallaroo/cpp_api/pony/sink_encoder.pony
@@ -32,11 +32,11 @@ class CPPSinkEncoder is SinkEncoder[CPPData val]
     @w_serializable_serialize_get_size(_sink_encoder)
 
   fun _serialise(bytes: Pointer[U8] tag) =>
-    @w_serializable_serialize(_sink_encoder, bytes, USize(0))
+    @w_serializable_serialize(_sink_encoder, bytes)
 
   fun ref _deserialise(bytes: Pointer[U8] tag) =>
     _sink_encoder = recover
-      @w_user_serializable_deserialize(bytes, USize(0))
+      @w_user_serializable_deserialize(bytes)
     end
 
   fun _final() =>

--- a/lib/wallaroo/cpp_api/pony/source_decoder.pony
+++ b/lib/wallaroo/cpp_api/pony/source_decoder.pony
@@ -6,7 +6,7 @@ use @w_source_decoder_payload_length[USize](source_decoder: SourceDecoderP,
   data: Pointer[U8] tag)
 
 use @w_source_decoder_decode[DataP](source_decoder: SourceDecoderP,
-  data: Pointer[U8] tag, size: USize)
+  data: Pointer[U8] tag)
 
 type SourceDecoderP is Pointer[U8] val
 
@@ -25,8 +25,7 @@ class CPPSourceDecoder is FramedSourceHandler[CPPData val]
     @w_source_decoder_payload_length(_source_decoder, data.cpointer())
 
   fun decode(data: Array[U8] val): CPPData val ? =>
-    match @w_source_decoder_decode(_source_decoder, data.cpointer(),
-      data.size())
+    match @w_source_decoder_decode(_source_decoder, data.cpointer())
     | let result: DataP if (not result.is_null()) =>
       recover CPPData(result) end
     else
@@ -37,11 +36,11 @@ class CPPSourceDecoder is FramedSourceHandler[CPPData val]
     @w_serializable_serialize_get_size(_source_decoder)
 
   fun _serialise(bytes: Pointer[U8] tag) =>
-    @w_serializable_serialize(_source_decoder, bytes, USize(0))
+    @w_serializable_serialize(_source_decoder, bytes)
 
   fun ref _deserialise(bytes: Pointer[U8] tag) =>
     _source_decoder = recover
-      @w_user_serializable_deserialize(bytes, USize(0))
+      @w_user_serializable_deserialize(bytes)
     end
 
   fun _final() =>

--- a/lib/wallaroo/cpp_api/pony/state_change_builder.pony
+++ b/lib/wallaroo/cpp_api/pony/state_change_builder.pony
@@ -20,11 +20,11 @@ class CPPStateChangeBuilder is StateChangeBuilder[CPPState]
     @w_serializable_serialize_get_size(_state_change_builder)
 
   fun _serialise(bytes: Pointer[U8] tag) =>
-    @w_serializable_serialize(_state_change_builder, bytes, USize(0))
+    @w_serializable_serialize(_state_change_builder, bytes)
 
   fun ref _deserialise(bytes: Pointer[U8] tag) =>
     _state_change_builder = recover
-      @w_user_serializable_deserialize(bytes, USize(0))
+      @w_user_serializable_deserialize(bytes)
     end
 
   fun _final() =>


### PR DESCRIPTION
This commit makes it possible to create a Wallaroo application using
on C++ code. The biggest addition is new classes that support
application creation and pipeline setup.

This also includes some API cleanup.

Get rid of EncodableData class

It doesn't seem to make sense to force the application developer to
subclass a special class of data in order to encode it. If the
application developer wishes to add methods to data to make it easier
to encode it, then they can, but this should not be required.

Requiring data that goes to the encoder to have a special type also
meant that these data classes were implemented differently than
standard data classes, which meant that more work would be required
when changing a pipeline layout. If data that had been going to a
computation now needed to go to a sink, it's type would have to be
changed.

Get rid of unused size arguments in serialization and encoding

The serialization and encoding methods and functions took size
arguments, but these arguments were not being set because it wasn't
possible to determine the sizes in the code. Therefore, these
arguments are no longer passed to these functions.

Change C++ StateBuilder class use use `build()` method

The method name now matches the intention of this class, which is to
be a builder for State objects.

Add ComputationBuilder to C++ API

The C++ API now uses a `ComputationBuilder` class rather than a
builder function to create a computation. This is more consistent with
other types which also use builder classes rather than builder
functions..

Fix bad return types introduced earlier in c++ API