### PR TITLE
Allow ctrl-c to cause Machida to exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Wallaroo Changelog
+
+## [ unreleased ] - [ unreleased ]
+
+### Wallaroo
+
+### Python API
+
+### C++ API
+
+### Machida
+
+- ctrl-c now exits a running Machida process

--- a/machida/main.pony
+++ b/machida/main.pony
@@ -1,4 +1,5 @@
 use "collections"
+use "signals"
 use "sendence/options"
 use "wallaroo"
 use "wallaroo/tcp_source"
@@ -12,6 +13,8 @@ actor Main
     Machida.start_python()
 
     try
+      SignalHandler(ShutdownHandler, Sig.int())
+
       var module_name: String = ""
 
       let options = Options(WallarooConfig.application_args(env.args), false)

--- a/machida/signal_handling.pony
+++ b/machida/signal_handling.pony
@@ -1,0 +1,8 @@
+use "signals"
+
+use @Py_Exit[None]()
+
+class iso ShutdownHandler is SignalNotify
+  fun ref apply(count: U32): Bool =>
+    @Py_Exit()
+    false


### PR DESCRIPTION
Before this change, sending "ctrl-c" to Machida from the command line
caused nothing to happen. In order to kill the application, you add to
send a `kill -9` to the process.

Fixes #803