### PR TITLE
Allow `--application-module=X` to appear anywhere in options

### DIFF
--- a/machida/main.pony
+++ b/machida/main.pony
@@ -11,7 +11,7 @@ use "lib:python-wallaroo"
 
 actor Main
   fun find_python_module(args: Array[String] val): String ? =>
-    let options = Options(args)
+    let options = Options(args, false)
     options.add("application-module", "", StringArgument)
 
     var module_name: (None | String) = None


### PR DESCRIPTION
The `--application-module=X` option should be able to appear anywhere in
the command line arguments given to the application.

The option parser has a constructor argument that can be set to
`false` to tell the parser to *not* treat unknown options as fatal
errors. If this option is not set then unknown options *are* treated
as fatal errors and the parser will stop return options once it
encounters such an option.

Prior to this commit, the parser that looked for the
`--application-module=X` option was not setting the argument to false,
so it if `--appplication-module=X` appeared anywhere besides the first
argument then it would encounter an unknown (to it) argument and stop
returning options.

This commit now sets the argument to false, so the parser skips
options that it does not know about.

Fixes #756

[skip ci]