### PR TITLE
Add a size argument to SourceDecoder::decode

### DIFF
--- a/examples/counter-app/cpp/Counter.cpp
+++ b/examples/counter-app/cpp/Counter.cpp
@@ -99,7 +99,7 @@ size_t CounterSourceDecoder::payload_length(char *bytes)
   return ((size_t)(bytes[0]) << 8) + (size_t)(bytes[1]);
 }
 
-Numbers *CounterSourceDecoder::decode(char *bytes)
+Numbers *CounterSourceDecoder::decode(char *bytes, size_t sz)
 {
   // std::cerr << "decoding in the source!" << std::endl;
   Numbers *n = new Numbers();

--- a/examples/counter-app/hpp/Counter.hpp
+++ b/examples/counter-app/hpp/Counter.hpp
@@ -53,7 +53,7 @@ class CounterSourceDecoder: public wallaroo::SourceDecoder
 public:
   virtual size_t header_length();
   virtual size_t payload_length(char *bytes);
-  virtual Numbers *decode(char *bytes);
+  virtual Numbers *decode(char *bytes, size_t sz);
 };
 
 class CounterSinkEncoder: public wallaroo::SinkEncoder

--- a/lib/wallaroo/cpp_api/cpp/cppapi/cpp/ApiHooks.cpp
+++ b/lib/wallaroo/cpp_api/cpp/cppapi/cpp/ApiHooks.cpp
@@ -97,9 +97,9 @@ extern size_t w_source_decoder_payload_length(SourceDecoder *source_decoder_,
 }
 
 extern Data *w_source_decoder_decode(SourceDecoder *source_decoder_,
-  char *bytes_)
+  char *bytes_, size_t sz_)
 {
-  return source_decoder_->decode(bytes_);
+  return source_decoder_->decode(bytes_, sz_);
 }
 
 extern const char *w_state_change_get_name(StateChange *state_change_)

--- a/lib/wallaroo/cpp_api/cpp/cppapi/hpp/ApiHooks.hpp
+++ b/lib/wallaroo/cpp_api/cpp/cppapi/hpp/ApiHooks.hpp
@@ -44,7 +44,8 @@ extern void w_sink_encoder_encode(SinkEncoder *sink_encoder_,
 extern size_t w_source_decoder_header_length(SourceDecoder *source_decoder_);
 extern size_t w_source_decoder_payload_length(SourceDecoder *source_decoder_,
   char *bytes_);
-extern Data *w_source_decoder_decode(SourceDecoder *source_decoder_, char *bytes_);
+extern Data *w_source_decoder_decode(SourceDecoder *source_decoder_,
+  char *bytes_, size_t sz_);
 
 extern const char *w_state_change_get_name(StateChange *state_change_);
 extern uint64_t w_state_change_get_id(StateChange *state_change_);

--- a/lib/wallaroo/cpp_api/cpp/cppapi/hpp/SourceDecoder.hpp
+++ b/lib/wallaroo/cpp_api/cpp/cppapi/hpp/SourceDecoder.hpp
@@ -11,7 +11,7 @@ class SourceDecoder: public ManagedObject
 public:
   virtual std::size_t header_length() = 0;
   virtual std::size_t payload_length(char *bytes_) = 0;
-  virtual Data *decode(char *bytes_) = 0;
+  virtual Data *decode(char *bytes_, size_t sz_) = 0;
 };
 }
 

--- a/lib/wallaroo/cpp_api/pony/source_decoder.pony
+++ b/lib/wallaroo/cpp_api/pony/source_decoder.pony
@@ -6,7 +6,7 @@ use @w_source_decoder_payload_length[USize](source_decoder: SourceDecoderP,
   data: Pointer[U8] tag)
 
 use @w_source_decoder_decode[DataP](source_decoder: SourceDecoderP,
-  data: Pointer[U8] tag)
+  data: Pointer[U8] tag, size: USize)
 
 type SourceDecoderP is Pointer[U8] val
 
@@ -25,7 +25,8 @@ class CPPSourceDecoder is FramedSourceHandler[CPPData val]
     @w_source_decoder_payload_length(_source_decoder, data.cpointer())
 
   fun decode(data: Array[U8] val): CPPData val ? =>
-    match @w_source_decoder_decode(_source_decoder, data.cpointer())
+    match @w_source_decoder_decode(_source_decoder, data.cpointer(),
+      data.size())
     | let result: DataP if (not result.is_null()) =>
       recover CPPData(result) end
     else

--- a/testing/performance/apps/market-spread-cpp/cpp/market-spread-cpp.cpp
+++ b/testing/performance/apps/market-spread-cpp/cpp/market-spread-cpp.cpp
@@ -228,7 +228,7 @@ size_t OrderSourceDecoder::payload_length(char *bytes)
   return reader.u32_be();
 }
 
-wallaroo::Data *OrderSourceDecoder::decode(char *bytes)
+wallaroo::Data *OrderSourceDecoder::decode(char *bytes, size_t sz)
 {
   Reader reader((unsigned char*) bytes);
 
@@ -267,7 +267,7 @@ size_t NbboSourceDecoder::payload_length(char *bytes)
   return reader.u32_be();
 }
 
-wallaroo::Data *NbboSourceDecoder::decode(char *bytes)
+wallaroo::Data *NbboSourceDecoder::decode(char *bytes, size_t sz)
 {
   Reader reader((unsigned char*) bytes);
 

--- a/testing/performance/apps/market-spread-cpp/hpp/market-spread-cpp.hpp
+++ b/testing/performance/apps/market-spread-cpp/hpp/market-spread-cpp.hpp
@@ -66,7 +66,7 @@ class OrderSourceDecoder: public wallaroo::SourceDecoder
 public:
   virtual size_t header_length();
   virtual size_t payload_length(char *bytes);
-  virtual wallaroo::Data *decode(char *bytes);
+  virtual wallaroo::Data *decode(char *bytes, size_t sz);
 };
 
 class NbboSourceDecoder: public wallaroo::SourceDecoder
@@ -74,7 +74,7 @@ class NbboSourceDecoder: public wallaroo::SourceDecoder
 public:
   virtual size_t header_length();
   virtual size_t payload_length(char *bytes);
-  virtual wallaroo::Data *decode(char *bytes);
+  virtual wallaroo::Data *decode(char *bytes, size_t sz);
 };
 
 class PartitionableMessage: public wallaroo::Data


### PR DESCRIPTION
The size argument indicates the number of bytes in the array that is
passed to the decoder. This makes it possible to write logic that
prevents reading beyond the end of the buffer, and also allows the
developer to use this length to read variable-length messages where
the overall message length can be used to determine the lengths of
parts of the message (for example strings or arrays of uniformly sized
items.

The counter-app and market-spread-cpp app have been updated to use the
new API.