### PR TITLE
Run Wallaroo unit tests faster

### DIFF
--- a/lib/wallaroo/data_channel/_test.pony
+++ b/lib/wallaroo/data_channel/_test.pony
@@ -260,8 +260,6 @@ class iso _TestDataChannelMute is UnitTest
     _TestDataChannel(h)(_TestDataChannelMuteSendNotify(h),
       _TestDataChannelMuteReceiveNotify(h))
 
-    h.long_test(2_000_000_000)
-
   fun timed_out(h: TestHelper) =>
     h.complete(true)
 
@@ -352,8 +350,6 @@ class iso _TestDataChannelUnmute is UnitTest
     _TestDataChannel(h)(_TestDataChannelMuteSendNotify(h),
       _TestDataChannelUnmuteReceiveNotify(h))
 
-    h.long_test(2_000_000_000)
-
 class _TestDataChannelUnmuteReceiveNotify is DataChannelNotify
   """
   Notifier to test that after muting and unmuting a connection, we get data
@@ -410,8 +406,6 @@ class iso _TestDataChannelThrottle is UnitTest
     _TestDataChannel(h)(_TestDataChannelThrottleSendNotify(h),
       _TestDataChannelThrottleReceiveNotify(h))
 
-    h.long_test(10_000_000_000)
-
 class _TestDataChannelThrottleReceiveNotify is DataChannelNotify
   """
   Notifier to that mutes itself on startup. We then send data to it in order
@@ -466,7 +460,7 @@ class _TestDataChannelThrottleSendNotify is DataChannelNotify
   fun ref throttled(conn: DataChannel ref) =>
     _throttled_yet = true
     _h.complete_action("sender throttled")
-    _h.complete(true)
+    _h.dispose_when_done(conn)
 
   fun ref sent(conn: DataChannel ref, data: ByteSeq): ByteSeq =>
     if not _throttled_yet then


### PR DESCRIPTION
Data Channel had duplicate calls to long_test in tests that already call
long test via calling `_TestDataChannel`. This resulted in two timers
being set up for the test, only one of which will be cancelled when the
test completes. This resulted in the second timer registered being run
to completion no matter what.