### PR TITLE
Add RouterRegistry and, on migration, update routers and routes

### DIFF
--- a/lib/wallaroo/network/connections.pony
+++ b/lib/wallaroo/network/connections.pony
@@ -131,6 +131,19 @@ actor Connections
       @printf[I32](("No outgoing boundary to worker " + worker + "\n").cstring())
     end
 
+  be notify_cluster_of_new_stateful_step[K: (Hashable val & Equatable[K] val)](
+    id: U128, key: K, state_name: String)
+  =>
+    try
+      let new_step_msg = ChannelMsgEncoder.new_stateful_step[K](id,
+        _worker_name, key, state_name, _auth)
+      for ch in _control_conns.values() do
+        ch.writev(new_step_msg)
+      end
+    else
+      Fail()
+    end
+
   be send_phone_home(msg: Array[ByteSeq] val) =>
     match _phone_home
     | let tcp: TCPConnection =>

--- a/lib/wallaroo/routing/_test_watermarking.pony
+++ b/lib/wallaroo/routing/_test_watermarking.pony
@@ -720,3 +720,6 @@ actor _TestProducer is Producer
 
   fun ref _flush(low_watermark: SeqId) =>
     None
+
+  fun ref update_router(router: Router val) =>
+    None

--- a/lib/wallaroo/routing/data_receiver_routes.pony
+++ b/lib/wallaroo/routing/data_receiver_routes.pony
@@ -13,6 +13,16 @@ class DataReceiverRoutes
 
     _routes(route_id) = _Route
 
+  fun contains(route_id: RouteId): Bool =>
+    _routes.contains(route_id)
+
+  fun is_fully_acked(): Bool =>
+    if not _filter_route.is_fully_acked() then return false end
+    for (_, route) in _routes.pairs() do
+      if not route.is_fully_acked() then return false end
+    end
+    true
+
   fun ref send(route_id: RouteId, seq_id: SeqId)
   =>
     ifdef debug then

--- a/lib/wallaroo/routing/producer.pony
+++ b/lib/wallaroo/routing/producer.pony
@@ -1,3 +1,7 @@
+use "collections"
+use "wallaroo/boundary"
+use "wallaroo/topology"
+
 trait tag Producer
   be mute(c: Consumer)
   be unmute(c: Consumer)
@@ -51,6 +55,16 @@ trait tag Producer
     end
 
     _x_resilience_routes().receive_ack(this, route_id, seq_id)
+
+trait tag Routable
+  be remove_route_for(moving_step: ConsumerStep)
+  be add_boundaries(boundary: Map[String, OutgoingBoundary] val)
+
+trait tag PartitionRoutable is Routable
+  be update_router(router: Router val)
+
+trait tag OmniRoutable is Routable
+  be update_omni_router(router: OmniRouter val)
 
 primitive HashProducer
   fun hash(o: Producer): U64 =>

--- a/lib/wallaroo/routing/routes.pony
+++ b/lib/wallaroo/routing/routes.pony
@@ -37,6 +37,26 @@ class Routes
 
     _routes(route.id()) = _Route
 
+  fun ref remove_route(route: Route) =>
+    try
+      let old_route = _routes(route.id())
+      ifdef debug then
+        // We currently assume stop the world and finishing all in-flight
+        // processing before any route migration.
+        Invariant(old_route.is_fully_acked())
+      end
+      _routes.remove(route.id())
+    else
+      Fail()
+    end
+
+  fun is_fully_acked(): Bool =>
+    if not _filter_route.is_fully_acked() then return false end
+    for (_, route) in _routes.pairs() do
+      if not route.is_fully_acked() then return false end
+    end
+    true
+
   fun ref send(producer: Producer ref, o_route_id: RouteId, o_seq_id: SeqId,
     i_origin: Producer, i_route_id: RouteId, i_seq_id: SeqId)
   =>

--- a/lib/wallaroo/startup.pony
+++ b/lib/wallaroo/startup.pony
@@ -297,18 +297,20 @@ actor Startup
           metrics_conn, m_addr(0), m_addr(1), is_initializer,
           connection_addresses_file)
 
+        let router_registry = RouterRegistry(auth, connections)
+
         let  local_topology_initializer = if is_swarm_managed then
           let cluster_manager: DockerSwarmClusterManager =
             DockerSwarmClusterManager(auth, swarm_manager_addr, c_service)
           LocalTopologyInitializer(
             application, worker_name, worker_count, env, auth, connections,
-            metrics_conn, is_initializer, alfred, input_addrs,
+            router_registry, metrics_conn, is_initializer, alfred, input_addrs,
             local_topology_file, data_channel_file, worker_names_file,
             cluster_manager)
         else
           LocalTopologyInitializer(
             application, worker_name, worker_count, env, auth, connections,
-            metrics_conn, is_initializer, alfred, input_addrs,
+            router_registry, metrics_conn, is_initializer, alfred, input_addrs,
             local_topology_file, data_channel_file, worker_names_file)
         end
 
@@ -330,7 +332,7 @@ actor Startup
         let control_notifier: TCPListenNotify iso =
           ControlChannelListenNotifier(worker_name, env, auth, connections,
           is_initializer, worker_initializer, local_topology_initializer,
-          alfred, control_channel_filepath)
+          alfred, router_registry, control_channel_filepath)
 
         ifdef "resilience" then
           if is_initializer then

--- a/lib/wallaroo/tcp_source/framed_source_notify.pony
+++ b/lib/wallaroo/tcp_source/framed_source_notify.pony
@@ -21,7 +21,7 @@ class FramedSourceNotify[In: Any val] is TCPSourceNotify
   let _source_name: String
   let _handler: FramedSourceHandler[In] val
   let _runner: Runner
-  let _router: Router val
+  var _router: Router val
   let _omni_router: OmniRouter val = EmptyOmniRouter
   let _metrics_reporter: MetricsReporter
   let _header_size: USize
@@ -113,6 +113,9 @@ class FramedSourceNotify[In: Any val] is TCPSourceNotify
         false
       end
     end
+
+  fun ref update_router(router: Router val) =>
+    _router = router
 
   fun ref accepted(conn: TCPSource ref) =>
     @printf[I32]((_source_name + ": accepted a connection\n").cstring())

--- a/lib/wallaroo/tcp_source/tcp_source_notify.pony
+++ b/lib/wallaroo/tcp_source/tcp_source_notify.pony
@@ -10,6 +10,8 @@ interface TCPSourceNotify
   // and it can then make routes available
   fun ref routes(): Array[ConsumerStep] val
 
+  fun ref update_router(router: Router val)
+
   fun ref accepted(conn: TCPSource ref) =>
     """
     Called when a TCPSource is accepted by a TCPSourceListener.

--- a/lib/wallaroo/topology/_test.pony
+++ b/lib/wallaroo/topology/_test.pony
@@ -249,7 +249,7 @@ primitive _DefaultRouterGenerator
 primitive _StepGenerator
   fun apply(alfred: Alfred): Step =>
     Step(RouterRunner, MetricsReporter("", "", MetricsSink("", "")),
-      1, EmptyRouteBuilder, alfred)
+      1, EmptyRouteBuilder, alfred, recover Map[String, OutgoingBoundary] end)
 
 primitive _BoundaryGenerator
   fun apply(worker_name: String, auth: AmbientAuth): OutgoingBoundary =>

--- a/lib/wallaroo/topology/partition.pony
+++ b/lib/wallaroo/topology/partition.pony
@@ -75,7 +75,7 @@ class KeyedPartitionAddresses[Key: (Hashable val & Equatable[Key] val)]
       error
     end
     KeyedPartitionAddresses[Key](consume new_addresses)
-  
+
   fun eq(that: box->PartitionAddresses): Bool =>
     match that
     | let that_keyed: box->KeyedPartitionAddresses[Key] =>
@@ -83,7 +83,7 @@ class KeyedPartitionAddresses[Key: (Hashable val & Equatable[Key] val)]
     else
       false
     end
-  
+
   fun ne(that: box->PartitionAddresses): Bool => not eq(that)
 
 interface StateAddresses
@@ -188,7 +188,7 @@ class KeyedStateSubpartition[PIn: Any val,
           let reporter = MetricsReporter(app_name, worker_name, metrics_conn)
           let next_state_step = Step(_runner_builder(where alfred = alfred, auth=auth),
             consume reporter, id, _runner_builder.route_builder(),
-              alfred)
+              alfred, outgoing_boundaries)
 
           initializables.set(next_state_step)
           data_routes(id) = next_state_step
@@ -211,7 +211,7 @@ class KeyedStateSubpartition[PIn: Any val,
     end
 
     @printf[I32](("Spinning up " + partition_count.string() + " state partitions for " + _pipeline_name + " pipeline\n").cstring())
- 
+
     LocalPartitionRouter[PIn, Key](consume m, _id_map, consume routes,
       _partition_function, default_router)
 

--- a/lib/wallaroo/topology/router_registry.pony
+++ b/lib/wallaroo/topology/router_registry.pony
@@ -1,0 +1,225 @@
+use "collections"
+use "wallaroo/boundary"
+use "wallaroo/fail"
+use "wallaroo/network"
+use "wallaroo/routing"
+
+actor RouterRegistry
+  let _auth: AmbientAuth
+  let _connections: Connections
+  var _data_router: (DataRouter val | None) = None
+  let _partition_routers: Map[String, PartitionRouter val] =
+    _partition_routers.create()
+  var _omni_router: (OmniRouter val | None) = None
+  let _data_receivers: SetIs[DataReceiver] = _data_receivers.create()
+  // All steps that have a PartitionRouter
+  let _partition_router_steps: SetIs[PartitionRoutable] =
+    _partition_router_steps.create()
+  // All steps that have an OmniRouter
+  let _omni_router_steps: SetIs[OmniRoutable] = _omni_router_steps.create()
+  let _outgoing_boundaries: Map[String, OutgoingBoundary] =
+    _outgoing_boundaries.create()
+
+  new create(auth: AmbientAuth, c: Connections) =>
+    _auth = auth
+    _connections = c
+
+  be set_data_router(dr: DataRouter val) =>
+    _data_router = dr
+
+  be set_partition_router(state_name: String, pr: PartitionRouter val) =>
+    _partition_routers(state_name) = pr
+
+  be set_omni_router(o: OmniRouter val) =>
+    _omni_router = o
+
+  be register_data_receiver(dr: DataReceiver) =>
+    _data_receivers.set(dr)
+
+  be register_partition_router_step(pr: PartitionRoutable) =>
+    _partition_router_steps.set(pr)
+
+  be register_omni_router_step(o: OmniRoutable) =>
+    _omni_router_steps.set(o)
+
+  // TODO: Call this when a new worker is added to cluster
+  be register_boundaries(ob: Map[String, OutgoingBoundary] val) =>
+    let new_boundaries: Map[String, OutgoingBoundary] trn =
+      recover Map[String, OutgoingBoundary] end
+    for (state_name, boundary) in ob.pairs() do
+      if not _outgoing_boundaries.contains(state_name) then
+        _outgoing_boundaries(state_name) = boundary
+        new_boundaries(state_name) = boundary
+      end
+    end
+
+    let new_boundaries_sendable: Map[String, OutgoingBoundary] val =
+      consume new_boundaries
+    for routable in _partition_router_steps.values() do
+      routable.add_boundaries(new_boundaries_sendable)
+    end
+    for routable in _omni_router_steps.values() do
+      routable.add_boundaries(new_boundaries_sendable)
+    end
+
+  be add_data_receiver(data_receiver: DataReceiver) =>
+    _data_receivers.set(data_receiver)
+    match _data_router
+    | let data_router: DataRouter val =>
+      data_receiver.update_router(data_router)
+    else
+      Fail()
+    end
+
+  /////
+  // Step moved off this worker or new step added to another worker
+  /////
+  be move_step_to_proxy(id: U128, proxy_address: ProxyAddress val) =>
+    """
+    Called when a stateless step has been migrated off this worker to another
+    worker
+    """
+    _move_step_to_proxy(id, proxy_address)
+
+  be move_stateful_step_to_proxy[K: (Hashable val & Equatable[K] val)](
+    id: U128, proxy_address: ProxyAddress val, key: K, state_name: String)
+  =>
+    """
+    Called when a stateful step has been migrated off this worker to another
+    worker
+    """
+    _add_state_proxy_to_partition_router[K](proxy_address, key, state_name)
+    _move_step_to_proxy(id, proxy_address)
+
+  fun ref _move_step_to_proxy(id: U128, proxy_address: ProxyAddress val) =>
+    """
+    Called when a step has been migrated off this worker to another worker
+    """
+    _remove_step_from_data_router(id)
+    _add_proxy_to_omni_router(id, proxy_address)
+
+  be add_state_proxy[K: (Hashable val & Equatable[K] val)](id: U128,
+    proxy_address: ProxyAddress val, key: K, state_name: String)
+  =>
+    """
+    Called when a stateful step has been added to another worker
+    """
+    _add_state_proxy_to_partition_router[K](proxy_address, key, state_name)
+    _add_proxy_to_omni_router(id, proxy_address)
+
+  fun ref _add_state_proxy_to_partition_router[
+    K: (Hashable val & Equatable[K] val)](proxy_address: ProxyAddress val,
+    key: K, state_name: String)
+  =>
+    try
+      let proxy_router = ProxyRouter(proxy_address.worker,
+        _outgoing_boundaries(state_name), proxy_address, _auth)
+      try
+        let partition_router =
+          _partition_routers(state_name).update_route[K](key, proxy_router)
+        _partition_routers(state_name) = partition_router
+        for routable in _partition_router_steps.values() do
+          routable.update_router(partition_router)
+        end
+      else
+        Fail()
+      end
+    else
+      Fail()
+    end
+
+  fun ref _remove_step_from_data_router(id: U128) =>
+    try
+      match _data_router
+      | let dr: DataRouter val =>
+        let moving_step = dr.step_for_id(id)
+
+        let new_data_router = dr.remove_route(id)
+        for data_receiver in _data_receivers.values() do
+          data_receiver.update_router(new_data_router)
+        end
+        _data_router = new_data_router
+
+        for routable in _omni_router_steps.values() do
+          routable.remove_route_for(moving_step)
+        end
+      else
+        Fail()
+      end
+    else
+      Fail()
+    end
+
+  fun ref _add_proxy_to_omni_router(id: U128,
+    proxy_address: ProxyAddress val)
+  =>
+    match _omni_router
+    | let o: OmniRouter val =>
+      let new_omni_router = o.update_route_to_proxy(id, proxy_address)
+      for routable in _omni_router_steps.values() do
+        routable.update_omni_router(new_omni_router)
+      end
+      _omni_router = new_omni_router
+    else
+      Fail()
+    end
+
+  /////
+  // Step moved onto this worker
+  /////
+  be move_proxy_to_step(id: U128, target: ConsumerStep) =>
+    """
+    Called when a stateless step has been migrated to this worker from another
+    worker
+    """
+    _move_proxy_to_step(id, target)
+
+  be move_proxy_to_stateful_step[K: (Hashable val & Equatable[K] val)](
+    id: U128, target: ConsumerStep, key: K, state_name: String)
+  =>
+    """
+    Called when a stateful step has been migrated to this worker from another
+    worker
+    """
+    try
+      match target
+      | let step: Step =>
+        let partition_router =
+          _partition_routers(state_name).update_route[K](key, step)
+        for routable in _partition_router_steps.values() do
+          routable.update_router(partition_router)
+        end
+      else
+        Fail()
+      end
+    else
+      Fail()
+    end
+    _move_proxy_to_step(id, target)
+    _connections.notify_cluster_of_new_stateful_step[K](id, key, state_name)
+
+  fun ref _move_proxy_to_step(id: U128, target: ConsumerStep) =>
+    """
+    Called when a step has been migrated to this worker from another worker
+    """
+    match _data_router
+    | let dr: DataRouter val =>
+      let new_data_router = dr.add_route(id, target)
+      for data_receiver in _data_receivers.values() do
+        data_receiver.update_router(new_data_router)
+      end
+      _data_router = new_data_router
+    else
+      Fail()
+    end
+
+    match _omni_router
+    | let o: OmniRouter val =>
+      let new_omni_router = o.update_route_to_step(id, target)
+      for routable in _omni_router_steps.values() do
+        routable.update_omni_router(new_omni_router)
+      end
+      _omni_router = new_omni_router
+    else
+      Fail()
+    end

--- a/lib/wallaroo/topology/step_initializer.pony
+++ b/lib/wallaroo/topology/step_initializer.pony
@@ -61,7 +61,7 @@ class StepBuilder
     _runner_builder.clone_router_and_set_input_type(r, default_r)
 
   fun apply(next: Router val, metrics_conn: MetricsSink, alfred: Alfred,
-    auth: AmbientAuth,
+    auth: AmbientAuth, outgoing_boundaries: Map[String, OutgoingBoundary] val,
     router: Router val = EmptyRouter,
     omni_router: OmniRouter val = EmptyOmniRouter,
     default_target: (Step | None) = None): Step tag
@@ -70,8 +70,8 @@ class StepBuilder
       pre_state_target_id' = pre_state_target_id())
     let step = Step(consume runner,
       MetricsReporter(_app_name, _worker_name, metrics_conn), _id,
-      _runner_builder.route_builder(), alfred, router, default_target,
-      omni_router)
+      _runner_builder.route_builder(), alfred, outgoing_boundaries,
+      router, default_target, omni_router)
     step.update_router(next)
     step
 


### PR DESCRIPTION
The RouterRegistry keeps track of all routers that might
be updated across a worker, as well as all the steps that
will need to be informed about such updates. Hooks allow
routers to be updated at the registry on state migration
and a new control message is used to inform the rest of
the workers of a new step that must be added to their
routers.
