### PR TITLE
Add cross-references and intros in python API.

### DIFF
--- a/book/examples/python/alphabet/README.md
+++ b/book/examples/python/alphabet/README.md
@@ -1,5 +1,12 @@
 # Alphabet
 
+This is an example application that will count the number of "votes" sent for
+each letter of the alphabet.
+
+You will need a working [Wallaroo Python API](/book/python/intro.md).
+
+## Running Alphabet
+
 In a shell, start up the Metrics UI if you don't already have it running:
 
 ```bash

--- a/book/examples/python/alphabet_partitioned/README.md
+++ b/book/examples/python/alphabet_partitioned/README.md
@@ -1,4 +1,11 @@
-# Alphabet Partioned
+# Alphabet Partitioned
+
+This is an example application that will count the number of "votes" sent for
+each letter of the alphabet, using paritioning.
+
+You will need a working [Wallaroo Python API](/book/python/intro.md).
+
+## Running Alphabet Partitioned
 
 In a shell, start up the Metrics UI if you don't already have it running:
 

--- a/book/examples/python/market_spread/README.md
+++ b/book/examples/python/market_spread/README.md
@@ -1,5 +1,19 @@
 # Market Spread
 
+Market Spread is an application designed to run alongside a trading system. Its goal is to monitor market data for irregularities around different symbols and potentially withdraw some trades that have been sent to market should certain anomalies occur. 
+
+When we break the application down into its key components we get:
+
+- A stream of market data, aka “NBBO Stream”
+- A stream of trades, aka “Order Stream”
+- State in the form of latest market conditions for various symbols
+- A calculation to possibly withdraw the trade based on state for that symbol
+
+You can read more about Market Spread in [What is Wallaroo](/book/getting-started/what-is-wallaroo.md)
+You will need a working [Wallaroo Python API](/book/python/intro.md).
+
+## Running Market Spread
+
 In a shell, start up the Metrics UI if you don't already have it running:
 
 ```bash

--- a/book/examples/python/reverse/README.md
+++ b/book/examples/python/reverse/README.md
@@ -1,6 +1,9 @@
 # Reverse
 
-The reverse application receives strings as input and outputs the reversed strings.
+This is an example application that receives strings as input and outputs the
+reversed strings.
+
+You will need a working [Wallaroo Python API](/book/python/intro.md).
 
 ## Running Reverse
 

--- a/book/examples/python/sequence/README.md
+++ b/book/examples/python/sequence/README.md
@@ -3,6 +3,8 @@
 Sequence window is a simple application that holds state in the form of a ring buffer.
 It receives integers from the natural sequence {1,2,3,4,...,n} as its input, and outputs a window of the last 4 values it has seen, in the order they were seen as a list, with the left-most value being the oldest.
 
+You will need a working [Wallaroo Python API](/book/python/intro.md).
+
 ## Running Sequence
 
 In a shell, start up the Metrics UI if you don't already have it running:

--- a/book/examples/python/sequence_partitioned/README.md
+++ b/book/examples/python/sequence_partitioned/README.md
@@ -3,6 +3,8 @@
 As with [Sequence window](/book/examples/python/sequence/), Sequence Window - Partitioned is a simple application that holds state in the form of a ring buffer.
 It receives integers from the natural sequence {1,2,3,4,...,n} as its input, and outputs a window of the last 4 values it has seen, in the order they were seen as a list, with the left-most value being the oldest.
 
+You will need a working [Wallaroo Python API](/book/python/intro.md).
+
 In the partitioned version of this application, states are partitioned using a modulo 2 operation
 
 ```python

--- a/machida/README.md
+++ b/machida/README.md
@@ -8,6 +8,9 @@ Machida is a Wallaroo-Python Runtime that enables a Wallaroo application to be w
 - sendence-ponyc
 - giles-sender
 
+You will also need your environment to be [set up with a working
+Wallaroo](/book/getting-started/setup.md).
+
 ## Build
 
 Create the `build` directory if it doesn't already exist.


### PR DESCRIPTION
A lot of the python docs and examples lack context and some pre-requisites
statements (e.g.  needing to have a working Wallaroo).