### PR TITLE
Fix python application startup from Machida

### DIFF
--- a/book/examples/python/alphabet/README.md
+++ b/book/examples/python/alphabet/README.md
@@ -21,9 +21,9 @@ export PATH="$PATH:../../../../machida/build"
 Run `machida` with `--application-module alphabet`.
 
 ```bash
-machida -i 127.0.0.1:7010 -o 127.0.0.1:7002 -m 127.0.0.1:8000 \
--c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker-name --ponythreads=1 \
---application-module alphabet
+machida --application-module alphabet -i 127.0.0.1:7010 -o 127.0.0.1:7002 \
+  -m 127.0.0.1:8000 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker-name \
+  --ponythreads=1
 ```
 
 In a third shell, send some messages

--- a/book/examples/python/alphabet_partitioned/README.md
+++ b/book/examples/python/alphabet_partitioned/README.md
@@ -22,8 +22,8 @@ Run `machida` with `--application-module alphabet_partitioned`.
 
 ```bash
 machida --application-module alphabet_partitioned -i 127.0.0.1:7010 \
--o 127.0.0.1:7002 -m 127.0.0.1:8000 -c 127.0.0.1:6000 -d 127.0.0.1:6001 \
--n worker-name --ponythreads=1
+  -o 127.0.0.1:7002 -m 127.0.0.1:8000 -c 127.0.0.1:6000 -d 127.0.0.1:6001 \
+  -n worker-name --ponythreads=1
 ```
 
 In a third shell, send some messages

--- a/book/examples/python/market_spread/README.md
+++ b/book/examples/python/market_spread/README.md
@@ -22,8 +22,8 @@ Run `machida` with `--application-module market_spread`:
 
 ```bash
 machida --application-module market_spread \
--i 127.0.0.1:7010,127.0.0.1:7011 -o 127.0.0.1:7002 -m 127.0.0.1:8000 \
--c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker-name --ponythreads=1
+  -i 127.0.0.1:7010,127.0.0.1:7011 -o 127.0.0.1:7002 -m 127.0.0.1:8000 \
+  -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker-name --ponythreads=1
 ```
 
 Send some market data messages

--- a/book/examples/python/reverse/README.md
+++ b/book/examples/python/reverse/README.md
@@ -25,9 +25,9 @@ export PATH="$PATH:../../../../machida/build"
 Run `machida` with `--application-module reverse`:
 
 ```bash
-machida -i 127.0.0.1:7010 -o 127.0.0.1:7002 -m 127.0.0.1:8000 \
--c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker-name --ponythreads=1 \
---application-module reverse
+machida --application-module reverse -i 127.0.0.1:7010 -o 127.0.0.1:7002 \
+  -m 127.0.0.1:8000 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker-name \
+  --ponythreads=1
 ```
 
 In a third shell, send some messages:

--- a/book/examples/python/sequence/README.md
+++ b/book/examples/python/sequence/README.md
@@ -26,9 +26,9 @@ export PATH="$PATH:../../../../machida/build"
 Run `machida` with `--application-module sequence`:
 
 ```bash
-machida -i 127.0.0.1:7010 -o 127.0.0.1:7002 -m 127.0.0.1:8000 \
--c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker-name --ponythreads=1 \
---application-module sequence
+machida --application-module sequence -i 127.0.0.1:7010 -o 127.0.0.1:7002 \
+  -m 127.0.0.1:8000 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker-name \
+  --ponythreads=1
 ```
 
 In a third shell, send some messages:

--- a/book/examples/python/sequence_partitioned/README.md
+++ b/book/examples/python/sequence_partitioned/README.md
@@ -44,9 +44,9 @@ export PATH="$PATH:../../../../machida/build"
 Run `machida` with `--application-module sequence`:
 
 ```bash
-machida -i 127.0.0.1:7010 -o 127.0.0.1:7002 -m 127.0.0.1:8000 \
--c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker-name --ponythreads=1 \
---application-module sequence
+machida --application-module sequence_partitioned -i 127.0.0.1:7010 \
+  -o 127.0.0.1:7002 -m 127.0.0.1:8000 -c 127.0.0.1:6000 -d 127.0.0.1:6001 \
+  -n worker-name --ponythreads=1
 ```
 
 In a third shell, send some messages:


### PR DESCRIPTION
Currently, it appears that Machida requires the --application-module
option to be the first command line option.