### PR TITLE
Attempt to reconnect to metrics periodically

### DIFF
--- a/lib/wallaroo/startup.pony
+++ b/lib/wallaroo/startup.pony
@@ -274,14 +274,7 @@ actor Startup
       // TODO::joining
       let connect_auth = TCPConnectAuth(auth)
       let metrics_conn = MetricsSink(m_addr(0),
-          m_addr(1))
-
-      let connect_msg = HubProtocol.connect()
-      let metrics_join_msg = HubProtocol.join_metrics(
-        "metrics:" + _application.name(),
-        _worker_name)
-      metrics_conn.writev(connect_msg)
-      metrics_conn.writev(metrics_join_msg)
+          m_addr(1), _application.name(), _worker_name)
 
       var is_recovering: Bool = false
 
@@ -480,13 +473,8 @@ actor Startup
       let input_addrs: Array[Array[String]] val =
         (_i_addrs_write = recover Array[Array[String]] end)
 
-      let metrics_conn = MetricsSink(m.metrics_host, m.metrics_service)
-
-      let connect_msg = HubProtocol.connect()
-      let metrics_join_msg = HubProtocol.join_metrics(
-        "metrics:" + m.metrics_app_name, _worker_name)
-      metrics_conn.writev(connect_msg)
-      metrics_conn.writev(metrics_join_msg)
+      let metrics_conn = MetricsSink(m.metrics_host, m.metrics_service,
+        _application.name(), _worker_name)
 
       // TODO: Are we creating connections to all addresses or just
       // initializer?

--- a/lib/wallaroo/topology/_test.pony
+++ b/lib/wallaroo/topology/_test.pony
@@ -253,14 +253,14 @@ primitive _DefaultRouterGenerator
 
 primitive _StepGenerator
   fun apply(event_log: EventLog, recovery_replayer: RecoveryReplayer): Step =>
-    Step(RouterRunner, MetricsReporter("", "", MetricsSink("", "")),
+    Step(RouterRunner, MetricsReporter("", "", MetricsSink("", "", "", "")),
       1, EmptyRouteBuilder, event_log, recovery_replayer,
       recover Map[String, OutgoingBoundary] end)
 
 primitive _BoundaryGenerator
   fun apply(worker_name: String, auth: AmbientAuth): OutgoingBoundary =>
     OutgoingBoundary(auth, worker_name,
-      MetricsReporter("", "", MetricsSink("", "")), "", "")
+      MetricsReporter("", "", MetricsSink("", "", "", "")), "", "")
 
 primitive _RouterRegistryGenerator
   fun apply(env: Env, auth: AmbientAuth): RouterRegistry =>
@@ -273,8 +273,8 @@ primitive _DataReceiversGenerator
 
 primitive _ConnectionsGenerator
   fun apply(env: Env, auth: AmbientAuth): Connections =>
-    Connections("", "", env, auth, "", "", "", "", "", "", MetricsSink("", ""),
-      "", "", false, "", false)
+    Connections("", "", env, auth, "", "", "", "", "", "",
+      MetricsSink("", "", "", ""), "", "", false, "", false)
 
 primitive _RecoveryReplayerGenerator
   fun apply(env: Env, auth: AmbientAuth): RecoveryReplayer =>


### PR DESCRIPTION
Use a 10s timer to attempt to reconnect the MetricsSink whenever the connection
is dropped or closed.