### PR TITLE
Clone Wallaroo before starting other installation steps

### DIFF
--- a/book/getting-started/run-a-application.md
+++ b/book/getting-started/run-a-application.md
@@ -4,28 +4,6 @@ In this section, we're going to show you how to quickly get a Wallaroo applicati
 
 We'll be sending our Celsius values into Wallaroo as a stream of bytes over TCP. The outputs of our application will be converted to a stream of bytes and sent over TCP to a data receiver.
 
-## Set up Environment for Wallaroo
-
-Create a directory called `~/wallaroo-tutorial` and navigate there by running
-
-```
-mkdir ~/wallaroo-tutorial
-cd ~/wallaroo-tutorial
-```
-
-This will be our base directory in what follows. If you haven't already
-cloned this repo, do so by running:
-
-```
-git clone https://github.com/sendence/wallaroo
-```
-
-Note: You need to login to GitHub for credentials
-
-This will create a subdirectory called `wallaroo`.
-
-If you haven't already, you now need to set up your environment for Wallaroo. Follow the instructions [here](setup.md).
-
 ## Start the Metrics UI
 
 To start the Metrics UI run:

--- a/book/getting-started/setup.md
+++ b/book/getting-started/setup.md
@@ -2,5 +2,29 @@
 
 It is currently possible to develop Wallaroo applications on MacOS or Linux. This guide currently has installation instructions for MacOS and Ubuntu Linux. It's assumed if you are using a different Linux distribution that you are able to translate the Ubuntu instructions to your distribution of choice.
 
+## Set up Environment for the Wallaroo Tutorial
+
+Create a directory called `~/wallaroo-tutorial` and navigate there by running
+
+```bash
+mkdir ~/wallaroo-tutorial
+cd ~/wallaroo-tutorial
+```
+
+This will be our base directory in what follows. If you haven't already
+cloned the Wallarroo repo, do so now:
+
+```bash
+git clone https://github.com/sendence/wallaroo
+```
+
+Note: You need to login to GitHub for credentials
+
+This will create a subdirectory called `wallaroo`.
+
+## Install for your operating system
+
+Next, follow the instructions for your operating system:
+
 - [MacOS setup](macos-setup.md)
 - [Ubunutu setup](linux-setup.md)


### PR DESCRIPTION
Without this in place then when we refer people back to steps
needed to get started, they can miss the clone Wallaroo repo
step. And without that, you won't be able to get anything to work.