### PR TITLE
Fix multi-worker join bug

### DIFF
--- a/lib/wallaroo/initialization/application_initializer.pony
+++ b/lib/wallaroo/initialization/application_initializer.pony
@@ -782,7 +782,7 @@ actor ApplicationInitializer
               sendable_step_map, state_subpartitions, sendable_pre_state_data,
               consume p_ids, default_target, application.default_state_name,
               application.default_target_id,
-              worker_names)
+              all_workers)
           else
             @printf[I32]("Problem cloning graph\n".cstring())
             error

--- a/lib/wallaroo/initialization/local_topology.pony
+++ b/lib/wallaroo/initialization/local_topology.pony
@@ -1338,8 +1338,8 @@ actor LocalTopologyInitializer
         let reporter = MetricsReporter(t.name(), t.worker_name(),
           _metrics_conn)
         let step = Step(runner_builder(where alfred = _alfred, auth = _auth),
-            consume reporter, msg.step_id(), runner_builder.route_builder(),
-            _alfred, _outgoing_boundaries)
+          consume reporter, msg.step_id(), runner_builder.route_builder(),
+          _alfred, _outgoing_boundaries)
         step.receive_state(msg.state())
         msg.update_router_registry(_router_registry, step)
       else

--- a/lib/wallaroo/startup_help.pony
+++ b/lib/wallaroo/startup_help.pony
@@ -27,6 +27,7 @@ primitive StartupHelp
         control channel address of any worker as the value for this parameter]
       --swarm-managed/-s [Sets this worker as managed by Docker Swarm]
       --swarm-manager-address/-a [Sets the Docker Swarm Manager address]
+      --stop-world/-u [Sets pause before state migration after stop the world]
       -----------------------------------------------------------------------------------
       """
     )


### PR DESCRIPTION
In the initial stop the world implementation,
data messages could get stuck between workers
and never processed until after migration.
This led to missing routes in DataRouters.
These changes fix that and adds the ability
to pass in stop the world pause as a parameter.