### PR TITLE
Pin Erlang/Elixir for OSX in Travix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,9 +98,18 @@ install:
   - cd $INSTALL_STARTED_AT
   - if [ "${TRAVIS_OS_NAME}" = "osx" ];
     then
-      brew install elixir;
+      brew install erlang@18;
+      brew link erlang@18 --force;
+      cd /tmp;
+      mkdir elixir-1.2.6;
+      wget https://github.com/elixir-lang/elixir/releases/download/v1.2.6/Precompiled.zip;
+      tar -xvf Precompiled.zip -C elixir-1.2.6;
+      ln -s /tmp/elixir-1.2.6/bin/elixir /usr/local/bin/elixir;
+      ln -s /tmp/elixir-1.2.6/bin/mix /usr/local/bin/mix;
+      ln -s /tmp/elixir-1.2.6/bin/iex /usr/local/bin/iex;
       mix local.hex --force;
       mix local.rebar --force;
+      cd $INSTALL_STARTED_AT;
     fi;
   - if [ "${TRAVIS_OS_NAME}" = "linux" ];
     then

--- a/monitoring_hub/apps/market_spread_reports_ui/test/controllers/page_controller_test.exs
+++ b/monitoring_hub/apps/market_spread_reports_ui/test/controllers/page_controller_test.exs
@@ -1,8 +1,8 @@
 defmodule MarketSpreadReportsUI.PageControllerTest do
   use MarketSpreadReportsUI.ConnCase
-  # FIX ME: Comment back in once Erlang/Elixir are pinned on OSX
-  # test "GET /", %{conn: conn} do
-  #   conn = get conn, "/"
-  #   assert html_response(conn, 200) =~ "Wallaroo: Market Spread Reports"
-  # end
+
+  test "GET /", %{conn: conn} do
+    conn = get conn, "/"
+    assert html_response(conn, 200) =~ "Wallaroo: Market Spread Reports"
+  end
 end

--- a/monitoring_hub/apps/metrics_reporter_ui/test/controllers/page_controller_test.exs
+++ b/monitoring_hub/apps/metrics_reporter_ui/test/controllers/page_controller_test.exs
@@ -1,10 +1,8 @@
 defmodule MetricsReporterUI.PageControllerTest do
   use MetricsReporterUI.ConnCase
-  # FIX ME: Comment back in once Erlang/Elixir are pinned on OSX
-  #	currently fails due to Erlang 20 being installed by Travis CI
-  # and :crypto.rand_bytes being deprecated
-  # test "GET /", %{conn: conn} do
-  #   conn = get conn, "/"
-  #   assert html_response(conn, 200) =~ "Metrics Reporter"
-  # end
+
+  test "GET /", %{conn: conn} do
+    conn = get conn, "/"
+    assert html_response(conn, 200) =~ "Metrics Reporter"
+  end
 end


### PR DESCRIPTION
- pin Erlang to v18
- pin Elixir to v1.2.6
- comment back in failing UI tests due to Erlang v20 deprecation
  of crypto.rand_bytes

Closes #876 