### PR TITLE
Fix rules.mk issue with not honoring disabled flags when in a directory

### DIFF
--- a/machida/Makefile
+++ b/machida/Makefile
@@ -16,16 +16,15 @@ RECURSE_SUBMAKEFILES := false
 # run from, so we get an absolute path based on $(buffy_path). This will work
 # whether make was run from the top level of Wallaroo or from within the
 # machida directory.
-MACHIDA_PATH := $(buffy_path)/machida
-MACHIDA_BUILD := $(MACHIDA_PATH)/build
-MACHIDA_CPP := $(MACHIDA_PATH)/cpp
-WALLAROO_LIB :=  $(buffy_path)/lib
+MACHIDA_PATH = $(buffy_path)/machida
+MACHIDA_BUILD = $(MACHIDA_PATH)/build
+MACHIDA_CPP = $(MACHIDA_PATH)/cpp
+WALLAROO_LIB =  $(buffy_path)/lib
 
 # Our top level Makefile has 3 rules that would have been generated for us if
 # we hadn't turned them off at the top of the Makefile. Here we recreate them
 # with our own custom rules. This allows the top level commands like
-# "make test" to work. From within our machida directory, currently this does
-# not work and needs to be fixed.
+# "make test" to work.
 build-machida-all = machida_clean machida_build
 test-machida-all = machida_clean machida_build machida_test
 clean-machida-all = machida_clean

--- a/rules.mk
+++ b/rules.mk
@@ -46,14 +46,37 @@ clean-buffyroot-all :=
 build-docker-buffyroot-all :=
 push-docker-buffyroot-all :=
 
-PONY_TARGET :=
-DOCKER_TARGET :=
-EXS_TARGET :=
-RECURSE_SUBMAKEFILES :=
-ponyc_docker_args :=
-monhub_docker_args :=
-quote :=
-ponyc_arch_args :=
+ifndef PONY_TARGET
+  PONY_TARGET :=
+endif
+
+ifndef DOCKER_TARGET
+  DOCKER_TARGET :=
+endif
+
+ifndef EXS_TARGET
+  EXS_TARGET :=
+endif
+
+ifndef RECURSE_SUBMAKEFILES
+  RECURSE_SUBMAKEFILES :=
+endif
+
+ifndef ponyc_docker_args
+  ponyc_docker_args :=
+endif
+
+ifndef monhub_docker_args
+  monhub_docker_args :=
+endif
+
+ifndef quote
+  quote :=
+endif
+
+ifndef ponyc_arch_args
+  ponyc_arch_args :=
+endif
 
 # function to lazily initialize a variable on first use and to only evaluate the expression once
 # see: http://www.oreilly.com/openbook/make3/book/ch10.pdf


### PR DESCRIPTION
`rules.mk` had an issue where it was not correctly honoring the
disable generating rules flags set in directory specific Makefiles
when `make` was run from within those directories. This commit
resolves that by ensuring that `rules.mk` doesn't accidentally
clobber those variables anymore.

resolves #816