### PR TITLE
Add support for requesting role-implementers

### DIFF
--- a/lib/wallaroo/w_actor/w_actor.pony
+++ b/lib/wallaroo/w_actor/w_actor.pony
@@ -26,6 +26,8 @@ trait WActorHelper
   fun ref send_to_role(role: String, data: Any val)
   fun ref send_to_sink[Out: Any val](sink_id: USize, output: Out)
   fun ref register_as_role(role: String)
+  fun ref roles_for(w_actor: U128): Array[String]
+  fun ref actors_in_role(role: String): Array[U128]
   fun ref create_actor(builder: WActorBuilder)
   fun ref destroy_actor(id: U128)
   fun ref set_timer(duration: U128, callback: {()},

--- a/lib/wallaroo/w_actor/w_actor_registry.pony
+++ b/lib/wallaroo/w_actor/w_actor_registry.pony
@@ -97,6 +97,22 @@ class WActorRegistry
     let wrapped = WMessage(sender, target, data)
     send_to(target, wrapped)
 
+  fun ref roles_for(w_actor: U128): Array[String] =>
+    let roles = Array[String]
+    for (r_name, role) in _roles.pairs() do
+      if role.contains(w_actor) then
+        roles.push(r_name)
+      end
+    end
+    roles
+
+  fun ref actors_in_role(role: String): Array[U128] =>
+    try
+      _roles(role).local_actors()
+    else
+      Array[U128]
+    end
+
 actor CentralWActorRegistry
   let _worker_name: String
   let _auth: AmbientAuth
@@ -396,9 +412,17 @@ class Role
   fun name(): String =>
     _name
 
-  fun empty(): Bool => _actors.size() == 0
+  fun empty(): Bool =>
+    _actors.size() == 0
 
-  fun actors(): Array[U128] box => _actors
+  fun actors(): Array[U128] box =>
+    _actors
+
+  fun ref local_actors(): Array[U128] =>
+    _actors
+
+  fun contains(w_actor: U128): Bool =>
+    _actors.contains(w_actor)
 
   fun ref remove_actor(id: U128) ? =>
     let idx = _actors.find(id)

--- a/lib/wallaroo/w_actor/w_actor_wrapper.pony
+++ b/lib/wallaroo/w_actor/w_actor_wrapper.pony
@@ -22,6 +22,8 @@ trait WActorWrapper
   fun ref _send_to(target: U128, data: Any val)
   fun ref _send_to_role(role: String, data: Any val)
   fun ref _send_to_sink[Out: Any val](sink_id: USize, output: Out)
+  fun ref _roles_for(w_actor: U128): Array[String]
+  fun ref _actors_in_role(role: String): Array[U128]
   fun ref _set_timer(duration: U128, callback: {()},
     is_repeating: Bool = false): WActorTimer
   fun ref _cancel_timer(t: WActorTimer)
@@ -169,6 +171,12 @@ actor WActorWithState is WActorWrapper
       Fail()
     end
 
+  fun ref _roles_for(w_actor: U128): Array[String] =>
+    _actor_registry.roles_for(w_actor)
+
+  fun ref _actors_in_role(role: String): Array[U128] =>
+    _actor_registry.actors_in_role(role)
+
   fun ref _set_timer(duration: U128, callback: {()},
     is_repeating: Bool = false): WActorTimer
   =>
@@ -223,6 +231,12 @@ class LiveWActorHelper is WActorHelper
   fun ref register_as_role(role: String) =>
     _w_actor._register_as_role(role)
 
+  fun ref roles_for(w_actor: U128): Array[String] =>
+    _w_actor._roles_for(w_actor)
+
+  fun ref actors_in_role(role: String): Array[U128] =>
+    _w_actor._actors_in_role(role)
+
   fun ref create_actor(builder: WActorBuilder) =>
     _w_actor.create_actor(builder)
 
@@ -249,6 +263,12 @@ class EmptyWActorHelper is WActorHelper
 
   fun ref register_as_role(role: String) =>
     None
+
+  fun ref roles_for(w_actor: U128): Array[String] =>
+    Array[String]
+
+  fun ref actors_in_role(role: String): Array[U128] =>
+    Array[U128]
 
   fun ref create_actor(builder: WActorBuilder) =>
     None

--- a/testing/runs/w_actor_roles/.gitignore
+++ b/testing/runs/w_actor_roles/.gitignore
@@ -1,0 +1,3 @@
+w_actor_roles.dSYM
+w_actor_roles
+w_actor_roles.o

--- a/testing/runs/w_actor_roles/Makefile
+++ b/testing/runs/w_actor_roles/Makefile
@@ -1,0 +1,46 @@
+# prevent rules from being evaluated/included multiple times
+ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
+$(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
+
+rules_mk_path := ../../../rules.mk
+
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
+# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
+#PONY_TARGET := false
+
+# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
+#EXS_TARGET := false
+
+# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
+#DOCKER_TARGET := false
+
+# uncomment to disable generate recursing into Makefiles of subdirectories
+#RECURSE_SUBMAKEFILES := false
+
+
+
+#########################################################################################
+#### don't change after this line unless to disable standard rules generation makefile
+MY_NAME := $(lastword $(MAKEFILE_LIST))
+$(MY_NAME)_PATH := $(dir $(MY_NAME))
+
+include $($(MY_NAME)_PATH:%/=%)/$(rules_mk_path)
+#### don't change before this line unless to disable standard rules generation makefile
+#########################################################################################
+
+
+# args to RUN_DAGON and RUN_DAGON_SPIKE: $1 = test name; $2 = ini file; $3 = timeout; $4 = wesley test command, $5 = include in CI
+# NOTE: all paths must be relative to buffy directory (use buffy_path variable)
+
+##<NAME OF TARGET>: #used as part of `make help` command ## <DESCRIPTION OF TARGET>
+#$(eval $(call RUN_DAGON\
+#,<NAME OF TARGET> \
+#,$(buffy_path)/<PATH TO INI FILE> \
+#,<TIMEOUT VALUE> \
+#,<WESLEY TEST COMMAND> \
+#,<INCLUDE IN CI>))
+
+# end of prevent rules from being evaluated/included multiple times
+endif

--- a/testing/runs/w_actor_roles/bundle.json
+++ b/testing/runs/w_actor_roles/bundle.json
@@ -1,0 +1,7 @@
+{
+  "deps": [
+    { "type": "local",
+      "local-path": "../../../lib/"
+    }
+  ]
+}

--- a/testing/runs/w_actor_roles/w_actor_roles.pony
+++ b/testing/runs/w_actor_roles/w_actor_roles.pony
@@ -1,0 +1,152 @@
+"""
+WActor Role Checking App
+
+1) reports sink:
+
+```
+nc -l 127.0.0.1 5555 >> /dev/null
+```
+
+2) metrics sink:
+
+```
+nc -l 127.0.0.1 5001 >> /dev/null
+```
+
+3a) 1 worker:
+
+```bash
+./w_actor_roles --in 127.0.0.1:7000 --out 127.0.0.1:5555 \
+  --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
+  --name node-name --ponythreads=4 --ponynoblock
+```
+
+3b) 2 workers:
+
+```bash
+./w_actor_roles --in 127.0.0.1:7000 --out 127.0.0.1:5555 \
+  --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
+  --name node-name --ponythreads=4 --ponynoblock --worker-count 2 \
+  --topology-initializer
+
+./w_actor_roles --in 127.0.0.1:7001 --out 127.0.0.1:5555 \
+  --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 --name worker2 --ponythreads=4 --ponynoblock --worker-count 2
+```
+
+4) sender
+
+```bash
+giles/sender/sender --host 127.0.0.1:7000 --batch-size 100 --interval \
+  50_000_000 --messages 1000 --binary --msg-size 12 --u64 --ponythreads=1 \
+  --no-write
+```
+
+Correct output:
+A sequence of messages outputted of the form
+
+```
+x_role rcvd msg from y_role
+```
+
+where x and y can be the same or different from among "first", "second", and
+"third"
+```
+
+"""
+use "assert"
+use "buffered"
+use "collections"
+use pers = "collections/persistent"
+use "net"
+use "random"
+use "time"
+use "sendence/bytes"
+use "sendence/fix"
+use "sendence/guid"
+use "sendence/hub"
+use "sendence/new_fix"
+use "sendence/options"
+use "sendence/rand"
+use "sendence/time"
+use "wallaroo"
+use "wallaroo/fail"
+use "wallaroo/metrics"
+use "wallaroo/tcp_source"
+use "wallaroo/topology"
+use "wallaroo/w_actor"
+
+
+primitive Roles
+  fun first_role(): String => "first_role"
+  fun second_role(): String => "second_role"
+  fun third_role(): String => "third_role"
+
+actor Main
+  new create(env: Env) =>
+    let seed: U64 = 12345
+    let actor_count: USize = 10
+    let iterations: USize = 100
+    let actor_system = create_actors(actor_count, iterations, seed)
+    ActorSystemStartup(env, actor_system, "toy-model-CRDT-app")
+
+  fun ref create_actors(n: USize, iterations: USize, init_seed: U64):
+    ActorSystem val
+  =>
+    recover
+      let rand = EnhancedRandom(init_seed)
+      let actor_system =
+        ActorSystem("Role Lookup App", rand.u64())
+          .> add_source(SimulationFramedSourceHandler, IngressWActorRouter)
+          .> add_actor(ABuilder(Roles.first_role(), rand.u64()))
+          .> add_actor(ABuilder(Roles.second_role(), rand.u64()))
+          .> add_actor(ABuilder(Roles.third_role(), rand.u64()))
+
+      actor_system
+    end
+
+class A is WActor
+  let _id: U64
+  let _role: String
+  let _rand: EnhancedRandom
+
+  new create(h: WActorHelper, role': String, id': U64, seed: U64) =>
+    _role = role'
+    h.register_as_role(_role)
+    h.register_as_role(BasicRoles.ingress())
+    _id = id'
+    _rand = EnhancedRandom(seed)
+
+  fun ref receive(sender: U128, payload: Any val, h: WActorHelper) =>
+    try
+      let roles = h.roles_for(sender)
+      @printf[I32]("%s rcvd msg from %s\n".cstring(), _role.cstring(),
+        roles(0).cstring())
+    else
+      @printf[I32]("Couldn't find role for %s\n".cstring(),
+        sender.string().cstring())
+    end
+
+  fun ref process(data: Any val, h: WActorHelper) =>
+    match data
+    | Act =>
+      act(h)
+    end
+
+  fun ref act(h: WActorHelper) =>
+    match _rand.usize_between(1, 3)
+    | 1 => h.send_to_role(Roles.first_role(), "1")
+    | 2 => h.send_to_role(Roles.second_role(), "2")
+    | 3 => h.send_to_role(Roles.third_role(), "3")
+    end
+
+class ABuilder
+  let _role: String
+  let _seed: U64
+
+  new val create(role: String = "", seed: U64) =>
+    _role = role
+    _seed = seed
+
+  fun apply(id: U128, wh: WActorHelper): WActor =>
+    let short_id = (id >> 96).u64()
+    A(wh, _role, short_id, _seed)


### PR DESCRIPTION
Whenever you receive a message at a WActor, you can
now request a list of that WActor's roles. Plus, you
can request all the known WActor ids for a given
role. This commit adds an app called w_actor_roles
to test this functionality.

Closes #913.
Closes #864.