### PR TITLE
Add Python WActor API

### DIFF
--- a/atkin/Makefile
+++ b/atkin/Makefile
@@ -1,0 +1,71 @@
+# prevent rules from being evaluated/included multiple times
+ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
+$(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
+
+rules_mk_path := ../rules.mk
+
+# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
+PONY_TARGET := false
+
+# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
+EXS_TARGET := false
+
+# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
+DOCKER_TARGET := false
+
+# uncomment to disable generate recursing into Makefiles of subdirectories
+RECURSE_SUBMAKEFILES := false
+
+# Set up our atkin specific paths. We don't know what directory make was
+# run from, so we get an absolute path based on $(buffy_path). This will work
+# whether make was run from the top level of Wallaroo or from within the
+# atkin directory.
+ATKIN_PATH = $(buffy_path)/atkin
+ATKIN_BUILD = $(ATKIN_PATH)/build
+ATKIN_CPP = $(ATKIN_PATH)/cpp
+WALLAROO_LIB =  $(buffy_path)/lib
+
+# Our top level Makefile has 3 rules that would have been generated for us if
+# we hadn't turned them off at the top of the Makefile. Here we recreate them
+# with our own custom rules. This allows the top level commands like
+# "make test" to work.
+build-atkin-all = atkin_clean atkin_build
+test-atkin-all = atkin_clean atkin_build atkin_test
+clean-atkin-all = atkin_clean
+
+atkin_clean:
+	rm -rf $(ATKIN_BUILD)
+
+atkin_build:
+	mkdir -p $(ATKIN_BUILD)
+	cc -g -o $(ATKIN_BUILD)/python-wactor.o -c $(ATKIN_CPP)/python-wactor.c
+	ar rvs $(ATKIN_BUILD)/libpython-wactor.a $(ATKIN_BUILD)/python-wactor.o
+	ponyc --debug --output=$(ATKIN_BUILD) --path=$(ATKIN_BUILD) --path=$(WALLAROO_LIB) $(ATKIN_PATH)
+
+atkin_test:
+	$(QUIET)echo "atkin tests"
+
+#########################################################################################
+#### don't change after this line unless to disable standard rules generation makefile
+MY_NAME := $(lastword $(MAKEFILE_LIST))
+$(MY_NAME)_PATH := $(dir $(MY_NAME))
+
+include $($(MY_NAME)_PATH:%/=%)/$(rules_mk_path)
+
+#### don't change before this line unless to disable standard rules generation makefile
+#########################################################################################
+
+
+# args to RUN_DAGON and RUN_DAGON_SPIKE: $1 = test name; $2 = ini file; $3 = timeout; $4 = wesley test command, $5 = include in CI
+# NOTE: all paths must be relative to buffy directory (use buffy_path variable)
+
+##<NAME OF TARGET>: #used as part of `make help` command ## <DESCRIPTION OF TARGET>
+#$(eval $(call RUN_DAGON\
+#,<NAME OF TARGET> \
+#,$(buffy_path)/<PATH TO INI FILE> \
+#,<TIMEOUT VALUE> \
+#,<WESLEY TEST COMMAND> \
+#,<INCLUDE IN CI>))
+
+# end of prevent rules from being evaluated/included multiple times
+endif

--- a/atkin/README.md
+++ b/atkin/README.md
@@ -1,0 +1,52 @@
+# Atkin
+
+Atkin is a Wallaroo-Python Runtime that enables a Wallaroo WActor-based
+application to be written in Python.
+
+## Requirements
+- clang >=3.5 on MacOS or gcc >=5 on Linux
+- python-dev
+- sendence-ponyc
+- giles-sender
+
+You will also need your environment to be [set up with a working
+Wallaroo](/book/getting-started/setup.md).
+
+## Build
+
+Create the `build` directory if it doesn't already exist.
+
+```
+mkdir build
+```
+
+Build the program.
+
+**On MacOS**:
+
+```bash
+clang -g -o build/python-wactor.o -c cpp/python-wactor.c
+ar rvs build/libpython-wactor.a build/python-wactor.o
+ponyc --debug --output=build --path=build --path=../lib/ .
+```
+
+**On Linux**:
+
+```bash
+gcc -g -o build/python-wactor.o -c cpp/python-wactor.c
+ar rvs build/libpython-wactor.a build/python-wactor.o
+ponyc --debug --output=build --path=build --path=../lib/ .
+```
+
+## Next Steps
+
+### The WActor Python API
+
+You can read up on the [WActor Python API](/book/python-wactor/api.md).
+
+### Run Some Applications
+
+#### Run Toy CRDT computation
+
+See [CRDT application instructions](/book/examples/python-wactor/CRDT/README.md).
+

--- a/atkin/cpp/python-wactor.c
+++ b/atkin/cpp/python-wactor.c
@@ -1,0 +1,242 @@
+#ifdef __APPLE__
+    #include <Python/Python.h>
+#else
+    #include <python2.7/Python.h>
+#endif
+
+
+extern void py_incref(PyObject *o)
+{
+  Py_INCREF(o);
+}
+
+extern void py_decref(PyObject *o)
+{
+  Py_DECREF(o);
+}
+
+extern size_t list_item_count(PyObject *list)
+{
+  return PyList_Size(list);
+}
+
+extern char *get_list_item_string(PyObject *list, size_t idx)
+{
+  PyObject *pValue;
+  pValue = PyList_GetItem(list, idx);
+
+  char * rtn = PyString_AsString(pValue);
+  Py_DECREF(pValue);
+  return rtn;
+}
+
+extern PyObject *load_module(char *module_name)
+{
+  PyObject *pName, *pModule;
+
+  pName = PyString_FromString(module_name);
+  /* Error checking of pName left out */
+
+  pModule = PyImport_Import(pName);
+  Py_DECREF(pName);
+
+  return pModule;
+}
+
+extern PyObject *create_actor_system(PyObject *pModule, PyObject *args)
+{
+  PyObject *pFunc, *pValue;
+
+  pFunc = PyObject_GetAttrString(pModule, "create_actor_system");
+  pValue = PyObject_CallFunctionObjArgs(pFunc, args, NULL);
+  Py_DECREF(pFunc);
+
+  return pValue;
+}
+
+extern PyObject *get_actor_count(PyObject *pModule)
+{
+  PyObject *pFunc, *pValue;
+  pFunc = PyObject_GetAttrString(pModule, "get_actor_count");
+  pValue = PyObject_CallFunctionObjArgs(pFunc, NULL);
+  Py_DECREF(pFunc);
+  return pValue;
+}
+
+extern char *get_app_name(PyObject *pModule)
+{
+  PyObject *pFunc, *pValue;
+  pFunc = PyObject_GetAttrString(pModule, "get_app_name");
+  pValue = PyObject_CallFunctionObjArgs(pFunc, NULL);
+  char * rtn = PyString_AsString(pValue);
+  Py_DECREF(pValue);
+  return rtn;
+}
+
+extern char *get_name(PyObject *pObj)
+{
+  PyObject *pValue;
+  pValue = PyObject_GetAttrString(pObj, "name");
+  char * rtn = PyString_AsString(pValue);
+  Py_DECREF(pValue);
+  return rtn;
+}
+
+extern PyObject *get_attribute(PyObject *pObj, const char *attrName)
+{
+  PyObject *pValue;
+  pValue = PyObject_GetAttrString(pObj, attrName);
+  return pValue;
+}
+
+extern PyObject *get_none()
+{
+  return Py_None;
+}
+
+extern char *get_string_attribute(PyObject *pObj, const char *attrName)
+{
+  PyObject *pValue;
+  pValue = PyObject_GetAttrString(pObj, attrName);
+  char * rtn = PyString_AsString(pValue);
+  Py_DECREF(pValue);
+  return rtn;
+}
+
+uint64_t *split_uint_128(__uint128_t big)
+{
+  uint64_t *r = malloc(2 * sizeof(uint64_t));
+  r[0] = (uint64_t) (big >> 64);
+  r[1] = (uint64_t) (big - (((__uint128_t) r[0]) << 64));
+  return r;
+}
+
+extern PyObject *call_fn_u128arg(PyObject *actor, const char* funcName, __uint128_t arg)
+{
+  PyObject *pFunc, *pValue, *pLeft, *pRight;
+  
+  uint64_t *longs = split_uint_128(arg);
+
+  pLeft = PyLong_FromUnsignedLongLong(longs[0]);
+  pRight = PyLong_FromUnsignedLongLong(longs[1]);
+  pFunc = PyObject_GetAttrString(actor, funcName);
+  pValue = PyObject_CallFunctionObjArgs(pFunc, pLeft, pRight, NULL);
+  Py_DECREF(pLeft);
+  Py_DECREF(pRight);
+  Py_DECREF(pFunc);
+  free(longs);
+
+  return pValue;
+}
+
+extern PyObject *call_fn_noargs(PyObject *actor, const char* funcName)
+{
+  PyObject *pFunc, *pValue;
+
+  pFunc = PyObject_GetAttrString(actor, funcName);
+  pValue = PyObject_CallFunctionObjArgs(pFunc, NULL);
+  Py_DECREF(pFunc);
+
+  return pValue;
+}
+
+extern size_t call_fn_sizet_noargs(PyObject *actor, const char* funcName)
+{
+  PyObject *pFunc, *pValue;
+
+  pFunc = PyObject_GetAttrString(actor, funcName);
+  pValue = PyObject_CallFunctionObjArgs(pFunc, NULL);
+  Py_DECREF(pFunc);
+
+  size_t sz = PyInt_AsSsize_t(pValue);
+  Py_DECREF(pValue);
+  return sz;
+}
+
+extern size_t call_fn_sizet_bufferarg(PyObject *actor, const char* funcName, char *bytes, size_t size)
+{
+  PyObject *pFunc, *pValue, *pBytes;
+
+  pFunc = PyObject_GetAttrString(actor, funcName);
+  pBytes = PyBytes_FromStringAndSize(bytes, size);
+  pValue = PyObject_CallFunctionObjArgs(pFunc, pBytes, NULL);
+
+  size_t sz = PyInt_AsSsize_t(pValue);
+  Py_DECREF(pFunc);
+  Py_DECREF(pBytes);
+  Py_DECREF(pValue);
+  return sz;
+}
+
+extern PyObject *call_fn_bufferarg(PyObject *actor, const char* funcName, char *bytes, size_t size)
+{
+  PyObject *pFunc, *pValue, *pBytes;
+
+  pFunc = PyObject_GetAttrString(actor, funcName);
+  pBytes = PyBytes_FromStringAndSize(bytes, size);
+  pValue = PyObject_CallFunctionObjArgs(pFunc, pBytes, NULL);
+
+  Py_DECREF(pFunc);
+  Py_DECREF(pBytes);
+  return pValue;
+}
+
+extern char *call_str_fn_noargs(PyObject *pObj, const char *fName)
+{
+  PyObject *pFunc, *pValue;
+  pFunc = PyObject_GetAttrString(pObj, fName);
+  pValue = PyObject_CallFunctionObjArgs(pFunc, NULL);
+  Py_DECREF(pFunc);
+  char * rtn = PyString_AsString(pValue);
+  Py_DECREF(pValue);
+  return rtn;
+}
+
+extern char *call_str_fn(PyObject *pObj, const char *fName, PyObject *args)
+{
+  PyObject *pFunc, *pValue;
+  pFunc = PyObject_GetAttrString(pObj, fName);
+  pValue = PyObject_CallFunctionObjArgs(pFunc, args, NULL);
+  Py_DECREF(pFunc);
+  char * rtn = PyString_AsString(pValue);
+  Py_DECREF(pValue);
+  return rtn;
+}
+
+extern PyObject *call_fn(PyObject *actor, const char* funcName, PyObject *args)
+{
+  PyObject *pFunc, *pCallLog;
+
+  pFunc = PyObject_GetAttrString(actor, funcName);
+  pCallLog = PyObject_CallFunctionObjArgs(pFunc, args, NULL);
+  Py_DECREF(pFunc);
+
+  return pCallLog;
+}
+
+extern PyObject *call_fn_with_id(PyObject *actor, const char* funcName,
+    __uint128_t sender_id, PyObject *args)
+{
+  PyObject *pFunc, *pCallLog, *pLeft, *pRight;
+  uint64_t *longs = split_uint_128(sender_id);
+  pLeft = PyLong_FromUnsignedLongLong(longs[0]);
+  pRight = PyLong_FromUnsignedLongLong(longs[1]);
+  pFunc = PyObject_GetAttrString(actor, funcName);
+  pCallLog = PyObject_CallFunctionObjArgs(pFunc, pLeft, pRight, args, NULL);
+  Py_DECREF(pFunc);
+  Py_DECREF(pLeft);
+  Py_DECREF(pRight);
+  free(longs);
+
+  return pCallLog;
+}
+
+extern __uint128_t join_longs(PyObject *long_pair)
+{
+  uint64_t l = PyLong_AsUnsignedLongLong(PyTuple_GetItem(long_pair, 0));
+  uint64_t r = PyLong_AsUnsignedLongLong(PyTuple_GetItem(long_pair, 1));
+  __uint128_t s = l;
+  s = s << 64;
+  s += r;
+  return s;
+}

--- a/atkin/main.pony
+++ b/atkin/main.pony
@@ -1,0 +1,46 @@
+use "collections"
+
+use "sendence/options"
+use "wallaroo"
+use "wallaroo/tcp_source"
+use "wallaroo/topology"
+
+use "lib:python2.7"
+use "lib:python-wactor"
+
+actor Main
+  new create(env: Env) =>
+    let seed: U64 = 12345
+
+    Atkin.start_python()
+
+    try
+      var module_name: String = ""
+
+      let options = Options(WallarooConfig.application_args(env.args), false)
+      options.add("application-module", "", StringArgument)
+
+      for option in options do
+        match option
+        | ("application-module", let arg: String) => module_name = arg
+        end
+      end
+
+      try
+        let module = Atkin.load_module(module_name)
+
+        try
+          let actor_system = Atkin.create_actor_system(module,
+            options.remaining(), seed)
+          Atkin.startup(env, module, actor_system)
+        else
+          env.err.print("Something went wrong while building the application")
+        end
+      else
+        env.err.print("Could not load module '" + module_name + "'")
+      end
+    else
+      env.err.print(
+        "Please use `--application-module=MODULE_NAME` to specify " +
+        "an application module")
+    end

--- a/atkin/toy_example.py
+++ b/atkin/toy_example.py
@@ -1,0 +1,95 @@
+import wactor
+import random
+import struct
+
+ALL_ROLES = ["one", "two", "three"]
+ACTOR_COUNT = 10
+
+
+def create_actor_system(args):
+    actor_system = wactor.ActorSystem("Toy Model")
+    actor_system.add_source(MessageSource())
+    actor_system.add_actor(A("one"))
+    actor_system.add_actor(A("two"))
+    actor_system.add_actor(A("three"))
+    for i in range(ACTOR_COUNT - 3):
+        actor_system.add_actor(A(random.choice(ALL_ROLES)))
+    return actor_system
+
+
+class SetActorProbability(object):
+    def __init__(self, prob):
+        self.prob = prob
+
+
+class SetNumberOfMessagesToSend(object):
+    def __init__(self, n):
+        self.n = n
+
+
+class ChangeMessageTypesToSend(object):
+    def __init__(self, types):
+        self.types = types
+
+
+class MessageSource(wactor.Source):
+    def header_length(self):
+        return 4
+
+    def payload_length(self, bs):
+        return struct.unpack(">L", bs)[0]
+
+    def decode(self, bs):
+        return "Act"
+
+
+class A(wactor.WActor):
+
+    def __init__(self, role):
+        wactor.WActor.__init__(self)
+        self.role = role
+        self.n = 1
+        self.prob = 0.5
+        self._all_message_types = ["SetActorProbability",
+                                   "SetNumberOfMessagesToSend",
+                                   "ChangeMessageTypesToSend"]
+        self._message_types_to_send = self._all_message_types
+
+    def setup(self):
+        self.register_as_role(self.role)
+        self.register_as_role("ingress")
+
+    def receive(self, sender_id, msg):
+        msg_type = type(msg)
+        if msg_type is SetActorProbability:
+            self._emission_prob = msg.prob
+            print("Setting prob to {0}".format(msg.prob))
+        elif msg_type is SetNumberOfMessagesToSend:
+            self._n = msg.n
+            print("Setting n to {0}".format(msg.n))
+        elif msg_type is ChangeMessageTypesToSend:
+            self._message_types_to_send = msg.types
+            print("Setting types to {0}".format(msg.types))
+        else:
+            print("Unknown message type {0} received".format(msg_type))
+
+    def process(self, data):
+        for i in range(0, self.n):
+            if random.random() < self.prob:
+                message = self.create_message()
+                role = random.choice(ALL_ROLES)
+                print("Sending {0} to {1}".format(str(message), role))
+                self.send_to_role(role, message)
+
+    def create_message(self):
+        msg_type = random.choice(self._message_types_to_send)
+        if msg_type == "SetActorProbability":
+            return SetActorProbability(random.random())
+        elif msg_type == "SetNumberOfMessagesToSend":
+            return SetNumberOfMessagesToSend(random.randint(1, 4))
+        elif msg_type == "ChangeMessageTypesToSend":
+            return ChangeMessageTypesToSend(random.sample(
+                            self._all_message_types,
+                            random.randint(1, len(self._all_message_types))))
+        else:
+            print("Unknown msg type {0} found".format(msg_type))

--- a/atkin/wactor.py
+++ b/atkin/wactor.py
@@ -1,0 +1,80 @@
+
+
+def join_longs(left, right):
+    r = left << 64
+    r += right
+    return r
+
+
+def split_longs(u128):
+    l = u128 >> 64
+    r = u128 - (l << 64)
+    return (l, r)
+
+
+class WActor:
+    def __init__(self):
+        self._call_log = []
+
+    def _clear_call_log(self):
+        self._call_log = []
+
+    def _get_call_log(self):
+        cl = self._call_log
+        self._clear_call_log()
+        return cl
+
+    def send_to(self, actor_id, msg):
+        self._call_log.append(("send_to", (split_longs(actor_id), msg)))
+
+    def send_to_role(self, role, msg):
+        self._call_log.append(("send_to_role", (role, msg)))
+
+    def send_to_sink(self, sink_id, msg):
+        self._call_log.append(("send_to_sink", (sink_id, msg)))
+
+    def register_as_role(self, role):
+        self._call_log.append(("register_as_role", (role)))
+
+    def receive_wrapper(self, sender_id_left, sender_id_right, msg):
+        self.receive(join_longs(sender_id_left, sender_id_right), msg)
+        return self._get_call_log()
+
+    def process_wrapper(self, data=None):
+        self.process(data)
+        return self._get_call_log()
+
+    def setup_wrapper(self, actor_id_left, actor_id_right):
+        self.actor_id = join_longs(actor_id_left, actor_id_right)
+        self.setup()
+        return self._get_call_log()
+
+
+class Source:
+    def kind(self):
+        return "external"
+
+
+class SimulatedSource:
+    def kind(self):
+        return "simulated"
+
+
+class ActorSystem:
+    def __init__(self, name):
+        self.name = name
+        self.actors = []
+        self.sources = []
+        self.sinks = []
+
+    def add_actor(self, actor):
+        self.actors.append(actor)
+
+    def add_source(self, source):
+        self.sources.append(source)
+
+    def add_sink(self, sink):
+        self.sinks.append(sink)
+
+    def add_simulated_source(self):
+        self.sources.append(SimulatedSource())

--- a/book/examples/python-wactor/CRDT/CRDT.py
+++ b/book/examples/python-wactor/CRDT/CRDT.py
@@ -1,0 +1,127 @@
+import wactor
+import random
+
+ACTOR_COUNT = 5
+ALL_ROLES = ["counter", "accumulator"]
+
+
+def create_actor_system(args):
+    actor_system = wactor.ActorSystem("Toy model CRDT App")
+    actor_system.add_simulated_source()
+    actor_system.add_actor(A("accumulator"))
+    for i in range(ACTOR_COUNT - 1):
+        actor_system.add_actor(A("counter"))
+    return actor_system
+
+
+class ActMsg(object):
+    pass
+
+
+class IncrementsMsg(object):
+    def __init__(self, count):
+        self.count = count
+
+
+class GossipMsg(object):
+    def __init__(self, data):
+        self.data = data
+
+
+class FinishMsg(object):
+    pass
+
+
+class FinishGossipMsg(object):
+    pass
+
+
+class GCounter:
+
+    def __init__(self, counter_id):
+        self._id = counter_id
+        self.data = {}
+
+    def increment(self):
+        if self._id in self.data:
+            self.data[self._id] += 1
+        else:
+            self.data[self._id] = 1
+
+    def merge(self, other):
+        for k in self.data.keys() + other.keys():
+            if k in other:
+                if k in self.data:
+                    self.data[k] = max(self.data[k], other[k])
+                else:
+                    self.data[k] = other[k]
+
+    def value(self):
+        return sum(self.data.values())
+
+    def __str__(self):
+        return "GCounter({0})".format(self.value())
+
+
+class A(wactor.WActor):
+
+    def __init__(self, role):
+        wactor.WActor.__init__(self)
+        self._pending_increments = 0
+        self._waiting = 0
+        self._round = 0
+        self.role = role
+
+    def setup(self):
+        self._g_counter = GCounter(counter_id=self.actor_id >> 96)
+        for role in ALL_ROLES + ["ingress"]:
+            self.register_as_role(role)
+
+    def receive(self, sender_id, msg):
+        message_type = type(msg)
+        if message_type is ActMsg:
+            self.act()
+        elif message_type is IncrementsMsg:
+            self._pending_increments += msg.count
+        elif message_type is GossipMsg:
+            self._g_counter.merge(msg.data)
+        elif message_type is FinishMsg:
+            for _ in range(self._pending_increments):
+                self._g_counter.increment()
+            self._pending_increments = 0
+            if self.role == "counter":
+                self.send_to_role("accumulator",
+                                  FinishGossipMsg(self._g_counter.data))
+        elif message_type is FinishGossipMsg:
+            self._g_counter.merge(m.data)
+            print "finishing: {0}".format(str(self._g_counter))
+        else:
+            print "unknown message type received: {0}".format(message_type)
+
+    def process(self, data):
+        self.act()
+        if self.role == "accumulator":
+            print "accumulator act report: {0}".format(str(self._g_counter))
+
+    def act(self):
+        if self.role == "accumulator":
+            print "round {0}: {1}".format(self._round, str(self._g_counter))
+        else:
+            while self._pending_increments > 0:
+                self._g_counter.increment()
+                self._pending_increments -= 1
+            self.emit_messages()
+        self._round += 1
+
+    def emit_messages(self):
+        inc_msg_count = random.randint(1, 4)
+        self._waiting += inc_msg_count
+        for i in range(0, inc_msg_count):
+            msg = IncrementsMsg(random.randint(1, 3))
+            self.send_to_role("counter", msg)
+        gossip_msg_count = random.randint(1, 4)
+        self._waiting += gossip_msg_count
+        msg = GossipMsg(self._g_counter.data)
+        for i in range(0, gossip_msg_count):
+            self.send_to_role("counter", msg)
+        self.send_to_role("accumulator", msg)

--- a/book/examples/python-wactor/CRDT/README.md
+++ b/book/examples/python-wactor/CRDT/README.md
@@ -1,0 +1,63 @@
+# CRDT Window
+
+The CRDT app has two actor roles: counter and accumulator. There are more than
+one counter but only a single accumulator. Each counter counts independently and
+sends its results to the accumulator, whilst also implementing a loose gossip
+protocol.
+
+You will need a working [WActor Python API](/book/python-wactor/intro.md).
+
+## Running CRDT
+
+In a shell, start up the Metrics UI if you don't already have it running:
+
+```bash
+docker start mui
+```
+
+In a shell, set up a listener:
+
+```bash
+nc -l 127.0.0.1 7002
+```
+
+In another shell, set up your environment variables if you haven't already done so. Assuming you installed Atkin according to the tutorial instructions you would do:
+
+```bash
+export PYTHONPATH="$PYTHONPATH:.:$HOME/wallaroo-tutorial/wallaroo/atkin"
+export PATH="$PATH:$HOME/wallaroo-tutorial/wallaroo/atkin/build"
+```
+
+Run `atkin` with `--application-module CRDT`:
+
+```bash
+atkin --application-module CRDT --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
+  --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
+  --name worker-name \
+  --ponythreads=1
+```
+
+In a third shell, send some messages:
+
+```bash
+../../../../giles/sender/sender --host 127.0.0.1:7010 --batch-size 10 \
+  --interval 100_000_000 --ponythreads=1 --binary --msg-size 12 --no-write \
+  --u64 --messages 100
+```
+
+##Output
+
+You should expect to see messages on screen about successful gossip and counting:
+```
+round 0: GCounter(0)
+accumulator act report: GCounter(0)
+round 1: GCounter(0)
+accumulator act report: GCounter(0)
+round 2: GCounter(11)
+accumulator act report: GCounter(11)
+round 3: GCounter(15)
+accumulator act report: GCounter(15)
+round 4: GCounter(17)
+accumulator act report: GCounter(17)
+round 5: GCounter(33)
+```

--- a/book/examples/python/README.md
+++ b/book/examples/python/README.md
@@ -16,7 +16,7 @@ To get set up for running examples, if you haven't already, refer to [Building a
 - [alphabet](alphabet/): a vote counting stream application.
 - [sequence](sequence/): a stream application designed to demonstrate and test state management and state recovery. It keeps a window of the last 4 values it has seen as its state.
 
-### Partitioned Stateful Applicatins
+### Partitioned Stateful Applications
 
 - [alphabet_partitioned](alphabet_partitioned/): a vote counting stream application using partitioning.
 - [market_spread](market_spread/): a stream application that keeps a state for market data and checks trade orders against it in real time. This application uses state, partitioning, and two pipelines, each with its own source.


### PR DESCRIPTION
This new API interfaces with wallaroo's WActor system, using pony's C FFI as an
intermediary, to run python modules that implement actor systems.
Includes a CRDT example with simulated source (in the book), and a toy example with a real source (in the directory).