### PR TITLE
Revive spike

### DIFF
--- a/lib/wallaroo/boundary/data_receiver.pony
+++ b/lib/wallaroo/boundary/data_receiver.pony
@@ -175,7 +175,7 @@ actor DataReceiver is Producer
     ifdef "trace" then
       @printf[I32]("Rcvd msg at DataReceiver\n".cstring())
     end
-    if seq_id >= _last_id_seen then
+    if seq_id > _last_id_seen then
       _ack_counter = _ack_counter + 1
       _last_id_seen = seq_id
       _router.route(d, pipeline_time_spent, this, seq_id, latest_ts,
@@ -195,7 +195,7 @@ actor DataReceiver is Producer
   be replay_received(r: ReplayableDeliveryMsg val, pipeline_time_spent: U64,
     seq_id: SeqId, latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64)
   =>
-    if seq_id >= _last_id_seen then
+    if seq_id > _last_id_seen then
       _last_id_seen = seq_id
       _router.replay_route(r, pipeline_time_spent, this, seq_id, latest_ts,
         metrics_id, worker_ingress_ts)

--- a/lib/wallaroo/initialization/worker_initializer.pony
+++ b/lib/wallaroo/initialization/worker_initializer.pony
@@ -72,7 +72,7 @@ actor WorkerInitializer
 
   be identify_data_address(worker: String, host: String, service: String) =>
     if (not _data_addrs.contains(worker)) and (not _topology_ready) then
-      @printf[I32]("Worker %s control channel identified\n".cstring(),
+      @printf[I32]("Worker %s data channel identified\n".cstring(),
         worker.cstring())
       _data_addrs(worker) = (host, service)
       _data_identified = _data_identified + 1

--- a/lib/wallaroo/network/connections.pony
+++ b/lib/wallaroo/network/connections.pony
@@ -12,13 +12,13 @@ use "wallaroo/initialization"
 use "wallaroo/messages"
 use "wallaroo/metrics"
 use "wallaroo/recovery"
+use "wallaroo/spike"
 use "wallaroo/tcp_source"
 use "wallaroo/topology"
 
 actor Connections is Cluster
   let _app_name: String
   let _worker_name: String
-  let _env: Env
   let _auth: AmbientAuth
   let _is_initializer: Bool
   var _my_control_addr: (String, String) = ("", "")
@@ -41,17 +41,17 @@ actor Connections is Cluster
   let _guid_gen: GuidGenerator = GuidGenerator
   let _connection_addresses_file: String
   let _is_joining: Bool
+  let _spike_config: (SpikeConfig | None)
 
   new create(app_name: String, worker_name: String,
-    env: Env, auth: AmbientAuth, c_host: String, c_service: String,
+    auth: AmbientAuth, c_host: String, c_service: String,
     d_host: String, d_service: String, ph_host: String, ph_service: String,
     metrics_conn: MetricsSink, metrics_host: String, metrics_service: String,
     is_initializer: Bool, connection_addresses_file: String,
-    is_joining: Bool)
+    is_joining: Bool, spike_config: (SpikeConfig | None) = None)
   =>
     _app_name = app_name
     _worker_name = worker_name
-    _env = env
     _auth = auth
     _is_initializer = is_initializer
     _metrics_conn = metrics_conn
@@ -61,6 +61,7 @@ actor Connections is Cluster
     _init_d_service = d_service
     _connection_addresses_file = connection_addresses_file
     _is_joining = is_joining
+    _spike_config = spike_config
 
     if _is_initializer then
       _my_control_addr = (c_host, c_service)
@@ -71,7 +72,7 @@ actor Connections is Cluster
 
     if (ph_host != "") and (ph_service != "") then
       let phone_home = TCPConnection(auth,
-        HomeConnectNotify(env, _worker_name, this), ph_host, ph_service)
+        HomeConnectNotify(_worker_name, this), ph_host, ph_service)
       _phone_home = phone_home
       if is_initializer then
         let ready_msg = ExternalMsgEncoder.ready(_worker_name)
@@ -269,7 +270,7 @@ actor Connections is Cluster
     | let tcp: TCPConnection =>
       tcp.writev(msg)
     else
-      _env.err.print("There is no phone home connection to send on!")
+      @printf[I32]("There is no phone home connection to send on!\n".cstring())
     end
 
   be create_boundary_to_new_worker(target: String, boundary_id: U128,
@@ -280,7 +281,7 @@ actor Connections is Cluster
       let reporter = MetricsReporter(_app_name,
         _worker_name, _metrics_conn)
       let builder = OutgoingBoundaryBuilder(_auth, _worker_name,
-        consume reporter, host, service)
+        consume reporter, host, service, _spike_config)
       let boundary = builder.build_and_initialize(boundary_id,
         local_topology_initializer)
       local_topology_initializer.add_boundary_to_new_worker(target, boundary,
@@ -312,7 +313,8 @@ actor Connections is Cluster
       out_bbs(target) = builder
     end
 
-    @printf[I32](("Preparing to update " + _data_conns.size().string() + " boundaries\n").cstring())
+    @printf[I32](("Preparing to update " + _data_conns.size().string() +
+      " boundaries\n").cstring())
 
     local_topology_initializer.update_boundaries(consume out_bs,
       consume out_bbs)
@@ -471,7 +473,7 @@ actor Connections is Cluster
   =>
     _control_addrs(target_name) = (host, service)
     let control_notifier: TCPConnectionNotify iso =
-      ControlSenderConnectNotifier(_env, _auth, target_name)
+      ControlSenderConnectNotifier(_auth, target_name)
     let control_conn: TCPConnection =
       TCPConnection(_auth, consume control_notifier, host, service)
     _control_conns(target_name) = control_conn
@@ -498,7 +500,8 @@ actor Connections is Cluster
   =>
     _data_addrs(target_name) = (host, service)
     let boundary_builder = OutgoingBoundaryBuilder(_auth, _worker_name,
-      MetricsReporter(_app_name, _worker_name, _metrics_conn), host, service)
+      MetricsReporter(_app_name, _worker_name, _metrics_conn), host, service,
+      _spike_config)
     let outgoing_boundary = boundary_builder(_guid_gen.u128())
     _data_conn_builders(target_name) = boundary_builder
     _data_conns(target_name) = outgoing_boundary
@@ -508,7 +511,8 @@ actor Connections is Cluster
   =>
     _data_addrs(target_name) = (host, service)
     let boundary_builder = OutgoingBoundaryBuilder(_auth, _worker_name,
-      MetricsReporter(_app_name, _worker_name, _metrics_conn), host, service)
+      MetricsReporter(_app_name, _worker_name, _metrics_conn), host, service,
+      _spike_config)
     let outgoing_boundary =
       boundary_builder.build_and_initialize(_guid_gen.u128(), lti)
     _data_conn_builders(target_name) = boundary_builder

--- a/lib/wallaroo/network/phone_home_tcp.pony
+++ b/lib/wallaroo/network/phone_home_tcp.pony
@@ -3,14 +3,12 @@ use "sendence/messages"
 use "sendence/bytes"
 
 class HomeConnectNotify is TCPConnectionNotify
-  let _env: Env
   let _name: String
   let _connections: Connections
   var _header: Bool = true
   var _has_connected: Bool = false
 
-  new iso create(env: Env, name: String, connections: Connections) =>
-    _env = env
+  new iso create(name: String, connections: Connections) =>
     _name = name
     _connections = connections
 
@@ -29,18 +27,19 @@ class HomeConnectNotify is TCPConnectionNotify
         conn.expect(expect)
         _header = false
       else
-        _env.err.print("Error reading header on phone home channel")
+        @printf[I32]("Error reading header on phone home channel\n".cstring())
       end
     else
       try
         let external_msg = ExternalMsgDecoder(consume data)
         match external_msg
         | let m: ExternalShutdownMsg val =>
-          _env.out.print("Received ExternalShutdownMsg")
+          @printf[I32]("Received ExternalShutdownMsg\n".cstring())
           _connections.shutdown()
         end
       else
-        _env.err.print("Phone home connection: error decoding phone home message")
+        @printf[I32](("Phone home connection: error decoding phone home " +
+          "message\n").cstring())
       end
 
       conn.expect(4)
@@ -49,4 +48,4 @@ class HomeConnectNotify is TCPConnectionNotify
     true
 
   fun ref closed(conn: TCPConnection ref) =>
-    _env.out.print("HomeConnectNotify: " + _name + ": server closed")
+    @printf[I32](("HomeConnectNotify: " + _name + ": server closed\n").cstring())

--- a/lib/wallaroo/spike/_test.pony
+++ b/lib/wallaroo/spike/_test.pony
@@ -25,17 +25,19 @@ actor Main is TestList
     test(_TestDoesntDropConnectionWhenThrottledWhenNotSpiked)
     test(_TestDoesntDropConnectionWhenUnthrottledWhenSpiked)
     test(_TestDoesntDropConnectionWhenUnthrottledWhenNotSpiked)
+    test(_TestDropsConnectionWhenSpikedWithMargin)
 
 class iso _TestDropsConnectionWhenConnectingWhenSpiked is UnitTest
   fun name(): String =>
     "spike/DropsConnectionWhenConnectingWhenSpiked"
 
-  fun ref apply(h: TestHelper) =>
+  fun ref apply(h: TestHelper) ? =>
     let connection = NullWallarooOutgoingNetworkActor(h, true)
     let connection_count = U32(1)
 
     let notify = ConnectingNotify(h, connection, connection_count)
-    let spike = recover ref DropConnection(1, 100, consume notify) end
+    let spike = recover ref DropConnection(SpikeConfig(where seed'=1, prob'=1,
+      margin'=0), consume notify) end
 
     h.expect_action("connecting")
     h.expect_action("closed")
@@ -48,12 +50,13 @@ class iso _TestDoesntDropConnectionWhenConnectingWhenNotSpiked is UnitTest
   fun name(): String =>
     "spike/DoesntDropConnectionWhenConnectingWhenNotSpiked"
 
-  fun ref apply(h: TestHelper) =>
+  fun ref apply(h: TestHelper) ? =>
     let connection = NullWallarooOutgoingNetworkActor(h, false)
     let connection_count = U32(1)
 
     let notify = ConnectingNotify(h, connection, connection_count)
-    let spike = recover ref DropConnection(1, 0, consume notify) end
+    let spike = recover ref DropConnection(SpikeConfig(where seed'=1, prob'=0,
+    margin'=0), consume notify) end
 
     h.expect_action("connecting")
 
@@ -113,12 +116,13 @@ class iso _TestDropsConnectionWhenConnectedWhenSpiked is UnitTest
   fun name(): String =>
     "spike/DropsConnectionWhenConnectedWhenSpiked"
 
-  fun ref apply(h: TestHelper) =>
+  fun ref apply(h: TestHelper) ? =>
     let connection = NullWallarooOutgoingNetworkActor(h, true)
     let connection_count = U32(1)
 
     let notify = ConnectedNotify(h, connection)
-    let spike = recover ref DropConnection(1, 100, consume notify) end
+    let spike = recover ref DropConnection(SpikeConfig(where seed'=1, prob'=1,
+    margin'=0), consume notify) end
 
     h.expect_action("connected")
     h.expect_action("closed")
@@ -131,12 +135,13 @@ class iso _TestDoesntDropConnectionWhenConnectedWhenNotSpiked is UnitTest
   fun name(): String =>
     "spike/DoesntDropConnectionWhenConnectedWhenNotSpiked"
 
-  fun ref apply(h: TestHelper) =>
+  fun ref apply(h: TestHelper) ? =>
     let connection = NullWallarooOutgoingNetworkActor(h, false)
     let connection_count = U32(1)
 
     let notify = ConnectedNotify(h, connection)
-    let spike = recover ref DropConnection(1, 0, consume notify) end
+    let spike = recover ref DropConnection(SpikeConfig(where seed'=1, prob'=0,
+    margin'=0), consume notify) end
 
     h.expect_action("connected")
 
@@ -191,11 +196,12 @@ class iso _TestDoesntDropConnectionWhenConnectFailedWhenSpiked is UnitTest
   fun name(): String =>
     "spike/DoesntDropConnectionWhenConnectFailed"
 
-  fun ref apply(h: TestHelper) =>
+  fun ref apply(h: TestHelper) ? =>
     let connection = NullWallarooOutgoingNetworkActor(h, false)
 
     let notify = ConnectFailedNotify(h, connection)
-    let spike = recover ref DropConnection(1, 100, consume notify) end
+    let spike = recover ref DropConnection(SpikeConfig(where seed'=1, prob'=1,
+    margin'=0), consume notify) end
 
     h.expect_action("connect_failed")
 
@@ -207,11 +213,12 @@ class iso _TestDoesntDropConnectionWhenConnectFailedWhenNotSpiked is UnitTest
   fun name(): String =>
     "spike/DoesntDropConnectionWhenConnectFailedWhenNotSpiked"
 
-  fun ref apply(h: TestHelper) =>
+  fun ref apply(h: TestHelper) ? =>
     let connection = NullWallarooOutgoingNetworkActor(h, false)
 
     let notify = ConnectFailedNotify(h, connection)
-    let spike = recover ref DropConnection(1, 0, consume notify) end
+    let spike = recover ref DropConnection(SpikeConfig(where seed'=1, prob'=0,
+    margin'=0), consume notify) end
 
     h.expect_action("connect_failed")
 
@@ -266,11 +273,12 @@ class iso _TestDoesntDropConnectionWhenClosedWhenSpiked is UnitTest
   fun name(): String =>
     "spike/DoesntDropConnectionWhenConnectFailed"
 
-  fun ref apply(h: TestHelper) =>
+  fun ref apply(h: TestHelper) ? =>
     let connection = NullWallarooOutgoingNetworkActor(h, false)
 
     let notify = ClosedNotify(h, connection)
-    let spike = recover ref DropConnection(1, 100, consume notify) end
+    let spike = recover ref DropConnection(SpikeConfig(where seed'=1, prob'=1,
+    margin'=0), consume notify) end
 
     h.expect_action("closed")
 
@@ -282,11 +290,12 @@ class iso _TestDoesntDropConnectionWhenClosedWhenNotSpiked is UnitTest
   fun name(): String =>
     "spike/DoesntDropConnectionWhenClosedWhenNotSpiked"
 
-  fun ref apply(h: TestHelper) =>
+  fun ref apply(h: TestHelper) ? =>
     let connection = NullWallarooOutgoingNetworkActor(h, false)
 
     let notify = ClosedNotify(h, connection)
-    let spike = recover ref DropConnection(1, 0, consume notify) end
+    let spike = recover ref DropConnection(SpikeConfig(where seed'=1, prob'=0,
+      margin'=0), consume notify) end
 
     h.expect_action("closed")
 
@@ -341,12 +350,13 @@ class iso _TestDropsConnectionWhenSentvWhenSpiked is UnitTest
   fun name(): String =>
     "spike/DropsConnectionWhenSentvWhenSpiked"
 
-  fun ref apply(h: TestHelper) =>
+  fun ref apply(h: TestHelper) ? =>
     let connection = NullWallarooOutgoingNetworkActor(h, true)
     let data = recover val ["Hello", "Willow"] end
 
     let notify = SentvNotify(h, connection, data)
-    let spike = recover ref DropConnection(1, 100, consume notify) end
+    let spike = recover ref DropConnection(SpikeConfig(where seed'=1, prob'=1,
+      margin'=0), consume notify) end
 
     h.expect_action("sentv")
     h.expect_action("closed")
@@ -359,12 +369,13 @@ class iso _TestDoesntDropConnectionWhenSentvWhenNotSpiked is UnitTest
   fun name(): String =>
     "spike/DoesntDropConnectionWhenSentvWhenNotSpiked"
 
-  fun ref apply(h: TestHelper) =>
+  fun ref apply(h: TestHelper) ? =>
     let connection = NullWallarooOutgoingNetworkActor(h, false)
     let data = recover val ["Goodbye", "Angel"] end
 
     let notify = SentvNotify(h, connection, data)
-    let spike = recover ref DropConnection(1, 0, consume notify) end
+    let spike = recover ref DropConnection(SpikeConfig(where seed'=1, prob'=0,
+      margin'=0), consume notify) end
 
     h.expect_action("sentv")
 
@@ -424,14 +435,15 @@ class iso _TestDropsConnectionWhenReceivedWhenSpiked is UnitTest
   fun name(): String =>
     "spike/DropsConnectionWhenReceivedWhenSpiked"
 
-  fun ref apply(h: TestHelper) =>
+  fun ref apply(h: TestHelper) ? =>
     let connection = NullWallarooOutgoingNetworkActor(h, true)
     let expected_data = recover val [as U8: 1, 2, 3, 4, 5, 10] end
     let send_data = recover iso [as U8: 1, 2, 3, 4, 5, 10] end
     let times = USize(3)
 
     let notify = ReceivedNotify(h, connection, expected_data, times)
-    let spike = recover ref DropConnection(1, 100, consume notify) end
+    let spike = recover ref DropConnection(SpikeConfig(where seed'=1, prob'=1,
+      margin'=0), consume notify) end
 
     h.expect_action("received")
     h.expect_action("closed")
@@ -444,14 +456,15 @@ class iso _TestDoesntDropConnectionWhenReceivedWhenNotSpiked is UnitTest
   fun name(): String =>
     "spike/DoesntDropConnectionWhenReceivedWhenNotSpiked"
 
-  fun ref apply(h: TestHelper) =>
+  fun ref apply(h: TestHelper) ? =>
     let connection = NullWallarooOutgoingNetworkActor(h, false)
     let expected_data = recover val [as U8: 1, 2, 3, 4, 5, 10] end
     let send_data = recover iso [as U8: 1, 2, 3, 4, 5, 10] end
     let times = USize(3)
 
     let notify = ReceivedNotify(h, connection, expected_data, times)
-    let spike = recover ref DropConnection(1, 0, consume notify) end
+    let spike = recover ref DropConnection(SpikeConfig(where seed'=1, prob'=0,
+      margin'=0), consume notify) end
 
     h.expect_action("received")
 
@@ -513,12 +526,13 @@ class iso _TestDoesntDropConnectionWhenExpectWhenSpiked is UnitTest
   fun name(): String =>
     "spike/DoesntDropConnectionWhenExpectWhenSpiked"
 
-  fun ref apply(h: TestHelper) =>
+  fun ref apply(h: TestHelper) ? =>
     let connection = NullWallarooOutgoingNetworkActor(h, false)
     let qty = USize(13)
 
     let notify = ExpectNotify(h, connection, qty)
-    let spike = recover ref DropConnection(1, 100, consume notify) end
+    let spike = recover ref DropConnection(SpikeConfig(where seed'=1, prob'=1,
+      margin'=0), consume notify) end
 
     h.expect_action("expect")
 
@@ -530,12 +544,13 @@ class iso _TestDoesntDropConnectionWhenExpectWhenNotSpiked is UnitTest
   fun name(): String =>
     "spike/DoesntDropConnectionWhenExpectWhenNotSpiked"
 
-  fun ref apply(h: TestHelper) =>
+  fun ref apply(h: TestHelper) ? =>
     let connection = NullWallarooOutgoingNetworkActor(h, false)
     let qty = USize(18)
 
     let notify = ExpectNotify(h, connection, qty)
-    let spike = recover ref DropConnection(1, 0, consume notify) end
+    let spike = recover ref DropConnection(SpikeConfig(where seed'=1, prob'=0,
+      margin'=0), consume notify) end
 
     h.expect_action("expect")
 
@@ -595,11 +610,12 @@ class iso _TestDoesntDropConnectionWhenThrottledWhenSpiked is UnitTest
   fun name(): String =>
     "spike/DoesntDropConnectionWhenThrottledWhenSpiked"
 
-  fun ref apply(h: TestHelper) =>
+  fun ref apply(h: TestHelper) ? =>
     let connection = NullWallarooOutgoingNetworkActor(h, false)
 
     let notify = ThrottledNotify(h, connection)
-    let spike = recover ref DropConnection(1, 100, consume notify) end
+    let spike = recover ref DropConnection(SpikeConfig(where seed'=1, prob'=1,
+      margin'=0), consume notify) end
 
     h.expect_action("throttled")
 
@@ -611,11 +627,12 @@ class iso _TestDoesntDropConnectionWhenThrottledWhenNotSpiked is UnitTest
   fun name(): String =>
     "spike/DoesntDropConnectionWhenThrottledWhenNotSpiked"
 
-  fun ref apply(h: TestHelper) =>
+  fun ref apply(h: TestHelper) ? =>
     let connection = NullWallarooOutgoingNetworkActor(h, false)
 
     let notify = ThrottledNotify(h, connection)
-    let spike = recover ref DropConnection(1, 0, consume notify) end
+    let spike = recover ref DropConnection(SpikeConfig(where seed'=1, prob'=0,
+      margin'=0), consume notify) end
 
     h.expect_action("throttled")
 
@@ -670,11 +687,12 @@ class iso _TestDoesntDropConnectionWhenUnthrottledWhenSpiked is UnitTest
   fun name(): String =>
     "spike/DoesntDropConnectionWhenUnthrottledWhenSpiked"
 
-  fun ref apply(h: TestHelper) =>
+  fun ref apply(h: TestHelper) ? =>
     let connection = NullWallarooOutgoingNetworkActor(h, false)
 
     let notify = UnthrottledNotify(h, connection)
-    let spike = recover ref DropConnection(1, 100, consume notify) end
+    let spike = recover ref DropConnection(SpikeConfig(where seed'=1, prob'=1,
+      margin'=0), consume notify) end
 
     h.expect_action("unthrottled")
 
@@ -686,11 +704,12 @@ class iso _TestDoesntDropConnectionWhenUnthrottledWhenNotSpiked is UnitTest
   fun name(): String =>
     "spike/DoesntDropConnectionWhenUnthrottledWhenNotSpiked"
 
-  fun ref apply(h: TestHelper) =>
+  fun ref apply(h: TestHelper) ? =>
     let connection = NullWallarooOutgoingNetworkActor(h, false)
 
     let notify = UnthrottledNotify(h, connection)
-    let spike = recover ref DropConnection(1, 0, consume notify) end
+    let spike = recover ref DropConnection(SpikeConfig(where seed'=1, prob'=0,
+      margin'=0), consume notify) end
 
     h.expect_action("unthrottled")
 
@@ -741,6 +760,30 @@ class UnthrottledNotify is WallarooOutgoingNetworkActorNotify
     _h.complete_action("unthrottled")
     _h.assert_true(conn is _conn)
 
+class iso _TestDropsConnectionWhenSpikedWithMargin is UnitTest
+  fun name(): String =>
+    "spike/DropsConnectionWhenSpikedWithMargin"
+
+  fun ref apply(h: TestHelper) ? =>
+    let connection = NullWallarooOutgoingNetworkActor(h, true)
+    let connection_count = U32(1)
+
+    let notify = ConnectedNotify(h, connection)
+    let spike = recover ref DropConnection(SpikeConfig(where seed'=1, prob'=1,
+    margin'=3), consume notify) end
+    // if margin = 3, the 4th action should drop
+    h.expect_action("connected")
+    h.expect_action("connected")
+    h.expect_action("connected")
+    h.expect_action("closed")
+
+    spike.connected(connection)
+    spike.connected(connection)
+    spike.connected(connection)
+    spike.connected(connection)
+
+    h.long_test(1)
+
 class NullWallarooOutgoingNetworkActor is WallarooOutgoingNetworkActor
   let _h: TestHelper
   let _should_close: Bool
@@ -755,13 +798,13 @@ class NullWallarooOutgoingNetworkActor is WallarooOutgoingNetworkActor
   fun ref expect(qty: USize = 0) =>
     None
 
+  fun ref receive_ack(seq_id: SeqId) =>
+    None
+
   fun ref receive_connect_ack(seq_id: SeqId) =>
     None
 
   fun ref start_normal_sending() =>
-    None
-
-  fun ref receive_ack(seq_id: SeqId) =>
     None
 
   fun ref close() =>

--- a/lib/wallaroo/spike/config.pony
+++ b/lib/wallaroo/spike/config.pony
@@ -1,0 +1,30 @@
+use "assert"
+use "time"
+
+class val SpikeConfig
+  let drop: Bool
+  let seed: U64
+  let prob: F64
+  let margin: USize
+
+  new val create(drop': Bool = true, prob': (F64 | None) = 0.001,
+    margin': (USize | None) = 10, seed': (U64 | None) = None) ?
+  =>
+    drop = drop'
+    match prob'
+    | let arg: F64 =>
+      Fact(arg <= 1, "prob' must be between 0 and 1")
+      prob = arg
+    else
+      prob = 0.001
+    end
+    match seed'
+    | let arg: U64 => seed = arg
+    else
+      seed = Time.millis()
+    end
+    match margin'
+    | let arg: USize => margin = arg
+    else
+      margin = 10
+    end

--- a/lib/wallaroo/spike/drop_connection.pony
+++ b/lib/wallaroo/spike/drop_connection.pony
@@ -1,30 +1,39 @@
+use "collections"
 use "random"
 use "wallaroo/network"
 
 class DropConnection is WallarooOutgoingNetworkActorNotify
   let _letter: WallarooOutgoingNetworkActorNotify
-  let _dice: Dice
-  let _prob: U64
+  let _rand: Random
+  let _prob: F64
+  let _margin: USize
+  var _count_since_last_dropped: USize = 0
+  let _c: Map[String, USize] = Map[String, USize](4)
 
-  new iso create(seed: U64, prob: U64,
+  new iso create(config: SpikeConfig,
     letter: WallarooOutgoingNetworkActorNotify iso)
   =>
-    _dice = Dice(MT(seed))
-    _prob = prob
+    _rand = MT(config.seed)
+    _prob = config.prob
+    _margin = config.margin
     _letter = consume letter
 
   fun ref connecting(conn: WallarooOutgoingNetworkActor ref, count: U32) =>
-    if spike() then
-      drop(conn)
+    ifdef "spiketrace" then
+      try
+        _c.upsert("connecting", 1, {(x: USize=0, y: USize): USize => x+y})
+      end
     end
-
+    spike(conn)
     _letter.connecting(conn, count)
 
   fun ref connected(conn: WallarooOutgoingNetworkActor ref) =>
-    if spike() then
-      drop(conn)
+    ifdef "spiketrace" then
+      try
+        _c.upsert("connected", 1, {(x: USize=0, y: USize): USize => x+y})
+      end
     end
-
+    spike(conn)
     _letter.connected(conn)
 
   fun ref connect_failed(conn: WallarooOutgoingNetworkActor ref) =>
@@ -36,18 +45,23 @@ class DropConnection is WallarooOutgoingNetworkActorNotify
   fun ref sentv(conn: WallarooOutgoingNetworkActor ref,
     data: ByteSeqIter): ByteSeqIter
   =>
-    if spike() then
-      drop(conn)
+    ifdef "spiketrace" then
+      try
+        _c.upsert("sentv", 1, {(x: USize=0, y: USize): USize => x+y})
+      end
     end
-
+    spike(conn)
     _letter.sentv(conn, data)
 
   fun ref received(conn: WallarooOutgoingNetworkActor ref, data: Array[U8] iso,
     n: USize): Bool
   =>
-    if spike() then
-      drop(conn)
+    ifdef "spiketrace" then
+      try
+        _c.upsert("received", 1, {(x: USize=0, y: USize): USize => x+y})
+      end
     end
+    spike(conn)
     // We need to always send the data we've read from the buffer along.
     // Even when we drop the connection, we've already read that data
     // and _letter is still expecting it.
@@ -63,8 +77,43 @@ class DropConnection is WallarooOutgoingNetworkActorNotify
   fun ref unthrottled(conn: WallarooOutgoingNetworkActor ref) =>
     _letter.unthrottled(conn)
 
-  fun ref spike(): Bool =>
-    _dice(1, 100) <= _prob
+  fun ref spike(conn: WallarooOutgoingNetworkActor ref) =>
+    _count_since_last_dropped = _count_since_last_dropped + 1
+    if _rand.real() <= _prob then
+      if _margin == 0 then
+        drop(conn)
+      elseif _count_since_last_dropped >= _margin then
+        drop(conn)
+      end
+    end
 
   fun ref drop(conn: WallarooOutgoingNetworkActor ref) =>
+    ifdef debug then
+      @printf[I32]("\n<<<<<<SPIKE: DROPPING CONNECTION!>>>>>>\n\n".cstring())
+    end
+    // reset count, return true
+    _count_since_last_dropped = 0
+    ifdef "spiketrace" then
+      // print and reset counts
+      _print_counts()
+      _c.clear()
+    end
+    // drop connection
     conn.close()
+
+  fun _print_counts() =>
+    try
+      let a: Array[U8] iso = recover Array[U8] end
+      a.append("SPIKE Counts: {")
+      for (k, v) in _c.pairs() do
+        a.append(k)
+        a.append(": ")
+        a.append(v.string())
+        a.append(", ")
+      end
+      a.pop()
+      a.pop()
+      a.append("}\n")
+      let s = String.from_array(consume a)
+      @printf[I32](s.cstring())
+    end

--- a/lib/wallaroo/spike/notify_wrapper.pony
+++ b/lib/wallaroo/spike/notify_wrapper.pony
@@ -1,13 +1,4 @@
-use "time"
 use "wallaroo/network"
-
-class SpikeConfig
-  let drop: Bool
-  let seed: U64
-
-  new val create(drop': Bool, seed': U64 = Time.millis()) =>
-    drop = drop'
-    seed = seed'
 
 primitive SpikeWrapper
   fun apply(letter: WallarooOutgoingNetworkActorNotify iso,
@@ -15,7 +6,7 @@ primitive SpikeWrapper
   =>
     var notify: WallarooOutgoingNetworkActorNotify iso = consume letter
     if config.drop then
-      notify = DropConnection(config.seed, 10, consume notify)
+      notify = DropConnection(config, consume notify)
     end
 
     consume notify

--- a/lib/wallaroo/topology/_test.pony
+++ b/lib/wallaroo/topology/_test.pony
@@ -273,7 +273,7 @@ primitive _DataReceiversGenerator
 
 primitive _ConnectionsGenerator
   fun apply(env: Env, auth: AmbientAuth): Connections =>
-    Connections("", "", env, auth, "", "", "", "", "", "",
+    Connections("", "", auth, "", "", "", "", "", "",
       MetricsSink("", "", "", ""), "", "", false, "", false)
 
 primitive _RecoveryReplayerGenerator

--- a/lib/wallaroo/w_actor/w_actor_startup.pony
+++ b/lib/wallaroo/w_actor/w_actor_startup.pony
@@ -212,7 +212,7 @@ actor ActorSystemStartup
 
 primitive EmptyConnections
   fun apply(env: Env, auth: AmbientAuth): Connections =>
-    Connections("", "", env, auth, "", "", "", "", "", "",
+    Connections("", "", auth, "", "", "", "", "", "",
       MetricsSink("", "", "", ""), "", "", false, "", false)
 
 primitive EmptyRouterRegistry

--- a/testing/correctness/apps/sequence-window/validator/.gitignore
+++ b/testing/correctness/apps/sequence-window/validator/.gitignore
@@ -1,2 +1,4 @@
 validator
 validator.o
+received.txt
+fallor-readable.txt

--- a/testing/correctness/playbooks/boundary-reconnect.md
+++ b/testing/correctness/playbooks/boundary-reconnect.md
@@ -1,0 +1,47 @@
+# Testing Reconnect in Wallaroo
+
+## Description
+
+Wallaroo can run a single application topology across several hosts. In order to properly test this behaviour, it is important to understand how it is implemented.
+Since Wallaroo topologies are DAGs, they are implemented as a collection of steps strung together by a lookup map. At the end of each step, a router is used to determine where the next step in the DAG resides. If it is local, the step is executed with the output of the current step. If, however, the next step is on another host, we have to move the output of the current step over to the correct step on the correct host. This flow looks like: 
+
+```
+[HOST_A: step -> router -> proxy router (if on another host) -> specific boundary] -> data_channel ->
+[HOST_B: data_receiver  -> data_router -> step]
+```
+
+
+##  Testing Boundary Reconnection
+Before we can test the reconnection behaviour, we must first introduce a disconnect in the system.
+To do this, we can use `spike`, a compile-time fault injection component of Wallaroo.
+`Spike` takes two parameters in the standard application startup: `--spike-drop`, a boolean determining whether the current process should perform any fault injection on its boundary connections, and `--spike-seed`, a value which is used to seed `Spike`'s psuedo-random choice of when to drop a connection. If you use the same seed value, you will get the exact same choices, in the same sequence, which is very useful to testing.
+
+In addition to `Spike`, we also need a boundary in our application.
+Luckily, `sequence-window` already has a boundary when run with two workers, so that's taken care of.
+
+The gist of the test is simple: We run `sequence-window` with `Spike` on the `initializer` worker, and observe that once the connection is dropped, a reconnect behaviour follows, is successful, and the data resumes to both processes of the application.
+
+
+### Setting Up for the Test:
+
+1. build Giles receiver and sender
+2. build `testing/correctness/apps/sequence-window` with `-D spike` (and optionally `-d` for debug messages)
+
+### Running the Test:
+
+1. start giles-receiver:  `../../../../giles/receiver/receiver --ponythreads=1 --ponynoblock --ponypinasio -l 127.0.0.1:5555`
+2. start initializer-worker: `./sequence-window -i 127.0.0.1:7000 -o 127.0.0.1:5555 -m 127.0.0.1:5001 --ponythreads=4 --ponypinasio --ponynoblock -c 127.0.0.1:12500 -d 127.0.0.1:12501 -r res-data -w 2 -n worker1 -t --spike-drop --spike-prob 0.001 --spike-margin 1000`
+3. start second worker: `./sequence-window -i 127.0.0.1:7000 -o 127.0.0.1:5555 -m 127.0.0.1:5001 --ponythreads=4 --ponypinasio --ponynoblock -c 127.0.0.1:12500 -d 127.0.0.1:12501 -r res-data -w 2 -n worker2`
+4. start giles-sender and send 10000 integers: `../../../../giles/sender/sender -h 127.0.0.1:7000 -s 10 -i 5_000_000 -u --ponythreads=1 -y -g 12 -w -m 10000`
+5. wait for giles-sender to complete
+6. Terminate all of the processes
+
+### Analysing the Test Results:
+
+#### Automatically
+1. Compile `testing/correctness/apps/sequence-window/validator`
+2. run `validator/validator -i received.txt -e 1000`
+
+#### Manually
+
+1. Decode the giles-receiver output with fallor and visually inspect the output sequences to comply with the expectation described above.


### PR DESCRIPTION
_Note_: this PR does **not** fix reconnection on a disconnected boundary. That should be addressed in its own issue.

As a result, you can only manually test that spike is working by running any wallaroo application with spike and observing that it does indeed drop the boundary's TCP connection.

## Changes:
- Add spike config to wallaroo_config
- Add updated spike
- Add SpikeConfig class to hold spike parameters
- Add new methods to NullWallarooOutgoingNetworkActor
- Update spike tests
- Update spike's drop_connection wrapper
- Use fraction for probabilities and set default to 0.001
- Add setting for minimum margin between spikes, set default to 10
- Add boudnary-reconnect playbook
- Fix off-by-1 seq_id deduplication
- Fix typo in printf: 'control' -> 'data'
- Replace env.out.print with @printf where encountered
- Plug spike all the way through from startup

## Testing:
With the `sequence-window` application, you can verify spike works by taking the following steps:

1. build sequence-window with spike: `stable env ponyc -d -D spike -D spiketrace`
1. run receiver: `../../../../giles/receiver/receiver --ponythreads=1 --ponynoblock --ponypinasio -l 127.0.0.1:5555`
1. run initializer, setting spike-probability to 1 and margin to 100: `./sequence-window -i 127.0.0.1:7000 -o 127.0.0.1:5555 -m 127.0.0.1:5001 --ponythreads=4 --ponypinasio --ponynoblock -c 127.0.0.1:12500 -d 127.0.0.1:12501 -r res-data -w 2 -n worker1 -t --spike-drop --spike-prob 1 --spike-margin 100`
1. run second worker with spike off (so only initializer drops): `./sequence-window -i 127.0.0.1:7000 -o 127.0.0.1:5555 -m 127.0.0.1:5001 --ponythreads=4 --ponypinasio --ponynoblock -c 127.0.0.1:12500 -d 127.0.0.1:12501 -r res-data -w 2 -n worker2`
1. send some data with sender: `../../../../giles/sender/sender -h 127.0.0.1:7000 -s 1 -i 50_000_000 --ponythreads=1 -y -g 12 -w -u -m 1000`

After a little under 200 messages (only half the input messages go over the boundary because of the partitioning), you should see the following in your process stdout:
```bash
output: [177,179,181,183]

<<<<<<SPIKE: DROPPING CONNECTION!>>>>>>

SPIKE Counts: {connecting: 1, sentv: 94, connected: 1, received: 4}
writev error: 32, iovcnt: 2
BoundaryNotify: closed

MUTE
```

And on the second worker:
```bash
output: [176,178,180,182]
DataChannelConnectNotifier : server closed
```


closes #335