### PR TITLE
Change sender `--buffy/-b` to `--host/-h`

### DIFF
--- a/book/examples/cpp/alphabet-cpp/README.md
+++ b/book/examples/cpp/alphabet-cpp/README.md
@@ -55,7 +55,7 @@ In a separate shell each:
     ```
 3. Start sending data
     ```bash
-     ../../../../giles/sender/sender --buffy 127.0.0.1:7010 --file votes.msg \
+     ../../../../giles/sender/sender --host 127.0.0.1:7010 --file votes.msg \
        --batch-size 50 --interval 10_000_000 --binary --msg-size 9 --repeat \
        --ponythreads=1 --messages 1000000
     ```

--- a/book/examples/cpp/counter-app/README.md
+++ b/book/examples/cpp/counter-app/README.md
@@ -72,7 +72,7 @@ In a separate shell each:
     ```
 3. Start sending data
     ```bash
-     ../../../../giles/sender/sender --buffy 127.0.0.1:7010 --file data_gen/numbers.msg \
+     ../../../../giles/sender/sender --host 127.0.0.1:7010 --file data_gen/numbers.msg \
        --batch-size 50 --interval 10_000_000 --binary --msg-size 44 --repeat \
        --ponythreads=1 --messages 1000000
     ```

--- a/book/examples/pony/alphabet/README.md
+++ b/book/examples/pony/alphabet/README.md
@@ -55,7 +55,7 @@ In a separate shell, each:
     ```
 3. Start a sender
     ```bash
-    ../../../../giles/sender/sender --buffy 127.0.0.1:7010 --file data_gen/votes.msg \
+    ../../../../giles/sender/sender --host 127.0.0.1:7010 --file data_gen/votes.msg \
       --batch-size 5 --interval 100_000_000 --messages 150 --binary \
       --variable-size --repeat --ponythreads=1 --no-write
     ```

--- a/book/examples/pony/celsius/README.md
+++ b/book/examples/pony/celsius/README.md
@@ -54,7 +54,7 @@ In a separate shell, each:
     ```
 3. Start a sender
     ```bash
-    ../../../../giles/sender/sender --buffy 127.0.0.1:7010 --file data_gen/celsius.msg \
+    ../../../../giles/sender/sender --host 127.0.0.1:7010 --file data_gen/celsius.msg \
       --batch-size 5 --interval 100_000_000 --messages 150 --binary \
       --variable-size --repeat --ponythreads=1 --no-write
     ```

--- a/book/examples/python/alphabet/README.md
+++ b/book/examples/python/alphabet/README.md
@@ -43,7 +43,7 @@ machida --application-module alphabet --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
 In a third shell, send some messages
 
 ```bash
-../../../../giles/sender/sender --buffy 127.0.0.1:7010 --file votes.msg \
+../../../../giles/sender/sender --host 127.0.0.1:7010 --file votes.msg \
   --batch-size 50 --interval 10_000_000 --messages 1000000 --binary \
   --msg-size 9 --repeat --ponythreads=1
 ```

--- a/book/examples/python/alphabet_partitioned/README.md
+++ b/book/examples/python/alphabet_partitioned/README.md
@@ -41,7 +41,7 @@ machida --application-module alphabet_partitioned --in 127.0.0.1:7010 \
 In a third shell, send some messages
 
 ```bash
-../../../../giles/sender/sender --buffy 127.0.0.1:7010 --file votes.msg \
+../../../../giles/sender/sender --host 127.0.0.1:7010 --file votes.msg \
   --batch-size 50 --interval 10_000_000 --messages 1000000 --binary \
   --msg-size 9 --repeat --ponythreads=1
 ```

--- a/book/examples/python/celsius/README.md
+++ b/book/examples/python/celsius/README.md
@@ -57,7 +57,7 @@ machida --application-module celsius --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
 In a third shell, send some messages:
 
 ```bash
-../../../../giles/sender/sender --buffy 127.0.0.1:7010 --file data_gen/celsius.msg \
+../../../../giles/sender/sender --host 127.0.0.1:7010 --file data_gen/celsius.msg \
   --batch-size 50 --interval 10_000_000 --messages 1000000 --repeat \
   --ponythreads=1 --binary --msg-size 8
 ```

--- a/book/examples/python/market_spread/README.md
+++ b/book/examples/python/market_spread/README.md
@@ -49,7 +49,7 @@ machida --application-module market_spread \
 Send some market data messages
 
 ```bash
-../../../../giles/sender/sender --buffy 127.0.0.1:7011 --file \
+../../../../giles/sender/sender --host 127.0.0.1:7011 --file \
   ../../../../demos/marketspread/350k-nbbo-fixish.msg --batch-size 20 \
   --interval 100_000_000 --messages 1000000 --binary --repeat --ponythreads=1 \
   --msg-size 46 --no-write
@@ -58,7 +58,7 @@ Send some market data messages
 and some orders messages
 
 ```bash
-../../../../giles/sender/sender --buffy 127.0.0.1:7010 --file \
+../../../../giles/sender/sender --host 127.0.0.1:7010 --file \
   ../../../../demos/marketspread/350k-orders-fixish.msg --batch-size 20 \
   --interval 100_000_000 --messages 1000000 --binary --repeat --ponythreads=1 \
   --msg-size 57 --no-write

--- a/book/examples/python/reverse/README.md
+++ b/book/examples/python/reverse/README.md
@@ -43,7 +43,7 @@ machida --application-module reverse --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
 In a third shell, send some messages:
 
 ```bash
-../../../../giles/sender/sender --buffy 127.0.0.1:7010 --file words.txt \
+../../../../giles/sender/sender --host 127.0.0.1:7010 --file words.txt \
 --batch-size 5 --interval 100_000_000 --messages 150 --repeat \
 --ponythreads=1
 ```

--- a/book/examples/python/sequence/README.md
+++ b/book/examples/python/sequence/README.md
@@ -43,7 +43,7 @@ machida --application-module sequence --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
 In a third shell, send some messages:
 
 ```bash
-../../../../giles/sender/sender --buffy 127.0.0.1:7010 --batch-size 10 \
+../../../../giles/sender/sender --host 127.0.0.1:7010 --batch-size 10 \
   --interval 100_000_000 --ponythreads=1 --binary --msg-size 12 --no-write \
   --u64 --messages 100
 ```

--- a/book/examples/python/sequence_partitioned/README.md
+++ b/book/examples/python/sequence_partitioned/README.md
@@ -60,7 +60,7 @@ machida --application-module sequence_partitioned --in 127.0.0.1:7010 \
 In a third shell, send some messages:
 
 ```bash
-../../../../giles/sender/sender --buffy 127.0.0.1:7010 --batch-size 10 \
+../../../../giles/sender/sender --host 127.0.0.1:7010 --batch-size 10 \
   --interval 100_000_000 --ponythreads=1 --binary --msg-size 12 --no-write \
   --u64 --messages 100
 ```

--- a/book/getting-started/run-a-application.md
+++ b/book/getting-started/run-a-application.md
@@ -122,7 +122,7 @@ This will create a binary called `sender`
 You will now be able to start the `sender` with the following command:
 
 ```bash
-./sender -b 127.0.0.1:7000 -m 100000 -y -s 300 \
+./sender -h 127.0.0.1:7000 -m 100000 -y -s 300 \
   -f ~/wallaroo-tutorial/wallaroo/book/examples/celsius/data_gen/celsius.msg \
   -r -w -g 8 --ponythreads=1
 ```

--- a/book/wallaroo-tools/giles-sender.md
+++ b/book/wallaroo-tools/giles-sender.md
@@ -4,9 +4,9 @@
 
 Giles components act as external testers for Wallaroo. Giles Sender is used to mimic the behavior of an incoming data source. Giles Sender sends data to Wallaroo in one of four ways:
 
-- With no other commandline options given, it will send string representations of integers, starting with `1` and increasing by `1` with each new message. For example, `./giles/sender -b 127.0.0.1:8081 -m 100` will send messages containing string representations of the numbers `1` through `100`.
-- With a file name given as the `--file/-f` argument it will send each line of the given file as a message. For example, `./giles/sender -b 127.0.0.1:8081 -m 100 -f war-and-peace.txt` will send messages containing each of the first 100 lines of the file `war-and-peace.txt`.
-- With a file name given as the `--file/-f` argument and binary format specified with `--binary/-y` and every message is 24 bytes, specified with `--msg-size/-g`, it will send every 24 bytes of the given file as a message. For example, `./giles/sender -b 127.0.0.1:8081 -m 100 -f binary-data-file.txt -y -g 24` will send every 24 bytes until it has sent 100 messages
+- With no other commandline options given, it will send string representations of integers, starting with `1` and increasing by `1` with each new message. For example, `./giles/sender -h 127.0.0.1:8081 -m 100` will send messages containing string representations of the numbers `1` through `100`.
+- With a file name given as the `--file/-f` argument it will send each line of the given file as a message. For example, `./giles/sender -h 127.0.0.1:8081 -m 100 -f war-and-peace.txt` will send messages containing each of the first 100 lines of the file `war-and-peace.txt`.
+- With a file name given as the `--file/-f` argument and binary format specified with `--binary/-y` and every message is 24 bytes, specified with `--msg-size/-g`, it will send every 24 bytes of the given file as a message. For example, `./giles/sender -h 127.0.0.1:8081 -m 100 -f binary-data-file.txt -y -g 24` will send every 24 bytes until it has sent 100 messages
 - With a file name given as the `--file/-f` argument and binary format specified with `--binary/-y` and variable message lengths specified with `--variable-size/-z`, it will read 4 bytes to get the message size, send that message and repeat. For example, `./giles/sender  127.0.0.1:8081 -m 100 -f binary-data-file.txt -y -z` will initially read a 4 byte header, send that message and repeat until it has sent 100 messages.
 
 ### Building `giles/sender`
@@ -28,7 +28,7 @@ stable env ponyc
 
 `giles/sender` takes several command line arguments, below is a list with accompanying notes:
 
-* `--buffy/-b` address and port combination that Wallaroo is listening on for incoming source data. Must be provided in the `127.0.0.1:8082` format.
+* `--host/-h` address and port combination that Wallaroo is listening on for incoming source data. Must be provided in the `127.0.0.1:8082` format.
 * `--messages/-m` number of messages to send before terminating the sender.
 * `--file/-f` a file with newline-separated entries from which to read entries to send. If multiple files are provided, the first file is read to the end before the next file is open and read, and so on.
 * `--batch-size/-s` specifies the number of messages sent at every interval.
@@ -62,7 +62,7 @@ amet
 Use
 
 ```bash
-sender --buffy 127.0.0.1:7000 --file words.txt --messages 100 --repeat
+sender --host 127.0.0.1:7000 --file words.txt --messages 100 --repeat
 ```
 
 ### Send binary data from a file
@@ -82,7 +82,7 @@ With a 4-byte header and 6-bytes of text, coming to a total of 10-bytes:
 Use
 
 ```bash
-sender --buffy 127.0.0.1:7000 --file=my_binary_data_file --messages=10 \
+sender --host 127.0.0.1:7000 --file=my_binary_data_file --messages=10 \
   --repeat --batch-size=1 --interval=10_000_000 --binary --msg-size 10 \
   --no-write
 ```
@@ -101,7 +101,7 @@ In this case, the data in the file is frame encoded, but the message length is n
 Use
 
 ```bash
-sender --buffy 127.0.0.1:7000 --file=my_variable_binary_data_file --messages=10 \
+sender --host 127.0.0.1:7000 --file=my_variable_binary_data_file --messages=10 \
   --repeat --batch-size=1 --interval=10_000_000 --binary --variable-size \
   --no-write
 ```
@@ -129,14 +129,14 @@ bc
 To concatenate the files, in order, use
 
 ```bash
-sender --buffy 127.0.0.1:7000 --file=file1,file2 --messages=100 --batch-size=1 \
+sender --host 127.0.0.1:7000 --file=file1,file2 --messages=100 --batch-size=1 \
   --interval=10_000_000 --no-write
 ```
 
 To send the contents of the first file twice, then the contents of the second file once, use
 
 ```bash
-sender --buffy 127.0.0.1:7000 --file=file1,file1,file2 --messages=100 \
+sender --host 127.0.0.1:7000 --file=file1,file1,file2 --messages=100 \
   --batch-size=1 --interval=10_000_000 --no-write
 ```
 
@@ -150,7 +150,7 @@ To send the sequence `'1', '2', '3', ..., '100'`
 Use
 
 ```bash
-sender --buffy 127.0.0.1:7000 --messages 100
+sender --host 127.0.0.1:7000 --messages 100
 ```
 
 ### Send a sequence of numbers, encoded as big-endian U64
@@ -160,7 +160,7 @@ To send the sequence `1,2,3,...,100`
 Use
 
 ```bash
-sender --buffy 127.0.0.1:7000 --messages 100 --u64
+sender --host 127.0.0.1:7000 --messages 100 --u64
 ```
 
 To send the sequence `101,102,...,200`
@@ -168,7 +168,7 @@ To send the sequence `101,102,...,200`
 Use
 
 ```bash
-sender --buffy 127.0.0.1:7000 --messages 100 --u64 --start-from 100
+sender --host 127.0.0.1:7000 --messages 100 --u64 --start-from 100
 ```
 
 ## Preparing Data Files for Giles Sender

--- a/dagon/howto-test-buffy-performance-in-AWS.org
+++ b/dagon/howto-test-buffy-performance-in-AWS.org
@@ -534,7 +534,7 @@ sudo cset proc -s user -e numactl -- -C 6-12 chrt -f 80 \
 Giles sender:
 #+BEGIN_SRC sh
 sudo cset proc -s user -e numactl -- -C 13-15 chrt -f 80 \
- giles/sender/sender -b 127.0.0.1:7000 -m 1000000 \
+ giles/sender/sender -h 127.0.0.1:7000 -m 1000000 \
  --ponythreads 1 -s 500
 #+END_SRC
 
@@ -558,12 +558,12 @@ sudo cset proc -s user -e numactl -- -C 5-11 chrt -f 80 \
 Giles sender:
 #+BEGIN_SRC sh
 sudo cset proc -s user -e numactl -- -C 12-13 chrt -f 80 \
- giles/sender/sender -b 127.0.0.1:7000 -m 1000000 \
+ giles/sender/sender -h 127.0.0.1:7000 -m 1000000 \
  -f ./demos/marketspread/trades.msg -r \
  --ponythreads 1 -s 500
 
 sudo cset proc -s user -e numactl -- -C 14-15 chrt -f 80 \
- giles/sender/sender -b 127.0.0.1:7001 -m 1000000 \
+ giles/sender/sender -h 127.0.0.1:7001 -m 1000000 \
  -f ./demos/marketspread/nbbo.msg -r \
  --ponythreads 1 -s 500
 #+END_SRC

--- a/giles/README.md
+++ b/giles/README.md
@@ -30,8 +30,8 @@ and that its Sink will send data to port 8082, then you would
 start Giles as follows:
 
 ```
-./giles/receiver -b 127.0.0.1:8082
-./giles/sender -b 127.0.0.1:8081 -m 100
+./giles/receiver -l 127.0.0.1:8082
+./giles/sender -h 127.0.0.1:8081 -m 100
 ```
 
 The sender also takes the following parameters:  
@@ -61,12 +61,12 @@ Currently the Giles sender sends messages in one of two way:
 
 - With no other commandline options given, it will send string
   representations of integers, starting with `1` and increasing by `1`
-  with each new message. For example, `./giles/sender -b 127.0.0.1:8081
+  with each new message. For example, `./giles/sender -h 127.0.0.1:8081
   -m 100` will send messages containing string representations of the
   numbers `1` through `100`.
 - With a file name given as the last argument it will send each line
   of the given file as a message. For example, `./giles/sender
-  -b 127.0.0.1:8081 -m 100 -f war-and-peace.txt` will send messages containing
+  -h 127.0.0.1:8081 -m 100 -f war-and-peace.txt` will send messages containing
   each of the first 100 lines of the file `war-and-peace.txt`.
 
 ## Human Readable Receiver Outputs

--- a/testing/correctness/apps/complex/complex.pony
+++ b/testing/correctness/apps/complex/complex.pony
@@ -15,7 +15,7 @@ nc -l 127.0.0.1 7003 >> /dev/null
 ./complex -i 127.0.0.1:7010 -o 127.0.0.1:7002 -m 127.0.0.1:8000 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -e 10000000 -w 3 -n worker3
 
 4) complex numbers:
-giles/sender/sender -b 127.0.0.1:7010 -m 10000000 -s 300 -i 2_500_000 -f apps/complex/complex_numbers.msg -r --ponythreads=1 -y -g 12
+giles/sender/sender -h 127.0.0.1:7010 -m 10000000 -s 300 -i 2_500_000 -f apps/complex/complex_numbers.msg -r --ponythreads=1 -y -g 12
 """
 
 use "buffered"

--- a/testing/correctness/apps/default-test/default.pony
+++ b/testing/correctness/apps/default-test/default.pony
@@ -9,7 +9,7 @@ APP:
 
 
 SENDER:
-giles/sender/sender -b 127.0.0.1:7000 -m 50000000 -s 300 -i 5_000_000 -f apps/default-test/default.txt -r --ponythreads=1 -w
+giles/sender/sender -h 127.0.0.1:7000 -m 50000000 -s 300 -i 5_000_000 -f apps/default-test/default.txt -r --ponythreads=1 -w
 
 """
 use "buffered"

--- a/testing/correctness/apps/sequence-window/main.pony
+++ b/testing/correctness/apps/sequence-window/main.pony
@@ -30,7 +30,7 @@ To run, use the following commands:
 ```
 4. Sender
 ```bash
-../../../../giles/sender/sender -b 127.0.0.1:7000 -s 100 -i 50_000_000 \
+../../../../giles/sender/sender -h 127.0.0.1:7000 -s 100 -i 50_000_000 \
 --ponythreads=1 -y -g 12 -w -u -m 10000
 ```
 
@@ -41,7 +41,7 @@ Restart `sequence-window`, and wait for it to complete its recovery process.
 
 Send one more message with giles sender:
 ```bash
-../../../../giles/sender/sender -b 127.0.0.1:7000 -s 100 -i 50_000_000 \
+../../../../giles/sender/sender -h 127.0.0.1:7000 -s 100 -i 50_000_000 \
 --ponythreads=1 -y -g -12 -w -u -m 2 -v 10000
 ```
 

--- a/testing/correctness/apps/weighted-test/weighted-test.pony
+++ b/testing/correctness/apps/weighted-test/weighted-test.pony
@@ -9,7 +9,7 @@ APP:
 
 
 SENDER:
-giles/sender/sender -b 127.0.0.1:7000 -m 50000000 -s 300 -i 5_000_000 -f apps/weighted-test/weighted.txt -r --ponythreads=1 -w
+giles/sender/sender -h 127.0.0.1:7000 -m 50000000 -s 300 -i 5_000_000 -f apps/weighted-test/weighted.txt -r --ponythreads=1 -w
 
 """
 use "buffered"

--- a/testing/correctness/playbooks/metrics.md
+++ b/testing/correctness/playbooks/metrics.md
@@ -11,7 +11,7 @@ Metrics is an external service that the application periodically sends data to. 
 1. sink: `nc -l 127.0.0.1 5555`
 1. metrics: `nc -l 127.0.0.1 5001`
 1. app: `./sequence-window -i 127.0.0.1:7000 -o 127.0.0.1:5555 -c 127.0.0.1:12500 -d 127.0.0.1:12501 -m 127.0.0.1:5001`
-1. sender: `sender -b 127.0.0.1:7000 -s 1 -i 1_000_000_000 -y -g 12 -w -u -m 100`
+1. sender: `sender -h 127.0.0.1:7000 -s 1 -i 1_000_000_000 -y -g 12 -w -u -m 100`
 1. terminate metrics with `Ctrl-C`
 1. restart metrics
 
@@ -34,7 +34,7 @@ Metrics is an external service that the application periodically sends data to. 
 
 1. sink: `nc -l 127.0.0.1 5555`
 1. app: `./sequence-window -i 127.0.0.1:7000 -o 127.0.0.1:5555 -c 127.0.0.1:12500 -d 127.0.0.1:12501 -m 127.0.0.1:5001`
-1. sender: `sender -b 127.0.0.1:7000 -s 1 -i 1_000_000_000 -y -g 12 -w -u -m 100`
+1. sender: `sender -h 127.0.0.1:7000 -s 1 -i 1_000_000_000 -y -g 12 -w -u -m 100`
 1. Wait a while for some metrics to be sent (10-20 seconds?)
 1. start metrics: `nc -l 127.0.0.1 5001`
 

--- a/testing/correctness/playbooks/recovery.md
+++ b/testing/correctness/playbooks/recovery.md
@@ -22,10 +22,10 @@ e.g. if in the control run, we observed the sequence of outputs `[10,11,12,13], 
 1. start giles-receiver:  `../../../../giles/receiver/receiver --ponythreads=1 --ponynoblock --ponypinasio -l 127.0.0.1:5555`
 1. start initializer-worker: `./sequence-window -i 127.0.0.1:7000 -o 127.0.0.1:5555 -m 127.0.0.1:5001 --ponythreads=4 --ponypinasio --ponynoblock -c 127.0.0.1:12500 -d 127.0.0.1:12501 -r res-data -w 2 -n worker1 -t`
 1. start second worker: `./sequence-window -i 127.0.0.1:7000 -o 127.0.0.1:5555 -m 127.0.0.1:5001 --ponythreads=4 --ponypinasio --ponynoblock -c 127.0.0.1:12500 -d 127.0.0.1:12501 -r res-data -w 2 -n worker2`
-1. start giles-sender and send the first 10000 integers: `../../../../giles/sender/sender -b 127.0.0.1:7000 -s 100 -i 50_000_000 -u --ponythreads=1 -y -g 12 -w -m 10000`
+1. start giles-sender and send the first 10000 integers: `../../../../giles/sender/sender -h 127.0.0.1:7000 -s 100 -i 50_000_000 -u --ponythreads=1 -y -g 12 -w -m 10000`
 1. terminate the second worker with Ctrl-C
 1. restart the second worker with the same command
-1. use giles sender to send the next 2 integers in the sequence: (10001,10002): `../../../../giles/sender/sender -b 127.0.0.1:7000 -s 100 -i 50_000_000 -u --ponythreads=1 -y -g 12 -w -m 2 -v 10000`
+1. use giles sender to send the next 2 integers in the sequence: (10001,10002): `../../../../giles/sender/sender -h 127.0.0.1:7000 -s 100 -i 50_000_000 -u --ponythreads=1 -y -g 12 -w -m 2 -v 10000`
 1. If you built the application in Debug mode, then each worker will have printed to its stdout the values in its sequence window at each step, and you can verify that the sequence "remembered" by the second worker after recovery is `[9996, 9998, 10000, 10002]` as expected.
 1. Terminate all of the processes
 
@@ -45,7 +45,7 @@ This test is similar to testing state recovery, except we run giles sender with 
 ### Running the Test:
 
 1. start giles receiver, worker 1, and worker 2 as in the previous test
-1. run giles with: `../../../../giles/sender/sender -b 127.0.0.1:7000 -s 1 -i 2_000_000_000 -u --ponythreads=1 -y -g 12 -w -m 10000`
+1. run giles with: `../../../../giles/sender/sender -h 127.0.0.1:7000 -s 1 -i 2_000_000_000 -u --ponythreads=1 -y -g 12 -w -m 10000`
 1. wait for a few lines to go through
 1. terminate worker2
 1. wait some more

--- a/testing/correctness/playbooks/sink.md
+++ b/testing/correctness/playbooks/sink.md
@@ -10,7 +10,7 @@ The purpose of these tests is to validate that the behaviour of the application 
 
 1. sink: `nc -l 127.0.0.1 5555`
 1. app: `./sequence-window -i 127.0.0.1:7000 -o 127.0.0.1:5555 -c 127.0.0.1:12500 -d 127.0.0.1:12501 -m 127.0.0.1:5001`
-1. sender: `sender -b 127.0.0.1:7000 -s 1 -i 1_000_000_000 -y -g 12 -w -u -m 100`
+1. sender: `sender -h 127.0.0.1:7000 -s 1 -i 1_000_000_000 -y -g 12 -w -u -m 100`
 1. terminate sink with `Ctrl-C`
 1. restart sink
 
@@ -30,7 +30,7 @@ The purpose of these tests is to validate that the behaviour of the application 
 ### Steps:
 
 1. app: `./sequence-window -i 127.0.0.1:7000 -o 127.0.0.1:5555 -c 127.0.0.1:12500 -d 127.0.0.1:12501 -m 127.0.0.1:5001`
-1. sender: `sender -b 127.0.0.1:7000 -s 1 -i 1_000_000_000 -y -g 12 -w -u -m 100`
+1. sender: `sender -h 127.0.0.1:7000 -s 1 -i 1_000_000_000 -y -g 12 -w -u -m 100`
 1. wait a few seconds
 1. sink: `nc -l 127.0.0.1 5555`
 

--- a/testing/performance/apps/WALLAROO_PERFORMANCE_TESTING.md
+++ b/testing/performance/apps/WALLAROO_PERFORMANCE_TESTING.md
@@ -102,12 +102,12 @@ sudo cset proc -s user -e numactl -- -C 1-4,17 chrt -f 80 ./market-spread -i 127
 
 To run the NBBO Sender: (must be started before Orders so that the initial NBBO can be set)
 ```
-sudo cset proc -s user -e numactl -- -C 15,17 chrt -f 80 ~/buffy/giles/sender/sender -b 127.0.0.1:7001 -m 10000000000 -s 300 -i 2_500_000 -f ~/buffy/demos/marketspread/350k-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 --ponypinasio -w —ponynoblock
+sudo cset proc -s user -e numactl -- -C 15,17 chrt -f 80 ~/buffy/giles/sender/sender -h 127.0.0.1:7001 -m 10000000000 -s 300 -i 2_500_000 -f ~/buffy/demos/marketspread/350k-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 --ponypinasio -w —ponynoblock
 ```
 
 To run the Orders Sender:
 ```
-sudo cset proc -s user -e numactl -- -C 16,17 chrt -f 80 ~/buffy/giles/sender/sender -b 127.0.0.1:7000 -m 5000000000 -s 300 -i 5_000_000 -f ~/buffy/demos/marketspread/350k-orders-fixish.msg -r --ponythreads=1 -y -g 57 --ponypinasio -w —ponynoblock
+sudo cset proc -s user -e numactl -- -C 16,17 chrt -f 80 ~/buffy/giles/sender/sender -h 127.0.0.1:7000 -m 5000000000 -s 300 -i 5_000_000 -f ~/buffy/demos/marketspread/350k-orders-fixish.msg -r --ponythreads=1 -y -g 57 --ponypinasio -w —ponynoblock
 ```
 
 
@@ -125,12 +125,12 @@ sudo cset proc -s user -e numactl -- -C 5-8,17 chrt -f 80 ./market-spread -i 127
 
 To run the NBBO Sender: (must be started before Orders so that the initial NBBO can be set)
 ```
-sudo cset proc -s user -e numactl -- -C 15,17 chrt -f 80 ~/buffy/giles/sender/sender -b 127.0.0.1:7001 -m 10000000000 -s 300 -i 2_500_000 -f ~/buffy/demos/marketspread/350k-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 --ponypinasio -w —ponynoblock
+sudo cset proc -s user -e numactl -- -C 15,17 chrt -f 80 ~/buffy/giles/sender/sender -h 127.0.0.1:7001 -m 10000000000 -s 300 -i 2_500_000 -f ~/buffy/demos/marketspread/350k-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 --ponypinasio -w —ponynoblock
 ```
 
 To run the Orders Sender:
 ```
-sudo cset proc -s user -e numactl -- -C 16,17 chrt -f 80 ~/buffy/giles/sender/sender -b 127.0.0.1:7000 -m 5000000000 -s 300 -i 5_000_000 -f ~/buffy/demos/marketspread/350k-orders-fixish.msg -r --ponythreads=1 -y -g 57 --ponypinasio -w —ponynoblock
+sudo cset proc -s user -e numactl -- -C 16,17 chrt -f 80 ~/buffy/giles/sender/sender -h 127.0.0.1:7000 -m 5000000000 -s 300 -i 5_000_000 -f ~/buffy/demos/marketspread/350k-orders-fixish.msg -r --ponythreads=1 -y -g 57 --ponypinasio -w —ponynoblock
 ```
 
 #####R3K Symbols:
@@ -145,12 +145,12 @@ sudo cset proc -s user -e numactl -- -C 1-4,17 chrt -f 80 ./market-spread -i 127
 
 To run the NBBO Sender: (must be started before Orders so that the initial NBBO can be set)
 ```
-sudo cset proc -s user -e numactl -- -C 15,17 chrt -f 80 ~/buffy/giles/sender/sender -b 127.0.0.1:7001 -m 10000000000 -s 300 -i 2_500_000 -f ~/buffy/demos/marketspread/350k-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 --ponypinasio -w —ponynoblock
+sudo cset proc -s user -e numactl -- -C 15,17 chrt -f 80 ~/buffy/giles/sender/sender -h 127.0.0.1:7001 -m 10000000000 -s 300 -i 2_500_000 -f ~/buffy/demos/marketspread/350k-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 --ponypinasio -w —ponynoblock
 ```
 
 To run the Orders Sender:
 ```
-sudo cset proc -s user -e numactl -- -C 16,17 chrt -f 80 ~/buffy/giles/sender/sender -b 127.0.0.1:7000 -m 5000000000 -s 300 -i 5_000_000 -f ~/buffy/demos/marketspread/350k-orders-fixish.msg -r --ponythreads=1 -y -g 57 --ponypinasio -w —ponynoblock
+sudo cset proc -s user -e numactl -- -C 16,17 chrt -f 80 ~/buffy/giles/sender/sender -h 127.0.0.1:7000 -m 5000000000 -s 300 -i 5_000_000 -f ~/buffy/demos/marketspread/350k-orders-fixish.msg -r --ponythreads=1 -y -g 57 --ponypinasio -w —ponynoblock
 ```
 
 
@@ -168,12 +168,12 @@ sudo cset proc -s user -e numactl -- -C 5-8,17 chrt -f 80 ./market-spread -i 127
 
 To run the NBBO Sender: (must be started before Orders so that the initial NBBO can be set)
 ```
-sudo cset proc -s user -e numactl -- -C 15,17 chrt -f 80 ~/buffy/giles/sender/sender -b 127.0.0.1:7001 -m 10000000000 -s 300 -i 2_500_000 -f ~/buffy/demos/marketspread/350k-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 --ponypinasio -w —ponynoblock
+sudo cset proc -s user -e numactl -- -C 15,17 chrt -f 80 ~/buffy/giles/sender/sender -h 127.0.0.1:7001 -m 10000000000 -s 300 -i 2_500_000 -f ~/buffy/demos/marketspread/350k-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 --ponypinasio -w —ponynoblock
 ```
 
 To run the Orders Sender:
 ```
-sudo cset proc -s user -e numactl -- -C 16,17 chrt -f 80 ~/buffy/giles/sender/sender -b 127.0.0.1:7000 -m 5000000000 -s 300 -i 5_000_000 -f ~/buffy/demos/marketspread/350k-orders-fixish.msg -r --ponythreads=1 -y -g 57 --ponypinasio -w —ponynoblock
+sudo cset proc -s user -e numactl -- -C 16,17 chrt -f 80 ~/buffy/giles/sender/sender -h 127.0.0.1:7000 -m 5000000000 -s 300 -i 5_000_000 -f ~/buffy/demos/marketspread/350k-orders-fixish.msg -r --ponythreads=1 -y -g 57 --ponypinasio -w —ponynoblock
 ```
 
 ####2 MACHINE market spread (2 workers)
@@ -211,13 +211,13 @@ sudo cset proc -s user -e numactl -- -C 1-4,7 chrt -f 80 ./market-spread -i 127.
 To run the NBBO Sender: (must be started before Orders so that the initial NBBO can be set)
 
 ```
-sudo cset proc -s user -e numactl -- -C 5,7 chrt -f 80 ~/buffy/giles/sender/sender -b 127.0.0.1:7001 -m 100000000 -s 300 -i 2_500_000 -f ~/buffy/demos/marketspread/350k-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 --ponypinasio -w —ponynoblock
+sudo cset proc -s user -e numactl -- -C 5,7 chrt -f 80 ~/buffy/giles/sender/sender -h 127.0.0.1:7001 -m 100000000 -s 300 -i 2_500_000 -f ~/buffy/demos/marketspread/350k-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 --ponypinasio -w —ponynoblock
 ```
 
 To run the Orders Sender:
 
 ```
-sudo cset proc -s user -e numactl -- -C 6,7 chrt -f 80 ~/buffy/giles/sender/sender -b 127.0.0.1:7000 -m 50000000 -s 300 -i 5_000_000 -f ~/buffy/demos/marketspread/350k-orders-fixish.msg -r --ponythreads=1 -y -g 57 --ponypinasio -w —ponynoblock
+sudo cset proc -s user -e numactl -- -C 6,7 chrt -f 80 ~/buffy/giles/sender/sender -h 127.0.0.1:7000 -m 50000000 -s 300 -i 5_000_000 -f ~/buffy/demos/marketspread/350k-orders-fixish.msg -r --ponythreads=1 -y -g 57 --ponypinasio -w —ponynoblock
 ```
 
 

--- a/testing/performance/apps/market-spread-cpp/market-spread-cpp/market-spread-cpp.pony
+++ b/testing/performance/apps/market-spread-cpp/market-spread-cpp/market-spread-cpp.pony
@@ -15,13 +15,13 @@ nc -l 127.0.0.1 5001 >> /dev/null
 ./market-spread-cpp -i 127.0.0.1:7000,127.0.0.1:7001 -o 127.0.0.1:5555 -m 127.0.0.1:5001 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker2 --ponythreads=4 --ponynoblock -w 2
 
 4) initialization:
-giles/sender/sender -b 127.0.0.1:7000 -m 5000000 -s 300 -i 5_000_000 -f demos/marketspread/initial-nbbo-fixish.msg -r --ponythreads=1 -y -g 57 -w
+giles/sender/sender -h 127.0.0.1:7000 -m 5000000 -s 300 -i 5_000_000 -f demos/marketspread/initial-nbbo-fixish.msg -r --ponythreads=1 -y -g 57 -w
 
 5) orders:
-giles/sender/sender -b 127.0.0.1:7000 -m 5000000 -s 300 -i 5_000_000 -f demos/marketspread/r3k-orders-fixish.msg -r --ponythreads=1 -y -g 57 -w
+giles/sender/sender -h 127.0.0.1:7000 -m 5000000 -s 300 -i 5_000_000 -f demos/marketspread/r3k-orders-fixish.msg -r --ponythreads=1 -y -g 57 -w
 
 6) nbbo:
-giles/sender/sender -b 127.0.0.1:7001 -m 10000000 -s 300 -i 2_500_000 -f demos/marketspread/r3k-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 -w
+giles/sender/sender -h 127.0.0.1:7001 -m 10000000 -s 300 -i 2_500_000 -f demos/marketspread/r3k-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 -w
 """
 
 use "wallaroo/cpp_api/pony"

--- a/testing/performance/apps/market-spread-encode/market-spread.pony
+++ b/testing/performance/apps/market-spread-encode/market-spread.pony
@@ -23,10 +23,10 @@ giles/receiver/receiver --ponythreads=1 --ponynoblock -w -l 127.0.0.1:5555
 ./market-spread -i 127.0.0.1:7000,127.0.0.1:7001 -o 127.0.0.1:5555 -m 127.0.0.1:5001 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker2 --ponythreads=4 --ponynoblock -w 2
 
 4) orders:
-giles/sender/sender -b 127.0.0.1:7000 -m 5000000 -s 300 -i 5_000_000 -f demos/marketspread/350k-orders-fixish.msg -r --ponythreads=1 -y -g 57 -w
+giles/sender/sender -h 127.0.0.1:7000 -m 5000000 -s 300 -i 5_000_000 -f demos/marketspread/350k-orders-fixish.msg -r --ponythreads=1 -y -g 57 -w
 
 5) nbbo:
-giles/sender/sender -b 127.0.0.1:7001 -m 10000000 -s 300 -i 2_500_000 -f demos/marketspread/350k-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 -w
+giles/sender/sender -h 127.0.0.1:7001 -m 10000000 -s 300 -i 2_500_000 -f demos/marketspread/350k-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 -w
 
 R3K or other Symbol Set (700, 1400, 2100)
 
@@ -39,10 +39,10 @@ R3K or other Symbol Set (700, 1400, 2100)
 ./market-spread -i 127.0.0.1:7000,127.0.0.1:7001 -o 127.0.0.1:5555 -m 127.0.0.1:5001 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker2 --ponythreads=4 --ponynoblock -w 2
 
 4) orders:
-giles/sender/sender -b 127.0.0.1:7000 -m 5000000 -s 300 -i 5_000_000 -f demos/marketspread/r3k-orders-fixish.msg -r --ponythreads=1 -y -g 57 -w
+giles/sender/sender -h 127.0.0.1:7000 -m 5000000 -s 300 -i 5_000_000 -f demos/marketspread/r3k-orders-fixish.msg -r --ponythreads=1 -y -g 57 -w
 
 5) nbbo:
-giles/sender/sender -b 127.0.0.1:7001 -m 10000000 -s 300 -i 2_500_000 -f demos/marketspread/r3k-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 -w
+giles/sender/sender -h 127.0.0.1:7001 -m 10000000 -s 300 -i 2_500_000 -f demos/marketspread/r3k-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 -w
 """
 use "assert"
 use "buffered"

--- a/testing/performance/apps/market-spread/PERFORMANCE_TESTING_MARKET_SPREAD.md
+++ b/testing/performance/apps/market-spread/PERFORMANCE_TESTING_MARKET_SPREAD.md
@@ -117,13 +117,13 @@ sudo cset proc -s user -e numactl -- -C 1-8,17 chrt -f 80 ./market-spread -i 127
 To run the NBBO Sender: (must be started before Orders so that the initial NBBO can be set)
 ```
 cd ~/buffy
-sudo cset proc -s user -e numactl -- -C 15,17 chrt -f 80 ~/buffy/giles/sender/sender -b 127.0.0.1:7001 -m 10000000000 -s 300 -i 2_500_000 -f ~/buffy/demos/marketspread/350k-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 --ponypinasio -w —ponynoblock
+sudo cset proc -s user -e numactl -- -C 15,17 chrt -f 80 ~/buffy/giles/sender/sender -h 127.0.0.1:7001 -m 10000000000 -s 300 -i 2_500_000 -f ~/buffy/demos/marketspread/350k-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 --ponypinasio -w —ponynoblock
 ```
 
 To run the Orders Sender:
 ```
 cd ~/buffy
-sudo cset proc -s user -e numactl -- -C 16,17 chrt -f 80 ~/buffy/giles/sender/sender -b 127.0.0.1:7000 -m 5000000000 -s 300 -i 5_000_000 -f ~/buffy/demos/marketspread/350k-orders-fixish.msg -r --ponythreads=1 -y -g 57 --ponypinasio -w —ponynoblock
+sudo cset proc -s user -e numactl -- -C 16,17 chrt -f 80 ~/buffy/giles/sender/sender -h 127.0.0.1:7000 -m 5000000000 -s 300 -i 5_000_000 -f ~/buffy/demos/marketspread/350k-orders-fixish.msg -r --ponythreads=1 -y -g 57 --ponypinasio -w —ponynoblock
 ```
 
 ### Running with System Tap (stap) on Linux

--- a/testing/performance/apps/market-spread/market-spread.pony
+++ b/testing/performance/apps/market-spread/market-spread.pony
@@ -19,10 +19,10 @@ nc -l 127.0.0.1 5001 >> /dev/null
 ./market-spread -i 127.0.0.1:7000,127.0.0.1:7001 -o 127.0.0.1:5555 -m 127.0.0.1:5001 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker2 --ponythreads=4 --ponynoblock -w 2
 
 4) orders:
-giles/sender/sender -b 127.0.0.1:7000 -m 5000000 -s 300 -i 5_000_000 -f demos/marketspread/350k-orders-fixish.msg -r --ponythreads=1 -y -g 57 -w
+giles/sender/sender -h 127.0.0.1:7000 -m 5000000 -s 300 -i 5_000_000 -f demos/marketspread/350k-orders-fixish.msg -r --ponythreads=1 -y -g 57 -w
 
 5) nbbo:
-giles/sender/sender -b 127.0.0.1:7001 -m 10000000 -s 300 -i 2_500_000 -f demos/marketspread/350k-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 -w
+giles/sender/sender -h 127.0.0.1:7001 -m 10000000 -s 300 -i 2_500_000 -f demos/marketspread/350k-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 -w
 
 R3K or other Symbol Set (700, 1400, 2100)
 
@@ -35,10 +35,10 @@ R3K or other Symbol Set (700, 1400, 2100)
 ./market-spread -i 127.0.0.1:7000,127.0.0.1:7001 -o 127.0.0.1:5555 -m 127.0.0.1:5001 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker2 --ponythreads=4 --ponynoblock -w 2
 
 4) orders:
-giles/sender/sender -b 127.0.0.1:7000 -m 5000000 -s 300 -i 5_000_000 -f demos/marketspread/r3k-orders-fixish.msg -r --ponythreads=1 -y -g 57 -w
+giles/sender/sender -h 127.0.0.1:7000 -m 5000000 -s 300 -i 5_000_000 -f demos/marketspread/r3k-orders-fixish.msg -r --ponythreads=1 -y -g 57 -w
 
 5) nbbo:
-giles/sender/sender -b 127.0.0.1:7001 -m 10000000 -s 300 -i 2_500_000 -f demos/marketspread/r3k-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 -w
+giles/sender/sender -h 127.0.0.1:7001 -m 10000000 -s 300 -i 2_500_000 -f demos/marketspread/r3k-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 -w
 """
 use "assert"
 use "buffered"

--- a/testing/performance/apps/one-stream-market/one-stream-market.pony
+++ b/testing/performance/apps/one-stream-market/one-stream-market.pony
@@ -20,7 +20,7 @@ For each follower:
 sudo cset proc -s user -e numactl -- -C 1-4,17 chrt -f 80 ~/buffy/apps/one-stream-market/one-stream-market -i 0.0.0.0:7000 -o 127.0.0.1:5555 -m <METRICS>:5001 -c <INITIALIZER>:12500 -d <INITIALIZER>:12501 --ponythreads 4 --ponypinasio --ponynoblock -n <NAME> -w 4
 
 4) nbbo:
-sudo cset proc -s user -e numactl -- -C 15,17 chrt -f 80 ~/buffy/giles/sender/sender -b 127.0.0.1:7000 -m 10000000000 -s 300 -i 2_500_000 -f ~/buffy/demos/marketspread/350k-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 --ponypinasio -w —ponynoblock
+sudo cset proc -s user -e numactl -- -C 15,17 chrt -f 80 ~/buffy/giles/sender/sender -h 127.0.0.1:7000 -m 10000000000 -s 300 -i 2_500_000 -f ~/buffy/demos/marketspread/350k-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 --ponypinasio -w —ponynoblock
 """
 use "assert"
 use "buffered"


### PR DESCRIPTION
- Change giles-sender `--buffy/-b` option to `--host/-h`
- Update docs and doscrtings to use --host/-h instead of --buffy/-b

**Note**:
Doesn't change:
- variables named buffy (e.g. in Makefile)
- paths containing "buffy"
- references to "buffy" throughout the older repo docs.


fixes #687 