### PR TITLE
Add information about object serialization in Python

### DIFF
--- a/book/python/interworker-serialization-and-resilience.md
+++ b/book/python/interworker-serialization-and-resilience.md
@@ -23,3 +23,7 @@ Deserialization is the other side of serialization, taking a string of bytes tha
 def deserialize(s):
     return pickle.loads(s)
 ```
+
+## A Note About Serializable Objects
+
+There are a number of Python packages that can serialize and deserialize Python objects (by default Wallaroo uses `pickle`). You can also design and implement your own serialization protocol if you feel that you have specific needs that are not met by existing systems. Whatever you do, you must make sure that all of your objects can be serialized and deserialized with the system that you are using. For example, if your application sends message data that contains objects created by third party libraries, you should make sure that those objects can be serialized. Some Python packages provide wrappers around C data, which cannot be serialized using `pickle`, so if you need to send this type of data then you will have to provide another way to serialize it.


### PR DESCRIPTION
The new text gives more detail about what what the user needs to do in
order to serialize objects. Some objects (such as third-party objects
that wrap C data) may not be able to be serialized with Python's
`pickle` module, so the user should be aware of what they are
serializing and make sure that their serialization mechanism supports
it.

Fixes #860

[skip ci]