### PR TITLE
Update docker tag for Metrics UI run commands

### DIFF
--- a/book/getting-started/run-a-application.md
+++ b/book/getting-started/run-a-application.md
@@ -10,10 +10,10 @@ To start the Metrics UI run:
 
 ```bash
 docker run -d --name mui -p 0.0.0.0:4000:4000 -p 0.0.0.0:5001:5001 \
-  sendence/wallaroo-metrics-ui
+  sendence/wallaroo-metrics-ui:pre-0.0.1
 ```
 
-You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000). 
+You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000).
 
 If you need to restart the UI, run:
 

--- a/book/wallaroo-tools/metrics-ui.md
+++ b/book/wallaroo-tools/metrics-ui.md
@@ -149,7 +149,7 @@ docker pull sendence/wallaroo-metrics-ui:pre-0.0.1
 To start the Metrics UI you will run:
 
 ```
-docker run -d --name mui -p 0.0.0.0:4000:4000 -p 0.0.0.0:5001:5001 sendence/wallaroo-metrics-ui
+docker run -d --name mui -p 0.0.0.0:4000:4000 -p 0.0.0.0:5001:5001 sendence/wallaroo-metrics-ui:pre-0.0.1
 ```
 
 If you are running locally, open [http://localhost:4000](http://localhost:4000)


### PR DESCRIPTION
include `pre-0.0.1` tag so it doesn't default to `latest`