### PR TITLE
Use correct giles sender has_next check in binary multi-file sources

### DIFF
--- a/giles/sender/giles-sender.pony
+++ b/giles/sender/giles-sender.pony
@@ -754,9 +754,9 @@ class MultiFileBinaryDataSource is Iterator[Array[U8 val] val]
     end
 
   fun ref next(): Array[U8 val] val ? =>
-    match _cur_source
-    | let f: BinaryFileDataSource =>
-      if f.has_next() then
+    if has_next() then
+      match _cur_source
+      | let f: BinaryFileDataSource =>
         f.next()
       else
         error
@@ -811,9 +811,9 @@ class MultiFileVariableBinaryDataSource is Iterator[Array[U8 val] val]
     end
 
   fun ref next(): Array[U8 val] val ? =>
-    match _cur_source
-    | let f: VariableLengthBinaryFileDataSource =>
-      if f.has_next() then
+    if has_next() then
+      match _cur_source
+      | let f: VariableLengthBinaryFileDataSource =>
         f.next()
       else
         error


### PR DESCRIPTION
Prior to this commit, in the MultiFileBinaryDataSource and the
MultiFileVariableBinaryDataSource would only check if the current
source has a next message to send or not. This would incorrectly
result in an error thrown if the current source ran out of messages
to send but there was another source (or a repeat of the current
source) from which messages were supposed to be read and sent.

This commit fixes the two sources to do a `has_next` check for
at the multi-file source level instead of just the current source.

Resolves #598