### PR TITLE
Don't download Wallaroo into itself

### DIFF
--- a/book/examples/alphabet/bundle.json
+++ b/book/examples/alphabet/bundle.json
@@ -1,8 +1,7 @@
 {
   "deps": [
-    { "type": "github",
-      "repo": "sendence/wallaroo",
-      "subdir": "lib"
-    }
+      { "type": "local",
+        "local-path": "../../../lib/"
+      }
   ]
 }

--- a/book/examples/celsius/bundle.json
+++ b/book/examples/celsius/bundle.json
@@ -1,8 +1,7 @@
 {
   "deps": [
-    { "type": "github",
-      "repo": "sendence/wallaroo",
-      "subdir": "lib"
-    }
+      { "type": "local",
+        "local-path": "../../../lib/"
+      }
   ]
 }

--- a/book/getting-started/run-a-application.md
+++ b/book/getting-started/run-a-application.md
@@ -73,7 +73,7 @@ cd ~/wallaroo-tutorial/wallaroo/book/examples/celsius
 Now compile the Celsius Converter app:
 
 ```bash
-stable fetch && stable env ponyc
+stable env ponyc
 ```
 
 This will create a binary called `celsius`.

--- a/book/python/building.md
+++ b/book/python/building.md
@@ -43,7 +43,7 @@ Build the sender we will be using to send framed data to Wallaroo.
 
 ```bash
 cd ~/wallaroo/giles/sender
-stable fetch && stable env ponyc
+stable env ponyc
 ```
 
 #### Wallaroo-Python

--- a/book/to-org/resilience.md
+++ b/book/to-org/resilience.md
@@ -19,7 +19,7 @@ following compiler argument:
 This means the full command to compile with resilience will be:
 
 ```
-stable fetch && stable env ponyc -D resilience
+stable env ponyc -D resilience
 ```
 
 When running a resilience-enabled Wallaroo app, you can optionally specify the 


### PR DESCRIPTION
Our examples would fetch Wallaroo into itself as a result of
bundle files that weren't update when the book repo was moved
into the Wallaroo repo.