### PR TITLE
Add Machida overview to python/intro.md [skip-ci]

### DIFF
--- a/book/core-concepts/core-concepts.md
+++ b/book/core-concepts/core-concepts.md
@@ -16,42 +16,54 @@ A Wallaroo application can have multiple interacting pipelines. For example, an 
 
 ## Concepts
 
-**State**
+### State
+
 : Accumulated result of data stored over the course of time
 
-**Computation**
+### Computation
+
 : Code that transforms an input of some type `In` to
 an output of some type `Out` (or optionally `None` if the input should be
 filtered out).
 
-**State Computation**
+### State Computation
+
 : Code that takes an input type `In` and a state
 object of some type `State`, operates on that input and state (possibly
 making state updates), and optionally producing an output of some type `Out`.
 
-**Source**
+### Source
+
 : Input point for data from external systems into an application.
 
-**Sink**
+### Sink
+
 : Output point from an application to external systems.
 
-**Decoder**
+### Decoder
+
 : Code that transforms a stream of bytes from an external system
 into a series of application input types.
 
-**Encoder**
+### Encoder
+
 : Code that transforms an application output type into bytes for
 sending to an external system.
 
-**Pipeline**
+### Pipeline
+
 : A sequence of computations and/or state computations originating
 from a source and optionally terminating in a sink.
 
-**Application**
+### Application
+
 : A collection of pipelines.
 
-**Topology**
+### Topology
+
 : A graph of how all sources, sinks, and computations are
 connected within an application.
 
-Wallaroo provides APIs for implementing all of these concepts.
+### API
+
+Wallaroo provides APIs for implementing all of the above concepts.

--- a/book/python/intro.md
+++ b/book/python/intro.md
@@ -6,6 +6,12 @@ In order to write a Wallaroo application in Python, the developer creates classe
 
 For a basic overview of what Wallaroo does, read [What is Wallaroo](/book/what-is-wallaroo.md) and [Core Concepts](/book/core-concepts/intro.md). These documents will help you understand the system at a high level so that you can see how the pieces of the Python API fit into it.
 
+## Machida
+
+Machida is the program that runs Wallaroo applications written using the Wallaroo Python API. It takes a `.py` file as its `--application-module` argument and requires a method called `application_setup(...)` to be defined in it. This method returns the structure describing the Wallaroo application in terms of Python objects, which is then used to coordinate calling those objects’ methods with the appropriate arguments as the application is running.
+
+## Next Steps
+
 To set up your environment for writing and running Wallaroo Python application, refer to [Building a Python Application](building.md).
 
 To learn how to write your own application, refer to [Writing Your Own Application](writing-your-own-application.md).

--- a/book/python/writing-your-own-partitioned-stateful-application.md
+++ b/book/python/writing-your-own-partitioned-stateful-application.md
@@ -19,19 +19,22 @@ Our partitioned application is going to be very similar to the Alphabet applicat
 ### Partition
 
 If we were to use partitioning in the alphabet application from the previous section, and we wanted to partition by key, then one way we could go about it is:
-The partition key list:
+
+Create a partition key list:
 
 ```python
 letter_partitions = list(string.ascii_lowercase)
 ```
 
-And the partitioning function:
+And then a partitioning function which returns a key from the above list for input data:
 
 ```python
 class LetterPartitionFunction(object):
     def partition(self, data):
         return data.letter[0]
 ```
+
+Later when we build the application topology, we will pass both the keys and the function to the builder.
 
 ### State and StateBuilder
 


### PR DESCRIPTION
- Add `Wallaroo Overview` and `Machida Overview` sections to `book/python/intro.md`
- Change core-concepts from **bold** to ### headers so they can be linked to


Par of https://github.com/Sendence/wallaroo/issues/777