### PR TITLE
Temporary fix for AWS us-east-1 vpc issues

### DIFF
--- a/orchestration/terraform/Makefile
+++ b/orchestration/terraform/Makefile
@@ -478,9 +478,9 @@ create-vpc: check-cluster-name init-vpc-terraform # confirm VPC is created
           --query 'AvailabilityZones[*].ZoneName' --output text | awk \
           'function f(v) {return v == 0 ? 2: (v < 0 ? -v : v)} {print \
           "-var aws_availability_zone_1=" $$(f(NF - 0)) \
-          " -var aws_availability_zone_2=" $$(f(NF - 1)) \
-          " -var aws_availability_zone_3=" $$(f(NF - 2)) \
-          " -var aws_availability_zone_4=" $$(f(NF - 3))}')
+          " -var aws_availability_zone_2=" $$(f(NF - 2)) \
+          " -var aws_availability_zone_3=" $$(f(NF - 3)) \
+          " -var aws_availability_zone_4=" $$(f(NF - 4))}')
 	@echo "\033[36m==> Successfully confirmed VPC is created in region \
 '$(region)' at provider '$(provider)'!\033[0m"
 


### PR DESCRIPTION
Without this fix the aws us-east-1 region vpc subnets get reordered
and terraform tries to delete and recreate them preventing clusters
from being created.

This is just a temporary/quick fix. A more proper fix would make
the subnets for each vpc stable so it wouldn't change if a new
AZ is added to a region.