### PR TITLE
Abort Python application if application_setup raise exception

### DIFF
--- a/machida/main.pony
+++ b/machida/main.pony
@@ -25,13 +25,12 @@ actor Main
     try
       let module_name = find_python_module(env.args)
       let module = Machida.load_module(module_name)
-      let application_setup = Machida.application_setup(module, env.args)
 
       try
+        let application_setup = Machida.application_setup(module, env.args)
+
         let application = recover val
-          let app = Application("")
-          Machida.apply_application_setup(app, application_setup)
-          app
+          Machida.apply_application_setup(application_setup)
         end
         Startup(env, application, None)
       else


### PR DESCRIPTION
If there is a problem in the application_setup function, the code can
raise an error to abort the application. Wallaroo will print the
exception and exit gracefully.

As part of this change also made a change to correctly set the
application name.

Fixes #713
Fixes #732