### PR TITLE
Add Serialisation to Atkin components

### DIFF
--- a/atkin/main.pony
+++ b/atkin/main.pony
@@ -30,6 +30,7 @@ actor Main
         let module = Atkin.load_module(module_name)
 
         try
+          Atkin.set_user_serialization_fns(module)
           let actor_system = Atkin.create_actor_system(module,
             options.remaining(), seed)
           Atkin.startup(env, module, actor_system)

--- a/atkin/wactor.py
+++ b/atkin/wactor.py
@@ -1,3 +1,12 @@
+import pickle
+
+def serialize(o):
+    return pickle.dumps(o)
+
+
+def deserialize(bs):
+    return pickle.loads(bs)
+
 
 
 def join_longs(left, right):


### PR DESCRIPTION
This is required for Multi-Worker on Atkin applications, so that we can send
data and actor information across worker boundaries.