### PR TITLE
Fix recovery bug when non-initializer recovers after initializer recovers

### DIFF
--- a/lib/wallaroo/initialization/cluster_initializer.pony
+++ b/lib/wallaroo/initialization/cluster_initializer.pony
@@ -36,7 +36,8 @@ actor ClusterInitializer
   new create(auth: AmbientAuth, worker_name: String, workers: USize,
     connections: Connections, distributor: Distributor,
     layout_initializer: LayoutInitializer,
-    data_addr: Array[String] val, metrics_conn: MetricsSink)
+    data_addr: Array[String] val, metrics_conn: MetricsSink,
+    is_recovering: Bool)
   =>
     _auth = auth
     _worker_name = worker_name
@@ -46,6 +47,7 @@ actor ClusterInitializer
     _metrics_conn = metrics_conn
     _distributor = distributor
     _layout_initializer = layout_initializer
+    if is_recovering then _topology_ready = true end
 
   be start(initializer_name: String = "") =>
     // TODO: Pipeline initialization needs to be updated so that we

--- a/lib/wallaroo/startup.pony
+++ b/lib/wallaroo/startup.pony
@@ -310,7 +310,7 @@ actor Startup
             _startup_options.worker_name,
             _startup_options.worker_count, connections,
             ad, local_topology_initializer, _startup_options.d_addr,
-            metrics_conn)
+            metrics_conn, is_recovering)
         end
       end
 

--- a/lib/wallaroo/w_actor/w_actor_startup.pony
+++ b/lib/wallaroo/w_actor/w_actor_startup.pony
@@ -233,7 +233,7 @@ actor ActorSystemStartup
         _cluster_initializer = ClusterInitializer(auth,
           _startup_options.worker_name, _startup_options.worker_count,
           connections, distributor, initializer, _startup_options.d_addr,
-          empty_metrics_conn)
+          empty_metrics_conn, is_recovering)
       end
 
       let control_channel_filepath: FilePath = FilePath(auth,


### PR DESCRIPTION
Fail() on data channel failing to listen uncovered a
latent bug in initializer recovery where it still created
a ClusterInitializer that thought the topology was yet
to be initialized.  This meant that when another worker
later recovered, the initializer would try to create a
new data listener in response to the recovering worker
identifying its data port. Since we were already listening
on the initializer data port, the initializer would
fail to listen a second time and Fail().  The ClusterInitializer
is now aware of the difference between initial spin up
and recovery.

Closes #954.