### PR TITLE
Run examples metrics on same port as Docker image

### DIFF
--- a/book/examples/python/alphabet/README.md
+++ b/book/examples/python/alphabet/README.md
@@ -28,7 +28,7 @@ Run `machida` with `--application-module alphabet`.
 
 ```bash
 machida --application-module alphabet -i 127.0.0.1:7010 -o 127.0.0.1:7002 \
-  -m 127.0.0.1:8000 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker-name \
+  -m 127.0.0.1:5001 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker-name \
   --ponythreads=1
 ```
 

--- a/book/examples/python/alphabet_partitioned/README.md
+++ b/book/examples/python/alphabet_partitioned/README.md
@@ -27,7 +27,7 @@ Run `machida` with `--application-module alphabet_partitioned`.
 
 ```bash
 machida --application-module alphabet_partitioned -i 127.0.0.1:7010 \
-  -o 127.0.0.1:7002 -m 127.0.0.1:8000 -c 127.0.0.1:6000 -d 127.0.0.1:6001 \
+  -o 127.0.0.1:7002 -m 127.0.0.1:5001 -c 127.0.0.1:6000 -d 127.0.0.1:6001 \
   -n worker-name --ponythreads=1
 ```
 

--- a/book/examples/python/market_spread/README.md
+++ b/book/examples/python/market_spread/README.md
@@ -28,7 +28,7 @@ Run `machida` with `--application-module market_spread`:
 
 ```bash
 machida --application-module market_spread \
-  -i 127.0.0.1:7010,127.0.0.1:7011 -o 127.0.0.1:7002 -m 127.0.0.1:8000 \
+  -i 127.0.0.1:7010,127.0.0.1:7011 -o 127.0.0.1:7002 -m 127.0.0.1:5001 \
   -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker-name --ponythreads=1
 ```
 

--- a/book/examples/python/reverse/README.md
+++ b/book/examples/python/reverse/README.md
@@ -32,7 +32,7 @@ Run `machida` with `--application-module reverse`:
 
 ```bash
 machida --application-module reverse -i 127.0.0.1:7010 -o 127.0.0.1:7002 \
-  -m 127.0.0.1:8000 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker-name \
+  -m 127.0.0.1:5001 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker-name \
   --ponythreads=1
 ```
 

--- a/book/examples/python/sequence/README.md
+++ b/book/examples/python/sequence/README.md
@@ -33,7 +33,7 @@ Run `machida` with `--application-module sequence`:
 
 ```bash
 machida --application-module sequence -i 127.0.0.1:7010 -o 127.0.0.1:7002 \
-  -m 127.0.0.1:8000 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker-name \
+  -m 127.0.0.1:5001 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker-name \
   --ponythreads=1
 ```
 

--- a/book/examples/python/sequence_partitioned/README.md
+++ b/book/examples/python/sequence_partitioned/README.md
@@ -51,7 +51,7 @@ Run `machida` with `--application-module sequence`:
 
 ```bash
 machida --application-module sequence_partitioned -i 127.0.0.1:7010 \
-  -o 127.0.0.1:7002 -m 127.0.0.1:8000 -c 127.0.0.1:6000 -d 127.0.0.1:6001 \
+  -o 127.0.0.1:7002 -m 127.0.0.1:5001 -c 127.0.0.1:6000 -d 127.0.0.1:6001 \
   -n worker-name --ponythreads=1
 ```
 


### PR DESCRIPTION
The docker image metrics UI is setup to listen on 5001, our examples
were broadcasting on 8000. Not a great mismatch.