### PR TITLE
Add remote stop-the-world migration

### DIFF
--- a/lib/wallaroo/messages/channel_messages.pony
+++ b/lib/wallaroo/messages/channel_messages.pony
@@ -34,6 +34,15 @@ primitive ChannelMsgEncoder
     _encode(KeyedStepMigrationMsg[K](step_id, state_name, key, state, worker),
       auth)
 
+  fun migration_complete(step_id: U128, auth: AmbientAuth): Array[ByteSeq] val ? =>
+    _encode(StepMigrationCompleteMsg(step_id), auth)
+
+  fun mute_request(originating_worker: String, auth: AmbientAuth): Array[ByteSeq] val ? =>
+    _encode(MuteRequestMsg(originating_worker), auth)
+
+  fun unmute_request(originating_worker: String, auth: AmbientAuth): Array[ByteSeq] val ? =>
+    _encode(UnmuteRequestMsg(originating_worker), auth)
+
   fun delivery[D: Any val](target_id: U128,
     from_worker_name: String, msg_data: D,
     metric_name: String, auth: AmbientAuth,
@@ -289,6 +298,22 @@ class KeyedStepMigrationMsg[K: (Hashable val & Equatable[K] val)] is ChannelMsg
   =>
     router_registry.move_proxy_to_stateful_step[K](_step_id, target, _key,
       _state_name, _worker)
+
+class MuteRequestMsg is ChannelMsg
+  let originating_worker: String
+  new val create(worker: String) =>
+    originating_worker = worker
+
+class UnmuteRequestMsg is ChannelMsg
+  let originating_worker: String
+  new val create(worker: String) =>
+    originating_worker = worker
+
+class StepMigrationCompleteMsg is ChannelMsg
+  let step_id: U128
+  new val create(step_id': U128)
+  =>
+    step_id = step_id'
 
 class AckWatermarkMsg is ChannelMsg
   let sender_name: String

--- a/lib/wallaroo/network/connections.pony
+++ b/lib/wallaroo/network/connections.pony
@@ -227,6 +227,34 @@ actor Connections
           ch.writev(new_step_msg)
         end
       end
+      let migration_complete_msg = ChannelMsgEncoder.migration_complete(id, _auth)
+      for origin in exclusions.values() do
+        _control_conns(origin).writev(migration_complete_msg)
+      end
+    else
+      Fail()
+    end
+
+  be stop_the_world() =>
+    try
+      let mute_request_msg = ChannelMsgEncoder.mute_request(_worker_name, _auth)
+      for (target, ch) in _control_conns.pairs() do
+        if target != _worker_name then
+          ch.writev(mute_request_msg)
+        end
+      end
+    else
+      Fail()
+    end
+
+  be resume_the_world() =>
+    try
+      let unmute_request_msg = ChannelMsgEncoder.unmute_request(_worker_name, _auth)
+      for (target, ch) in _control_conns.pairs() do
+        if target != _worker_name then
+          ch.writev(unmute_request_msg)
+        end
+      end
     else
       Fail()
     end

--- a/lib/wallaroo/network/control_channel_tcp.pony
+++ b/lib/wallaroo/network/control_channel_tcp.pony
@@ -209,9 +209,17 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
         _local_topology_initializer.inform_joining_worker(conn, m.worker_name)
       | let m: AnnounceNewStatefulStepMsg val =>
         m.update_registry(_router_registry)
+      | let m: StepMigrationCompleteMsg val =>
+        _router_registry.migration_complete(m.step_id)
       | let m: JoiningWorkerInitializedMsg val =>
         _local_topology_initializer.add_new_worker(m.worker_name,
           m.control_addr, m.data_addr)
+      | let m: StepMigrationCompleteMsg val =>
+        _router_registry.migration_complete(m.step_id)
+      | let m: MuteRequestMsg val =>
+        _router_registry.remote_mute_request(m.originating_worker)
+      | let m: UnmuteRequestMsg val =>
+        _router_registry.remote_unmute_request(m.originating_worker)
       | let m: UnknownChannelMsg val =>
         _env.err.print("Unknown channel message type.")
       else

--- a/lib/wallaroo/routing/consumer.pony
+++ b/lib/wallaroo/routing/consumer.pony
@@ -1,3 +1,7 @@
 trait tag Consumer
   be register_producer(producer: Producer)
   be unregister_producer(producer: Producer)
+
+actor DummyConsumer is Consumer
+  be register_producer(producer: Producer) => None
+  be unregister_producer(producer: Producer) => None

--- a/lib/wallaroo/startup.pony
+++ b/lib/wallaroo/startup.pony
@@ -335,7 +335,7 @@ actor Startup
         metrics_conn, m_addr(0), m_addr(1), _is_initializer,
         _connection_addresses_file, _is_joining)
 
-      let router_registry = RouterRegistry(auth, connections)
+      let router_registry = RouterRegistry(auth, connections, _worker_name)
 
       let local_topology_initializer = if _is_swarm_managed then
         let cluster_manager: DockerSwarmClusterManager =
@@ -449,7 +449,7 @@ actor Startup
         metrics_conn, m.metrics_host, m.metrics_service, _is_initializer,
         _connection_addresses_file, _is_joining)
 
-      let router_registry = RouterRegistry(auth, connections)
+      let router_registry = RouterRegistry(auth, connections, _worker_name)
 
       let local_topology_initializer = if _is_swarm_managed then
         let cluster_manager: DockerSwarmClusterManager =

--- a/lib/wallaroo/tcp_source/tcp_source_listener.pony
+++ b/lib/wallaroo/tcp_source/tcp_source_listener.pony
@@ -174,7 +174,7 @@ actor TCPSourceListener
         _metrics_reporter.clone())
       // TODO: We need to figure out how to unregister this when the
       // connection dies
-      _router_registry.register_partition_router_step(source)
+      _router_registry.register_source(source)
       _count = _count + 1
     else
       @pony_os_socket_close[None](ns)

--- a/lib/wallaroo/topology/router.pony
+++ b/lib/wallaroo/topology/router.pony
@@ -821,6 +821,7 @@ class LocalPartitionRouter[In: Any val,
         | let s: Step =>
           s.send_state[Key](boundary, state_name, key)
           let step_id = _step_ids(key)
+          router_registry.add_to_waiting_list(step_id)
           router_registry.move_stateful_step_to_proxy[Key](step_id,
             ProxyAddress(target_worker, step_id), key, state_name)
           left_to_send = left_to_send - 1

--- a/lib/wallaroo/topology/steps.pony
+++ b/lib/wallaroo/topology/steps.pony
@@ -471,10 +471,8 @@ actor Step is (RunnableStep & Resilient & Producer &
     else
       Fail()
     end
-
-  be send_state[K: (Hashable val & Equatable[K] val)](
-    boundary: OutgoingBoundary, state_name: String, key: K)
-  =>
+    
+  be send_state[K: (Hashable val & Equatable[K] val)](boundary: OutgoingBoundary, state_name: String, key: K) =>
     match _runner
     | let r: SerializableStateRunner =>
       let state: ByteSeq val = r.serialize_state()
@@ -482,3 +480,4 @@ actor Step is (RunnableStep & Resilient & Producer &
     else
       Fail()
     end
+


### PR DESCRIPTION
When we migrate a step, we need to stop the world, request all other workers to
stop, and keep track of all the elements we need to be able to resume processing
when every worker has finished rebalancing itself.