### PR TITLE
Replace all env.out and env.err print with @printf

### DIFF
--- a/book/examples/cpp/counter-app/counter-app/spewer.pony
+++ b/book/examples/cpp/counter-app/counter-app/spewer.pony
@@ -17,13 +17,13 @@ actor SpewerApp
   new create(env: Env) =>
     _env = env
     let config = parse_config(env.args)
-    env.err.print("host: " + config.host)
-    env.err.print("port: " + config.port)
-    env.err.print("count: " + config.count.string())
+    @printf[I32](("host: " + config.host + "\n").cstring())
+    @printf[I32](("port: " + config.port + "\n").cstring())
+    @printf[I32](("count: " + config.count.string() + "\n").cstring())
     Spewer(config.host, config.port, config.count, env.out, this)
 
   be report_sum(sum: U64) =>
-    _env.err.print("final sum = " + sum.string())
+    @printf[I32](("final sum = " + sum.string() + "\n").cstring())
 
   fun parse_config(args: Array[String] val): SpewerConfig =>
     try

--- a/book/examples/pony/alphabet/alphabet.pony
+++ b/book/examples/pony/alphabet/alphabet.pony
@@ -23,7 +23,7 @@ actor Main
       end
       Startup(env, application, "alphabet-contest")
     else
-      env.out.print("Couldn't build topology")
+      @printf[I32]("Couldn't build topology\n".cstring())
     end
 
 class val LetterStateBuilder

--- a/book/examples/pony/alphabet/data_gen/gen.pony
+++ b/book/examples/pony/alphabet/data_gen/gen.pony
@@ -36,7 +36,8 @@ actor Main
       let file = File(FilePath(auth, file_path))
 
       if message_count == 0 then
-        env.out.print("Please specify a message count (--message-count/-m)")
+        @printf[I32](("Please specify a message count " +
+          "(--message-count/-m)\n").cstring())
         error
       end
 

--- a/book/examples/pony/celsius/celsius.pony
+++ b/book/examples/pony/celsius/celsius.pony
@@ -16,7 +16,7 @@ actor Main
       end
       Startup(env, application, "celsius-conversion")
     else
-      env.out.print("Couldn't build topology")
+      @printf[I32]("Couldn't build topology\n".cstring())
     end
 
 primitive Multiply is Computation[F32, F32]

--- a/book/examples/pony/celsius/data_gen/main.pony
+++ b/book/examples/pony/celsius/data_gen/main.pony
@@ -33,7 +33,8 @@ actor Main
       let file = File(FilePath(auth, file_path))
 
       if message_count == 0 then
-        env.out.print("Specify a message count (--message-count/-m)!")
+        @printf[I32]("Specify a message count (--message-count/-m)!\n"
+          .cstring())
         error
       end
 

--- a/book/pony/api-basics-stateful.md
+++ b/book/pony/api-basics-stateful.md
@@ -37,7 +37,7 @@ actor Main
       end
       Startup(env, application, "alphabet-contest")
     else
-      env.out.print("Couldn't build topology")
+      @printf[I32]("Couldn't build topology\n".cstring())
     end
 ```
 
@@ -329,7 +329,7 @@ actor Main
       end
       Startup(env, application, "alphabet-contest")
     else
-      env.out.print("Couldn't build topology")
+      @printf[I32]("Couldn't build topology\n".cstring())
     end
 ```
 

--- a/book/pony/api-basics-stateless.md
+++ b/book/pony/api-basics-stateless.md
@@ -122,7 +122,7 @@ actor Main
       end
       Startup(env, application, "celsius-conversion")
     else
-      env.out.print("Couldn't build topology")
+      @printf[I32]("Couldn't build topology\n".cstring())
     end
 ```
 

--- a/fallor/fallor.pony
+++ b/fallor/fallor.pony
@@ -21,15 +21,14 @@ actor Main
         | ("input", let arg: String) => input_file_path = arg
         | ("output", let arg: String) => output_file_path = arg
         | ("help", None) =>
-          env.out.print(
+          @printf[I32](
             """
             PARAMETERS:
             -----------------------------------------------------------------------------------
             --input/-i [Sets file to read from (default: received.txt)]
             --output/-o [Sets file to write to (default: fallor-readable.txt)]
             -----------------------------------------------------------------------------------
-            """
-          )
+            """.cstring())
           return
         end
       end
@@ -46,14 +45,14 @@ actor Main
           try
             FallorMsgDecoder.with_timestamp(bytes)
           else
-            env.err.print("Problem decoding!")
+            @printf[I32]("Problem decoding!\n".cstring())
             error
           end
         output_file.print(", ".join(fields))
       end
       output_file.dispose()
     else
-      env.err.print("Error reading and writing files.")
+      @printf[I32]("Error reading and writing files.\n".cstring())
     end
 
 class ReceiverFileDataSource is Iterator[Array[U8] val]

--- a/fix-generator/initial-nbbo-generator/initial_nbbo_generator.pony
+++ b/fix-generator/initial-nbbo-generator/initial_nbbo_generator.pony
@@ -62,7 +62,7 @@ actor Main
     end
 
   fun help() =>
-    _env.out.print(
+    @printf[I32](
       """
       PARAMETERS:
       -----------------------------------------------------------------------------------
@@ -70,7 +70,7 @@ actor Main
       --symbols_file/-s [Sets file to read non rejected symbols from]
       --output/-o [Sets file to write to]
       -----------------------------------------------------------------------------------
-      """)
+      """.cstring())
 
   fun generate_instruments(instruments_file: File): Array[InstrumentData val] val =>
     let instruments = recover trn Array[InstrumentData val] end

--- a/fix-generator/nbbo-generator/nbbo-generator.pony
+++ b/fix-generator/nbbo-generator/nbbo-generator.pony
@@ -46,7 +46,7 @@ actor Main
         output_msgs_per_sec, messages_duration_secs,
         output_folder, instruments)
 
-      env.out.print("Starting nbbo generation...")
+      @printf[I32]("Starting nbbo generation...\n".cstring())
       nbbo_files_generator.write_to_files()
     end
 
@@ -131,7 +131,8 @@ actor NbboFilesGenerator
         output_file.writev(_wb.done())
         output_file.dispose()
       end
-      _env.out.print("Finished writing generated NBBO messages to files")
+      @printf[I32]("Finished writing generated NBBO messages to files\n"
+        .cstring())
     end
 
   be generate_for_sec(sec: U64) =>

--- a/fix-generator/orders-generator/order-generator.pony
+++ b/fix-generator/orders-generator/order-generator.pony
@@ -71,7 +71,7 @@ actor Main
         instruments_skew_percent, rejection_percent_per_sec,
         output_folder, instruments, rejected_instruments)
 
-      env.out.print("Starting orders generation...")
+      @printf[I32]("Starting orders generation...\n".cstring())
       order_file_generator.write_to_files()
     end
 
@@ -154,7 +154,7 @@ actor OrderFileGenerator
         output_file.writev(_wb.done())
         output_file.dispose()
       end
-    _env.out.print("Finished writing generated orders to files")
+    @printf[I32]("Finished writing generated orders to files\n".cstring())
     end
 
   fun ref check_output_file_size(output_file: File): File ?  =>

--- a/fixish-converter/fixish.pony
+++ b/fixish-converter/fixish.pony
@@ -99,7 +99,7 @@ actor Main
       input_file.dispose()
       output_file.dispose()
     else
-      env.err.print("Error reading and writing files.")
+      @printf[I32]("Error reading and writing files.\n".cstring())
     end
 
   fun pad_symbol(symbol': String): String =>
@@ -116,12 +116,11 @@ actor Main
     symbol
 
   fun help() =>
-    _env.out.print(
+    @printf[I32](
       """
       PARAMETERS:
       -----------------------------------------------------------------------------------
       --input/-i [Sets file to read from]
       --output/-o [Sets file to write to]
       -----------------------------------------------------------------------------------
-      """
-    )
+      """.cstring())

--- a/giles/receiver/giles-receiver.pony
+++ b/giles/receiver/giles-receiver.pony
@@ -55,28 +55,31 @@ actor Main
         end
 
         if l_arg is None then
-          env.err.print("Must supply required '--listen' argument")
+          @printf[I32]("Must supply required '--listen' argument\n".cstring())
           required_args_are_present = false
         else
           if (l_arg as Array[String]).size() != 2 then
-            env.err.print(
-              "'--listen' argument should be in format: '127.0.0.1:8080")
+            @printf[I32](
+              "'--listen' argument should be in format: '127.0.0.1:8080\n"
+              .cstring())
             required_args_are_present = false
           end
         end
 
         if p_arg isnt None then
           if (p_arg as Array[String]).size() != 2 then
-            env.err.print(
-              "'--phone-home' argument should be in format: '127.0.0.1:8080")
+            @printf[I32](
+              "'--phone-home' argument should be in format: '127.0.0.1:8080\n"
+              .cstring())
             required_args_are_present = false
           end
         end
 
         if (p_arg isnt None) or (n_arg isnt None) then
           if (p_arg is None) or (n_arg is None) then
-            env.err.print(
-              "'--phone-home' must be used in conjunction with '--name'")
+            @printf[I32](
+              "'--phone-home' must be used in conjunction with '--name'\n"
+              .cstring())
             required_args_are_present = false
           end
         end
@@ -86,8 +89,9 @@ actor Main
             let e' = (e_arg as USize)
             if e' < 1 then error end
           else
-            env.err.print(
-              "'--expect' must be an integer greater than 0")
+            @printf[I32](
+              "'--expect' must be an integer greater than 0\n"
+              .cstring())
             required_args_are_present = false
           end
         end
@@ -112,7 +116,7 @@ actor Main
           error
         end
       else
-        env.err.print(
+        @printf[I32](
           """
           --phone-home/-p <address> [Sets the address for phone home]
           --name/-n <name> [Name of giles-receiver node]
@@ -172,7 +176,7 @@ class FromBuffyNotify is TCPConnectionNotify
         conn.expect(expect)
         _header = false
       else
-        _stderr.print("Blew up reading header from Buffy")
+        @printf[I32]("Blew up reading header from Buffy\n".cstring())
       end
     else
       if not _no_write then
@@ -214,7 +218,7 @@ class ToDagonNotify is TCPConnectionNotify
         conn.expect(expect)
         _header = false
       else
-        _stderr.print("Blew up reading header from Buffy")
+        @printf[I32]("Blew up reading header from Buffy\n".cstring())
       end
     else
       try
@@ -223,10 +227,10 @@ class ToDagonNotify is TCPConnectionNotify
         | let d: ExternalShutdownMsg val =>
           _coordinator.finished()
         else
-          _stderr.print("Unexpected data from Dagon")
+          @printf[I32]("Unexpected data from Dagon\n".cstring())
         end
       else
-        _stderr.print("Unable to decode message Dagon")
+        @printf[I32]("Unable to decode message Dagon\n".cstring())
       end
 
       conn.expect(4)
@@ -315,8 +319,8 @@ actor WithoutDagonCoordinator is Coordinator
     end
     _count = _count + 1
     if _count >= _expected then
-      _env.err.print(_count.string() + " expected messages received. " +
-            "Terminating...")
+      @printf[I32]((_count.string() + " expected messages received. " +
+            "Terminating...\n").cstring())
       if _use_metrics then
         _metrics.set_end(Time.nanos(), _expected)
       end
@@ -326,10 +330,10 @@ actor WithoutDagonCoordinator is Coordinator
   be from_buffy_listener(listener: TCPListener, state: WorkerState) =>
     _from_buffy_listener = (listener, state)
     if state is Failed then
-      _env.err.print("Unable to open listener")
+      @printf[I32]("Unable to open listener\n".cstring())
       listener.dispose()
     elseif state is Ready then
-      _env.out.print("Listening for data")
+      @printf[I32]("Listening for data\n".cstring())
     end
 
   be connection_added(c: TCPConnection) =>
@@ -380,8 +384,8 @@ actor WithDagonCoordinator is Coordinator
     end
     _count = _count + 1
     if _count >= _expected then
-      _env.err.print(_count.string() + " expected messages received. " +
-            "Terminating...")
+      @printf[I32]((_count.string() + " expected messages received. " +
+            "Terminating...\n").cstring())
       if _use_metrics then
         _metrics.set_end(Time.nanos(), _expected)
       end
@@ -391,17 +395,17 @@ actor WithDagonCoordinator is Coordinator
   be from_buffy_listener(listener: TCPListener, state: WorkerState) =>
     _from_buffy_listener = (listener, state)
     if state is Failed then
-      _env.err.print("Unable to open listener")
+      @printf[I32]("Unable to open listener\n".cstring())
       listener.dispose()
     elseif state is Ready then
-      _env.out.print("Listening for data")
+      @printf[I32]("Listening for data\n".cstring())
       _alert_ready_if_ready()
     end
 
   be to_dagon_socket(sock: TCPConnection, state: WorkerState) =>
     _to_dagon_socket = (sock, state)
     if state is Failed then
-      _env.err.print("Unable to open dagon socket")
+      @printf[I32]("Unable to open dagon socket\n".cstring())
       sock.dispose()
     elseif state is Ready then
       _alert_ready_if_ready()

--- a/giles/sender/giles-sender.pony
+++ b/giles/sender/giles-sender.pony
@@ -98,47 +98,52 @@ actor Main
         end
 
         if h_arg is None then
-          env.err.print("Must supply required '--host' argument")
+          @printf[I32]("Must supply required '--host' argument\n".cstring())
           required_args_are_present = false
         else
           if (h_arg as Array[String]).size() != 2 then
-            env.err.print(
-              "'--host' argument should be in format: '127.0.0.1:8080")
+            @printf[I32](
+              "'--host' argument should be in format: '127.0.0.1:8080\n"
+              .cstring())
             required_args_are_present = false
           end
         end
 
         if m_arg is None then
-          env.err.print("Must supply required '--messages' argument")
+          @printf[I32]("Must supply required '--messages' argument\n".cstring())
           required_args_are_present = false
         end
 
         if p_arg isnt None then
           if (p_arg as Array[String]).size() != 2 then
-            env.err.print(
-              "'--dagon' argument should be in format: '127.0.0.1:8080")
+            @printf[I32](
+              "'--dagon' argument should be in format: '127.0.0.1:8080\n"
+              .cstring())
             required_args_are_present = false
           end
         end
 
         if (p_arg isnt None) or (n_arg isnt None) then
           if (p_arg is None) or (n_arg is None) then
-            env.err.print(
-              "'--dagon' must be used in conjunction with '--name'")
+            @printf[I32](
+              "'--dagon' must be used in conjunction with '--name'\n"
+              .cstring())
             required_args_are_present = false
           end
         end
 
         if (g_arg isnt None) and variable_size then
-          env.err.print(
-            "--msg-size and --variable-size can't be used together")
+          @printf[I32](
+            "--msg-size and --variable-size can't be used together\n"
+            .cstring())
           required_args_are_present = false
         end
 
         if binary_fmt then
           if (variable_size == false) and (g_arg is None) then
-            env.err.print(
-              "--binary requires either --msg-size or --variable-size")
+            @printf[I32](
+              "--binary requires either --msg-size or --variable-size\n"
+              .cstring())
             required_args_are_present = false
           end
         end
@@ -150,7 +155,7 @@ actor Main
             for str in (consume fs).values() do
               let path = FilePath(env.root as AmbientAuth, str)
               if not path.exists() then
-                env.err.print("Error opening file '" + str + "'.")
+                @printf[I32](("Error opening file '" + str + "'.\n").cstring())
                 required_args_are_present = false
               end
             end
@@ -214,7 +219,7 @@ actor Main
           coordinator.sending_actor(sa)
         end
       else
-        env.err.print("FUBAR! FUBAR!")
+        @printf[I32]("FUBAR! FUBAR!\n".cstring())
       end
     end
 
@@ -267,10 +272,10 @@ class ToDagonNotify is TCPConnectionNotify
         | let m: ExternalStartMsg val =>
             _coordinator.go()
         else
-          _stderr.print("Unexpected message from Dagon")
+          @printf[I32]("Unexpected message from Dagon\n".cstring())
         end
       else
-        _stderr.print("Unable to decode message from Dagon")
+        @printf[I32]("Unable to decode message from Dagon\n".cstring())
       end
     end
     true
@@ -326,10 +331,10 @@ actor WithoutDagonCoordinator
   be to_host_socket(sock: TCPConnection, state: WorkerState) =>
     _to_host_socket = (sock, state)
     if state is Failed then
-      _env.err.print("Unable to connect")
+      @printf[I32]("Unable to connect\n".cstring())
       sock.dispose()
     elseif state is Ready then
-      _env.out.print("Connected")
+      @printf[I32]("Connected\n".cstring())
       _go_if_ready()
     end
 
@@ -379,7 +384,7 @@ actor WithDagonCoordinator
   be to_host_socket(sock: TCPConnection, state: WorkerState) =>
     _to_host_socket = (sock, state)
     if state is Failed then
-      _env.err.print("Unable to open host socket")
+      @printf[I32]("Unable to open host socket\n".cstring())
       sock.dispose()
     elseif state is Ready then
       _go_if_ready()
@@ -388,7 +393,7 @@ actor WithDagonCoordinator
   be to_dagon_socket(sock: TCPConnection, state: WorkerState) =>
     _to_dagon_socket = (sock, state)
     if state is Failed then
-      _env.err.print("Unable to open dagon socket")
+      @printf[I32]("Unable to open dagon socket\n".cstring())
       sock.dispose()
     elseif state is Ready then
       _go_if_ready()

--- a/lib/wallaroo/cpp_api/pony/wallaroo_main.pony
+++ b/lib/wallaroo/cpp_api/pony/wallaroo_main.pony
@@ -20,7 +20,7 @@ class WallarooMain
 
       Startup(env, consume application, None)
     else
-      env.err.print("Could not build application")
+      @printf[I32]("Could not build application\n".cstring())
     end
 
   fun _extract_c_args(pony_args: Array[String] val): (U32, Pointer[Pointer[U8] tag] tag) =>

--- a/lib/wallaroo/startup.pony
+++ b/lib/wallaroo/startup.pony
@@ -193,7 +193,8 @@ actor Startup
       let o_addr: Array[String] val = consume o_addr_trn
 
       if _startup_options.worker_name == "" then
-        _env.out.print("You must specify a worker name via --name/-n.")
+        @printf[I32](("You must specify a worker name via " +
+          "--name/-n.\n").cstring())
         error
       end
 
@@ -324,7 +325,7 @@ actor Startup
         end
 
       if _startup_options.is_initializer then
-        _env.out.print("Running as Initializer...")
+        @printf[I32]("Running as Initializer...\n".cstring())
         _application_initializer = ApplicationInitializer(auth,
           local_topology_initializer, input_addrs, o_addr)
         match _application_initializer

--- a/lib/wallaroo/startup_help.pony
+++ b/lib/wallaroo/startup_help.pony
@@ -1,6 +1,6 @@
 primitive StartupHelp
   fun apply(env: Env) =>
-    env.out.print(
+    @printf[I32](
       """
       To run Wallaroo:
       -----------------------------------------------------------------------------------

--- a/machida/main.pony
+++ b/machida/main.pony
@@ -37,13 +37,15 @@ actor Main
           end
           Startup(env, application, None)
         else
-          env.err.print("Something went wrong while building the application")
+          @printf[I32]("Something went wrong while building the application\n"
+            .cstring())
         end
       else
-        env.err.print("Could not load module '" + module_name + "'")
+        @printf[I32](("Could not load module '" + module_name + "'\n")
+          .cstring())
       end
     else
-      env.err.print(
+      @printf[I32]((
         "Please use `--application-module=MODULE_NAME` to specify " +
-        "an application module")
+        "an application module\n").cstring())
     end

--- a/merrick/merrick.pony
+++ b/merrick/merrick.pony
@@ -53,40 +53,45 @@ actor Main
         end
 
         if l_arg is None then
-          env.err.print("Must supply required '--listen' argument")
+          @printf[I32]("Must supply required '--listen' argument\n".cstring())
           required_args_are_present = false
         else
           if (l_arg as Array[String]).size() != 2 then
-            env.err.print(
-              "'--listen' argument should be in format: '127.0.0.1:8080'")
+            @printf[I32](
+              "'--listen' argument should be in format: '127.0.0.1:8080'\n"
+              .cstring())
             required_args_are_present = false
           end
         end
 
         if p_arg isnt None then
           if (p_arg as Array[String]).size() != 2 then
-            env.err.print(
-              "'--phone-home' argument should be in format: '127.0.0.1:8080'")
+            @printf[I32](
+              "'--phone-home' argument should be in format: '127.0.0.1:8080'\n"
+              .cstring())
               required_args_are_present = false
           end
         end
 
         if (p_arg isnt None) or (n_arg isnt None) then
           if (p_arg is None) or (n_arg is None) then
-            env.err.print(
-              "'--phone-home' must be used in conjuction with '--name'")
+            @printf[I32](
+              "'--phone-home' must be used in conjuction with '--name'\n"
+              .cstring())
             required_args_are_present = false
           end
         end
 
         if forward isnt false then
           if f_addr_arg is None then
-            env.err.print(
-              "'--forward-addr' must be used in conjucion with '--forward'")
+            @printf[I32](
+              "'--forward-addr' must be used in conjucion with '--forward'\n"
+              .cstring())
           else
             if (f_addr_arg as Array[String]).size() != 2 then
-              env.err.print(
-                "'--forward-addr' arg should be in format: '127.0.0.1:8080")
+              @printf[I32](
+                "'--forward-addr' arg should be in format: '127.0.0.1:8080\n"
+                .cstring())
             end
           end
         end
@@ -118,7 +123,7 @@ actor Main
             listener_addr(1))
         end
       else
-        env.err.print(
+        @printf[I32](
           """
           --phone-home/-p <address> [Sets the address for phone home]
           --name/-n <name> [Name of metrics-receiver node]
@@ -185,7 +190,7 @@ class FromWallarooNotify is TCPConnectionNotify
         conn.expect(expect)
         _header = false
       else
-        _stderr.print("Blew up reading header from Wallaroo")
+        @printf[I32]("Blew up reading header from Wallaroo\n".cstring())
       end
     else
       var data_copy: Array[U8 val] val = consume data
@@ -229,7 +234,7 @@ class ToDagonNotify is TCPConnectionNotify
         conn.expect(expect)
         _header = false
       else
-        _stderr.print("Blew up reading header from Wallaroo")
+        @printf[I32]("Blew up reading header from Wallaroo\n".cstring())
       end
     else
       try
@@ -238,10 +243,10 @@ class ToDagonNotify is TCPConnectionNotify
         | let d: ExternalShutdownMsg val =>
           _coordinator.finished()
         else
-          _stderr.print("Unexpected data from Dagon")
+          @printf[I32]("Unexpected data from Dagon\n".cstring())
         end
       else
-        _stderr.print("Unable to decode message from Dagon")
+        @printf[I32]("Unable to decode message from Dagon\n".cstring())
       end
 
       conn.expect(4)
@@ -308,10 +313,10 @@ actor WithoutDagonCoordinator is Coordinator
   be from_wallaroo_listener(listener: TCPListener, state: WorkerState) =>
     _from_wallaroo_listener = (listener, state)
     if state is Failed then
-      _env.err.print("Unable to open listener")
+      @printf[I32]("Unable to open listener\n".cstring())
       listener.dispose()
     elseif state is Ready then
-      _env.out.print("Listening for data")
+      @printf[I32]("Listening for data\n".cstring())
     end
 
   be connection_added(c: TCPConnection) =>
@@ -347,17 +352,17 @@ actor WithDagonCoordinator is Coordinator
   be from_wallaroo_listener(listener: TCPListener, state: WorkerState) =>
     _from_wallaroo_listener = (listener, state)
     if state is Failed then
-      _env.err.print("Unable to open listener")
+      @printf[I32]("Unable to open listener\n".cstring())
       listener.dispose()
     elseif state is Ready then
-      _env.out.print("Listening for data")
-        _alert_ready_if_ready()
+      @printf[I32]("Listening for data\n".cstring())
+      _alert_ready_if_ready()
     end
 
   be to_dagon_socket(sock: TCPConnection, state: WorkerState) =>
     _to_dagon_socket = (sock, state)
     if state is Failed then
-      _env.err.print("Unable to open dagon socket")
+      @printf[I32]("Unable to open dagon socket\n".cstring())
       sock.dispose()
     elseif state is Ready then
       _alert_ready_if_ready()

--- a/robson/robson.pony
+++ b/robson/robson.pony
@@ -24,7 +24,7 @@ actor Main
       | ("input", let arg: String) => input_file_path = arg
       | ("output", let arg: String) => output_file_path = arg
       | ("help", None) =>
-        env.out.print(
+        @printf[I32](
         """
         --input/-i <file path> [Input file path where metrics are stored]
         --output/-o <file path> [Output file path where report will be written]
@@ -35,7 +35,7 @@ actor Main
       end
     end
     if (input_file_path == "") or (output_file_path == "") then
-        env.err.print(
+        @printf[I32](
         """
         --input/-i <file path> [Input file path where metrics are stored]
         --output/-o <file path> [Output file path where report will be written]
@@ -78,8 +78,8 @@ actor MetricsCollector
     | ("node-ingress-egress") =>
       add_worker_metrics(metrics_msg)
     else
-      _env.out.print("Unable to save metrics for category: " +
-        metrics_msg.category)
+      @printf[I32](("Unable to save metrics for category: " +
+        metrics_msg.category + "\n").cstring())
     end
 
   fun ref add_overall_metrics(metrics_msg: HubMetricsMsg val) =>
@@ -139,11 +139,11 @@ actor MetricsCollector
       let print_timestamp = WallClock.milliseconds()
       output_file.print("Report generated at: " + print_timestamp.string())
       output_file.dispose()
-      _env.out.print("Output file disposed")
+      @printf[I32]("Output file disposed\n".cstring())
     end
 
   be collect_metrics() =>
-     _env.out.print("Collecting Metrics")
+     @printf[I32]("Collecting Metrics\n".cstring())
     try
       let auth = _env.root as AmbientAuth
 
@@ -160,22 +160,22 @@ actor MetricsCollector
           let hub_msg = HubProtocolDecoder(rb.block(next_payload_size))
           match hub_msg
           | HubJoinMsg =>
-            _env.out.print("Decoded HubJoinMsg")
+            @printf[I32]("Decoded HubJoinMsg\n".cstring())
           | HubConnectMsg =>
-            _env.out.print("Decoded HubConnectMsg")
+            @printf[I32]("Decoded HubConnectMsg\n".cstring())
           | HubOtherMsg =>
-            _env.out.print("Decoded HubOtherMsg")
+            @printf[I32]("Decoded HubOtherMsg\n".cstring())
           else
             add_metrics(hub_msg as HubMetricsMsg val)
           end
 
         else
-          _env.err.print("Problem decoding!")
+          @printf[I32]("Problem decoding!\n".cstring())
         end
         bytes_left = bytes_left - (next_payload_size + 4)
       end
       input_file.dispose()
-      _env.out.print("Input file disposed")
+      @printf[I32]("Input file disposed\n".cstring())
     end
     generate_overall_metrics_data()
     generate_computation_metrics_data()
@@ -183,7 +183,7 @@ actor MetricsCollector
     print_metrics()
 
   fun ref generate_metrics_data() =>
-    _env.out.print("Generate Metrics Data")
+    @printf[I32]("Generate Metrics Data\n".cstring())
     generate_overall_metrics_data()
     generate_computation_metrics_data()
     generate_worker_metrics_data()

--- a/testing/correctness/apps/complex/complex.pony
+++ b/testing/correctness/apps/complex/complex.pony
@@ -44,7 +44,7 @@ actor Main
       end
       Startup(env, application, None)//, 1)
     else
-      env.out.print("Couldn't build topology")
+      @printf[I32]("Couldn't build topology\n".cstring())
     end
 
 class Complex

--- a/testing/correctness/apps/default-test/default.pony
+++ b/testing/correctness/apps/default-test/default.pony
@@ -40,7 +40,7 @@ actor Main
       end
       Startup(env, application, None)//, 1)
     else
-      env.out.print("Couldn't build topology")
+      @printf[I32]("Couldn't build topology\n".cstring())
     end
 
 class val NormalStateBuilder

--- a/testing/correctness/apps/sequence-window/main.pony
+++ b/testing/correctness/apps/sequence-window/main.pony
@@ -87,7 +87,7 @@ actor Main
       end
       Startup(env, application, "sequence-window")
     else
-      env.out.print("Couldn't build topology")
+      @printf[I32]("Couldn't build topology\n".cstring())
     end
 
 primitive WindowPartitionFunction

--- a/testing/correctness/apps/sequence-window/validator/validator.pony
+++ b/testing/correctness/apps/sequence-window/validator/validator.pony
@@ -40,7 +40,7 @@ actor Main
         | ("expected", let arg: I64) => expected = arg.u64()
         | ("at-least-once", None) => at_least_once = true
         | ("help", None) =>
-          env.out.print(
+          @printf[I32](
             """
             PARAMETERS:
             -----------------------------------------------------------------------------------
@@ -66,7 +66,7 @@ actor Main
           try
             FallorMsgDecoder.with_timestamp(bytes)
           else
-            env.err.print("Problem decoding!")
+            @printf[I32]("Problem decoding!\n".cstring())
             error
           end
         let ts = fields(0)
@@ -74,9 +74,9 @@ actor Main
         validator(consume v, consume ts)
       end
       validator.finalize()
-      env.out.print("Validation successful!")
+      @printf[I32]("Validation successful!\n".cstring())
     else
-      env.err.print("Error validating file.")
+      @printf[I32]("Error validating file.\n".cstring())
     end
 
 class WindowValidator

--- a/testing/correctness/apps/weighted-test/weighted-test.pony
+++ b/testing/correctness/apps/weighted-test/weighted-test.pony
@@ -35,7 +35,7 @@ actor Main
       end
       Startup(env, application, None)//, 1)
     else
-      env.out.print("Couldn't build topology")
+      @printf[I32]("Couldn't build topology\n".cstring())
     end
 
 class val NormalStateBuilder

--- a/testing/performance/apps/market-spread-encode/market-spread.pony
+++ b/testing/performance/apps/market-spread-encode/market-spread.pony
@@ -124,7 +124,7 @@ actor Main
       end
       Startup(env, application, "market-spread")
     else
-      env.out.print("Couldn't build topology")
+      @printf[I32]("Couldn't build topology\n".cstring())
     end
 
 primitive Identity[In: Any val]

--- a/testing/performance/apps/market-spread/market-spread.pony
+++ b/testing/performance/apps/market-spread/market-spread.pony
@@ -119,7 +119,7 @@ actor Main
       end
       Startup(env, application, "market-spread")
     else
-      env.out.print("Couldn't build topology")
+      @printf[I32]("Couldn't build topology\n".cstring())
     end
 
 primitive Identity[In: Any val]

--- a/testing/performance/apps/one-stream-market/one-stream-market.pony
+++ b/testing/performance/apps/one-stream-market/one-stream-market.pony
@@ -93,7 +93,7 @@ actor Main
       end
       Startup(env, application, "market-spread")
     else
-      env.out.print("Couldn't build topology")
+      @printf[I32]("Couldn't build topology\n".cstring())
     end
 
 interface Symboly

--- a/wesley/message-file-reader.pony
+++ b/wesley/message-file-reader.pony
@@ -69,13 +69,15 @@ class TextMessageFileReader
                 end
               end
             else
-              env.err.print("Failed reading on line "
-                + cur_line_number.string() + ":")
-              env.err.print(
-                "---------------------------------------------------")
-              env.err.print(cur_line)
-              env.err.print(
-                "---------------------------------------------------")
+              @printf[I32](("Failed reading on line "
+                  + cur_line_number.string() + ":" + "\n").cstring())
+              @printf[I32](
+                "---------------------------------------------------\n"
+                .cstring())
+              @printf[I32]((cur_line + "\n").cstring())
+              @printf[I32](
+                "---------------------------------------------------\n"
+                .cstring())
               error
             end
         else  // no field separator, return the parser over the entire line
@@ -104,7 +106,7 @@ class ReceivedMessageFileReader
         try
           FallorMsgDecoder.with_timestamp(rb.block(next_payload_size.usize()))
         else
-          env.err.print("Problem decoding!")
+          @printf[I32]("Problem decoding!\n".cstring())
           error
         end
       bytes_left = bytes_left - next_payload_size.usize()

--- a/wesley/verifier-cli.pony
+++ b/wesley/verifier-cli.pony
@@ -9,15 +9,15 @@ primitive VerifierCLI[S: Message val, R: Message val]
   fun run(env: Env, test_name: String, result_mapper: ResultMapper[S, R], 
     sent_parser: SentParser[S], received_parser: ReceivedParser[R]) 
   =>
-    env.out.print("wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww")
-    env.out.print(" Wesley: Starting " + test_name)
-    env.out.print("wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww")
+    @printf[I32]("wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww\n".cstring())
+    @printf[I32]((" Wesley: Starting " + test_name + "\n").cstring())
+    @printf[I32]("wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww\n".cstring())
     match stateless_verifier_from_command_line(env, result_mapper, 
       sent_parser, received_parser)
     | let verifier: StatelessVerifier[S, R] => verify(env, verifier)
     | let setup_error: SetupError =>
       env.exitcode(setup_error.exitcode())
-      env.err.print(setup_error.message())
+      @printf[I32]((setup_error.message() + "\n").cstring())
     end
 
   fun run_with_initialization[I: Message val, 
@@ -28,15 +28,15 @@ primitive VerifierCLI[S: Message val, R: Message val]
     sent_parser: SentParser[S], 
     received_parser: ReceivedParser[R]) 
   =>
-    env.out.print("wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww")
-    env.out.print(" Wesley: Starting " + test_name)
-    env.out.print("wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww")
+    @printf[I32]("wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww\n".cstring())
+    @printf[I32]((" Wesley: Starting " + test_name + "\n").cstring())
+    @printf[I32]("wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww\n".cstring())
     match stateful_verifier_from_command_line[I, State](env, result_mapper, 
       initialization_parser, sent_parser, received_parser)
     | let verifier: StatefulVerifier[S, R, I, State] => verify(env, verifier)
     | let setup_error: SetupError =>
       env.exitcode(setup_error.exitcode())
-      env.err.print(setup_error.message())
+      @printf[I32]((setup_error.message() + "\n").cstring())
     end
 
   fun stateless_verifier_from_command_line(env: Env, 
@@ -228,7 +228,7 @@ primitive VerifierCLI[S: Message val, R: Message val]
 
   fun verify(env:Env, verifier: Verifier ref) =>
     let pass_fail = verifier.test()
-    env.err.print(pass_fail.exitmessage())
+    @printf[I32]((pass_fail.exitmessage() + "\n").cstring())
     env.exitcode(pass_fail.exitcode())
 
 interface SetupError


### PR DESCRIPTION
Tested by:
1. build `lib/wallaroo`
2. build and run some wallaroo apps to make sure nothing broke
3. build other applications that are touched (machida, merrick, stuff in fix-generator, etc)


- All uses of env.out.print and env.err.print are replaced with @printf[I32].
- a newline is added where necessary (multiline strings with """ """ are exempt)
- a `.cstring()` is added to the end
- String concat expressions are wrapped in ( ) before the `.cstring()`
- Dagon files remain untouched for now.

closes #540 