### PR TITLE
Use `rm -f` when clearing resilience files in /tmp

### DIFF
--- a/testing/correctness/apps/sequence_window/Makefile
+++ b/testing/correctness/apps/sequence_window/Makefile
@@ -46,7 +46,7 @@ sequence_window_build_recovery_spike:
 
 sequence_window_test:
 	export PATH="$(PATH):$(INTEGRATION_BIN_PATH)" && \
-	rm /tmp/sequence* && \
+	rm -f /tmp/sequence* && \
 	cd $(SEQUENCE_WINDOW_PATH) && \
 	integration_test --sequence-sender '(0,1000]' \
 	  --log-level error \


### PR DESCRIPTION
As it says on the tin.

Tested by running `make test-testing-correctness-apps-sequence_window-all` and observing that the integration test is run and doesn't error on the `rm` command trying to remove non-existing files.