### PR TITLE
Correctly route data to newly joined worker

### DIFF
--- a/lib/wallaroo/boundary/data_receiver.pony
+++ b/lib/wallaroo/boundary/data_receiver.pony
@@ -181,15 +181,6 @@ actor DataReceiver is Producer
       _last_id_seen = seq_id
       _router.route(d, pipeline_time_spent, this, seq_id, latest_ts,
         metrics_id, worker_ingress_ts)
-
-      // ifdef "resilience" then
-      //   if (_estimated_boundary_queue_size > _request_threshold) and
-      //     ((_ack_counter - _last_request) > _request_pause)
-      //   then
-      //     _request_ack()
-      //   end
-      // end
-
       _maybe_ack()
     end
 

--- a/lib/wallaroo/data_channel/data_channel.pony
+++ b/lib/wallaroo/data_channel/data_channel.pony
@@ -199,7 +199,10 @@ actor DataChannel
     `unmute` is called.
     """
     _muted_downstream.set(d)
-    _muted = true
+    if not _muted then
+      @printf[I32]("Muting DataChannel\n".cstring())
+      _muted = true
+    end
 
   be unmute(d: Any tag) =>
     """
@@ -208,6 +211,7 @@ actor DataChannel
     _muted_downstream.unset(d)
 
     if _muted_downstream.size() == 0 then
+      @printf[I32]("Unmuting DataChannel\n".cstring())
       _muted = false
       _pending_reads()
     end

--- a/lib/wallaroo/data_channel/data_channel_listener.pony
+++ b/lib/wallaroo/data_channel/data_channel_listener.pony
@@ -148,7 +148,7 @@ actor DataChannelListener
     """
     try
       let data_channel = DataChannel._accept(this, _notify.connected(this,
-        _data_receivers), ns,
+        _data_receivers, _router_registry), ns,
         _init_size, _max_size)
       _router_registry.register_data_channel(data_channel)
       _count = _count + 1

--- a/lib/wallaroo/data_channel/data_channel_listener_notify.pony
+++ b/lib/wallaroo/data_channel/data_channel_listener_notify.pony
@@ -1,5 +1,6 @@
 use "collections"
 use "wallaroo/boundary"
+use "wallaroo/topology"
 
 interface DataChannelListenNotify
   """
@@ -27,7 +28,8 @@ interface DataChannelListenNotify
     None
 
   fun ref connected(listen: DataChannelListener ref,
-    drs: Map[String, DataReceiver] val): DataChannelNotify iso^ ?
+    drs: Map[String, DataReceiver] val,
+    router_registry: RouterRegistry): DataChannelNotify iso^ ?
     """
     Create a new DataChannelNotify to attach to a new DataChannel for a
     newly established connection to the server.

--- a/lib/wallaroo/network/control_channel_tcp.pony
+++ b/lib/wallaroo/network/control_channel_tcp.pony
@@ -210,15 +210,22 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
       | let m: AnnounceNewStatefulStepMsg val =>
         m.update_registry(_router_registry)
       | let m: StepMigrationCompleteMsg val =>
-        _router_registry.migration_complete(m.step_id)
+        _router_registry.step_migration_complete(m.step_id)
       | let m: JoiningWorkerInitializedMsg val =>
         _local_topology_initializer.add_new_worker(m.worker_name,
           m.control_addr, m.data_addr)
-      | let m: StepMigrationCompleteMsg val =>
-        _router_registry.migration_complete(m.step_id)
+      | let m: AckMigrationBatchCompleteMsg val =>
+        ifdef "trace" then
+          @printf[I32]("Received AckMigrationBatchCompleteMsg on Control Channel\n".cstring())
+        end
+        _router_registry.process_migrating_target_ack(m.sender_name)
       | let m: MuteRequestMsg val =>
+        @printf[I32]("Control Ch: Received Mute Request from %s\n".cstring(),
+          m.originating_worker.cstring())
         _router_registry.remote_mute_request(m.originating_worker)
       | let m: UnmuteRequestMsg val =>
+        @printf[I32]("Control Ch: Received Unmute Request from %s\n".cstring(),
+          m.originating_worker.cstring())
         _router_registry.remote_unmute_request(m.originating_worker)
       | let m: UnknownChannelMsg val =>
         _env.err.print("Unknown channel message type.")

--- a/lib/wallaroo/routing/route.pony
+++ b/lib/wallaroo/routing/route.pony
@@ -83,6 +83,7 @@ class EmptyRoute is Route
     frac_ids: None, i_seq_id: SeqId, i_route_id: RouteId,
     latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64): Bool
   =>
+    Fail()
     true
 
   fun ref forward(delivery_msg: ReplayableDeliveryMsg val,
@@ -91,4 +92,5 @@ class EmptyRoute is Route
     i_route_id: RouteId, latest_ts: U64, metrics_id: U16, metric_name: String,
     worker_ingress_ts: U64): Bool
   =>
+    Fail()
     true

--- a/lib/wallaroo/routing/routes.pony
+++ b/lib/wallaroo/routing/routes.pony
@@ -24,7 +24,7 @@ class Routes
 
   fun print_flushing() =>
     if _flushing then
-      @printf[I32]("Still Flushing!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!\n".cstring())
+      @printf[I32]("Still Flushing!\n".cstring())
     end
 
   fun ref add_route(route: Route) =>

--- a/lib/wallaroo/tcp_sink/tcp_sink.pony
+++ b/lib/wallaroo/tcp_sink/tcp_sink.pony
@@ -187,9 +187,9 @@ actor TCPSink is (Consumer & RunnableStep & Initializable)
     No-op: TCPSink has no router
     """
     None
-  
+
   be receive_state(state: ByteSeq val) => Fail()
-   
+
   be dispose() =>
     """
     Gracefully shuts down the sink. Allows all pending writes
@@ -231,11 +231,15 @@ actor TCPSink is (Consumer & RunnableStep & Initializable)
   //
   // CREDIT FLOW
   be register_producer(producer: Producer) =>
-    ifdef debug then
-      Invariant(not _upstreams.contains(producer))
+    //TODO: Do we need this invariant? Joining worker somehow registers
+    // the same thing multiple times. Can we replace _upstreams with a
+    // set?
+    // ifdef debug then
+    //   Invariant(not _upstreams.contains(producer))
+    // end
+    if not _upstreams.contains(producer) then
+      _upstreams.push(producer)
     end
-
-    _upstreams.push(producer)
 
   be unregister_producer(producer: Producer) =>
     ifdef debug then

--- a/lib/wallaroo/topology/partition.pony
+++ b/lib/wallaroo/topology/partition.pony
@@ -183,7 +183,6 @@ class KeyedStateSubpartition[PIn: Any val,
       let proxy_address = _partition_addresses(key)
       match proxy_address
       | let pa: ProxyAddress val =>
-	//@printf[I32]("%s == %s ?\n".cstring(), pa.worker.cstring(), worker_name.cstring())
         if pa.worker == worker_name then
           let reporter = MetricsReporter(app_name, worker_name, metrics_conn)
           let next_state_step = Step(_runner_builder(where alfred = alfred, auth=auth),


### PR DESCRIPTION
When a new worker joins, steps are migrated for
every partition. This commit makes it so that
incoming messages are correctly routed to the
joined worker's steps. It currently only works
for a worker joining a single worker running
cluster.