### PR TITLE
Add CLI docs and Output Decoding docs

### DIFF
--- a/book/appendix/decoding-giles-receiver-output.md
+++ b/book/appendix/decoding-giles-receiver-output.md
@@ -1,0 +1,115 @@
+# Decoding `giles/receiver` Output
+
+Since Giles-Receiver is designed to be a fast sink receiver, it doesn't decode the data it receives from Wallaroo, but instead saves as frame encoded binary data.
+As the obvious next step is for a user to want to consume this data, we also provide [Fallor](https://github.com/Sendence/wallaroo/fallor) to decode this data.
+
+## Fallor Command-Line Options
+
+Fallor takes the following arguments:
+
+```bash
+PARAMETERS:
+-------------------------------------------------------------------------------
+--input/-i [Sets file to read from (default: received.txt)]
+--output/-o [Sets file to write to (default: fallor-readable.txt)]
+-------------------------------------------------------------------------------
+```
+
+## Decoded Structure
+
+Giles receiver stores data as frame-encoded tuples of (_received timestamp_, _binary blob_). As `fallor` decodes the file, it saves each decoded tuple in a new line, with the _received timestamp_, followed by a comma, a space, and the data received by giles-receiver--unchanged.
+If the data received by giles-receiver was text, then it will show as text. However, if it the data is anything other than text, then that data will show as a binary blob, which may or may not be readable as text.
+
+The next section describes how to create your own encoder if your application's output data is not text.
+
+## Binary Data
+
+If your application is sending binary encoded data from its sink, then even after decoding the receiver's output file, that data will still remain a binary data.
+
+In order to decode that data, you will need to build your own decoder.
+
+There are two ways to go about this:
+
+1. Use `fallor` to decode the receiver's output file, and then consume the file as text, splitting on the first comma, and treating the remainder of the line as binary data. This method only works if your binary data is guaranteed to not contain any new lines, however.
+2. Write a custom decoder to for the `giles-receiver` output file your application generated.
+
+### Writing a Custom Output File Decoder
+
+If you need to write a custom file decoder for the giles-receiver output file, then may want to refer to the [Giles-receiver output encoding](/book/wallaroo-tools/giles-receiver.md#output-file-encoding) section.
+
+### Template Custom Output File Decoder in Python
+
+A Python template for a custom output file decoder is provided below. It requires `click` to be installed (`sudo pip install click`), but if you don't need a CLI, you can forego this requirement.
+
+In this example, [struct.unpack](https://docs.python.org/2/library/struct.html#struct.unpack) is used in conjunction with a user-defined unpacking specification.
+In addition, the user may also determine if the `msg_length` included by `giles/receiver` should be used when unpacking the application's binary blob.
+
+For example, if the binary data is a variable length string, then `--format '>{}s' --size-dependent` will tell the decoder to decode is a string.
+If, instead, the binary data is a list of 32-bit signed integers, then the user will need to override (in the code) the `fmt_function` provided.
+A replacement function could be
+
+```python
+def format_function(size):
+    # Divide size by 4 to get number of integers in the list
+    return '>{}I'.format(size/4)
+
+# run decode_file with the new format_function
+decode_file(format_function, f_in, f_out)
+```
+
+The complete template is:
+
+```python
+
+# decoder.py
+
+import click
+import struct
+import sys
+
+
+def decode_msg(fmt, msg_data):
+    return struct.unpack(fmt, msg_data)
+
+
+LENGTH_WITH_TIMESTAMP_FMT = '>LQ'
+LENGTH_WITH_TIMESTAMP_LENGTH = 12
+def decode_file(fmt_function, f_in, f_out):
+    # get file length
+    f_in.seek(0,2)
+    total_size = f_in.tell()
+    f_in.seek(0,0)
+
+    # start reading
+    while total_size > 0:
+        msg_len, ts = struct.unpack(LENGTH_WITH_TIMESTAMP_FMT, f_in.read(12))
+        total_size -= (12 + msg_len)
+        msg = struct.unpack(fmt_function(msg_len), f_in.read(msg_len))[0]
+        f_out.write(", ".join((str(ts), msg)))
+        f_out.write("\n")
+
+
+@click.command()
+@click.option('--input', '-i', 'input_path', nargs=1, required=True, type=str,
+              help='Path of file to open for decoding')
+@click.option('--output', '-o', 'output_path', nargs=1, required=True, type=str,
+              help='Path of file to open for writing output')
+@click.option('--format', '-f', 'fmt', nargs=1, required=True, type=str,
+              help='format string to provide struct.unpack')
+@click.option('--size-dependent', '-s', 'size_dependent', is_flag=True, default=False,
+              help='Recompute format for message size')
+def decode_cli(input_path, output_path, fmt, size_dependent):
+    with open(output_path, 'wb') as f_out:
+        with open(input_path, 'rb') as f_in:
+            if size_dependent:
+                # If you have multiple size-dependent arguments, replace this
+                # function with your own custom one!
+                fmt_function = lambda s: fmt.format(s)
+            else:
+                fmt_function = lambda s: fmt
+            decode_file(fmt_function, f_in, f_out)
+
+
+if __name__ == '__main__':
+    decode_cli()
+```

--- a/book/appendix/giles-receiver-command-line-options.md
+++ b/book/appendix/giles-receiver-command-line-options.md
@@ -1,0 +1,41 @@
+# `giles/receiver` Command Line Options
+
+`giles/receiver` takes several command line arguments, below are a list with accompanying notes:
+
+* `--listen/-l` address to listen on for incoming data from Wallaroo. Must be given in the `127.0.0.1:5555` format.
+* `--no-write/-w` flag to drop receive and drop incoming data.
+* `--phone-home/-p` Dagon address. Must be provided in the `127.0.0.1:8082` format. This is only used when `giles/receiver` is run by Dagon.
+* `--name/-n` Name to register itself with to Dagon. This is only used when `giles/receiver` is run by Dagon.
+
+
+You may find more information about `giles/receiver` in the [wallaroo-tools/giles-receiver](/book/wallaroo-tools/giles-receiver.md) section.
+
+## Examples
+
+### Listen for Wallaroo output and save to `received.txt`
+
+```bash
+receiver --listen 127.0.0.1:5555
+```
+
+### Listen for Wallaroo output, but don't save anything (e.g. "A Very Fast Sink Receiver")
+
+If you just want your application to run as fast as possible without spending any resources on _saving output data_, use
+
+```bash
+receiver --listen 127.0.0.1:5555 --no-write
+```
+
+## Pony Runtime Options
+
+The following pony runtime parameters may also be useful in some situations
+
+* `--ponythreads` limits the number of threads the pony runtime will use.
+* `--ponynoblock`
+* `--ponypinasio`
+
+A common usecase is limiting `giles/receiver` to one thread, noblock, and pinning asio:
+
+```bash
+receiver --listen 127.0.0.1:5555 --ponythreads=1 --ponynoblock --ponypinasio
+```

--- a/book/appendix/giles-sender-command-line-options.md
+++ b/book/appendix/giles-sender-command-line-options.md
@@ -1,0 +1,80 @@
+# `giles/sender` Command Line Options
+
+`giles/sender` takes several command line arguments, below is a list with accompanying notes:
+
+* `--buffy/-b` address and port combination that Wallaroo is listening on for incoming source data. Must be provided in the `127.0.0.1:8082` format.
+* `--messages/-m` number of messages to send before terminating the sender.
+* `--file/-f` a file with newline-separated entries from which to read entries to send.
+* `--batch-size/-s` specifies the number of messages sent at every interval.
+* `--interval/-i` interval at which to send a batch of messages to Wallaroo. Defaults to `5_000_000`. The value is in nanoseconds.
+* `--repeat/-r` tells the sender to repeat reading the file/s as long as necessary to send the number of messages specified by `-m`.
+* `--binary/-y` a flag to pass if the data source file is in binary format.
+* `--u64/-u` send binary-encoded U64 values, starting from offset and incrementing by 1. The first value sent is offset+1.
+* `--start-from/-v` Set the offset for use with `--u64/-u` or when `--file/-f` is not used.
+* `--variable-size/-z` a flag to pass if using binary format and the binary messages have varying lengths.
+* `--msg-size/-g` the size of the binary message in bytes.
+* `--no-write/-w` flag to stop the `sender` from writing the messages sent to file.
+* `--phone-home/-p` Dagon address. Must be provided in the `127.0.0.1:8082` format. Only used when run by Dagon.
+* `--name/-n` Name to register itself with to Dagon. Only used when run by Dagon.
+
+You may find more information about `giles/sender` in the [wallaroo-tools/giles-sender](/book/wallaroo-tools/giles-sender.md) section.
+
+## Examples
+
+### Send words from a file
+
+Each line contains a single word:
+
+```bash
+# words.txt
+hello
+world
+lorem
+ipsum
+sit
+amet
+```
+
+Use
+
+```bash
+sender --buffy 127.0.0.1:7000 --file words.txt --messages 100 --repeat
+```
+
+
+### Send a sequence of numbers, encoded as strings
+
+To send the sequence `'1', '2', '3', ..., '100'`
+
+
+Use
+
+```bash
+sender --buffy 127.0.0.1:7000 --messages 100
+```
+
+### Send a sequence of numbers, encoded as big-endian U64
+
+To send the sequence `1,2,3,...,100`
+
+Use
+
+```bash
+sender --buffy 127.0.0.1:7000 --messages 100 --u64
+```
+
+To send the sequence `101,102,...,200`
+
+Use
+
+```bash
+sender --buffy 127.0.0.1:7000 --messages 100 --u64 --start-from 100
+```
+
+## Pony Runtime Options
+
+The following pony runtime parameters may also be useful in some situations
+
+* `--ponythreads` limits the number of threads the pony runtime will use.
+* `--ponynoblock`
+* `--ponypinasio`

--- a/book/appendix/wallaroo-command-line-options.md
+++ b/book/appendix/wallaroo-command-line-options.md
@@ -21,6 +21,7 @@ When running a Wallaroo application binary, we use some of the following command
         e.g. -r /tmp/data (no trailing slash)]
       --ponythreads [Number of application threads. Used as part of a high-performance configuration.]
       --ponypinasio [Used as part of a high-performance configuration.]
+      --ponynoblock [Used as part of a high-performance configuration.]
 ```
 
 Wallaroo currently supports one input stream per pipeline. We provide comma-separated IP addresses for TCP source listeners via the `--in` parameter. Currently, the order of these addresses corresponds to the order in which pipelines are defined in your application code.
@@ -71,7 +72,7 @@ NOTE: Currently, worker 1 is automatically assigned the name "initializer" no ma
 
 ### Resilience
 
-If [resilience is turned on](/book/core-concepts/resilience.md), you can optionally specify the target directory for resilience files via the `--resilience-dir` parameter (default is `/tmp`).
+If [resilience is turned on](/book/core-concepts/resilience.md), you can optionally specify the target directory for resilience files via the `--resilience-dir/-r` parameter (default is `/tmp`).
 
 ## Performance Flags
 
@@ -84,4 +85,4 @@ argument:
 
 If you do not specify the number of `ponythreads`, the process will try to use all available cores.
 
-There's an additional performance flag `--ponypinasio` that is used as part of a high-performance configuration. Documentation on how to configure for best performance is coming soon. 
+There are additional performance flags`--ponypinasio` and `--ponynoblock` that can be used as part of a high-performance configuration. Documentation on how to configure for best performance is coming soon.

--- a/book/examples/python/alphabet/README.md
+++ b/book/examples/python/alphabet/README.md
@@ -27,8 +27,9 @@ export PATH="$PATH:../../../../machida/build"
 Run `machida` with `--application-module alphabet`.
 
 ```bash
-machida --application-module alphabet -i 127.0.0.1:7010 -o 127.0.0.1:7002 \
-  -m 127.0.0.1:5001 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker-name \
+machida --application-module alphabet --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
+  --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
+  --worker-name worker-name \
   --ponythreads=1
 ```
 
@@ -36,8 +37,8 @@ In a third shell, send some messages
 
 ```bash
 ../../../../giles/sender/sender --buffy 127.0.0.1:7010 --file votes.msg \
---batch-size 5 --interval 100_000_000 --messages 150 --binary \
---variable-size --repeat --ponythreads=1
+  --batch-size 5 --interval 100_000_000 --messages 150 --binary \
+  --variable-size --repeat --ponythreads=1
 ```
 
 The messages have a 32-bit big-endian integer that represents the message length, followed by a byte that represents the character that is being voted on, followed by a 32-bit big-endian integer that represents the number of votes received for that letter.  The output is a byte representing the character that is being voted on, followed by the total number of votes for that character. You can view the output file with a tool like `hexdump`.

--- a/book/examples/python/alphabet_partitioned/README.md
+++ b/book/examples/python/alphabet_partitioned/README.md
@@ -26,17 +26,17 @@ export PATH="$PATH:../../../../machida/build"
 Run `machida` with `--application-module alphabet_partitioned`.
 
 ```bash
-machida --application-module alphabet_partitioned -i 127.0.0.1:7010 \
-  -o 127.0.0.1:7002 -m 127.0.0.1:5001 -c 127.0.0.1:6000 -d 127.0.0.1:6001 \
-  -n worker-name --ponythreads=1
+machida --application-module alphabet_partitioned --in 127.0.0.1:7010 \
+  --out 127.0.0.1:7002 --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 \
+  --data 127.0.0.1:6001 --worker-name worker-name --ponythreads=1
 ```
 
 In a third shell, send some messages
 
 ```bash
 ../../../../giles/sender/sender --buffy 127.0.0.1:7010 --file votes.msg \
---batch-size 5 --interval 100_000_000 --messages 150 --binary \
---variable-size --repeat --ponythreads=1
+  --batch-size 5 --interval 100_000_000 --messages 150 --binary \
+  --variable-size --repeat --ponythreads=1
 ```
 
 The messages have a 32-bit big-endian integer that represents the message length, followed by a byte that represents the character that is being voted on, followed by a 32-bit big-endian integer that represents the number of votes received for that letter.  The output is a byte representing the character that is being voted on, followed by the total number of votes for that character. You can view the output file with a tool like `hexdump`.

--- a/book/examples/python/market_spread/README.md
+++ b/book/examples/python/market_spread/README.md
@@ -36,16 +36,16 @@ Send some market data messages
 
 ```bash
 ../../../../giles/sender/sender --buffy 127.0.0.1:7011 --file \
-../../../../demos/marketspread/350k-nbbo-fixish.msg --batch-size 20 \
---interval 100_000_000 --messages 1000000 --binary --repeat --ponythreads=1 -\
--msg-size 46 --no-write
+  ../../../../demos/marketspread/350k-nbbo-fixish.msg --batch-size 20 \
+  --interval 100_000_000 --messages 1000000 --binary --repeat --ponythreads=1 \
+  --msg-size 46 --no-write
 ```
 
 and some orders messages
 
 ```bash
 ../../../../giles/sender/sender --buffy 127.0.0.1:7010 --file \
-../../../../demos/marketspread/350k-orders-fixish.msg --batch-size 20 \
---interval 100_000_000 --messages 1000000 --binary --repeat --ponythreads=1 \
---msg-size 57 --no-write
+  ../../../../demos/marketspread/350k-orders-fixish.msg --batch-size 20 \
+  --interval 100_000_000 --messages 1000000 --binary --repeat --ponythreads=1 \
+  --msg-size 57 --no-write
 ```

--- a/book/examples/python/reverse/README.md
+++ b/book/examples/python/reverse/README.md
@@ -31,8 +31,9 @@ export PATH="$PATH:../../../../machida/build"
 Run `machida` with `--application-module reverse`:
 
 ```bash
-machida --application-module reverse -i 127.0.0.1:7010 -o 127.0.0.1:7002 \
-  -m 127.0.0.1:5001 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker-name \
+machida --application-module reverse --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
+  --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
+  --worker-name worker-name \
   --ponythreads=1
 ```
 

--- a/book/examples/python/sequence/README.md
+++ b/book/examples/python/sequence/README.md
@@ -32,14 +32,16 @@ export PATH="$PATH:../../../../machida/build"
 Run `machida` with `--application-module sequence`:
 
 ```bash
-machida --application-module sequence -i 127.0.0.1:7010 -o 127.0.0.1:7002 \
-  -m 127.0.0.1:5001 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker-name \
+machida --application-module sequence --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
+  --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
+  --worker-name worker-name \
   --ponythreads=1
 ```
 
 In a third shell, send some messages:
 
 ```bash
-../../../../giles/sender/sender -b 127.0.0.1:7010 -s 10 -i 100_000_000 \
---ponythreads=1 -y -g 12 -w -u -m 100
+../../../../giles/sender/sender --buffy 127.0.0.1:7010 --batch-size 10 \
+  --interval 100_000_000 --ponythreads=1 --binary --msg-size 12 --no-write \
+  --u64 --messages 100
 ```

--- a/book/examples/python/sequence_partitioned/README.md
+++ b/book/examples/python/sequence_partitioned/README.md
@@ -50,14 +50,15 @@ export PATH="$PATH:../../../../machida/build"
 Run `machida` with `--application-module sequence`:
 
 ```bash
-machida --application-module sequence_partitioned -i 127.0.0.1:7010 \
-  -o 127.0.0.1:7002 -m 127.0.0.1:5001 -c 127.0.0.1:6000 -d 127.0.0.1:6001 \
-  -n worker-name --ponythreads=1
+machida --application-module sequence_partitioned --in 127.0.0.1:7010 \
+  --out 127.0.0.1:7002 --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 \
+  --data 127.0.0.1:6001 --worker-name worker-name --ponythreads=1
 ```
 
 In a third shell, send some messages:
 
 ```bash
-../../../../giles/sender/sender -b 127.0.0.1:7010 -s 10 -i 100_000_000 \
---ponythreads=1 -y -g 12 -w -u -m 100
+../../../../giles/sender/sender --buffy 127.0.0.1:7010 --batch-size 10 \
+  --interval 100_000_000 --ponythreads=1 --binary --msg-size 12 --no-write \
+  --u64 --messages 100
 ```

--- a/book/python/building.md
+++ b/book/python/building.md
@@ -107,3 +107,5 @@ If you would like to skip this step in the future, you can replace the relative 
 To try running an example, go to [the Reverse example application](https://github.com/Sendence/wallaroo/tree/master/book/examples/python/reverse/) and follow its [instructions](/book/examples/python/reverse/README.md).
 
 To learn how to write your own Wallaroo Python application, continue to [Writing Your Own Application](writing-your-own-application.md)
+
+To read about the Machida command line arguments, refer to [Appendix: Wallaroo Command-Line Options](/book/appendix/wallaroo-command-line-options.md).

--- a/book/python/intro.md
+++ b/book/python/intro.md
@@ -11,3 +11,5 @@ To set up your environment for writing and running Wallaroo Python application, 
 To learn how to write your own application, refer to [Writing Your Own Application](writing-your-own-application.md).
 
 To read about the structure and requirements of each API class, refer to [Wallaroo Python API Classes](api.md).
+
+To read about the command-line arguments Wallaroo takes, refer to [Appendix: Wallaroo Command-Line Options](/book/appendix/wallaroo-command-line-options.md).

--- a/book/wallaroo-tools/giles-sender.md
+++ b/book/wallaroo-tools/giles-sender.md
@@ -9,7 +9,7 @@ Giles components act as external testers for Wallaroo. Giles Sender is used to m
 - With a file name given as the `--file/-f` argument and binary format specified with `--binary/-y` and every message is 24 bytes, specified with `--msg-size/-g`, it will send every 24 bytes of the given file as a message. For example, `./giles/sender -b 127.0.0.1:8081 -m 100 -f binary-data-file.txt -y -g 24` will send every 24 bytes until it has sent 100 messages
 - With a file name given as the `--file/-f` argument and binary format specified with `--binary/-y` and variable message lengths specified with `--variable-size/-z`, it will read 4 bytes to get the message size, send that message and repeat. For example, `./giles/sender  127.0.0.1:8081 -m 100 -f binary-data-file.txt -y -z` will initially read a 4 byte header, send that message and repeat until it has sent 100 messages.
 
-### Getting Wallaroo
+### Building `giles/sender`
 
 If you do not already have the `wallaroo` repo, create a local copy:
 
@@ -17,12 +17,10 @@ If you do not already have the `wallaroo` repo, create a local copy:
 git clone https://github.com/sendence/wallaroo
 ```
 
-## Compiling
-
-To compile the `giles-sender` binary:
+Compile the `giles-sender` binary:
 
 ```bash
-cd wallaroo
+cd wallaroo/giles/sender
 stable env ponyc
 ```
 
@@ -34,9 +32,11 @@ stable env ponyc
 
 `--messages/-m` number of messages to send before terminating the sender.
 
+`--file/-f` a file with newline-separated values from which to read entries to send.
+
 `--batch-size/-s` specifies the number of messages sent at every interval.
 
-`--interval/-i` interval at which to send a batch of messages to Wallaroo. Defaults to `5_000_000`.
+`--interval/-i` interval at which to send a batch of messages to Wallaroo. Defaults to `5_000_000`. The value is in nanoseconds.
 
 `--repeat/-r` tells the sender to repeat reading the file/s as long as necessary to send the number of messages specified by `-m`.
 


### PR DESCRIPTION
- Add links  to Wallroo CLI docs in `python/intro.md` and `python/building.md`
- Update book/wallaroo-tools/giles-receiver.md notes
- Add book/appendix/decoding-giles-receiver-output.md
- Add giles-sender CLI doc
- Add notes on pony performance flags
- Use named options in example READMEs
- Indent multiline commands in READMEs
- Expand notes on custom decoders for giles output


@SeanTAllen can you expand the notes on `--ponynoblock` and `--ponypinasio` in `giles-receiver-command-line-options.md`, `giles-sender-command-line-options.md` and `wallaroo-command-line-options.md`?
I don't know how to describe them well.