### PR TITLE
Each TCPSource gets its own boundary to every worker

### DIFF
--- a/lib/wallaroo/data_channel/data_channel_listener.pony
+++ b/lib/wallaroo/data_channel/data_channel_listener.pony
@@ -17,12 +17,10 @@ actor DataChannelListener
   var _init_size: USize
   var _max_size: USize
 
-  var _data_receivers: Map[String, DataReceiver] val
   let _router_registry: RouterRegistry
 
   new create(auth: DataChannelListenerAuth,
     notify: DataChannelListenNotify iso,
-    data_receivers: Map[String, DataReceiver] val,
     router_registry: RouterRegistry,
     host: String = "", service: String = "0", limit: USize = 0,
     init_size: USize = 64, max_size: USize = 16384)
@@ -30,7 +28,6 @@ actor DataChannelListener
     """
     Listens for both IPv4 and IPv6 connections.
     """
-    _data_receivers = data_receivers
     _router_registry = router_registry
     _limit = limit
     _notify = consume notify
@@ -40,9 +37,6 @@ actor DataChannelListener
     _max_size = max_size
     _fd = @pony_asio_event_fd(_event)
     _notify_listening()
-
-  be update_data_receivers(drs: Map[String, DataReceiver] val) =>
-    _data_receivers = drs
 
   be set_notify(notify: DataChannelListenNotify iso) =>
     """
@@ -148,8 +142,7 @@ actor DataChannelListener
     """
     try
       let data_channel = DataChannel._accept(this, _notify.connected(this,
-        _data_receivers, _router_registry), ns,
-        _init_size, _max_size)
+        _router_registry), ns, _init_size, _max_size)
       _router_registry.register_data_channel(data_channel)
       _count = _count + 1
     else

--- a/lib/wallaroo/data_channel/data_channel_listener_notify.pony
+++ b/lib/wallaroo/data_channel/data_channel_listener_notify.pony
@@ -28,7 +28,6 @@ interface DataChannelListenNotify
     None
 
   fun ref connected(listen: DataChannelListener ref,
-    drs: Map[String, DataReceiver] val,
     router_registry: RouterRegistry): DataChannelNotify iso^ ?
     """
     Create a new DataChannelNotify to attach to a new DataChannel for a

--- a/lib/wallaroo/data_channel/data_channel_notify.pony
+++ b/lib/wallaroo/data_channel/data_channel_notify.pony
@@ -8,7 +8,15 @@ interface DataChannelNotify
   For an example of using this class please see the documentation for the
   `DataChannel` and `DataChannelListener` actors.
   """
-  fun ref update_data_receivers(drs: Map[String, DataReceiver] val)
+  fun ref identify_data_receiver(dr: DataReceiver, sender_boundary_id: U128,
+    conn: DataChannel ref)
+    """
+    Each abstract data channel (a connection from an OutgoingBoundary)
+    corresponds to a single DataReceiver. On reconnect, we want a new
+    DataChannel for that boundary to use the same DataReceiver. This is
+    called once we have found (or initially created) the DataReceiver for
+    the DataChannel corresponding to this notify.
+    """
 
   fun ref accepted(conn: DataChannel ref) =>
     """

--- a/lib/wallaroo/initialization/worker_initializer.pony
+++ b/lib/wallaroo/initialization/worker_initializer.pony
@@ -52,7 +52,7 @@ actor WorkerInitializer
       _topology_ready = true
       let workers: Array[String] val = recover [_worker_name] end
       _application_initializer.initialize(this, _expected, workers)
-      _local_topology_initializer.create_data_receivers(
+      _local_topology_initializer.create_data_channel_listener(
         recover Array[String] end, "", "", this)
     end
 
@@ -66,7 +66,7 @@ actor WorkerInitializer
       if _control_identified == _expected then
         @printf[I32]("All worker channels identified\n".cstring())
 
-        _create_data_receivers()
+        _create_data_channel_listeners()
       end
     end
 
@@ -137,7 +137,7 @@ actor WorkerInitializer
   // be register_proxy(worker: String, proxy: Step tag) =>
   //   _connections.register_proxy(worker, proxy)
 
-  fun _create_data_receivers() =>
+  fun _create_data_channel_listeners() =>
     let ws: Array[String] trn = recover Array[String] end
 
     ws.push("initializer")
@@ -148,15 +148,16 @@ actor WorkerInitializer
     let workers: Array[String] val = consume ws
 
     try
-      let create_data_receivers_msg = ChannelMsgEncoder.create_data_receivers(
-        workers, _auth)
+      let create_data_channel_listener_msg =
+        ChannelMsgEncoder.create_data_channel_listener(workers, _auth)
       for key in _control_addrs.keys() do
-        _connections.send_control(key, create_data_receivers_msg)
+        _connections.send_control(key, create_data_channel_listener_msg)
       end
 
       // Pass in empty host and service because data listener is created
       // in a special manner in .create_data_receiver() for initializer
-      _local_topology_initializer.create_data_receivers(workers, "", "", this)
+      _local_topology_initializer.create_data_channel_listener(workers, "", "",
+        this)
     else
       @printf[I32]("Failed to create message to create data receivers\n".cstring())
     end

--- a/lib/wallaroo/messages/channel_messages.pony
+++ b/lib/wallaroo/messages/channel_messages.pony
@@ -116,10 +116,10 @@ primitive ChannelMsgEncoder
   =>
     _encode(ConnectionsReadyMsg(worker_name), auth)
 
-  fun create_data_receivers(workers: Array[String] val, auth: AmbientAuth):
-    Array[ByteSeq] val ?
+  fun create_data_channel_listener(workers: Array[String] val,
+    auth: AmbientAuth): Array[ByteSeq] val ?
   =>
-    _encode(CreateDataReceivers(workers), auth)
+    _encode(CreateDataChannelListener(workers), auth)
 
   fun data_connect(sender_name: String, sender_step_id: U128,
     auth: AmbientAuth): Array[ByteSeq] val ?
@@ -267,7 +267,7 @@ class ConnectionsReadyMsg is ChannelMsg
   new val create(name: String) =>
     worker_name = name
 
-class CreateDataReceivers is ChannelMsg
+class CreateDataChannelListener is ChannelMsg
   let workers: Array[String] val
 
   new val create(ws: Array[String] val) =>
@@ -275,11 +275,11 @@ class CreateDataReceivers is ChannelMsg
 
 class DataConnectMsg is ChannelMsg
   let sender_name: String
-  let sender_step_id: U128
+  let sender_boundary_id: U128
 
-  new val create(sender_name': String, sender_step_id': U128) =>
+  new val create(sender_name': String, sender_boundary_id': U128) =>
     sender_name = sender_name'
-    sender_step_id = sender_step_id'
+    sender_boundary_id = sender_boundary_id'
 
 class ReplayCompleteMsg is ChannelMsg
   let _sender_name: String

--- a/lib/wallaroo/network/control_channel_tcp.pony
+++ b/lib/wallaroo/network/control_channel_tcp.pony
@@ -215,11 +215,11 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
         | let wi: WorkerInitializer =>
           wi.connections_ready(m.worker_name)
         end
-      | let m: CreateDataReceivers val =>
+      | let m: CreateDataChannelListener val =>
         ifdef "trace" then
-          @printf[I32]("Received CreateDataReceivers on Control Channel\n".cstring())
+          @printf[I32]("Received CreateDataChannelListener on Control Channel\n".cstring())
         end
-        _local_topology_initializer.create_data_receivers(m.workers,
+        _local_topology_initializer.create_data_channel_listener(m.workers,
           _d_host, _d_service)
       | let m: JoinClusterMsg val =>
         _local_topology_initializer.inform_joining_worker(conn, m.worker_name)

--- a/lib/wallaroo/routing/producer.pony
+++ b/lib/wallaroo/routing/producer.pony
@@ -56,16 +56,6 @@ trait tag Producer
 
     _x_resilience_routes().receive_ack(this, route_id, seq_id)
 
-trait tag Routable
-  be remove_route_for(moving_step: ConsumerStep)
-  be add_boundaries(boundary: Map[String, OutgoingBoundary] val)
-
-trait tag PartitionRoutable is Routable
-  be update_router(router: Router val)
-
-trait tag OmniRoutable is Routable
-  be update_omni_router(router: OmniRouter val)
-
 primitive HashProducer
   fun hash(o: Producer): U64 =>
     o.hash()

--- a/lib/wallaroo/startup.pony
+++ b/lib/wallaroo/startup.pony
@@ -356,7 +356,7 @@ actor Startup
         _connection_addresses_file, _is_joining)
 
       let router_registry = RouterRegistry(auth, _worker_name, connections,
-        _stop_the_world_pause)
+        _alfred as Alfred, _stop_the_world_pause)
 
       let local_topology_initializer = if _is_swarm_managed then
         let cluster_manager: DockerSwarmClusterManager =
@@ -491,7 +491,7 @@ actor Startup
         _connection_addresses_file, _is_joining)
 
       let router_registry = RouterRegistry(auth, _worker_name, connections,
-        _stop_the_world_pause)
+        _alfred as Alfred, _stop_the_world_pause)
 
       let local_topology_initializer = if _is_swarm_managed then
         let cluster_manager: DockerSwarmClusterManager =
@@ -511,7 +511,7 @@ actor Startup
 
       router_registry.set_data_router(DataRouter)
       local_topology_initializer.update_topology(m.local_topology)
-      local_topology_initializer.create_data_receivers(m.worker_names,
+      local_topology_initializer.create_data_channel_listener(m.worker_names,
         my_d_host, my_d_service)
 
       // Prepare control and data addresses, but sub in correct host for
@@ -541,6 +541,7 @@ actor Startup
       // initialization order
       local_topology_initializer.create_connections(consume control_addrs,
         consume data_addrs)
+      local_topology_initializer.quick_initialize_data_connections()
 
       let control_channel_filepath: FilePath = FilePath(auth,
         _control_channel_file)

--- a/lib/wallaroo/tcp_source/tcp_source_notify.pony
+++ b/lib/wallaroo/tcp_source/tcp_source_notify.pony
@@ -1,3 +1,5 @@
+use "collections"
+use "wallaroo/boundary"
 use "wallaroo/messages"
 use "wallaroo/routing"
 use "wallaroo/topology"
@@ -11,6 +13,8 @@ interface TCPSourceNotify
   fun ref routes(): Array[ConsumerStep] val
 
   fun ref update_router(router: Router val)
+
+  fun ref update_boundaries(obs: box->Map[String, OutgoingBoundary])
 
   fun ref accepted(conn: TCPSource ref) =>
     """

--- a/lib/wallaroo/topology/steps.pony
+++ b/lib/wallaroo/topology/steps.pony
@@ -43,8 +43,7 @@ interface Initializable
 
 type ConsumerStep is (RunnableStep & Consumer & Initializable tag)
 
-actor Step is (RunnableStep & Resilient & Producer &
-  Consumer & Initializable & PartitionRoutable & OmniRoutable)
+actor Step is (RunnableStep & Resilient & Producer & Consumer & Initializable)
   """
   # Step
 
@@ -470,7 +469,7 @@ actor Step is (RunnableStep & Resilient & Producer &
     else
       Fail()
     end
-    
+
   be send_state[K: (Hashable val & Equatable[K] val)](boundary: OutgoingBoundary, state_name: String, key: K) =>
     match _runner
     | let r: SerializableStateRunner =>

--- a/testing/performance/apps/market-spread-encode/market-spread.pony
+++ b/testing/performance/apps/market-spread-encode/market-spread.pony
@@ -8,6 +8,10 @@ nc -l 127.0.0.1 5555 >> /dev/null
 2) metrics sink (if not using Monitoring Hub):
 nc -l 127.0.0.1 5001 >> /dev/null
 
+or
+
+giles/receiver/receiver --ponythreads=1 --ponynoblock -w -l 127.0.0.1:5555
+
 350 Symbols
 
 3a) market spread app (1 worker):


### PR DESCRIPTION
Though there is still a canonical OutgoingBoundary/
DataReceiver pair per pair of workers used by all
steps, every TCPSource creates its own boundary per
worker and that worker a corresponding DataReceiver.
This allows for greater throughput across workers.