### PR TITLE
Fix instructions for building C++ examples.

### DIFF
--- a/book/examples/cpp/alphabet-cpp/README.md
+++ b/book/examples/cpp/alphabet-cpp/README.md
@@ -18,7 +18,7 @@ mkdir build
 clang++ --debug -c -o build/alphabet.o cpp/alphabet.cpp -Wall -std=c++11 -Iinclude
 ar rs build/libalphabet.a build/alphabet.o
 ponyc --debug --export --output=build \
-  --path=../../../../lib:../../../../cpp_api/cpp/cppapi/build/build/lib:./build \
+  --path=../../../../lib:../../../../cpp_api/cpp/cppapi/build/build/lib:./build:../../../../cpp_api \
     alphabet-app
 ```
 
@@ -28,7 +28,7 @@ ponyc --debug --export --output=build \
 g++ --debug -c -o build/alphabet.o cpp/alphabet.cpp -Wall -std=c++11 -Iinclude
 ar rs build/libalphabet.a build/alphabet.o
 ponyc --linker c++ --debug --export --output=build \
-  --path=../../../../lib:../../../../cpp_api/cpp/cppapi/build/build/lib:./build \
+  --path=../../../../lib:../../../../cpp_api/cpp/cppapi/build/build/lib:./build:../../../../cpp_api \
     alphabet-app
 ```
 

--- a/book/examples/cpp/counter-app/README.md
+++ b/book/examples/cpp/counter-app/README.md
@@ -18,7 +18,7 @@ mkdir build
 clang++ --debug -c -o build/Counter.o cpp/Counter.cpp -Wall -std=c++11 -Ihpp
 ar rs build/libcounter.a build/Counter.o
 ponyc --linker c++ --debug --export --output=build \
-  --path=../../../../lib:../../../../cpp_api/cpp/cppapi/build/build/lib:./build \
+  --path=../../../../lib:../../../../cpp_api/cpp/cppapi/build/build/lib:./build:../../../../cpp_api \
     counter-app
 ```
 
@@ -28,7 +28,7 @@ ponyc --linker c++ --debug --export --output=build \
 g++ --debug -c -o build/Counter.o cpp/Counter.cpp -Wall -std=c++11 -Ihpp
 ar rs build/libcounter.a build/Counter.o
 ponyc --linker c++ --debug --export --output=build \
-  --path=../../../../lib:../../../../cpp_api/cpp/cppapi/build/build/lib:./build \
+  --path=../../../../lib:../../../../cpp_api/cpp/cppapi/build/build/lib:./build:../../../../cpp_api \
     counter-app
 ```
 


### PR DESCRIPTION
The makefiles work fine but the directions themselves fell out of sync.
Open question: should the build instructions be switched to using the
Makefiles?

Closes #963