### PR TITLE
Use remote_address() to determine hosts

### DIFF
--- a/lib/wallaroo/boundary/boundary.pony
+++ b/lib/wallaroo/boundary/boundary.pony
@@ -118,7 +118,8 @@ actor OutgoingBoundary is (Consumer & RunnableStep & Initializable)
       _from.cstring())
     _notify_connecting()
 
-    @printf[I32](("Connecting OutgoingBoundary to " + _host + ":" + _service + "\n").cstring())
+    @printf[I32](("Connecting OutgoingBoundary to " + _host + ":" + _service +
+      "\n").cstring())
 
   be application_initialized(initializer: LocalTopologyInitializer) =>
     try
@@ -140,7 +141,7 @@ actor OutgoingBoundary is (Consumer & RunnableStep & Initializable)
 
   be quick_initialize(initializer: LocalTopologyInitializer) =>
     """
-    Called when initializing as part of joining a running cluster.
+    Called when initializing as part of a new worker joining a running cluster.
     """
     try
       _initializer = initializer
@@ -149,6 +150,9 @@ actor OutgoingBoundary is (Consumer & RunnableStep & Initializable)
         _host.cstring(), _service.cstring(),
         _from.cstring())
       _notify_connecting()
+
+      @printf[I32](("Connecting OutgoingBoundary to " + _host + ":" +
+        _service + "\n").cstring())
 
       if _step_id == 0 then
         Fail()
@@ -880,7 +884,7 @@ class BoundaryNotify is WallarooOutgoingNetworkActorNotify
     end
 
   fun ref connecting(conn: WallarooOutgoingNetworkActor ref, count: U32) =>
-    @printf[I32]("BoundaryNotify: connecting\n\n".cstring())
+    @printf[I32]("BoundaryNotify: attempting to connect...\n\n".cstring())
 
   fun ref connected(conn: WallarooOutgoingNetworkActor ref) =>
     @printf[I32]("BoundaryNotify: connected\n\n".cstring())

--- a/lib/wallaroo/data_channel/data_channel_tcp.pony
+++ b/lib/wallaroo/data_channel/data_channel_tcp.pony
@@ -49,6 +49,8 @@ class DataChannelListenNotifier is DataChannelListenNotify
           @printf[I32]("Recovery file exists for data channel\n".cstring())
         end
         if _joining_existing_cluster then
+          //TODO: Do we actually need to do this? Isn't this sent as
+          // part of joining worker initialized message?
           let message = ChannelMsgEncoder.identify_data_port(_name, _service,
             _auth)
           _connections.send_control_to_cluster(message)

--- a/lib/wallaroo/initialization/worker_initializer.pony
+++ b/lib/wallaroo/initialization/worker_initializer.pony
@@ -53,7 +53,7 @@ actor WorkerInitializer
       let workers: Array[String] val = recover [_worker_name] end
       _application_initializer.initialize(this, _expected, workers)
       _local_topology_initializer.create_data_receivers(
-        recover Array[String] end, this)
+        recover Array[String] end, "", "", this)
     end
 
   be identify_control_address(worker: String, host: String, service: String) =>
@@ -154,7 +154,9 @@ actor WorkerInitializer
         _connections.send_control(key, create_data_receivers_msg)
       end
 
-      _local_topology_initializer.create_data_receivers(workers, this)
+      // Pass in empty host and service because data listener is created
+      // in a special manner in .create_data_receiver() for initializer
+      _local_topology_initializer.create_data_receivers(workers, "", "", this)
     else
       @printf[I32]("Failed to create message to create data receivers\n".cstring())
     end

--- a/lib/wallaroo/messages/channel_messages.pony
+++ b/lib/wallaroo/messages/channel_messages.pony
@@ -156,7 +156,7 @@ primitive ChannelMsgEncoder
     _encode(JoinClusterMsg(worker_name), auth)
 
   // TODO: Update this once new workers become first class citizens
-  fun inform_joining_worker(metric_app_name: String,
+  fun inform_joining_worker(worker_name: String, metric_app_name: String,
     l_topology: LocalTopology val, metric_host: String,
     metric_service: String, control_addrs: Map[String, (String, String)] val,
     data_addrs: Map[String, (String, String)] val,
@@ -166,7 +166,9 @@ primitive ChannelMsgEncoder
     This message is sent as a response to a JoinCluster message. Currently it
     only informs the new worker of metrics-related info
     """
-    _encode(InformJoiningWorkerMsg(metric_app_name, l_topology, metric_host, metric_service, control_addrs, data_addrs, worker_names), auth)
+    _encode(InformJoiningWorkerMsg(worker_name, metric_app_name, l_topology,
+      metric_host, metric_service, control_addrs, data_addrs, worker_names),
+      auth)
 
   fun joining_worker_initialized(worker_name: String, c_addr: (String, String),
     d_addr: (String, String), auth: AmbientAuth): Array[ByteSeq] val ?
@@ -507,6 +509,7 @@ class InformJoiningWorkerMsg is ChannelMsg
   This message is sent as a response to a JoinCluster message. Currently it
   only informs the new worker of metrics-related info
   """
+  let sender_name: String
   let local_topology: LocalTopology val
   let metrics_app_name: String
   let metrics_host: String
@@ -515,12 +518,13 @@ class InformJoiningWorkerMsg is ChannelMsg
   let data_addrs: Map[String, (String, String)] val
   let worker_names: Array[String] val
 
-  new val create(app: String, l_topology: LocalTopology val,
+  new val create(sender: String, app: String, l_topology: LocalTopology val,
     m_host: String, m_service: String,
     c_addrs: Map[String, (String, String)] val,
     d_addrs: Map[String, (String, String)] val,
     w_names: Array[String] val)
   =>
+    sender_name = sender
     local_topology = l_topology
     metrics_app_name = app
     metrics_host = m_host
@@ -529,6 +533,7 @@ class InformJoiningWorkerMsg is ChannelMsg
     data_addrs = d_addrs
     worker_names = w_names
 
+// TODO: Don't send host over since we need to determine that on receipt
 class JoiningWorkerInitializedMsg is ChannelMsg
   let worker_name: String
   let control_addr: (String, String)

--- a/lib/wallaroo/network/connections.pony
+++ b/lib/wallaroo/network/connections.pony
@@ -494,6 +494,7 @@ actor Connections
       c_addrs(w) = addr
     end
     c_addrs(_worker_name) = _my_control_addr
+
     let d_addrs: Map[String, (String, String)] trn =
       recover Map[String, (String, String)] end
     for (w, addr) in _data_addrs.pairs() do
@@ -502,9 +503,10 @@ actor Connections
     d_addrs(_worker_name) = _my_data_addr
 
     try
-      let inform_msg = ChannelMsgEncoder.inform_joining_worker(_app_name,
-        local_topology.for_new_worker(worker), _metrics_host, _metrics_service,
-        consume c_addrs, consume d_addrs, local_topology.worker_names, _auth)
+      let inform_msg = ChannelMsgEncoder.inform_joining_worker(_worker_name,
+        _app_name, local_topology.for_new_worker(worker), _metrics_host,
+        _metrics_service, consume c_addrs, consume d_addrs,
+        local_topology.worker_names, _auth)
       conn.writev(inform_msg)
       @printf[I32]("***Worker %s attempting to join the cluster. Sent necessary information.***\n".cstring(), worker.cstring())
     else

--- a/lib/wallaroo/startup_help.pony
+++ b/lib/wallaroo/startup_help.pony
@@ -6,8 +6,10 @@ primitive StartupHelp
       -----------------------------------------------------------------------------------
       --in/-i *[Comma-separated list of input addresses sources listen on]
       --out/-o *[Sets address for sink outputs]
-      --control/-c *[Sets address for control channel]
-      --data/-d *[Sets address for data channel]
+      --control/-c *[Sets address for initializer control channel]
+      --data/-d *[Sets address for initializer data channel]
+      --my-control [Optionally sets address for my control channel]
+      --my-data [Optionally sets address for my data channel]
       --phone-home/-p [Sets address for phone home connection]
       --worker-count/-w *[Sets total number of workers, including topology
         initializer]


### PR DESCRIPTION
During new worker join process, when workers
are informing each other of their addresses,
make sure we use the host string as seen
from the perspective of the other worker.