### PR TITLE
Hash _BoundaryId fields rather than `this`

### DIFF
--- a/lib/wallaroo/boundary/data_receivers.pony
+++ b/lib/wallaroo/boundary/data_receivers.pony
@@ -16,7 +16,7 @@ class _BoundaryId is Equatable[_BoundaryId]
     (name == that.name) and (step_id == that.step_id)
 
   fun hash(): U64 =>
-    (digestof this).hash()
+    name.hash() xor step_id.hash()
 
 interface DataReceiversSubscriber
   be data_receiver_added(sender_name: String, boundary_step_id: U128,

--- a/testing/correctness/apps/sequence-window/test_increments.pony
+++ b/testing/correctness/apps/sequence-window/test_increments.pony
@@ -1,0 +1,29 @@
+use "collections"
+
+primitive TestIncrements
+  fun apply(values: Array[U64] val): Bool =>
+  """
+  Test that values are incrementing correctly, except for leading zeroes.
+  """
+    // diff may be 0, 1, or 2, and only 2 after 1 or 2
+    try
+      var previous: U64 = values(0)
+      for pos in Range[USize](1,4) do
+        let cur = values(pos)
+        let diff = cur - previous
+        if (diff == 0) or (diff == 1) then
+          if previous != 0 then
+            return false
+          else
+            previous = cur
+          end
+        elseif diff != 2 then
+          return false
+        else
+          previous = cur
+        end
+      end
+    else
+      return false
+    end
+    true


### PR DESCRIPTION
Due to using `(digestof this).hash()` instead of hashing the fields of _BoundaryId (a string and a U128), 
 attempts to retrieve an existing DataReceiver weren't always successful.
The new hash method for _BoundaryId XORs the hashes of its fields (following the pattern in net/http/_host_service.pony).

Additionally:
- the window increment test is embedded in the sequence-window application and can be enabled to run in real-time and Fail the process if the test fails by using `--define/-D validate`.

closes #832 


## Testing
### Without resilience
This tests a 2-worker topology with spiking roughly every 100 connection method calls. To build confidence in the bug fix, we'll run the test for a while so that many reconnections occur. 

0. Build sequence-window with spike and online validation: `stable env ponyc -d -D spike -D spiketrace -D validate`
1. start receiver: `../../../../giles/receiver/receiver --ponythreads=1 --ponynoblock --ponypinasio -l 127.0.0.1:5555`
2. start initializer: `./sequence-window -i 127.0.0.1:7000 -o 127.0.0.1:5555 -m 127.0.0.1:5001 --ponythreads=4 --ponypinasio --ponynoblock -c 127.0.0.1:12500 -d 127.0.0.1:12501 -r res-data -w 2 -n worker1 -t --spike-drop --spike-prob 0.01 --spike-margin 100`
3. start worker: `./sequence-window -i 127.0.0.1:7000 -o 127.0.0.1:5555 -m 127.0.0.1:5001 --ponythreads=4 --ponypinasio --ponynoblock -c 127.0.0.1:12500 -d 127.0.0.1:12501 -r res-data -w 2 -n worker2`
4. start sender: `../../../../giles/sender/sender -h 127.0.0.1:7000 -s 50 -i 20_000_000 -u --ponythreads=1 -y -g 12 -w -m 100000`
5. Once everything is complete, validate the results with the validator; `./validator/validator -i received.txt -e 100000`

### With resilience

Note that spike during resilience recovery/replay causes a crash for different reasons, so you need to set `--spike-margin 1000` to give the application enough time to complete recovery before the next spike event occurs.
0. build with resilience: `stable env ponyc -d -D spike -D spiketrace -D validate -D resilience`
1. create `res-data` directory, and make sure it has no files in it.
2. start receiver as above
3. start initializer with a higher spike margin: `./sequence-window -i 127.0.0.1:7000 -o 127.0.0.1:5555 -m 127.0.0.1:5001 --ponythreads=4 --ponypinasio --ponynoblock -c 127.0.0.1:12500 -d 127.0.0.1:12501 -r res-data -w 2 -n worker1 -t --spike-drop --spike-prob 0.01 --spike-margin 1000`
4. start worker as above
5. start sender as above
6. ctrl-c the worker and restart it several times throughout the process
7. once everything is complete, validate as above. You may need to use the `-a` flag to switch the test to at-least-once mode: `./validator/validator -i received.txt -e 100000 -a`

