### PR TITLE
Book fixes 3

### DIFF
--- a/book/examples/python/README.md
+++ b/book/examples/python/README.md
@@ -1,0 +1,25 @@
+# Wallaroo Python Examples
+
+In this section you will find the complete examples from the [Wallaroo Python](/book/python/intro.md) section, as well as some additional examples. Each example includes a README describing its purpose and how to set it up and run it.
+
+To get set up for running examples, if you haven't already, refer to [Building a Python application](/book/python/building.md).
+
+## Examples by Category
+
+### Simple Stateless Applications
+
+- [reverse](reverse/): a string reversing stream application.
+- [celsius](celsius/): a Celsius-to-Fahrenheit stream application.
+
+### Simple Stateful Applications
+
+- [alphabet](alphabet/): a vote counting stream application.
+- [sequence](sequence/): a stream application designed to demonstrate and test state management and state recovery. It keeps a window of the last 4 values it has seen as its state.
+
+### Partitioned Stateful Applicatins
+
+- [alphabet_partitioned](alphabet_partitioned/): a vote counting stream application using partitioning.
+- [market_spread](market_spread/): a stream application that keeps a state for market data and checks trade orders against it in real time. This application uses state, partitioning, and two pipelines, each with its own source.
+- [sequence_partitioned](sequence_partitioned/): a stream application designed to demonstrate and test state management and recovery. It keeps a window of the last 4 values seen as its state, partitioned modulo 2.
+
+

--- a/book/examples/python/alphabet/README.md
+++ b/book/examples/python/alphabet/README.md
@@ -44,8 +44,26 @@ In a third shell, send some messages
 
 ```bash
 ../../../../giles/sender/sender --buffy 127.0.0.1:7010 --file votes.msg \
-  --batch-size 5 --interval 100_000_000 --messages 150 --binary \
-  --variable-size --repeat --ponythreads=1
+  --batch-size 50 --interval 10_000_000 --messages 1000000 --binary \
+  --msg-size 9 --repeat --ponythreads=1
 ```
 
 The messages have a 32-bit big-endian integer that represents the message length, followed by a byte that represents the character that is being voted on, followed by a 32-bit big-endian integer that represents the number of votes received for that letter.  The output is a byte representing the character that is being voted on, followed by the total number of votes for that character. You can view the output file with a tool like `hexdump`.
+
+## Reading the Output
+
+The output is binary data, formatted as a 4-byte message length header, followed by a character, followed by 4 byte 32-bit uint.
+
+You can read it with the following code stub:
+
+```python
+import struct
+
+
+with open('alphabet.out', 'rb') as f:
+    while True:
+        try:
+            print struct.unpack('>LsL', f.read(9))
+        except:
+            break
+```

--- a/book/examples/python/alphabet/alphabet.py
+++ b/book/examples/python/alphabet/alphabet.py
@@ -45,10 +45,10 @@ class Decoder(object):
         return 4
 
     def payload_length(self, bs):
-        return struct.unpack(">I", bs)[0]
+        return struct.unpack(">L", bs)[0]
 
     def decode(self, bs):
-        (letter, vote_count) = struct.unpack(">1sI", bs)
+        (letter, vote_count) = struct.unpack(">sL", bs)
         return Votes(letter, vote_count)
 
 
@@ -64,4 +64,4 @@ class AddVotes(object):
 class Encoder(object):
     def encode(self, data):
         # data is a Votes
-        return struct.pack(">1sI", data.letter, data.votes)
+        return struct.pack(">LsL", 5, data.letter, data.votes)

--- a/book/examples/python/alphabet_partitioned/README.md
+++ b/book/examples/python/alphabet_partitioned/README.md
@@ -42,8 +42,26 @@ In a third shell, send some messages
 
 ```bash
 ../../../../giles/sender/sender --buffy 127.0.0.1:7010 --file votes.msg \
-  --batch-size 5 --interval 100_000_000 --messages 150 --binary \
-  --variable-size --repeat --ponythreads=1
+  --batch-size 50 --interval 10_000_000 --messages 1000000 --binary \
+  --msg-size 9 --repeat --ponythreads=1
 ```
 
 The messages have a 32-bit big-endian integer that represents the message length, followed by a byte that represents the character that is being voted on, followed by a 32-bit big-endian integer that represents the number of votes received for that letter.  The output is a byte representing the character that is being voted on, followed by the total number of votes for that character. You can view the output file with a tool like `hexdump`.
+
+## Reading the Output
+
+The output is binary data, formatted as a 4-byte message length header, followed by a character, followed by 4 byte 32-bit uint.
+
+You can read it with the following code stub:
+
+```python
+import struct
+
+
+with open('alphabet.out', 'rb') as f:
+    while True:
+        try:
+            print struct.unpack('>LsL', f.read(9))
+        except:
+            break
+```

--- a/book/examples/python/celsius/.gitignore
+++ b/book/examples/python/celsius/.gitignore
@@ -1,0 +1,3 @@
+*.pyc
+celsius.out
+celsius.msg

--- a/book/examples/python/celsius/README.md
+++ b/book/examples/python/celsius/README.md
@@ -1,0 +1,81 @@
+# Celsius
+
+This is an example of a stateless application that takes a floating point Celsius value and sends out a floating point Fahrenheit value.
+
+You will need a working [Wallaroo Python API](/book/python/intro.md).
+
+## Generating Data
+
+The Celsius application takes a binary 32-bit float as its input, encoded in the [source message framing protocol](/book/appendix/writing-your-own-feed.md#source-message-framing-protocol).
+
+A data generator is bundled with the application:
+
+```bash
+cd data_gen
+python data_gen.py 1000000
+```
+
+Will generate a million messages.
+
+Return to the `celsius` app directory for the [running](#running) instructions.
+
+## Running Celsius
+
+In a shell, start up the Metrics UI if you don't already have it running:
+
+```bash
+docker start mui
+```
+
+In a shell, set up a listener:
+
+```bash
+nc -l 127.0.0.1 7002 > celsius.out
+```
+
+In another shell, export the current directory and `wallaroo.py` directories to `PYTHONPATH`:
+
+```bash
+export PYTHONPATH="$PYTHONPATH:.:../../../../machida"
+```
+
+Export the machida binary directory to `PATH`:
+
+```bash
+export PATH="$PATH:../../../../machida/build"
+```
+
+Run `machida` with `--application-module celsius`:
+
+```bash
+machida --application-module celsius --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
+  --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
+  --worker-name worker-name \
+  --ponythreads=1
+```
+
+In a third shell, send some messages:
+
+```bash
+../../../../giles/sender/sender --buffy 127.0.0.1:7010 --file data_gen/celsius.msg \
+  --batch-size 50 --interval 10_000_000 --messages 1000000 --repeat \
+  --ponythreads=1 --binary --msg-size 8
+```
+
+## Reading the Output
+
+The output is binary data, formatted as a 4-byte message length header, followed by a 4 byte 32-bit floating point value.
+
+You can read it with the following code stub:
+
+```python
+import struct
+
+
+with open('celsius.out', 'rb') as f:
+    while True:
+        try:
+            print struct.unpack('>Lf', f.read(8))
+        except:
+            break
+```

--- a/book/examples/python/celsius/celsius.py
+++ b/book/examples/python/celsius/celsius.py
@@ -1,0 +1,45 @@
+import struct
+
+import wallaroo
+
+
+def application_setup(args):
+    ab = wallaroo.ApplicationBuilder("Celsius to Fahrenheit")
+    ab.new_pipeline("convert", Decoder())
+    ab.to(Multiply)
+    ab.to(Add)
+    ab.to_sink(Encoder())
+    return ab.build()
+
+
+class Decoder(object):
+    def header_length(self):
+        return 4
+
+    def payload_length(self, bs):
+        return struct.unpack(">L", bs)[0]
+
+    def decode(self, bs):
+        return struct.unpack('>f', bs)[0]
+
+
+class Multiply(object):
+    def name(self):
+        return "multiply by 1.8"
+
+    def compute(self, data):
+        return data * 1.8
+
+
+class Add(object):
+    def name(self):
+        return "add 32"
+
+    def compute(self, data):
+        return data + 32
+
+
+class Encoder(object):
+    def encode(self, data):
+        # data is a float
+        return struct.pack('>Lf', 4, data)

--- a/book/examples/python/celsius/data_gen/.gitignore
+++ b/book/examples/python/celsius/data_gen/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+celsius.msg

--- a/book/examples/python/celsius/data_gen/data_gen.py
+++ b/book/examples/python/celsius/data_gen/data_gen.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python2
+
+import random
+import struct
+
+
+def generate_messages(num_messages):
+    with open('celsius.msg', 'wb') as f:
+        for x in xrange(num_messages):
+            f.write(struct.pack('>Lf', 4, random.randrange(10000, _int=float)))
+
+
+if __name__ == '__main__':
+    import sys
+    try:
+        num_messages = int(sys.argv[1])
+        generate_messages(num_messages)
+    except:
+        raise

--- a/book/getting-started/run-a-application.md
+++ b/book/getting-started/run-a-application.md
@@ -89,6 +89,25 @@ This tells Wallaroo that it should listen on port 7000 for incoming data, write 
 
 ## Let's Get Some Data: Running Giles Sender
 
+### Generating Some Data
+
+A data generator is bundled with the application. It needs to be built:
+
+```bash
+cd data_gen
+ponyc
+```
+
+Then you can generate a file with a fixed number of psuedo-random votes:
+
+```
+./data_gen --messages 10000
+```
+
+This will create a `celsius.msg` file in your current working directory.
+
+### Sending Data
+
 Giles Sender is used to mimic the behavior of an incoming data source.
 
 Open a new terminal and run the following to compile the sender:
@@ -103,9 +122,9 @@ This will create a binary called `sender`
 You will now be able to start the `sender` with the following command:
 
 ```bash
-./sender -b 127.0.0.1:7000 -m 10000000 -y -s 300 \
--f ~/wallaroo-tutorial/wallaroo/book/examples/celsius/generator/celsius.msg \
--r -w -g 8 --ponythreads=1
+./sender -b 127.0.0.1:7000 -m 100000 -y -s 300 \
+  -f ~/wallaroo-tutorial/wallaroo/book/examples/celsius/data_gen/celsius.msg \
+  -r -w -g 8 --ponythreads=1
 ```
 
 If the sender is working correctly, you should see `Connected` printed to the screen. If you see that, you can be assured that we are now sending data into our example application.

--- a/book/python/intro.md
+++ b/book/python/intro.md
@@ -19,3 +19,5 @@ To learn how to write your own application, refer to [Writing Your Own Applicati
 To read about the structure and requirements of each API class, refer to [Wallaroo Python API Classes](api.md).
 
 To read about the command-line arguments Wallaroo takes, refer to [Appendix: Wallaroo Command-Line Options](/book/appendix/wallaroo-command-line-options.md).
+
+To browse complete examples, go to [Wallaroo Python Examples](/book/examples/python).


### PR DESCRIPTION
- Update run-a-application instructions
- Add README to examples/python
- Add Celsius python example + data generator
- Change decoder/encoder in python examples to use unsigned longs rather than signed (we don't send signed values currently, so it's incorrect to read them as signed)
- Make alphabet and celsius output encoders giles-receiver compatible (prepend U32 message length to output)
- Add a python code stub to the end of celsius, alphabet, and alphabet_partitioned READMEs showing readers how to read the output file.
- Add ref to examples in /book/python/intro.md

closes #763 