### PR TITLE
Replace undocumented `_int=float` in data_gen with `random.uniform(a,b)`

### DIFF
--- a/book/examples/python/celsius/data_gen/data_gen.py
+++ b/book/examples/python/celsius/data_gen/data_gen.py
@@ -7,7 +7,7 @@ import struct
 def generate_messages(num_messages):
     with open('celsius.msg', 'wb') as f:
         for x in xrange(num_messages):
-            f.write(struct.pack('>If', 4, random.randrange(10000, _int=float)))
+            f.write(struct.pack('>If', 4, random.uniform(0, 10000)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR replaces usage of an undocumented parameter used in the python data_gen code to generate floating point values in a range with a documented method instead.