### PR TITLE
Add instructions for how to start docker automatically

### DIFF
--- a/book/examples/python/reverse/README.md
+++ b/book/examples/python/reverse/README.md
@@ -4,6 +4,12 @@ The reverse application receives strings as input and outputs the reversed strin
 
 ## Running Reverse
 
+In a shell, start up the Metrics UI if you don't already have it running:
+
+```bash
+docker start mui
+```
+
 In a shell, set up a listener:
 
 ```bash

--- a/book/getting-started/linux-setup.md
+++ b/book/getting-started/linux-setup.md
@@ -149,7 +149,7 @@ sudo make install
 
 ## Install Docker
 
-You'll need Docker (CE or EE) to run the Wallaroo metrics UI. There are [instructions](https://docs.docker.com/engine/installation/linux/ubuntu/) for getting Docker up and running on Ubuntu on the [Docker website](https://docs.docker.com/engine/installation/linux/ubuntu/).
+You'll need Docker (CE or EE) to run the Wallaroo metrics UI. There are [instructions](https://docs.docker.com/engine/installation/linux/ubuntu/) for getting Docker up and running on Ubuntu on the [Docker website](https://docs.docker.com/engine/installation/linux/ubuntu/). Installing Docker will result in it running on your machine. After you reboot your machine, that will no longer be the case. In the future, you'll need to have Docker running in order to use a variety of commands in this book. We suggest that you [set up Docker to boot automatically](https://docs.docker.com/engine/installation/linux/linux-postinstall/#configure-docker-to-start-on-boot).
 
 ## Install the Metrics UI
 

--- a/book/getting-started/macos-setup.md
+++ b/book/getting-started/macos-setup.md
@@ -77,7 +77,7 @@ sudo make install
 
 ## Install Docker
 
-You'll need Docker to run the Wallaroo metrics UI. There are [instructions](https://docs.docker.com/docker-for-mac/) for getting Docker up and running on MacOS on the [Docker website](https://docs.docker.com/docker-for-mac/).
+You'll need Docker to run the Wallaroo metrics UI. There are [instructions](https://docs.docker.com/docker-for-mac/) for getting Docker up and running on MacOS on the [Docker website](https://docs.docker.com/docker-for-mac/). Installing Docker will result in it running on your machine. After you reboot your machine, that will no longer be the case. In the future, you'll need to have Docker running in order to use a variety of commands in this book. We suggest that you [set up Docker to boot automatically](https://docs.docker.com/docker-for-mac/#general).
 
 ## Install the Metrics UI
 


### PR DESCRIPTION
Point out to user where in the Docker instructions they will find how to
set up to automatically start Docker. Also explain why they want to do
that.