### PR TITLE
Fix book issues #1

### DIFF
--- a/book/getting-started/linux-setup.md
+++ b/book/getting-started/linux-setup.md
@@ -14,17 +14,7 @@ sudo apt-get install git
 
 ## Install LLVM 3.9
 
-Visit [http://apt.llvm.org](http://apt.llvm.org) and select the correct apt mirror for you version of Ubuntu. 
-
-### Trusty Ubuntu: Add the LLVM apt repos to /etc/apt/sources.list
-
-Open `/etc/apt/sources.list` and add the following lines to the end of
-the file:
-
-```
-deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main
-deb-src http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main
-```
+Visit [http://apt.llvm.org](http://apt.llvm.org) and select the correct apt mirror for you version of Ubuntu.
 
 ### Xenial Ubuntu: Add the LLVM apt repos to /etc/apt/sources.list
 
@@ -34,6 +24,16 @@ the file:
 ```
 deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-3.9 main
 deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-3.9 main
+```
+
+### Trusty Ubuntu: Add the LLVM apt repos to /etc/apt/sources.list
+
+Open `/etc/apt/sources.list` and add the following lines to the end of
+the file:
+
+```
+deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main
+deb-src http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main
 ```
 
 ### Add the LLVM repo as a trusted source
@@ -51,7 +51,14 @@ sudo apt-get update
 sudo apt-get install -y llvm-3.9
 ```
 
-## Install GCC 5
+## Install Pony compiler dependencies
+
+```bash
+sudo apt-get install -y build-essential zlib1g-dev \
+  libncurses5-dev libssl-dev
+```
+
+### Install GCC 5 or Higher
 
 You'll need to be using at least `gcc-5`. We rely on its atomics support. If you have at least `gcc-5` installed on your machine, you don't need to do anything. If you have gcc 4 or lower, you'll need to upgrade. You can check you `gcc` version by running:
 
@@ -79,19 +86,6 @@ sudo update-alternatives --install /usr/bin/gcc gcc \
   /usr/bin/gcc-5 60 --slave /usr/bin/g++ g++ /usr/bin/g++-5
 ```
 
-## Make sure apt is up to date
-
-```bash
-sudo apt-get update
-```
-
-## Install Pony compiler dependencies
-
-```bash
-sudo apt-get install -y build-essential git zlib1g-dev \
-  libncurses5-dev libssl-dev
-```
-
 ### Install prce2
 
 #### Xenial Ubuntu:
@@ -110,7 +104,7 @@ install from source like this:
 ```bash
 cd ~/
 wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2
-tar xvf pcre2-10.21.tar.bz2
+tar xjvf pcre2-10.21.tar.bz2
 cd pcre2-10.21
 ./configure --prefix=/usr
 make
@@ -123,9 +117,9 @@ Now you need to install the Sendence fork of the Pony compiler `ponyc`. Run:
 
 ```bash
 cd ~/
-git clone https://github.com/sendence/ponyc
-cd ponyc
-git checkout sendence-19.2.8
+wget https://github.com/Sendence/ponyc/archive/sendence-19.2.8.tar.gz
+tar xzfv sendence-19.2.8.tar.gz
+cd ponyc-sendence-19.2.8
 sudo make config=release install
 ```
 
@@ -178,6 +172,7 @@ cloned the Wallaroo repo, do so now:
 
 ```bash
 git clone https://github.com/sendence/wallaroo
+cd wallaroo
 git checkout 0.0.1-rc6
 ```
 

--- a/book/python/building.md
+++ b/book/python/building.md
@@ -7,26 +7,19 @@ You should have already completed the [setup instructions](/book/getting-started
 ### Requirements
 
 * git
-* clang >=3.5
+* clang >=3.5 (on MacOS) or gcc >=5 (on Linux)
 * python development libraries
 * Sendence Pony compiler
 * Wallaroo Python API
 * Giles Sender
 
-#### clang
+#### clang (MacOS)
 
-* On MacOS: you should already have as part of `XCode`. No further steps are needed.
+* You should already have `clang` as part of `XCode`. No further steps are needed.
 
-* on Ubuntu Trusty
-  ```bash
-  sudo apt-get install clang-3.5
-  sudo ln -s /usr/bin/clang-3.5 /usr/bin/clang
-  ```
+#### gcc (Linux)
 
-* on Ubuntu Xenial
-  ```bash
-  sudo apt-get install clang
-  ```
+* You should already have `gcc` after completing the [Wallaro Linux Setup](/book/getting-started/linux-setup.md).
 
 #### Python-dev
 
@@ -35,7 +28,7 @@ You should have already completed the [setup instructions](/book/getting-started
 * On Ubuntu:
 
   ```bash
-  sudo apt-get install python-dev
+  sudo apt-get install -y python-dev
   ```
 
 #### Giles sender
@@ -63,8 +56,18 @@ mkdir build
 
 Build the `machida` binary
 
+**On MacOS**:
+
 ```bash
 clang -g -o build/python-wallaroo.o -c cpp/python-wallaroo.c
+ar rvs build/libpython-wallaroo.a build/python-wallaroo.o
+ponyc --debug --output=build --path=build --path=../lib/ .
+```
+
+** On Linux**:
+
+```bash
+gcc -g -o build/python-wallaroo.o -c cpp/python-wallaroo.c
 ar rvs build/libpython-wallaroo.a build/python-wallaroo.o
 ponyc --debug --output=build --path=build --path=../lib/ .
 ```

--- a/machida/README.md
+++ b/machida/README.md
@@ -3,7 +3,7 @@
 Machida is a Wallaroo-Python Runtime that enables a Wallaroo application to be written in Python.
 
 ## Requirements
-- clang
+- clang >=3.5 on MacOS or gcc >=5 on Linux
 - python-dev
 - sendence-ponyc
 - giles-sender
@@ -21,8 +21,18 @@ mkdir build
 
 Build the program.
 
-```
+**On MacOS**:
+
+```bash
 clang -g -o build/python-wallaroo.o -c cpp/python-wallaroo.c
+ar rvs build/libpython-wallaroo.a build/python-wallaroo.o
+ponyc --debug --output=build --path=build --path=../lib/ .
+```
+
+**On Linux**:
+
+```bash
+gcc -g -o build/python-wallaroo.o -c cpp/python-wallaroo.c
 ar rvs build/libpython-wallaroo.a build/python-wallaroo.o
 ponyc --debug --output=build --path=build --path=../lib/ .
 ```

--- a/machida/main.pony
+++ b/machida/main.pony
@@ -1,6 +1,5 @@
 use "collections"
 use "options"
-use "debug"
 
 use "wallaroo"
 use "wallaroo/tcp_source"


### PR DESCRIPTION
- Remove unnecessary printfs/Debugs
- Split build instructions for gcc/clang
- Make order of split instructions (MacOS, Ubuntu Xenial, Ubuntu Trusty) consistent.
- Correct tar command for bzip (`xvjf` instead of `xvzf`)
- Reorder build-essential and gcc instructions to avoid the build-essential installation on Ubuntu 14.04 overriding the default gcc we set during the gcc-5 installation instructions.
- add -y to python-dev installation command
- Use tar.gz for sendence/ponyc install instructions (instead of git clone)


closes #762 