### PR TITLE
Remove ThroughputBasedClusterGrowthTrigger from source MetricsReporters

### DIFF
--- a/lib/wallaroo/initialization/local_topology.pony
+++ b/lib/wallaroo/initialization/local_topology.pony
@@ -1049,12 +1049,9 @@ actor LocalTopologyInitializer
                   end
                 end
 
-              let metrics_monitor: ThroughputBasedClusterGrowthTrigger iso =
-                recover ThroughputBasedClusterGrowthTrigger(this, 10_000) end
               let source_reporter = MetricsReporter(t.name(),
                 t.worker_name(),
-                _metrics_conn
-                where metrics_monitor = consume metrics_monitor)
+                _metrics_conn)
 
               // Get all the sinks so far, which should include any sinks
               // prestate on this source might target


### PR DESCRIPTION
Removes `ThroughputBasedClusterGrowthTrigger` from source `MetricsReporter`s so we no longer output `Attempting to request a new worker but cluster manager is None` when the throughput for a given source exceeds 10,000.

**Manual test:**

Run any application with a source that exceeds 10,000 messages per second and verify that `Attempting to request a new worker but cluster manager is None` is not output by the Wallaroo worker

closes #702 