### PR TITLE
Don't FAIL application when TCPSource gets a "bad" message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix segfault that occurs when a network connection is abruptly disconnected
 - Support more than 1 sink per application
+- Don't FAIL application when TCPSource receives undecodable message
 
 ### Python API
 

--- a/lib/wallaroo/tcp_source/framed_source_notify.pony
+++ b/lib/wallaroo/tcp_source/framed_source_notify.pony
@@ -92,7 +92,11 @@ class FramedSourceNotify[In: Any val] is TCPSourceNotify
             conn, _router, _omni_router, conn, _guid_gen.u128(), None, 0, 0,
             decode_end_ts, latest_metrics_id, ingest_ts, _metrics_reporter)
         else
-          Fail()
+          @printf[I32](("Unable to decode message at " + _pipeline_name +
+            " source\n").cstring())
+          ifdef debug then
+            Fail()
+          end
           (true, true, ingest_ts)
         end
 


### PR DESCRIPTION
Previously, if you sent a non-decodable message to a `TCPSource`, it
would call `Fail()` and stop the entire application. This is great for
debugging but not so good for regular production usage.

Now, we will only `Fail()` when in debug mode. This allows us to catch
errors more easily during development (assuming you are running in
debug) while avoiding shutting down a production application.

Closes #510