### PR TITLE
Use specific commit of pony-stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,7 @@ install:
     cd /tmp;
     git clone https://github.com/jemc/pony-stable.git;
     cd pony-stable;
+    git checkout 0054b429a54818d187100ed40f5525ec7931b31b;
     sudo make install;
   - cd $INSTALL_STARTED_AT
   - if [ "${TRAVIS_OS_NAME}" = "osx" ];


### PR DESCRIPTION
All our CI jobs started failing because we were tracking master for
pony-stable and it became broken. 2 hours later, I figured it out. This
commit will lock us to a specific version of stable.