### PR TITLE
Use "Epoch friendly" timestamps in Giles

### DIFF
--- a/giles/receiver/giles-receiver.pony
+++ b/giles/receiver/giles-receiver.pony
@@ -9,6 +9,7 @@ use "signals"
 use "time"
 use "sendence/messages"
 use "sendence/bytes"
+use "sendence/wall_clock"
 use "debug"
 
 // tests
@@ -180,7 +181,7 @@ class FromBuffyNotify is TCPConnectionNotify
       end
     else
       if not _no_write then
-        _store.received(consume data, Time.wall_to_nanos(Time.now()))
+        _store.received(consume data, WallClock.nanoseconds())
       end
       _coordinator.received_message()
       conn.expect(4)

--- a/giles/sender/giles-sender.pony
+++ b/giles/sender/giles-sender.pony
@@ -12,6 +12,7 @@ use "sendence/bytes"
 use "sendence/messages"
 use "sendence/options"
 use "sendence/tcp"
+use "sendence/wall_clock"
 
 // documentation
 // more tests
@@ -546,7 +547,7 @@ actor SendingActor
         _to_host_socket.write(i)
       end
       if _write_to_file then
-        _store.sentv(consume d', Time.wall_to_nanos(Time.now()))
+        _store.sentv(consume d', WallClock.nanoseconds())
       end
     else
       _finished = true


### PR DESCRIPTION
Giles currently uses unadjusted monotonic timestamps that can only be
compared to one another. With this change, timestamps are nanoseconds
since the unix epoch allowing it to be compared to times from other
applications like say, a Python wallaroo application.

This would allow for comparing of a timestamp from inside a C++ or
Python application with Giles timestamps and track the amount of time
spent at different points not just in a Wallaroo application but
throughout its lifecycle.