### PR TITLE
Add Metrics Monitor Throughout Trigger

### DIFF
--- a/lib/sendence/hub/hub_protocol.pony
+++ b/lib/sendence/hub/hub_protocol.pony
@@ -79,7 +79,7 @@ primitive HubProtocol
     consume encoded
 
   fun metrics(name: String, category: String, pipeline_name: String,
-    worker_name: String, id: U16, histogram: Histogram,
+    worker_name: String, id: U16, histogram: Histogram val,
     period: U64, period_ends_at: U64, wb: Writer)
   =>
     let name_size = name.size().u32()

--- a/lib/wallaroo/cluster_manager/_test.pony
+++ b/lib/wallaroo/cluster_manager/_test.pony
@@ -9,3 +9,4 @@ actor Main is TestList
 
   fun tag tests(test: PonyTest) =>
     TestDockerSwarmClusterManager.make().tests(test)
+    TestThroughputBasedClusterGrowthTrigger.make().tests(test)

--- a/lib/wallaroo/cluster_manager/_test_throughput_based_cluster_growth_trigger.pony
+++ b/lib/wallaroo/cluster_manager/_test_throughput_based_cluster_growth_trigger.pony
@@ -1,0 +1,132 @@
+use "collections"
+use "ponytest"
+use "wallaroo/metrics"
+
+actor TestThroughputBasedClusterGrowthTrigger is TestList
+  new make() =>
+    None
+
+  fun tag tests(test: PonyTest) =>
+    test(_TestWhenAboveThreshold)
+    test(_TestWhenBelowThreshold)
+    test(_TestOnlyTriggersOnce)
+
+class iso _TestWhenAboveThreshold is UnitTest
+  """
+  Test that we make a request_new_worker() call when the throughput per
+  second exceeds the throughput trigger amount.
+  """
+  fun name(): String =>
+    "throughput_based_cluster_growth_trigger/WhenAboveThreshold"
+
+  fun apply(h: TestHelper) =>
+    let trigger_histogram =
+      _HistogramGenerator(_ThroughputBasedClusterGrowthTriggerThreshold() +
+        1_000)
+
+    let triggering_metrics_list =
+      recover val [_TestMetricData(trigger_histogram)] end
+
+    let test_worker_request = _TestNewWorkerRequester(h)
+    let new_worker_request_trigger_monitor =
+      ThroughputBasedClusterGrowthTrigger(test_worker_request,
+        _ThroughputBasedClusterGrowthTriggerThreshold())
+
+    new_worker_request_trigger_monitor.on_send(triggering_metrics_list)
+    h.expect_action("request_new_worker")
+    h.long_test(1_000_000_000)
+
+class iso _TestWhenBelowThreshold is UnitTest
+  """
+  Test that we do not make a request_new_worker() call when the throughput per
+  second does not exceed the throughput trigger amount.
+  """
+  fun name(): String =>
+    "throughput_based_cluster_growth_trigger/WhenBelowThreshold"
+
+  fun apply(h: TestHelper) =>
+    let non_trigger_histogram =
+      _HistogramGenerator(_ThroughputBasedClusterGrowthTriggerThreshold() -
+        1_000)
+
+    let non_triggering_metrics_list =
+      recover val [_TestMetricData(non_trigger_histogram)] end
+
+    let test_worker_request = _TestNewWorkerRequester(h)
+
+    let new_worker_request_trigger_monitor =
+      ThroughputBasedClusterGrowthTrigger(test_worker_request,
+        _ThroughputBasedClusterGrowthTriggerThreshold())
+
+    new_worker_request_trigger_monitor.on_send(non_triggering_metrics_list)
+    test_worker_request.test_call_count(0)
+
+class iso _TestOnlyTriggersOnce is UnitTest
+  """
+  Test that we only make a single request_new_worker() call when the
+  throughput per second exceeds the throughput trigger amount.
+  """
+  fun name(): String =>
+    "throughput_based_cluster_growth_trigger/OnlyTriggersOnce"
+
+  fun apply(h: TestHelper) =>
+    let trigger_histogram =
+      _HistogramGenerator(_ThroughputBasedClusterGrowthTriggerThreshold() +
+        1_000)
+
+    let multi_triggering_metrics_list =
+      recover val [_TestMetricData(trigger_histogram),
+        _TestMetricData(trigger_histogram)] end
+
+    let test_worker_request = _TestNewWorkerRequester(h)
+
+    let new_worker_request_trigger_monitor =
+      ThroughputBasedClusterGrowthTrigger(test_worker_request,
+        _ThroughputBasedClusterGrowthTriggerThreshold())
+
+    new_worker_request_trigger_monitor.on_send(multi_triggering_metrics_list)
+    new_worker_request_trigger_monitor.on_send(multi_triggering_metrics_list)
+    test_worker_request.test_call_count(1)
+
+actor _TestNewWorkerRequester is NewWorkerRequester
+  let _h: TestHelper
+  var _call_count: U64 = 0
+
+  new create(h: TestHelper) =>
+    _h = h
+
+  be test_call_count(expected_count: U64) =>
+    _h.assert_eq[U64](expected_count, _call_count)
+
+  be request_new_worker() =>
+    _call_count = _call_count + 1
+    _h.complete_action("request_new_worker")
+
+primitive _TestMetricData
+  """
+  _TestMetricData
+
+  Creates a mock metric object where the only value we care about for this
+  test is the Histogram.
+  """
+  fun apply(histogram: Histogram val): MetricData =>
+    ("Update NBBO", "computation", "NBBO", "worker1", U16(1),
+      histogram, U64(1_000_000_000), U64(2_000_000_000), "metrics",
+      "app")
+
+primitive _ThroughputBasedClusterGrowthTriggerThreshold
+  """
+  _ThroughputBasedClusterGrowthTriggerThreshold
+
+  Testing throughput threshold for ThroughputBasedClusterGrowthTrigger
+  """
+  fun apply(): U64 =>
+    10_000
+
+primitive _HistogramGenerator
+  fun apply(size: U64) : Histogram val =>
+    let histogram: Histogram iso = Histogram
+    for i in Range[U64](0, size) do
+      histogram(1)
+    end
+    histogram

--- a/lib/wallaroo/cluster_manager/cluster_manager.pony
+++ b/lib/wallaroo/cluster_manager/cluster_manager.pony
@@ -6,3 +6,12 @@ interface tag ClusterManager
   new Wallaroo worker.
   """
   be request_new_worker()
+
+interface tag NewWorkerRequester
+  """
+  NewWorkerRequester
+
+  Interface for actors that can request a new Wallaroo worker from a
+  ClusterManager.
+  """
+  be request_new_worker()

--- a/lib/wallaroo/cluster_manager/throughput_based_cluster_growth_trigger.pony
+++ b/lib/wallaroo/cluster_manager/throughput_based_cluster_growth_trigger.pony
@@ -1,0 +1,61 @@
+use "collections"
+use "wallaroo/metrics"
+
+primitive _Triggered
+primitive _Untriggered
+
+type _ThroughputBasedClusterGrowthTriggerState is
+  ( _Triggered
+  | _Untriggered
+  )
+
+class ThroughputBasedClusterGrowthTrigger is MetricsMonitor
+  """
+  ThroughputBasedClusterGrowthTrigger
+
+  Triggers a request_new_worker() function call if the throughput
+  per second exceeds the throughput trigger amount. This is called only
+  once to avoid new worker overload.
+  """
+  var state: _ThroughputBasedClusterGrowthTriggerState = _Untriggered
+  var _throughput_trigger_amount: U64
+  let _new_worker_requester: NewWorkerRequester
+
+  new create(new_worker_requester: NewWorkerRequester,
+    throughput_trigger_amount: U64)
+  =>
+    _new_worker_requester = new_worker_requester
+    _throughput_trigger_amount = throughput_trigger_amount
+
+  fun clone(): ThroughputBasedClusterGrowthTrigger iso^ =>
+    recover
+      ThroughputBasedClusterGrowthTrigger(_new_worker_requester,
+      _throughput_trigger_amount)
+    end
+
+  fun ref on_send(metrics: MetricDataList val) =>
+    if state is _Untriggered then
+      try
+        _monitor_throughput_for(metrics)
+      end
+    end
+
+  fun ref _monitor_throughput_for(metrics: MetricDataList val) ? =>
+    let metrics_size = metrics.size()
+    for i in Range(0, metrics_size) do
+      let metric = metrics(i)
+      if _throughput_per_sec(metric) >= _throughput_trigger_amount.f64() then
+        _new_worker_requester.request_new_worker()
+        _transition_to(_Triggered)
+        break
+      end
+    end
+
+  fun _throughput_per_sec(metric: MetricData): F64 =>
+    (let metric_name, let category, let pipeline, let worker_name,
+      let id, let histogram, let period, let period_ends_at, let topic,
+      let event) = metric
+    (histogram.size().f64() / (period.f64() * 0.000000001))
+
+  fun ref _transition_to(state': _ThroughputBasedClusterGrowthTriggerState) =>
+    state = state'

--- a/lib/wallaroo/initialization/local_topology.pony
+++ b/lib/wallaroo/initialization/local_topology.pony
@@ -1018,9 +1018,12 @@ actor LocalTopologyInitializer
                   end
                 end
 
+              let metrics_monitor: ThroughputBasedClusterGrowthTrigger iso =
+                recover ThroughputBasedClusterGrowthTrigger(this, 10_000) end
               let source_reporter = MetricsReporter(t.name(),
                 t.worker_name(),
-                _metrics_conn)
+                _metrics_conn
+                where metrics_monitor = consume metrics_monitor)
 
               // Get all the sinks so far, which should include any sinks
               // prestate on this source might target
@@ -1039,7 +1042,8 @@ actor LocalTopologyInitializer
                   TCPSourceListenerBuilder(
                     source_data.builder()(source_data.runner_builder(),
                       out_router, _metrics_conn,
-                      source_data.pre_state_target_id(), t.worker_name()),
+                      source_data.pre_state_target_id(), t.worker_name(),
+                      source_reporter.clone()),
                     out_router, _router_registry,
                     source_data.route_builder(),
                     _outgoing_boundaries, sinks_for_source,

--- a/lib/wallaroo/metrics/histogram.pony
+++ b/lib/wallaroo/metrics/histogram.pony
@@ -32,7 +32,7 @@ class Histogram
     end
     s
 
-  fun ref counts(): Array[U64] ref => _counts
+  fun counts(): this->Array[U64] ref => _counts
 
   fun min(): U64 => _min
 

--- a/lib/wallaroo/metrics/metrics_monitor.pony
+++ b/lib/wallaroo/metrics/metrics_monitor.pony
@@ -1,0 +1,19 @@
+interface MetricsMonitor
+  """
+  MetricsMonitor
+
+  Interface for hooking into a MetricsReporter and being able to
+  monitor metrics via on_send prior to a send_metrics() call.
+  """
+  fun clone(): MetricsMonitor iso^
+
+  fun ref on_send(metrics: MetricDataList val) =>
+    """
+    Hook for monitoring metrics prior to send_metrics() call.
+    """
+    None
+
+class DefaultMetricsMonitor is MetricsMonitor
+
+  fun clone(): DefaultMetricsMonitor iso^ =>
+    recover DefaultMetricsMonitor end

--- a/lib/wallaroo/metrics/metrics_sink.pony
+++ b/lib/wallaroo/metrics/metrics_sink.pony
@@ -151,17 +151,15 @@ actor MetricsSink
       _pending.push((data, 0))
     end
 
-  be send_metrics(metrics: Array[(String, String, String, String, U16,
-    Histogram iso, U64, U64, String, String)] iso)
-  =>
+  be send_metrics(metrics: MetricDataList val) =>
     try
       let payload_wb: Writer = Writer
-      while metrics.size() > 0 do
+      for i in Range(0,metrics.size()) do
         (let metric_name, let category, let pipeline, let worker_name, let id,
           let histogram, let period, let period_ends_at, let topic, let event) =
-          metrics.shift()
+          metrics(i)
         HubProtocol.metrics(metric_name, category, pipeline,
-          worker_name, id, consume histogram, period, period_ends_at, payload_wb)
+          worker_name, id, histogram, period, period_ends_at, payload_wb)
         HubProtocol.payload(event, topic, payload_wb.done(), _wb)
       end
       _writev(_wb.done())

--- a/lib/wallaroo/tcp_source/tcp_source_listener_notify.pony
+++ b/lib/wallaroo/tcp_source/tcp_source_listener_notify.pony
@@ -17,13 +17,15 @@ class _SourceBuilder[In: Any val]
   let _router: Router val
   let _metrics_conn: MetricsSink
   let _pre_state_target_id: (U128 | None)
+  let _metrics_reporter: MetricsReporter
 
   new val create(app_name: String, worker_name: String,
     name': String,
     runner_builder: RunnerBuilder val,
     handler: FramedSourceHandler[In] val,
     router: Router val, metrics_conn: MetricsSink,
-    pre_state_target_id: (U128 | None) = None)
+    pre_state_target_id: (U128 | None) = None,
+    metrics_reporter: MetricsReporter iso)
   =>
     _app_name = app_name
     _worker_name = worker_name
@@ -33,22 +35,22 @@ class _SourceBuilder[In: Any val]
     _router = router
     _metrics_conn = metrics_conn
     _pre_state_target_id = pre_state_target_id
+    _metrics_reporter = consume metrics_reporter
 
   fun name(): String => _name
 
   fun apply(alfred: Alfred tag, auth: AmbientAuth, target_router: Router val):
     TCPSourceNotify iso^
   =>
-    let reporter = MetricsReporter(_app_name, _worker_name, _metrics_conn)
-
     FramedSourceNotify[In](_name, auth, _handler, _runner_builder, _router,
-      consume reporter, alfred, target_router, _pre_state_target_id)
+      _metrics_reporter.clone(), alfred, target_router, _pre_state_target_id)
 
 interface SourceBuilderBuilder
   fun name(): String
   fun apply(runner_builder: RunnerBuilder val, router: Router val,
     metrics_conn: MetricsSink, pre_state_target_id: (U128 | None) = None,
-    worker_name: String):
+    worker_name: String,
+    metrics_reporter: MetricsReporter iso):
       SourceBuilder val
 
 class TypedSourceBuilderBuilder[In: Any val]
@@ -67,12 +69,12 @@ class TypedSourceBuilderBuilder[In: Any val]
 
   fun apply(runner_builder: RunnerBuilder val, router: Router val,
     metrics_conn: MetricsSink, pre_state_target_id: (U128 | None) = None,
-    worker_name: String):
+    worker_name: String, metrics_reporter: MetricsReporter iso):
       SourceBuilder val
   =>
     _SourceBuilder[In](_app_name, worker_name,
       _name, runner_builder, _handler, router,
-      metrics_conn, pre_state_target_id)
+      metrics_conn, pre_state_target_id, consume metrics_reporter)
 
 interface TCPSourceListenerNotify
   """


### PR DESCRIPTION
- Adds MetricsMonitor interface for hooking into a MetricsReporter

- Adds DefaultMetricsMonitor to do nothing by default in MetricsReporter

- Adds ThroughputTriggerMetricsMonitor which calls request_new_worker()
on a  WorkerManager if the throughput exceeds a specified amount

- Updates MetricsReporter/Histogram/HubProtocol to accept new ref caps

- Adds automated tests for ThroughputTriggerMetricsMonitor

- Adds missing step reporting for PreStateRunner

## Testing

Automated tests have been added to `lib/wallaroo`

### Manual Test:

#### Pre-app setup:
`nc -l 5555 >>/dev/null`

#### Start UI:
`cd monitoring_hub/apps/metrics_reporter_ui`
`mix phoenix.server`

#### Start Market Spread:
```./market-spread -i 127.0.0.1:7000,127.0.0.1:7001 -o 127.0.0.1:5555 -m 127.0.0.1:5001 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n node-name```


#### Start Giles:
```
giles/sender/sender -b 127.0.0.1:7001 -m 10000000 -s 10 -i 2_500_000 -f demos/marketspread/350k-nbbo-fixish.msg -r -y -g 46 -w -k 100000 -j 20
```

You should see the following output in the log for Market Spread only after the throughput for a source is over 10,000:
`Attempting to request a new worker but cluster manager is None`

This should only be output once.

Closes #498 