### PR TITLE
Add multiworker ActorSystem recovery

### DIFF
--- a/lib/wallaroo/data_channel/data_channel_tcp.pony
+++ b/lib/wallaroo/data_channel/data_channel_tcp.pony
@@ -219,14 +219,22 @@ class DataChannelConnectNotifier is DataChannelNotify
           @printf[I32]("Received ReplayMsg on Data Channel\n".cstring())
         end
         try
-          let data_msg = r.data_msg(_auth)
-          _metrics_reporter.step_metric(data_msg.metric_name,
-            "Before replay receive on data channel (network time)",
-            data_msg.metrics_id, data_msg.latest_ts, ingest_ts)
-          _receiver.replay_received(data_msg.delivery_msg,
-            data_msg.pipeline_time_spent + (ingest_ts - data_msg.latest_ts),
-            data_msg.seq_id, my_latest_ts, data_msg.metrics_id + 1,
-            my_latest_ts)
+          match r.data_msg(_auth)
+          | let data_msg: DataMsg val =>
+            _metrics_reporter.step_metric(data_msg.metric_name,
+              "Before replay receive on data channel (network time)",
+              data_msg.metrics_id, data_msg.latest_ts, ingest_ts)
+            _receiver.replay_received(data_msg.delivery_msg,
+              data_msg.pipeline_time_spent + (ingest_ts - data_msg.latest_ts),
+              data_msg.seq_id, my_latest_ts, data_msg.metrics_id + 1,
+              my_latest_ts)
+          | let ad: ActorDataMsg val =>
+            // TODO: When we introduce wactor message replay, add
+            // functionality here
+            None
+          else
+            Fail()
+          end
         else
           Fail()
         end

--- a/lib/wallaroo/network/connections.pony
+++ b/lib/wallaroo/network/connections.pony
@@ -3,6 +3,7 @@ use "collections"
 use "files"
 use "net"
 use "serialise"
+use "time"
 use "sendence/guid"
 use "sendence/messages"
 use "wallaroo/boundary"
@@ -196,6 +197,20 @@ actor Connections is Cluster
   fun _send_control_to_cluster(data: Array[ByteSeq] val) =>
     for worker in _control_conns.keys() do
       _send_control(worker, data)
+    end
+
+  be send_control_to_random(data: Array[ByteSeq] val) =>
+    _send_control_to_random(data)
+
+  fun _send_control_to_random(data: Array[ByteSeq] val) =>
+    let target_idx: USize = Time.nanos().usize() % _control_conns.size()
+    var count: USize = 0
+    for worker in _control_conns.keys() do
+      if target_idx == count then
+        _send_control(worker, data)
+        break
+      end
+      count = count + 1
     end
 
   be send_data(worker: String, data: Array[ByteSeq] val) =>

--- a/lib/wallaroo/spike/drop_connection.pony
+++ b/lib/wallaroo/spike/drop_connection.pony
@@ -89,7 +89,7 @@ class DropConnection is WallarooOutgoingNetworkActorNotify
 
   fun ref drop(conn: WallarooOutgoingNetworkActor ref) =>
     ifdef debug then
-      @printf[I32]("\n<<<<<<SPIKE: DROPPING CONNECTION!>>>>>>\n\n".cstring())
+      @printf[I32]("\n((((((SPIKE: DROPPING CONNECTION!))))))\n\n".cstring())
     end
     // reset count, return true
     _count_since_last_dropped = 0

--- a/lib/wallaroo/startup.pony
+++ b/lib/wallaroo/startup.pony
@@ -273,8 +273,8 @@ actor Startup
         _startup_options.worker_name, data_receivers, router_registry,
         connections, is_recovering)
 
-      let recovery = Recovery(_startup_options.worker_name,
-        _event_log as EventLog, recovery_replayer)
+      let recovery = Recovery(auth, _startup_options.worker_name,
+        _event_log as EventLog, recovery_replayer, connections)
 
       let local_topology_initializer =
         if _startup_options.is_swarm_managed then
@@ -320,7 +320,7 @@ actor Startup
         ControlChannelListenNotifier(_startup_options.worker_name,
           auth, connections,
           _startup_options.is_initializer, _cluster_initializer,
-          local_topology_initializer,
+          local_topology_initializer, recovery,
           recovery_replayer, router_registry,
           control_channel_filepath, _startup_options.my_d_host,
           _startup_options.my_d_service)
@@ -434,8 +434,8 @@ actor Startup
           EventLog(_env, None)
         end
 
-      let recovery = Recovery(_startup_options.worker_name,
-        _event_log as EventLog, recovery_replayer)
+      let recovery = Recovery(auth, _startup_options.worker_name,
+        _event_log as EventLog, recovery_replayer, connections)
 
       let local_topology_initializer = if _startup_options.is_swarm_managed then
         let cluster_manager: DockerSwarmClusterManager =
@@ -494,7 +494,7 @@ actor Startup
         ControlChannelListenNotifier(_startup_options.worker_name,
           auth, connections,
           _startup_options.is_initializer, _cluster_initializer,
-          local_topology_initializer,
+          local_topology_initializer, recovery,
           recovery_replayer, router_registry, control_channel_filepath,
           _startup_options.my_d_host, _startup_options.my_d_service)
 

--- a/lib/wallaroo/topology/router.pony
+++ b/lib/wallaroo/topology/router.pony
@@ -425,23 +425,30 @@ class StepIdRouter is OmniRouter
 
 trait val ActorSystemDataRouter is Equatable[ActorSystemDataRouter]
   fun route(d_msg: ActorDeliveryMsg val)
-  fun register_actor_for_worker(id: WActorId, worker: String)
-  fun register_as_role(role: String, w_actor: WActorId)
+  fun register_actor_for_worker(id: U128, worker: String)
+  fun register_as_role(role: String, w_actor: U128)
   fun broadcast_to_actors(data: Any val)
+  fun send_digest_to(worker: String)
+  fun process_digest(digest: WActorRegistryDigest)
 
 class val EmptyActorSystemDataRouter is ActorSystemDataRouter
   fun route(d_msg: ActorDeliveryMsg val) =>
     Fail()
 
-  fun register_actor_for_worker(id: WActorId, worker: String) =>
+  fun register_actor_for_worker(id: U128, worker: String) =>
     Fail()
 
-  fun register_as_role(role: String, w_actor: WActorId) =>
+  fun register_as_role(role: String, w_actor: U128) =>
     Fail()
 
   fun broadcast_to_actors(data: Any val) =>
     Fail()
 
+  fun send_digest_to(worker: String) =>
+    Fail()
+
+  fun process_digest(digest: WActorRegistryDigest) =>
+    Fail()
 
 class val ActiveActorSystemDataRouter is ActorSystemDataRouter
   let _registry: CentralWActorRegistry
@@ -456,14 +463,20 @@ class val ActiveActorSystemDataRouter is ActorSystemDataRouter
     end
     d_msg.deliver(_registry)
 
-  fun register_actor_for_worker(id: WActorId, worker: String) =>
+  fun register_actor_for_worker(id: U128, worker: String) =>
     _registry.register_actor_for_worker(id, worker)
 
-  fun register_as_role(role: String, w_actor: WActorId) =>
+  fun register_as_role(role: String, w_actor: U128) =>
     _registry.register_as_role(role, w_actor where external = true)
 
   fun broadcast_to_actors(data: Any val) =>
     _registry.broadcast(data where external = true)
+
+  fun send_digest_to(worker: String) =>
+    _registry.send_digest(worker)
+
+  fun process_digest(digest: WActorRegistryDigest) =>
+    _registry.process_digest(digest)
 
 class DataRouter is Equatable[DataRouter]
   let _data_routes: Map[U128, ConsumerStep tag] val

--- a/lib/wallaroo/topology/router_registry.pony
+++ b/lib/wallaroo/topology/router_registry.pony
@@ -177,14 +177,20 @@ actor RouterRegistry
       source.add_boundary_builders(new_boundary_builders_sendable)
     end
 
-  be register_actor_for_worker(id: WActorId, worker: String) =>
+  be register_actor_for_worker(id: U128, worker: String) =>
     _actor_data_router.register_actor_for_worker(id, worker)
 
-  be register_as_role(role: String, w_actor: WActorId) =>
+  be register_as_role(role: String, w_actor: U128) =>
     _actor_data_router.register_as_role(role, w_actor)
 
   be broadcast_to_actors(data: Any val) =>
     _actor_data_router.broadcast_to_actors(data)
+
+  be process_digest(digest: WActorRegistryDigest) =>
+    _actor_data_router.process_digest(digest)
+
+  be send_digest_to(worker: String) =>
+    _actor_data_router.send_digest_to(worker)
 
   fun _distribute_data_router() =>
     _data_receivers.update_data_router(_data_router)

--- a/lib/wallaroo/w_actor/actor_system_distributor.pony
+++ b/lib/wallaroo/w_actor/actor_system_distributor.pony
@@ -95,7 +95,7 @@ actor ActorSystemDistributor is Distributor
         let worker_name = workers(w_idx)
         let ls = LocalActorSystem(_system.name(), shares(w_idx),
           _system.sources(), _system.sinks(), sendable_actor_to_worker_map,
-          workers)
+          workers, recover Map[String, Role box] end)
         let msg = ChannelMsgEncoder.spin_up_local_actor_system(ls, _auth)
         _connections.send_control(worker_name, msg)
       end
@@ -103,7 +103,7 @@ actor ActorSystemDistributor is Distributor
       // Create our local system and initialize
       let local_system = LocalActorSystem(_system.name(), shares(0),
         _system.sources(), _system.sinks(), sendable_actor_to_worker_map,
-        workers)
+        workers, recover Map[String, Role box] end)
       _w_actor_initializer.update_local_actor_system(local_system)
       _w_actor_initializer.update_actor_to_worker_map(
         sendable_actor_to_worker_map)

--- a/lib/wallaroo/w_actor/w_actor.pony
+++ b/lib/wallaroo/w_actor/w_actor.pony
@@ -4,7 +4,7 @@ primitive BasicRoles
   fun ingress(): String => "ingress"
 
 trait WActor
-  fun ref receive(sender: WActorId, payload: Any val, h: WActorHelper)
+  fun ref receive(sender: U128, payload: Any val, h: WActorHelper)
     """
     Called when receiving a message from another WActor
     """
@@ -14,7 +14,7 @@ trait WActor
     """
 
 class EmptyWActor is WActor
-  fun ref receive(sender: WActorId, payload: Any val, h: WActorHelper) =>
+  fun ref receive(sender: U128, payload: Any val, h: WActorHelper) =>
     Fail()
   fun ref process(data: Any val, h: WActorHelper) => Fail()
 
@@ -22,12 +22,12 @@ interface val WActorBuilder
   fun apply(id: U128, wh: WActorHelper): WActor
 
 trait WActorHelper
-  fun ref send_to(target: WActorId, data: Any val)
+  fun ref send_to(target: U128, data: Any val)
   fun ref send_to_role(role: String, data: Any val)
   fun ref send_to_sink[Out: Any val](sink_id: USize, output: Out)
   fun ref register_as_role(role: String)
   fun ref create_actor(builder: WActorBuilder)
-  fun ref destroy_actor(id: WActorId)
+  fun ref destroy_actor(id: U128)
   fun ref set_timer(duration: U128, callback: {()},
     is_repeating: Bool = false): WActorTimer
   fun ref cancel_timer(t: WActorTimer)

--- a/lib/wallaroo/w_actor/w_actor_startup.pony
+++ b/lib/wallaroo/w_actor/w_actor_startup.pony
@@ -213,8 +213,8 @@ actor ActorSystemStartup
         _startup_options.worker_name, data_receivers, router_registry,
         connections, is_recovering)
 
-      let recovery = Recovery(_startup_options.worker_name, event_log,
-        recovery_replayer)
+      let recovery = Recovery(auth, _startup_options.worker_name, event_log,
+        recovery_replayer, connections)
 
       let initializer = WActorInitializer(_startup_options.worker_name,
         _app_name, auth, event_log, _startup_options.input_addrs,
@@ -240,7 +240,7 @@ actor ActorSystemStartup
       let control_notifier: TCPListenNotify iso =
         ControlChannelListenNotifier(_startup_options.worker_name,
           auth, connections, _startup_options.is_initializer,
-          _cluster_initializer, initializer, recovery_replayer,
+          _cluster_initializer, initializer, recovery, recovery_replayer,
           router_registry, control_channel_filepath,
           _startup_options.my_d_host, _startup_options.my_d_service)
 

--- a/lib/wallaroo/w_actor/w_message.pony
+++ b/lib/wallaroo/w_actor/w_message.pony
@@ -1,9 +1,9 @@
 class WMessage
-  let sender: WActorId
-  let receiver: WActorId
+  let sender: U128
+  let receiver: U128
   let payload: Any val
 
-  new val create(s: WActorId, r: WActorId, p: Any val) =>
+  new val create(s: U128, r: U128, p: Any val) =>
     sender = s
     receiver = r
     payload = p

--- a/testing/runs/w_actor/main.pony
+++ b/testing/runs/w_actor/main.pony
@@ -134,7 +134,7 @@ class A is WActor
     _message_types_to_send = _all_message_types
     _rand = EnhancedRandom(seed)
 
-  fun ref receive(sender: WActorId, payload: Any val, h: WActorHelper) =>
+  fun ref receive(sender: U128, payload: Any val, h: WActorHelper) =>
     match payload
     | let m: SetActorProbabilityMsg val =>
       ifdef debug then

--- a/testing/runs/w_actor_celsius/main.pony
+++ b/testing/runs/w_actor_celsius/main.pony
@@ -81,7 +81,7 @@ class Celsius is WActor
   new create(h: WActorHelper) =>
     h.register_as_role(BasicRoles.ingress())
 
-  fun ref receive(sender: WActorId, payload: Any val, h: WActorHelper) =>
+  fun ref receive(sender: U128, payload: Any val, h: WActorHelper) =>
     None
 
   fun ref process(data: Any val, h: WActorHelper) =>

--- a/testing/runs/w_actor_crdt/main.pony
+++ b/testing/runs/w_actor_crdt/main.pony
@@ -105,7 +105,7 @@ class A is WActor
     _g_counter = GCounter(_id)
     _rand = EnhancedRandom(seed)
 
-  fun ref receive(sender: WActorId, payload: Any val, h: WActorHelper) =>
+  fun ref receive(sender: U128, payload: Any val, h: WActorHelper) =>
     match payload
     | ActMsg =>
       act(h)


### PR DESCRIPTION
Prior to this, recovery only worked for single worker
ActorSystem clusters. Now information about which
actors have been registered (on workers and for roles)
is properly distributed to a recovering worker.