### PR TITLE
Make length-framing optional at Decoder

### DIFF
--- a/lib/wallaroo/tcp_source/framed_source_notify.pony
+++ b/lib/wallaroo/tcp_source/framed_source_notify.pony
@@ -12,8 +12,8 @@ use "wallaroo/topology"
 
 
 interface FramedSourceHandler[In: Any val]
-  fun header_length(): USize
-  fun payload_length(data: Array[U8] iso): USize ?
+  fun header_length(): USize => 0
+  fun payload_length(data: Array[U8] iso): USize ? => 0
   fun decode(data: Array[U8] val): In ?
 
 class FramedSourceNotify[In: Any val] is TCPSourceNotify
@@ -47,7 +47,7 @@ class FramedSourceNotify[In: Any val] is TCPSourceNotify
     _router.routes()
 
   fun ref received(conn: TCPSource ref, data: Array[U8] iso): Bool =>
-    if _header then
+    if _header and (_header_size > 0) then
       // TODO: we need to provide a good error handling route for crap
       try
         let payload_size: USize = _handler.payload_length(consume data)
@@ -102,7 +102,9 @@ class FramedSourceNotify[In: Any val] is TCPSourceNotify
       end
 
       conn.expect(_header_size)
-      _header = true
+      if _header_size > 0 then
+        _header = true
+      end
 
       ifdef linux then
         true


### PR DESCRIPTION
A user can determine whether wallaroo uses the length-framing scheme of `<header-length><header><body>` by setting their FramedSourceHandler class's `header_size(): USize => 0`

This, for example, makes it much easier to design an app that takes an input from netcat for user-friendly examples:

```pony
primitive PalindromeDecoder is FramedSourceHandler[String]
  fun header_length(): USize => 0

  fun payload_length(data: Array[U8] val): USize => 0

  fun decode(data: Array[U8] val): String =>
    String.from_array(data)

primitive PalindromeEncoder
  fun apply(f: String, wb: Writer): Array[ByteSeq] val =>
    wb.write(f)
    wb.done()
```

The `FramedSourceHandler` interface now defaults to `header_length(): USize => 0` so a user only needs to provide their own `header_length()` and `paylod_length()` functions when they're using the length-framed scheme.