### PR TITLE
Add partition rebalancing algo for new worker join

### DIFF
--- a/lib/wallaroo/_test.pony
+++ b/lib/wallaroo/_test.pony
@@ -8,6 +8,7 @@ All tests can be run by compiling and running this package.
 use "ponytest"
 use cluster_manager = "cluster_manager"
 use initialization = "initialization"
+use rebalancing = "rebalancing"
 use routing = "routing"
 use spike = "spike"
 use topology = "topology"
@@ -22,6 +23,7 @@ actor Main is TestList
   fun tag tests(test: PonyTest) =>
     cluster_manager.Main.make().tests(test)
     initialization.Main.make().tests(test)
+    rebalancing.Main.make().tests(test)
     routing.Main.make().tests(test)
     spike.Main.make().tests(test)
     topology.Main.make().tests(test)

--- a/lib/wallaroo/boundary/boundary.pony
+++ b/lib/wallaroo/boundary/boundary.pony
@@ -146,14 +146,17 @@ actor OutgoingBoundary is (Consumer & RunnableStep & Initializable)
 
     @printf[I32](("RE-Connecting OutgoingBoundary to " + _host + ":" + _service + "\n").cstring())
 
-  be migrate_step(step_id: U128, state_name: String, key: Any val, state: ByteSeq val) =>
+  be migrate_step[K: (Hashable val & Equatable[K] val)](step_id: U128,
+    state_name: String, key: K, state: ByteSeq val)
+  =>
     try
-      let outgoing_msg = ChannelMsgEncoder.migrate_step(step_id, state_name, key, state, _auth)
+      let outgoing_msg = ChannelMsgEncoder.migrate_step[K](step_id,
+        state_name, key, state, _worker_name, _auth)
       _writev(outgoing_msg)
     else
       Fail()
     end
- 
+
   be register_step_id(step_id: U128) =>
     _step_id = step_id
 

--- a/lib/wallaroo/network/control_channel_tcp.pony
+++ b/lib/wallaroo/network/control_channel_tcp.pony
@@ -193,7 +193,7 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
         _local_topology_initializer.create_data_receivers(m.workers)
       | let m: JoinClusterMsg val =>
         _connections.inform_joining_worker(conn, m.worker_name)
-      | let m: NewStatefulStepMsg val =>
+      | let m: AnnounceNewStatefulStepMsg val =>
         m.update_registry(_router_registry)
       | let m: UnknownChannelMsg val =>
         _env.err.print("Unknown channel message type.")

--- a/lib/wallaroo/network/data_channel_tcp.pony
+++ b/lib/wallaroo/network/data_channel_tcp.pony
@@ -141,8 +141,7 @@ class DataChannelConnectNotifier is TCPConnectionNotify
         ifdef "trace" then
           @printf[I32]("Received StepMigrationMsg on Data Channel\n".cstring())
         end
-        _local_topology_initializer.receive_immigrant_step(sm.step_id,
-          sm.state, sm.state_name, sm.key)
+        _local_topology_initializer.receive_immigrant_step(sm)
       | let aw: AckWatermarkMsg val =>
         ifdef "trace" then
           @printf[I32]("Received AckWatermarkMsg on Data Channel\n".cstring())

--- a/lib/wallaroo/rebalancing/_test.pony
+++ b/lib/wallaroo/rebalancing/_test.pony
@@ -1,0 +1,175 @@
+use "collections"
+use "ponytest"
+
+actor Main is TestList
+  new make() =>
+    None
+
+  fun tag tests(test: PonyTest) =>
+    test(_TestRebalancerStepsFromOne)
+    test(_TestRebalancerStepsForNewWorker)
+
+class iso _TestRebalancerStepsFromOne is UnitTest
+  """
+  Test that PartitionRebalancer correctly rebalances from the perspective
+  of a single worker (which calculates what it must send in isolation).
+  """
+  fun name(): String =>
+    "rebalancing/RebalancerStepsFromOne"
+
+  fun ref apply(h: TestHelper) =>
+    let my_steps_count_1: USize = 5
+    let total_steps_count_1: USize = 10
+    let current_workers_count_1: USize = 2
+    let expected_step_count_to_send_1: USize = 2
+    let step_count_to_send_1: USize = PartitionRebalancer.step_count_to_send(
+       total_steps_count_1, my_steps_count_1, current_workers_count_1)
+    h.assert_eq[USize](expected_step_count_to_send_1, step_count_to_send_1)
+
+    let my_steps_count_2: USize = 4
+    let total_steps_count_2: USize = 8
+    let current_workers_count_2: USize = 2
+    let expected_step_count_to_send_2: USize = 1
+    let step_count_to_send_2: USize = PartitionRebalancer.step_count_to_send(
+       total_steps_count_2, my_steps_count_2, current_workers_count_2)
+    h.assert_eq[USize](expected_step_count_to_send_2, step_count_to_send_2)
+
+    let my_steps_count_3: USize = 3
+    let total_steps_count_3: USize = 6
+    let current_workers_count_3: USize = 2
+    let expected_step_count_to_send_3: USize = 1
+    let step_count_to_send_3: USize = PartitionRebalancer.step_count_to_send(
+       total_steps_count_3, my_steps_count_3, current_workers_count_3)
+    h.assert_eq[USize](expected_step_count_to_send_3, step_count_to_send_3)
+
+    let my_steps_count_4: USize = 2
+    let total_steps_count_4: USize = 4
+    let current_workers_count_4: USize = 2
+    let expected_step_count_to_send_4: USize = 1
+    let step_count_to_send_4: USize = PartitionRebalancer.step_count_to_send(
+       total_steps_count_4, my_steps_count_4, current_workers_count_4)
+    h.assert_eq[USize](expected_step_count_to_send_4, step_count_to_send_4)
+
+    let my_steps_count_5: USize = 1
+    let total_steps_count_5: USize = 2
+    let current_workers_count_5: USize = 2
+    let expected_step_count_to_send_5: USize = 0
+    let step_count_to_send_5: USize = PartitionRebalancer.step_count_to_send(
+       total_steps_count_5, my_steps_count_5, current_workers_count_5)
+    h.assert_eq[USize](expected_step_count_to_send_5, step_count_to_send_5)
+
+class iso _TestRebalancerStepsForNewWorker is UnitTest
+  """
+  Test that PartitionRebalancer correctly rebalances across all workers
+  involved. It checks that after each rebalancing, each worker approximates
+  having an equal number of the steps in the partition (within a tolerance).
+  """
+  fun name(): String =>
+    "rebalancing/RebalancerStepsForNewWorker"
+
+  fun ref apply(h: TestHelper) =>
+    // The tolerance is how far we allow a worker's step count to be off from
+    // the ideal (where the ideal is the total partition size divided by the
+    // number of workers).
+    let tolerance: F64 = 2.0
+    h.assert_eq[Bool](true, _WorkerIterations(5, tolerance))
+    h.assert_eq[Bool](true, _WorkerIterations(11, tolerance))
+    h.assert_eq[Bool](true, _WorkerIterations(12, tolerance))
+    h.assert_eq[Bool](true, _WorkerIterations(13, tolerance))
+    h.assert_eq[Bool](true, _WorkerIterations(14, tolerance))
+    h.assert_eq[Bool](true, _WorkerIterations(15, tolerance))
+    h.assert_eq[Bool](true, _WorkerIterations(16, tolerance))
+    h.assert_eq[Bool](true, _WorkerIterations(17, tolerance))
+    h.assert_eq[Bool](true, _WorkerIterations(18, tolerance))
+    h.assert_eq[Bool](true, _WorkerIterations(19, tolerance))
+    h.assert_eq[Bool](true, _WorkerIterations(20, tolerance))
+    // TODO: A partition of size 66 only passes with a tolerance of
+    // 3.0. It is within the tolerance of 2.0 until the 5th worker is added.
+    // This means the algo can be improved, but works as a rough heuristic
+    // (given that everything else passes within 2.0). Eventually we should
+    // improve the algo to handle this case as well.
+    h.assert_eq[Bool](true, _WorkerIterations(66, 3.0))
+    h.assert_eq[Bool](true, _WorkerIterations(73, tolerance))
+    h.assert_eq[Bool](true, _WorkerIterations(150, tolerance))
+    h.assert_eq[Bool](true, _WorkerIterations(329, tolerance))
+    h.assert_eq[Bool](true, _WorkerIterations(750, tolerance))
+    h.assert_eq[Bool](true, _WorkerIterations(2123, tolerance))
+    h.assert_eq[Bool](true, _WorkerIterations(5500, tolerance))
+    h.assert_eq[Bool](true, _WorkerIterations(105_500, tolerance))
+
+primitive _WorkerIterations
+  fun apply(partition_size: USize, tolerance: F64): Bool =>
+    // Add worker 2 and reallocate steps
+    var current_workers_count: USize = 1
+    var w1_count: USize = partition_size
+
+    var w1_to_send = PartitionRebalancer.step_count_to_send(partition_size,
+      w1_count, current_workers_count)
+    var w2_count: USize = w1_to_send
+    let w2_ideal: F64 =
+      partition_size.f64() / (current_workers_count + 1).f64()
+    var diff = w2_count.f64() - w2_ideal
+    if not ((diff <= tolerance) and (diff >= -tolerance)) then
+      return false
+    end
+
+    w1_count = w1_count - w1_to_send
+
+    // Add worker 3 and reallocate steps
+    current_workers_count = 2
+
+    w1_to_send = PartitionRebalancer.step_count_to_send(partition_size,
+      w1_count, current_workers_count)
+    var w2_to_send = PartitionRebalancer.step_count_to_send(partition_size,
+      w2_count, current_workers_count)
+
+    var w3_count: USize = w1_to_send + w2_to_send
+    let w3_ideal: F64 =
+      partition_size.f64() / (current_workers_count + 1).f64()
+    diff = w3_count.f64() - w3_ideal
+    if not ((diff <= tolerance) and (diff >= -tolerance)) then
+      return false
+    end
+
+    w1_count = w1_count - w1_to_send
+    w2_count = w2_count - w2_to_send
+
+    // Add worker 4 and reallocate steps
+    current_workers_count = 3
+
+    w1_to_send = PartitionRebalancer.step_count_to_send(partition_size,
+      w1_count, current_workers_count)
+    w2_to_send = PartitionRebalancer.step_count_to_send(partition_size,
+      w2_count, current_workers_count)
+    var w3_to_send = PartitionRebalancer.step_count_to_send(partition_size,
+      w3_count, current_workers_count)
+    var w4_count: USize = w1_to_send + w2_to_send + w3_to_send
+    let w4_ideal: F64 =
+      partition_size.f64() / (current_workers_count + 1).f64()
+    diff = w4_count.f64() - w4_ideal
+    if not ((diff <= tolerance) and (diff >= -tolerance)) then
+      return false
+    end
+
+    w1_count = w1_count - w1_to_send
+    w2_count = w2_count - w2_to_send
+    w3_count = w3_count - w3_to_send
+
+    // Add worker 5 and reallocate steps
+    current_workers_count = 4
+
+    w1_to_send = PartitionRebalancer.step_count_to_send(partition_size,
+      w1_count, current_workers_count)
+    w2_to_send = PartitionRebalancer.step_count_to_send(partition_size,
+      w2_count, current_workers_count)
+    w3_to_send = PartitionRebalancer.step_count_to_send(partition_size,
+      w3_count, current_workers_count)
+    var w4_to_send = PartitionRebalancer.step_count_to_send(partition_size,
+      w4_count, current_workers_count)
+
+    var w5_count: USize = w1_to_send + w2_to_send + w3_to_send + w4_to_send
+
+    let w5_ideal: F64 =
+      partition_size.f64() / (current_workers_count + 1).f64()
+    diff = w5_count.f64() - w5_ideal
+    (diff <= tolerance) and (diff >= -tolerance)

--- a/lib/wallaroo/rebalancing/rebalancer.pony
+++ b/lib/wallaroo/rebalancing/rebalancer.pony
@@ -1,0 +1,41 @@
+
+
+primitive PartitionRebalancer
+  fun step_count_to_send(total_steps: USize, worker_portion: USize,
+    current_workers_count: USize): USize
+  =>
+    """
+    Calculate how many steps a worker should send based on the total steps
+    in the partition, the portion of those steps on the sending worker,
+    and the current count of workers.
+
+    The aim of this algorithm is to have a roughly equal number of steps on
+    each worker.
+    """
+    // Ideal # of steps per worker before sending
+    let ideal_pre: F64 = total_steps.f64() / current_workers_count.f64()
+    // Ideal # of steps per worker after sending
+    let ideal_post: F64 = total_steps.f64() / (current_workers_count + 1).f64()
+    // How far this worker is off from the ideal before sending
+    let off_by = worker_portion.f64() - ideal_pre
+
+    // Adjust for how far off from the ideal we are. This means we don't
+    // need to coordinate across workers. Each can converge to the correct
+    // overall value independently.
+    let try_to_send =
+      if off_by > 1 then
+        let adjusted = ideal_post + (off_by - 1)
+        worker_portion - adjusted.round().usize()
+      elseif off_by < -1 then
+        let adjusted = ideal_post + (off_by - 1)
+        worker_portion - adjusted.round().usize()
+      else
+        worker_portion - ideal_post.round().usize()
+      end
+
+    // Never send your last step.
+    if (worker_portion - try_to_send) > 0 then
+      try_to_send
+    else
+      0
+    end

--- a/lib/wallaroo/topology/steps.pony
+++ b/lib/wallaroo/topology/steps.pony
@@ -472,12 +472,13 @@ actor Step is (RunnableStep & Resilient & Producer &
       Fail()
     end
 
-  be send_state(boundary: OutgoingBoundary, state_name: String, key: Any val) =>
+  be send_state[K: (Hashable val & Equatable[K] val)](
+    boundary: OutgoingBoundary, state_name: String, key: K)
+  =>
     match _runner
     | let r: SerializableStateRunner =>
       let state: ByteSeq val = r.serialize_state()
-      //TODO: get state name, partition key
-      boundary.migrate_step(_id, state_name, key, state)
+      boundary.migrate_step[K](_id, state_name, key, state)
     else
       Fail()
     end


### PR DESCRIPTION
RouterRegistry has a hook called migrate_partition_steps()
that can be called when a new worker joins and we are
ready to rebalance a partition. It kicks off an algo
that determines how to approximate rebalancing steps in
the partition such that there are an equal number on
each worker. When steps are successfully migrated,
messages are sent between workers to notify them that
they should update their routers accordingly.
