### PR TITLE
Validator at least once mode

### DIFF
--- a/fallor/fallor.pony
+++ b/fallor/fallor.pony
@@ -2,6 +2,7 @@ use "buffered"
 use "net"
 use "options"
 use "files"
+use "sendence/bytes"
 use "sendence/messages"
 
 actor Main
@@ -36,30 +37,48 @@ actor Main
     try
       let auth = env.root as AmbientAuth
 
-      let input_file = File(FilePath(auth, input_file_path))
-      let input: Array[U8] val = input_file.read(input_file.size())
-
+      let fp = FilePath(auth, input_file_path)
+      let input = ReceiverFileDataSource(fp)
       let output_file = File(FilePath(auth, output_file_path))
 
-      let rb = Reader
-      rb.append(input)
-      var bytes_left = input.size()
-      while bytes_left > 0 do
-        // Msg size, msg size u32, and timestamp together make up next payload
-        // size
-        let next_payload_size = rb.peek_u32_be() + 12
+      for bytes in input do
         let fields =
           try
-            FallorMsgDecoder.with_timestamp(rb.block(next_payload_size.usize()))
+            FallorMsgDecoder.with_timestamp(bytes)
           else
             env.err.print("Problem decoding!")
             error
           end
         output_file.print(", ".join(fields))
-        bytes_left = bytes_left - next_payload_size.usize()
       end
-      input_file.dispose()
       output_file.dispose()
     else
       env.err.print("Error reading and writing files.")
+    end
+
+class ReceiverFileDataSource is Iterator[Array[U8] val]
+  let _file: File
+
+  new create(path: FilePath val) =>
+    _file = File(path)
+
+  fun ref has_next(): Bool =>
+    if _file.position() < _file.size() then
+      true
+    else
+      false
+    end
+
+  fun ref next(): Array[U8] val =>
+    // 4 bytes LENGTH HEADER + 8 byte U64 giles receiver timestamp
+    let h = _file.read(12)
+    try
+      let expect: USize = Bytes.to_u32(h(0), h(1), h(2), h(3)).usize()
+      h.append(_file.read(expect))
+      h
+    else
+      ifdef debug then
+        @printf[I32]("Failed to convert message header!\n".cstring())
+      end
+      recover Array[U8] end
     end


### PR DESCRIPTION
This adds an `--at-least-once/-a` flag and mode to the sequence-window validator, to allow explicit switching between exactly-once and at-least-once testing.
The default mode is exactly-once, and the `--at-least-once/-a` flag will allow sequences in the test data to _revert back to an older sequence_, but will not allow forward skipping. All of the other tests are still valid.

Also adds:
- **Read a message from the file at a time instead of reading the entire fie at once**
- **Update Fallor's input mode to stream-reading instead of loading entire file into memory**
- Testable range test on sequence values (currently capping at `i64.max_value()` due to logic related to `at-least-once` mode
- Test increments inside a sequence are valid (increment by 0,1, or 2, and always 2 after a previously non-zero increment)
- Include the timestamp from the offending application output line (e.g. from giles' `received.txt`) to the error message reported to the user on exit (makes finding the offending line in the fallor-decoded output easier).