### PR TITLE
Use strings instead of bytearrays in Python encoders and decoders

### DIFF
--- a/book/python/writing-your-own-application.md
+++ b/book/python/writing-your-own-application.md
@@ -4,7 +4,7 @@ In this section, we will go over the components that are required in order to wr
 
 ## A Stateless Application - Reverse Words
 
-The `reverse_word.py` application is going to receive text as its input, reverse it, and then send out the reversed text to its sink. In order to do this, our application needs to provide the following functions:  
+The `reverse_word.py` application is going to receive text as its input, reverse it, and then send out the reversed text to its sink. In order to do this, our application needs to provide the following functions:
 
 * Input decoding - how to translate the incoming bytestream into a Python string
 * Computation - this is where the input string is going to get reversed
@@ -32,9 +32,8 @@ Next, we are going to define how the output gets constructed for the output. It 
 ```python
 class Encoder(object):
     def encode(self, data):
-        # data is already string, so let's just add a newline to the end and
-        # turn it into a bytearray.
-        return bytearray(data + "\n", "utf-8")
+        # data is already string, so let's just add a newline to the end
+        return data + "\n"
 ```
 
 ### SourceDecoder
@@ -57,7 +56,7 @@ This one is different. Wallaroo handles _streams of bytes_, and in order to do t
 
 To read more about this, please refer to the [Framed Source Handling](/book/intro/framed-source-handling.md) section.
 
-For our application purposes, we will simply define the structure and how it is going to get parsed:  
+For our application purposes, we will simply define the structure and how it is going to get parsed:
 
 1. input messages have the following structure: `HEADER_LENGTH``MSG_LENGTH``MSG`
 1. Wallaroo requires three methods to parse this type of message:
@@ -74,7 +73,7 @@ In our case:
 ### Application Setup
 
 So now that we have input decoding, computation, and output decoding defined, how do we build it all into an application?
-For this, two things are needed:  
+For this, two things are needed:
 1. an entry point for Wallaroo to create the application. This is the function `application_setup` that you need to define.
 1. the actual topology `application_setup` is going to return for Wallaroo to create the application.A
 

--- a/book/python/writing-your-own-stateful-application.md
+++ b/book/python/writing-your-own-stateful-application.md
@@ -6,7 +6,7 @@ In this section, we will go over how to write a stateful application with the Wa
 
 Our stateful application is going to be a vote counter, called Alphabet. It receives as its input a message containing an alphabet character and a number of votes, which it then increments in its internal state. After each update, it sends the new updated vote count or that character to its output.
 
-As with the Reverse Word example, we will list the components required:  
+As with the Reverse Word example, we will list the components required:
 
 * Input decoding
 * Output encoding
@@ -30,7 +30,7 @@ class AddVotes(object):
 
 ### State and StateBuilder
 
-The state for this appliation is two-tiered. There is a a vote count for each character:  
+The state for this appliation is two-tiered. There is a a vote count for each character:
 
 ```python
 class Votes(object):
@@ -39,7 +39,7 @@ class Votes(object):
         self.votes = votes
 ```
 
-And a state map:  
+And a state map:
 
 ```python
 class AllVotes(object):
@@ -59,10 +59,10 @@ class AllVotes(object):
         return Votes(letter, vbl.votes)
 ```
 
-This map is the `state` object that `AddVotes.compute` above takes.  
+This map is the `state` object that `AddVotes.compute` above takes.
 An important thing to note here is that `get_votes` returns a _new_ `Votes` instance. This is important, as this is the value that is returned eventually passed to `Encoder.encode`, and if we passed a reference to a mutable object here, there is no guarantee that `Encoder.encode` will execute before another update to this object.
 
-Lastly, a stateful application's pipeline is going to need a `StateBuilder`, so let's create one:  
+Lastly, a stateful application's pipeline is going to need a `StateBuilder`, so let's create one:
 
 ```python
 class LetterStateBuilder(object):
@@ -71,7 +71,7 @@ class LetterStateBuilder(object):
 ```
 
 ### Encoder
-The encoder is going to receive a `Votes` instance and encode into a bytearray with the letter, followed by the vote count as a big-endian 32-bit unsigned integer:  
+The encoder is going to receive a `Votes` instance and encode into a string with the letter, followed by the vote count as a big-endian 32-bit unsigned integer:
 
 ```python
 class Encoder(object):
@@ -79,7 +79,7 @@ class Encoder(object):
         # data is a Votes
         letter = data.letter
         votes = data.votes
-        return bytearray(letter, "utf-8") + struct.pack(">I", votes)
+        return struct.pack(">1sI", letter, votes)
 ```
 
 ### Decoder
@@ -102,7 +102,7 @@ class Decoder(object):
 
 ### Application Setup
 Finally, let's set up our application topology:
-  
+
 ```python
 def application_setup(args):
     ab = wallaroo.ApplicationBuilder("alphabet")
@@ -112,14 +112,14 @@ def application_setup(args):
     return ab.build()
 ```
 
-The only difference between this setup and the stateless Reverse Word's one is that while in Reverse Word we used:  
+The only difference between this setup and the stateless Reverse Word's one is that while in Reverse Word we used:
 
 ```python
 ab.to(Reverse)
 ```
 
 here we use:
-  
+
 ```python
 ab.to_stateful(AddVotes(), LetterStateBuilder(), "letter state")
 ```
@@ -128,7 +128,7 @@ That is, while the stateless computation constructor took only a computation cla
 
 ### Miscellaneous
 
-This module needs its imports:  
+This module needs its imports:
 ```python
 import struct
 

--- a/horse-snake/dianoga/alphabet.py
+++ b/horse-snake/dianoga/alphabet.py
@@ -51,8 +51,7 @@ class Decoder(object):
         return l
 
     def decode(self, bs):
-        letter = chr(bs[0])
-        vote_count = struct.unpack(">I", bs[1:])[0]
+        (letter, vote_count) = struct.unpack(">1sI", bs)
         return Votes(letter, vote_count)
 
 class AddVotes(object):
@@ -67,6 +66,4 @@ class AddVotes(object):
 class Encoder(object):
     def encode(self, data):
         # data is a Votes
-        letter = data.letter
-        votes = data.votes
-        return bytearray(letter, "utf-8") + struct.pack(">I", votes)
+        return struct.pack(">1sI", data.letter, data.votes)

--- a/horse-snake/dianoga/alphabet_partitioned.py
+++ b/horse-snake/dianoga/alphabet_partitioned.py
@@ -56,8 +56,7 @@ class Decoder(object):
         return l
 
     def decode(self, bs):
-        letter = chr(bs[0])
-        vote_count = struct.unpack(">I", bs[1:])[0]
+        (letter, vote_count) = struct.unpack(">1sI", bs)
         print "decode"
         return Votes(letter, vote_count)
 
@@ -73,6 +72,4 @@ class AddVotes(object):
 class Encoder(object):
     def encode(self, data):
         # data is a Votes
-        letter = data.letter
-        votes = data.votes
-        return bytearray(letter, "utf-8") + struct.pack(">I", votes)
+        return struct.pack(">1sI", data.letter, data.votes)

--- a/horse-snake/dianoga/cpp/python-wallaroo.c
+++ b/horse-snake/dianoga/cpp/python-wallaroo.c
@@ -89,7 +89,7 @@ extern size_t source_decoder_payload_length(PyObject *source_decoder, char *byte
   PyObject *pFunc, *pValue, *pBytes;
 
   pFunc = PyObject_GetAttrString(source_decoder, "payload_length");
-  pBytes = PyByteArray_FromStringAndSize(bytes, size);
+  pBytes = PyBytes_FromStringAndSize(bytes, size);
   pValue = PyObject_CallFunctionObjArgs(pFunc, pBytes, NULL);
 
   size_t sz = PyInt_AsSsize_t(pValue);
@@ -106,7 +106,7 @@ extern PyObject *source_decoder_decode(PyObject *source_decoder, char *bytes, si
   PyObject *pFunc, *pBytes, *pValue;
 
   pFunc = PyObject_GetAttrString(source_decoder, "decode");
-  pBytes = PyByteArray_FromStringAndSize(bytes, size);
+  pBytes = PyBytes_FromStringAndSize(bytes, size);
   pValue = PyObject_CallFunctionObjArgs(pFunc, pBytes, NULL);
 
   Py_DECREF(pFunc);

--- a/horse-snake/dianoga/dianoga.pony
+++ b/horse-snake/dianoga/dianoga.pony
@@ -46,9 +46,8 @@ use @py_decref[None](o: Pointer[U8] box)
 
 use @Py_Initialize[None]()
 use @PyTuple_GetItem[Pointer[U8] val](t: Pointer[U8] val, idx: USize)
-use @PyByteArray_AsString[Pointer[U8]](ba: Pointer[U8] box)
-use @PyByteArray_Size[USize](ba: Pointer[U8] box)
-use @PyString_AsString[Pointer[U8]](ba: Pointer[U8] box)
+use @PyString_Size[USize](str: Pointer[U8] box)
+use @PyString_AsString[Pointer[U8]](str: Pointer[U8] box)
 use @PyString_FromStringAndSize[Pointer[U8]](str: Pointer[U8] tag, size: USize)
 use @PyList_New[Pointer[U8] val](size: USize)
 use @PyList_Size[USize](l: Pointer[U8] box)
@@ -230,7 +229,7 @@ class PyEncoder is SinkEncoder[PyData val]
     let byte_buffer = Dianoga.sink_encoder_encode(_sink_encoder, data.obj())
     let arr = recover val
       // create a temporary Array[U8] wrapper for the C array, then clone it
-      Array[U8].from_cpointer(@PyByteArray_AsString(byte_buffer), @PyByteArray_Size(byte_buffer)).clone()
+      Array[U8].from_cpointer(@PyString_AsString(byte_buffer), @PyString_Size(byte_buffer)).clone()
     end
     Dianoga.dec_ref(byte_buffer)
     wb.write(arr)

--- a/horse-snake/dianoga/market_spread.py
+++ b/horse-snake/dianoga/market_spread.py
@@ -128,7 +128,7 @@ class OrderResultEncoder(object):
             data.offer,
             data.timestamp)
 
-        return bytearray(p)
+        return p
 
 class MarketDataMessage(object):
     def __init__(self, symbol, transact_time, bid, offer):

--- a/horse-snake/dianoga/reverse_word.py
+++ b/horse-snake/dianoga/reverse_word.py
@@ -20,13 +20,13 @@ class Decoder(object):
         print "header_length"
         return 4
 
-    def payload_length(self, bytes):
-        print "payload_length " + bytes
-        return struct.unpack(">I", bytes)[0]
+    def payload_length(self, bs):
+        print "payload_length " + bs
+        return struct.unpack(">I", bs)[0]
 
-    def decode(self, bytes):
-        print "decode " + bytes
-        return bytes.decode("utf-8")
+    def decode(self, bs):
+        print "decode " + bs
+        return bs.decode("utf-8")
 
 
 class Reverse(object):
@@ -42,4 +42,4 @@ class Encoder(object):
     def encode(self, data):
         # data is a string
         print "encode " + data
-        return bytearray(data + "\n", "utf-8")
+        return data + "\n"

--- a/horse-snake/dianoga/sequence.py
+++ b/horse-snake/dianoga/sequence.py
@@ -66,4 +66,4 @@ class Encoder(object):
     def encode(self, data):
         print "Encoder:encode: ", data
         # data is a list of integers
-        return bytearray(str(data) + "\n", "utf-8")
+        return str(data) + "\n"

--- a/horse-snake/dianoga/sequence_partitioned.py
+++ b/horse-snake/dianoga/sequence_partitioned.py
@@ -74,4 +74,4 @@ class Encoder(object):
     def encode(self, data):
         print "Encoder:encode: ", data
         # data is a list of integers
-        return bytearray(str(data) + "\n", "utf-8")
+        return str(data) + "\n"


### PR DESCRIPTION
Change the Python API to use strings instead of byte arrays as the
input to decoders and the output from encoders. Strings and bytearrays
are almost the same, except that bytearrays are mutable. The bytes
going into and coming out of the encoders and decoders should not be
mutable, so strings should be used here.

There are changes to:
* the C and Pony code that implements the Python API
* the documentation
* the existing example programs

Fixes #711.