### PR TITLE
Switch giles-sender to using "sendence/options"

### DIFF
--- a/giles/sender/giles-sender.pony
+++ b/giles/sender/giles-sender.pony
@@ -6,11 +6,11 @@ use "collections"
 use "debug"
 use "files"
 use "net"
-use "options"
 use "random"
 use "time"
 use "sendence/bytes"
 use "sendence/messages"
+use "sendence/options"
 use "sendence/tcp"
 
 // documentation


### PR DESCRIPTION
We now use our own fork of options. This change was missed as part of
6c22c41b0c355a6799aee90e78055343d4534209