### PR TITLE
Don't "corrupt" tcp connection state machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Wallaroo
 
+- Fix segfault that occurs when a network connection is abruptly disconnected
+
 ### Python API
 
 - Added support for multi-worker applications

--- a/lib/wallaroo/data_channel/data_channel.pony
+++ b/lib/wallaroo/data_channel/data_channel.pony
@@ -351,21 +351,23 @@ actor DataChannel
       end
     else
       // At this point, it's our event.
-      if AsioEvent.writeable(flags) then
-        _writeable = true
-        _complete_writes(arg)
-          ifdef not windows then
-            if _pending_writes() then
-              //sent all data; release backpressure
-              _release_backpressure()
+      if _connected and not _shutdown_peer then
+        if AsioEvent.writeable(flags) then
+          _writeable = true
+          _complete_writes(arg)
+            ifdef not windows then
+              if _pending_writes() then
+                //sent all data; release backpressure
+                _release_backpressure()
+              end
             end
-          end
-      end
+        end
 
-      if AsioEvent.readable(flags) then
-        _readable = true
-        _complete_reads(arg)
-        _pending_reads()
+        if AsioEvent.readable(flags) then
+          _readable = true
+          _complete_reads(arg)
+          _pending_reads()
+        end
       end
 
       if AsioEvent.disposable(flags) then
@@ -460,7 +462,9 @@ actor DataChannel
       let writev_batch_size: USize = @pony_os_writev_max[I32]().usize()
       var num_to_send: USize = 0
       var bytes_to_send: USize = 0
-      while _writeable and (_pending_writev_total > 0) do
+      while _writeable and not _shutdown_peer
+        and (_pending_writev_total > 0)
+      do
         try
           //determine number of bytes and buffers to send
           if (_pending_writev.size()/2) < writev_batch_size then
@@ -649,7 +653,7 @@ actor DataChannel
       else
         // The socket has been closed from the other side.
         _shutdown_peer = true
-        close()
+        _hard_close()
       end
     end
 

--- a/lib/wallaroo/tcp_source/tcp_source.pony
+++ b/lib/wallaroo/tcp_source/tcp_source.pony
@@ -264,9 +264,11 @@ actor TCPSource is Producer
         end
       end
     else
-      if AsioEvent.readable(flags) then
-        _readable = true
-        _pending_reads()
+      if _connected and not _shutdown_peer then
+        if AsioEvent.readable(flags) then
+          _readable = true
+          _pending_reads()
+        end
       end
 
       if AsioEvent.disposable(flags) then
@@ -450,7 +452,7 @@ actor TCPSource is Producer
     else
       // The socket has been closed from the other side.
       _shutdown_peer = true
-      close()
+      _hard_close()
     end
 
     _reading = false


### PR DESCRIPTION
Each of our classes that handle a TCPConnection had a couple subtle race
conditions in them caused by sloppy handling of state machine variables.
The final fix for this is to move state for each of these classes into a
proper state machine so everything can't get wildly out of whack.

An example issue is #869 where we could continue trying to send data
after our connection had been dropped. In order to fix, we need to:

Not update readable and writeable to true unless we have a connection.
Hard close in _pending_read when we hit an error (close() can leave us
in an invalid state).
Check to make sure that _shutdown_peer isn't set when writing (or
already did this for reading).

Closes #869