### PR TITLE
Allow to disable generating test targets in directory Makefiles

### DIFF
--- a/dagon/Makefile
+++ b/dagon/Makefile
@@ -1,5 +1,8 @@
 rules_mk_path := ../rules.mk
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 

--- a/dagon/dagon-child/Makefile
+++ b/dagon/dagon-child/Makefile
@@ -1,5 +1,8 @@
 rules_mk_path := ../../rules.mk
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 

--- a/dagon/dagon-notifier/Makefile
+++ b/dagon/dagon-notifier/Makefile
@@ -1,5 +1,8 @@
 rules_mk_path := ../../rules.mk
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 

--- a/fallor/Makefile
+++ b/fallor/Makefile
@@ -1,5 +1,8 @@
 rules_mk_path := ../rules.mk
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 

--- a/fix-generator/Makefile
+++ b/fix-generator/Makefile
@@ -1,5 +1,8 @@
 rules_mk_path := ../rules.mk
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 

--- a/fix-generator/initial-nbbo-generator/Makefile
+++ b/fix-generator/initial-nbbo-generator/Makefile
@@ -1,5 +1,8 @@
 rules_mk_path := ../../rules.mk
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 

--- a/fix-generator/nbbo-generator/Makefile
+++ b/fix-generator/nbbo-generator/Makefile
@@ -1,5 +1,8 @@
 rules_mk_path := ../../rules.mk
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 

--- a/fix-generator/orders-generator/Makefile
+++ b/fix-generator/orders-generator/Makefile
@@ -1,5 +1,8 @@
 rules_mk_path := ../../rules.mk
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 

--- a/fixish-converter/Makefile
+++ b/fixish-converter/Makefile
@@ -1,5 +1,8 @@
 rules_mk_path := ../rules.mk
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 

--- a/merrick/Makefile
+++ b/merrick/Makefile
@@ -1,5 +1,8 @@
 rules_mk_path := ../rules.mk
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 

--- a/robson/Makefile
+++ b/robson/Makefile
@@ -1,5 +1,8 @@
 rules_mk_path := ../rules.mk
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 

--- a/rules.mk
+++ b/rules.mk
@@ -46,6 +46,10 @@ clean-buffyroot-all :=
 build-docker-buffyroot-all :=
 push-docker-buffyroot-all :=
 
+ifndef TEST_TARGET
+  TEST_TARGET :=
+endif
+
 ifndef PONY_TARGET
   PONY_TARGET :=
 endif
@@ -368,7 +372,9 @@ define pony-test-goal
 test-pony-all: test-$(subst /,-,$(subst $(abs_buffy_dir)/,,$(abspath $1)))
 test-$(subst /,-,$(subst $(abs_buffy_dir)/,,$(abspath $1)))-all += test-$(subst /,-,$(subst $(abs_buffy_dir)/,,$(abspath $1)))
 test-$(subst /,-,$(subst $(abs_buffy_dir)/,,$(abspath $1))): build-$(subst /,-,$(subst $(abs_buffy_dir)/,,$(abspath $1)))
+ifneq ($(TEST_TARGET),false)
 	cd $(abspath $(1:%/=%)) && ./$(notdir $(abspath $(1:%/=%)))
+endif
 .PHONY: test-$(subst /,-,$(subst $(abs_buffy_dir)/,,$(abspath $1))) test-$(subst /,-,$(subst $(abs_buffy_dir)/,,$(abspath $1)))-all
 endef
 
@@ -416,7 +422,9 @@ define monhub-test-goal
 test-monhub-all: test-$(subst /,-,$(subst $(abs_buffy_dir)/,,$(abspath $1)))
 test-$(subst /,-,$(subst $(abs_buffy_dir)/,,$(abspath $1)))-all += test-$(subst /,-,$(subst $(abs_buffy_dir)/,,$(abspath $1)))
 test-$(subst /,-,$(subst $(abs_buffy_dir)/,,$(abspath $1))): build-$(subst /,-,$(subst $(abs_buffy_dir)/,,$(abspath $1)))
+ifneq ($(TEST_TARGET),false)
 	cd $(abspath $(1:%/=%)) && mix test
+endif
 .PHONY: test-$(subst /,-,$(subst $(abs_buffy_dir)/,,$(abspath $1))) test-$(subst /,-,$(subst $(abs_buffy_dir)/,,$(abspath $1)))-all
 endef
 
@@ -669,6 +677,7 @@ endif
 $(eval $(call subdir-goal,$(PREV_PATH)))
 
 # reset variables before including sub-makefiles
+TEST_TARGET :=
 PONY_TARGET :=
 DOCKER_TARGET :=
 EXS_TARGET :=

--- a/testing/correctness/apps/complex/Makefile
+++ b/testing/correctness/apps/complex/Makefile
@@ -1,5 +1,8 @@
 rules_mk_path := ../../../../rules.mk
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 

--- a/testing/correctness/apps/default-test/Makefile
+++ b/testing/correctness/apps/default-test/Makefile
@@ -1,5 +1,8 @@
 rules_mk_path := ../../../../rules.mk
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 

--- a/testing/correctness/apps/sequence-window/Makefile
+++ b/testing/correctness/apps/sequence-window/Makefile
@@ -1,5 +1,8 @@
 rules_mk_path := ../../../../rules.mk
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 

--- a/testing/correctness/apps/sequence-window/validator/Makefile
+++ b/testing/correctness/apps/sequence-window/validator/Makefile
@@ -1,5 +1,8 @@
 rules_mk_path := ../../../../../rules.mk
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 

--- a/testing/correctness/apps/weighted-test/Makefile
+++ b/testing/correctness/apps/weighted-test/Makefile
@@ -1,5 +1,8 @@
 rules_mk_path := ../../../../rules.mk
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 

--- a/testing/performance/apps/market-spread-encode/Makefile
+++ b/testing/performance/apps/market-spread-encode/Makefile
@@ -1,5 +1,8 @@
 rules_mk_path := ../../../../rules.mk
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 

--- a/testing/performance/apps/market-spread/Makefile
+++ b/testing/performance/apps/market-spread/Makefile
@@ -1,5 +1,8 @@
 rules_mk_path := ../../../../rules.mk
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 

--- a/testing/performance/apps/one-stream-market/Makefile
+++ b/testing/performance/apps/one-stream-market/Makefile
@@ -1,5 +1,8 @@
 rules_mk_path := ../../../../rules.mk
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 

--- a/wesley/Makefile
+++ b/wesley/Makefile
@@ -1,5 +1,8 @@
 rules_mk_path := ../rules.mk
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 PONY_TARGET := false
 

--- a/wesley/double-test/Makefile
+++ b/wesley/double-test/Makefile
@@ -1,5 +1,8 @@
 rules_mk_path := ../../rules.mk
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 

--- a/wesley/identity-test/Makefile
+++ b/wesley/identity-test/Makefile
@@ -1,5 +1,8 @@
 rules_mk_path := ../../rules.mk
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 

--- a/wesley/market-spread-test/Makefile
+++ b/wesley/market-spread-test/Makefile
@@ -1,5 +1,8 @@
 rules_mk_path := ../../rules.mk
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 

--- a/wesley/word-length-count-test/Makefile
+++ b/wesley/word-length-count-test/Makefile
@@ -1,5 +1,8 @@
 rules_mk_path := ../../rules.mk
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 

--- a/wesley/wordcount-test/Makefile
+++ b/wesley/wordcount-test/Makefile
@@ -1,5 +1,8 @@
 rules_mk_path := ../../rules.mk
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 


### PR DESCRIPTION
This commit allows for the ability to disable generating test
targets on a per directory basis in the directory `Makefile`.

---------------------

This is a feature that was requested a month or two ago I think. I kind of lost track of it and just remembered while looking into the machida related issue. IIRC, this was requested because the test targets just ran the command compiled and that sometimes didn't actually run any tests but just printed out usage information cluttering the CI output.

I've disabled generating the tests for `market-spread` as an example. Assuming this is good, I can go ahead an disable generating tests in other places where it's unnecessary also.