### PR TITLE
Add support for initializer recovery

### DIFF
--- a/lib/wallaroo/data_channel/data_channel_tcp.pony
+++ b/lib/wallaroo/data_channel/data_channel_tcp.pony
@@ -71,7 +71,7 @@ class DataChannelListenNotifier is DataChannelListenNotify
             _auth)
           _connections.send_control_to_cluster(message)
         else
-          if not (_is_initializer or _recovery_file.exists()) then
+          if not _recovery_file.exists() then
             let message = ChannelMsgEncoder.identify_data_port(_name, _service,
               _auth)
             _connections.send_control_to_cluster(message)
@@ -83,11 +83,9 @@ class DataChannelListenNotifier is DataChannelListenNotify
         f.sync()
         f.dispose()
       else
-        if not _is_initializer then
-          let message = ChannelMsgEncoder.identify_data_port(_name, _service,
-            _auth)
-          _connections.send_control("initializer", message)
-        end
+        let message = ChannelMsgEncoder.identify_data_port(_name, _service,
+          _auth)
+        _connections.send_control("initializer", message)
       end
     else
       @printf[I32]((_name + "data : couldn't get local address").cstring())

--- a/lib/wallaroo/initialization/local_topology.pony
+++ b/lib/wallaroo/initialization/local_topology.pony
@@ -401,7 +401,6 @@ actor LocalTopologyInitializer
       Fail()
     end
 
-
   be recover_and_initialize(ws: Array[String] val,
     worker_initializer: (WorkerInitializer | None) = None)
   =>
@@ -503,6 +502,8 @@ actor LocalTopologyInitializer
   be initialize(worker_initializer: (WorkerInitializer | None) = None,
     recovering: Bool = false)
   =>
+    _recovering = recovering
+
     if _is_joining then
       _initialize_joining_worker()
       return

--- a/lib/wallaroo/initialization/worker_initializer.pony
+++ b/lib/wallaroo/initialization/worker_initializer.pony
@@ -50,8 +50,8 @@ actor WorkerInitializer
 
     if _expected == 1 then
       _topology_ready = true
-      let workers: Array[String] val = recover [_worker_name] end
-      _application_initializer.initialize(this, _expected, workers)
+      _application_initializer.initialize(this, _expected,
+        recover Array[String] end)
       _local_topology_initializer.create_data_channel_listener(
         recover Array[String] end, "", "", this)
     end
@@ -171,6 +171,7 @@ actor WorkerInitializer
         _connections.send_control(key, message)
       end
 
+      _connections.save_connections()
       _connections.update_boundaries(_local_topology_initializer)
     else
       @printf[I32]("Initializer: Error initializing interconnections\n".cstring())

--- a/lib/wallaroo/network/control_channel_tcp.pony
+++ b/lib/wallaroo/network/control_channel_tcp.pony
@@ -74,11 +74,9 @@ class ControlChannelListenNotifier is TCPListenNotify
             _service, _auth)
           _connections.send_control_to_cluster(message)
         else
-          if not (_is_initializer) then
-            let message = ChannelMsgEncoder.identify_control_port(_name,
-              _service, _auth)
-            _connections.send_control_to_cluster(message)
-          end
+          let message = ChannelMsgEncoder.identify_control_port(_name,
+            _service, _auth)
+          _connections.send_control_to_cluster(message)
         end
         let f = File(_recovery_file)
         f.print(_host)
@@ -86,11 +84,9 @@ class ControlChannelListenNotifier is TCPListenNotify
         f.sync()
         f.dispose()
       else
-        if not _is_initializer then
-          let message = ChannelMsgEncoder.identify_control_port(_name,
-            _service, _auth)
-          _connections.send_control_to_cluster(message)
-        end
+        let message = ChannelMsgEncoder.identify_control_port(_name,
+          _service, _auth)
+        _connections.send_control_to_cluster(message)
       end
 
       _env.out.print(_name + " control: listening on " + _host + ":" + _service)

--- a/lib/wallaroo/startup.pony
+++ b/lib/wallaroo/startup.pony
@@ -375,6 +375,8 @@ actor Startup
           if _is_multi_worker then
             local_topology_initializer.recover_and_initialize(
               recovered_workers, _worker_initializer)
+          else
+            local_topology_initializer.initialize(where recovering = true)
           end
         end
       end


### PR DESCRIPTION
Initializer worker can now recover in single
worker clusters and if it fails in a multiworker
cluster

fixes #595 
fixes #596 