### PR TITLE
Remove demo-specific infrastructure

### DIFF
--- a/lib/wallaroo/recovery/recovery.pony
+++ b/lib/wallaroo/recovery/recovery.pony
@@ -89,6 +89,7 @@ actor Recovery
       _start_msg_replay(workers)
     | let wai: WActorInitializer =>
       _start_w_actor_registry_recovery(workers)
+      wai.start_app()
     else
       Fail()
     end
@@ -125,7 +126,6 @@ actor Recovery
       _event_log.start_pipeline_logging(lti)
     | let wai: WActorInitializer =>
       _event_log.start_actor_system_logging(wai)
-      wai.kick_off_demo()
     else
       Fail()
     end

--- a/lib/wallaroo/w_actor/w_actor_startup.pony
+++ b/lib/wallaroo/w_actor/w_actor_startup.pony
@@ -44,10 +44,7 @@ actor ActorSystemStartup
   var _ph_host: String = ""
   var _ph_service: String = ""
 
-  // TODO: remove DEMO param actor_count
-  new create(env: Env, system: ActorSystem val, app_name: String,
-    actor_count: USize)
-  =>
+  new create(env: Env, system: ActorSystem val, app_name: String) =>
     _env = env
     _system = system
     _app_name = app_name
@@ -209,6 +206,10 @@ actor ActorSystemStartup
       let router_registry = RouterRegistry(auth, _startup_options.worker_name,
         data_receivers, connections, _startup_options.stop_the_world_pause)
 
+      //TODO: Remove this once we have application lifecycle implemented
+      //for ActorSystem
+      router_registry.application_ready_to_work()
+
       let recovery_replayer = RecoveryReplayer(auth,
         _startup_options.worker_name, data_receivers, router_registry,
         connections, is_recovering)
@@ -218,7 +219,7 @@ actor ActorSystemStartup
 
       let initializer = WActorInitializer(_startup_options.worker_name,
         _app_name, auth, event_log, _startup_options.input_addrs,
-        _startup_options.output_addrs, _local_actor_system_file, actor_count,
+        _startup_options.output_addrs, _local_actor_system_file,
         _iterations, recovery, recovery_replayer, _data_channel_file,
         _worker_names_file, data_receivers, empty_metrics_conn, seed,
         connections, router_registry, _startup_options.is_initializer)

--- a/lib/wallaroo/w_actor/w_actor_wrapper.pony
+++ b/lib/wallaroo/w_actor/w_actor_wrapper.pony
@@ -25,8 +25,6 @@ trait WActorWrapper
   fun ref _set_timer(duration: U128, callback: {()},
     is_repeating: Bool = false): WActorTimer
   fun ref _cancel_timer(t: WActorTimer)
-  // Temporary for demonstration
-  be pickle(m: SerializeTarget)
 
 actor WActorWithState is WActorWrapper
   let _worker_name: String
@@ -108,16 +106,6 @@ actor WActorWithState is WActorWrapper
     This won't scale if there are lots of w_actors
     """
     _timers.tick()
-
-  // Temporary for demonstration
-  be pickle(m: SerializeTarget) =>
-    try
-      let serialized = Pickle[WActor](_w_actor, _auth)
-      m.add_serialized(serialized)
-    else
-      @printf[I32]("Did you save a reference to WActorHelper on a WActor definition? That will cause serialization to fail.\n".cstring())
-      Fail()
-    end
 
   be create_actor(builder: WActorBuilder) =>
     let new_builder = StatefulWActorWrapperBuilder(_guid_gen.u128(),
@@ -216,10 +204,6 @@ class val StatefulWActorWrapperBuilder
 
   fun id(): U128 =>
     _id
-
-//Temporary for demo
-interface tag SerializeTarget
-  be add_serialized(s: ByteSeq val)
 
 class LiveWActorHelper is WActorHelper
   let _w_actor: WActorWrapper ref

--- a/testing/runs/w_actor/main.pony
+++ b/testing/runs/w_actor/main.pony
@@ -1,3 +1,46 @@
+"""
+CRDT WActor App
+
+1) reports sink:
+
+```
+nc -l 127.0.0.1 5555 >> /dev/null
+```
+
+2) metrics sink:
+
+```
+nc -l 127.0.0.1 5001 >> /dev/null
+```
+
+3a) 1 worker:
+
+```
+./w_actor -i 127.0.0.1:7000 -o 127.0.0.1:5555 -m 127.0.0.1:5001 \
+-c 127.0.0.1:6000 -d 127.0.0.1:6001 -n node-name --ponythreads=4 --ponynoblock
+```
+
+3b) 2 workers:
+
+```
+./w_actor -i 127.0.0.1:7000 -o 127.0.0.1:5555 -m 127.0.0.1:5001 \
+  -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n node-name --ponythreads=4 \
+  --ponynoblock -w 2 -t
+
+./w_actor -i 127.0.0.1:7001 -o 127.0.0.1:5555 -m 127.0.0.1:5001 \
+  -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker2 --ponythreads=4 \
+  --ponynoblock -w 2
+```
+127.0.0.1:6001 -n worker2 --ponythreads=4 --ponynoblock -w 2
+
+4) sender
+
+```
+giles/sender/sender -h 127.0.0.1:7000 -s 100 -i 50_000_000 \
+--ponythreads=1 -y -g 12 -w -u -m 10000
+```
+
+"""
 use "assert"
 use "buffered"
 use "collections"
@@ -26,7 +69,7 @@ actor Main
     let actor_count: USize = 10
     try
       let actor_system = create_actors(actor_count, seed)
-      ActorSystemStartup(env, actor_system, "toy-model-app", actor_count)
+      ActorSystemStartup(env, actor_system, "toy-model-app")
     else
       Fail()
     end

--- a/testing/runs/w_actor_celsius/main.pony
+++ b/testing/runs/w_actor_celsius/main.pony
@@ -63,10 +63,8 @@ use "wallaroo/w_actor"
 actor Main
   new create(env: Env) =>
     let seed: U64 = 12345
-    let actor_count: USize = 1
     let actor_system = create_actors(seed)
-    ActorSystemStartup(env, actor_system, "actor-system-celsius-app",
-      actor_count)
+    ActorSystemStartup(env, actor_system, "actor-system-celsius-app")
 
   fun ref create_actors(init_seed: U64): ActorSystem val
   =>

--- a/testing/runs/w_actor_crdt/main.pony
+++ b/testing/runs/w_actor_crdt/main.pony
@@ -1,3 +1,46 @@
+"""
+CRDT WActor App
+
+1) reports sink:
+
+```
+nc -l 127.0.0.1 5555 >> /dev/null
+```
+
+2) metrics sink:
+
+```
+nc -l 127.0.0.1 5001 >> /dev/null
+```
+
+3a) 1 worker:
+
+```
+./w_actor_crdt -i 127.0.0.1:7000 -o 127.0.0.1:5555 -m 127.0.0.1:5001 \
+-c 127.0.0.1:6000 -d 127.0.0.1:6001 -n node-name --ponythreads=4 --ponynoblock
+```
+
+3b) 2 workers:
+
+```
+./w_actor_crdt -i 127.0.0.1:7000 -o 127.0.0.1:5555 -m 127.0.0.1:5001 \
+  -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n node-name --ponythreads=4 \
+  --ponynoblock -w 2 -t
+
+./w_actor_crdt -i 127.0.0.1:7001 -o 127.0.0.1:5555 -m 127.0.0.1:5001 \
+  -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker2 --ponythreads=4 \
+  --ponynoblock -w 2
+```
+127.0.0.1:6001 -n worker2 --ponythreads=4 --ponynoblock -w 2
+
+4) sender
+
+```
+giles/sender/sender -h 127.0.0.1:7000 -s 100 -i 50_000_000 \
+--ponythreads=1 -y -g 12 -w -u -m 10000
+```
+
+"""
 use "assert"
 use "buffered"
 use "collections"
@@ -31,7 +74,7 @@ actor Main
     let actor_count: USize = 10
     let iterations: USize = 100
     let actor_system = create_actors(actor_count, iterations, seed)
-    ActorSystemStartup(env, actor_system, "toy-model-CRDT-app", actor_count)
+    ActorSystemStartup(env, actor_system, "toy-model-CRDT-app")
 
   fun ref create_actors(n: USize, iterations: USize, init_seed: U64):
     ActorSystem val


### PR DESCRIPTION
When ActorSystem work began, it was tailored to a
particular toy model demo. This commit removes the
demo-specific infrastructure to make the ActorSystem
code general-purpose.