### PR TITLE
Add reconnect logic to BoundaryNotify

### DIFF
--- a/lib/wallaroo/network/wallaroo_outgoing_network_actor_notify.pony
+++ b/lib/wallaroo/network/wallaroo_outgoing_network_actor_notify.pony
@@ -1,4 +1,4 @@
-interface WallarooOutgoingNetworkActorNotify
+trait WallarooOutgoingNetworkActorNotify
   fun ref connecting(conn: WallarooOutgoingNetworkActor ref, count: U32)
     """
     Called if name resolution succeeded for a WallarooOutgoingNetworkActor
@@ -67,3 +67,9 @@ interface WallarooOutgoingNetworkActorNotify
     receiving this notification, you should feel free to start making calls to
     `write` and `writev` again.
     """
+
+  fun ref dispose() =>
+    """
+    Called when the parent actor's dispose is called.
+    """
+    None


### PR DESCRIPTION
- Add reconnect timer class
- Two timings:
  - 100ms timer to attempt reconnect after connection closed
  - 10s timer to attempt reconnect after connection failure (e.g. if the first reconnect attempt failed)
- To do this, BoundaryNotify needs a tag to the OutgoingBoundary actor whose notify it is, so those changes are made.
- The timers need to be disposed, so a `fun dispose()` is added to the WallarooOutgoingNetworkActorNotify interface, which is also changed to a trait, to allow that function to have a null default action.

### Testing
0. Build sequence window with spike (and optionally spiketrace):
  ```bash
  stable env ponyc -d -D spike -D spiketrace
  ```
1. start giles-receiver:  
  ```bash
  ../../../../giles/receiver/receiver --ponythreads=1 --ponynoblock \
  --ponypinasio -l 127.0.0.1:5555
  ```
2. start initializer-worker: 
  ```bash
  ./sequence-window -i 127.0.0.1:7000 -o 127.0.0.1:5555 -m 127.0.0.1:5001 \
  --ponythreads=4 --ponypinasio --ponynoblock -c 127.0.0.1:12500 \
  -d 127.0.0.1:12501 -r res-data -w 2 -n worker1 -t \
  --spike-drop --spike-prob 0.001 --spike-margin 1000
  ```
3. start second worker: 
  ```bash
  ./sequence-window -i 127.0.0.1:7000 -o 127.0.0.1:5555 -m 127.0.0.1:5001 \
  --ponythreads=4 --ponypinasio --ponynoblock -c 127.0.0.1:12500 \
  -d 127.0.0.1:12501 -r res-data -w 2 -n worker2
  ```
4. start giles-sender and send 10000 integers:
  ```bash
  ../../../../giles/sender/sender -h 127.0.0.1:7000 -s 10 -i 5_000_000 \
  -u --ponythreads=1 -y -g 12 -w -m 10000
  ```
5. Look for the spike message in your initializer process's STDOUT:
   ```bash
   <<<<<<SPIKE: DROPPING CONNECTION!>>>>>>
   ```
6. Then observe that the workers reconnected and resumed sending successfully.


closes #643 