### PR TITLE
Don't do backpressure release logic when not called for

### DIFF
--- a/lib/wallaroo/metrics/metrics_sink.pony
+++ b/lib/wallaroo/metrics/metrics_sink.pony
@@ -36,6 +36,7 @@ actor MetricsSink
   var _connected: Bool = false
   var _readable: Bool = false
   var _writeable: Bool = false
+  var _throttled: Bool = false
   var _closed: Bool = false
   var _shutdown: Bool = false
   var _shutdown_peer: Bool = false
@@ -836,21 +837,27 @@ actor MetricsSink
         _host.cstring(), _service.cstring(),
         _from.cstring())
     end
-  
+
   fun ref _apply_backpressure() =>
-    ifdef not windows then
-      _writeable = false
-      ifdef linux then
-        // this is safe because asio thread isn't currently subscribed
-        // for a write event so will not be writing to the readable flag
-        AsioEvent.set_writeable(_event, false)
-        @pony_asio_event_resubscribe_write(_event)
+    if not _throttled then
+      _throttled = true
+      ifdef not windows then
+        _writeable = false
+        ifdef linux then
+          // this is safe because asio thread isn't currently subscribed
+          // for a write event so will not be writing to the readable flag
+          AsioEvent.set_writeable(_event, false)
+          @pony_asio_event_resubscribe_write(_event)
+        end
       end
+      _notify.throttled(this)
     end
-    _notify.throttled(this)
 
   fun ref _release_backpressure() =>
-    _notify.unthrottled(this)
+    if _throttled then
+      _throttled = false
+      _notify.unthrottled(this)
+    end
 
 interface _MetricsSinkNotify
   fun ref connecting(conn: MetricsSink ref, count: U32) =>

--- a/lib/wallaroo/tcp_sink/tcp_sink.pony
+++ b/lib/wallaroo/tcp_sink/tcp_sink.pony
@@ -66,6 +66,7 @@ actor TCPSink is (Consumer & RunnableStep & Initializable)
   var _connected: Bool = false
   var _closed: Bool = false
   var _writeable: Bool = false
+  var _throttled: Bool = false
   var _event: AsioEventID = AsioEvent.none()
   embed _pending: List[(ByteSeq, USize)] = _pending.create()
   embed _pending_tracking: List[(USize, SeqId)] = _pending_tracking.create()
@@ -757,19 +758,25 @@ actor TCPSink is (Consumer & RunnableStep & Initializable)
     end
 
   fun ref _apply_backpressure() =>
-    _writeable = false
-    ifdef linux then
-      // this is safe because asio thread isn't currently subscribed
-      // for a write event so will not be writing to the readable flag
-      AsioEvent.set_writeable(_event, false)
-      @pony_asio_event_resubscribe_write(_event)
+    if not _throttled then
+      _throttled = true
+      _writeable = false
+      ifdef linux then
+        // this is safe because asio thread isn't currently subscribed
+        // for a write event so will not be writing to the readable flag
+        AsioEvent.set_writeable(_event, false)
+        @pony_asio_event_resubscribe_write(_event)
+      end
+      _notify.throttled(this)
+      _maybe_mute_or_unmute_upstreams()
     end
-    _notify.throttled(this)
-    _maybe_mute_or_unmute_upstreams()
 
   fun ref _release_backpressure() =>
-    _notify.unthrottled(this)
-    _maybe_mute_or_unmute_upstreams()
+    if _throttled then
+      _throttled = false
+      _notify.unthrottled(this)
+      _maybe_mute_or_unmute_upstreams()
+    end
 
   fun ref _maybe_mute_or_unmute_upstreams() =>
     if _mute_outstanding then


### PR DESCRIPTION
We currently don't check to see if we are throttled when calling
release backpressure. This means that we execute all the release
backpressure code even if we aren't throttled. This can happen in
several different ways resulting in spurious logic being run and lots of
noise in the logs.

Currently on OSX where we aren't using KQueue one-shot each message sent
can result in "backpressure release" happening.