### PR TITLE
Change `--wallaroo-module` to `--application-module` in Machida

### DIFF
--- a/machida/machida.pony
+++ b/machida/machida.pony
@@ -264,9 +264,11 @@ primitive Machida
       String.copy_cstring(@test_python())
     end
 
-  fun load_module(module_name: String): ModuleP =>
+  fun load_module(module_name: String): ModuleP ? =>
     let r = @load_module(module_name.cstring())
-    print_errors()
+    if print_errors() then
+      error
+    end
     r
 
   fun application_setup(module: ModuleP, args: Array[String] val): Pointer[U8] val ? =>


### PR DESCRIPTION
The `--wallaroo-module` option was confusing because there is a module
called `wallaroo` that contains helper code, but this option was meant
to communicate the name of the module that contained the application
code. This change should eliminate that confusion.

This commit also improves error handling for the option.

Fixes #737

[skip ci]