### PR TITLE
Don't segfault when a network connection is disconnected

### DIFF
--- a/lib/wallaroo/data_channel/data_channel.pony
+++ b/lib/wallaroo/data_channel/data_channel.pony
@@ -370,6 +370,8 @@ actor DataChannel
 
       if AsioEvent.disposable(flags) then
         @pony_asio_event_destroy(event)
+        _writeable = false
+        _readable = false
         _event = AsioEvent.none()
       end
 

--- a/lib/wallaroo/data_channel/data_channel_listener.pony
+++ b/lib/wallaroo/data_channel/data_channel_listener.pony
@@ -72,6 +72,8 @@ actor DataChannelListener
 
     if AsioEvent.disposable(flags) then
       @pony_asio_event_destroy(_event)
+      _writeable = false
+      _readable = false
       _event = AsioEvent.none()
     end
 

--- a/lib/wallaroo/metrics/metrics_sink.pony
+++ b/lib/wallaroo/metrics/metrics_sink.pony
@@ -430,6 +430,8 @@ actor MetricsSink
 
       if AsioEvent.disposable(flags) then
         @pony_asio_event_destroy(event)
+        _writeable = false
+        _readable = false
         _event = AsioEvent.none()
       end
 

--- a/lib/wallaroo/tcp_sink/tcp_sink.pony
+++ b/lib/wallaroo/tcp_sink/tcp_sink.pony
@@ -375,6 +375,8 @@ actor TCPSink is (Consumer & RunnableStep & Initializable)
 
       if AsioEvent.disposable(flags) then
         @pony_asio_event_destroy(event)
+        _writeable = false
+        _readable = false
         _event = AsioEvent.none()
       end
 

--- a/lib/wallaroo/tcp_source/tcp_source.pony
+++ b/lib/wallaroo/tcp_source/tcp_source.pony
@@ -271,6 +271,8 @@ actor TCPSource is Producer
 
       if AsioEvent.disposable(flags) then
         @pony_asio_event_destroy(event)
+        _writeable = false
+        _readable = false
         _event = AsioEvent.none()
       end
 

--- a/lib/wallaroo/tcp_source/tcp_source_listener.pony
+++ b/lib/wallaroo/tcp_source/tcp_source_listener.pony
@@ -154,6 +154,8 @@ actor TCPSourceListener
 
     if AsioEvent.disposable(flags) then
       @pony_asio_event_destroy(_event)
+      _writeable = false
+      _readable = false
       _event = AsioEvent.none()
     end
 


### PR DESCRIPTION
Our network code could allow for a segfault when the connection became
disconnected. By not setting `_writeable` and `_readable` to false when
we set our `_event` to AsioEvent.None, we would continue to try and
process read and write events that require `_event` to be a full event.

Fixes #869