### PR TITLE
Make "private tests" package private

### DIFF
--- a/lib/wallaroo/broadcast/_test.pony
+++ b/lib/wallaroo/broadcast/_test.pony
@@ -10,5 +10,5 @@ actor Main is TestList
     None
 
   fun tag tests(test: Connemara) =>
-    TestVectorTimestamp.make().tests(test)
-    TestExternalBroadcastVariableUpdater.make().tests(test)
+    _TestVectorTimestamp.make().tests(test)
+    _TestExternalBroadcastVariableUpdater.make().tests(test)

--- a/lib/wallaroo/broadcast/_test_broadcast_variables_map.pony
+++ b/lib/wallaroo/broadcast/_test_broadcast_variables_map.pony
@@ -1,7 +1,7 @@
 use "collections"
 use "sendence/connemara"
 
-actor TestExternalBroadcastVariableUpdater is TestList
+actor _TestExternalBroadcastVariableUpdater is TestList
   new make() =>
     None
 

--- a/lib/wallaroo/broadcast/_test_vector_ts.pony
+++ b/lib/wallaroo/broadcast/_test_vector_ts.pony
@@ -1,7 +1,7 @@
 use "collections"
 use "sendence/connemara"
 
-actor TestVectorTimestamp is TestList
+actor _TestVectorTimestamp is TestList
   new make() =>
     None
 

--- a/lib/wallaroo/cluster_manager/_test.pony
+++ b/lib/wallaroo/cluster_manager/_test.pony
@@ -8,5 +8,5 @@ actor Main is TestList
     None
 
   fun tag tests(test: Connemara) =>
-    TestDockerSwarmClusterManager.make().tests(test)
-    TestThroughputBasedClusterGrowthTrigger.make().tests(test)
+    _TestDockerSwarmClusterManager.make().tests(test)
+    _TestThroughputBasedClusterGrowthTrigger.make().tests(test)

--- a/lib/wallaroo/cluster_manager/_test_docker_swarm_cluster_manager.pony
+++ b/lib/wallaroo/cluster_manager/_test_docker_swarm_cluster_manager.pony
@@ -1,7 +1,7 @@
 use "sendence/connemara"
 use "json"
 
-actor TestDockerSwarmClusterManager is TestList
+actor _TestDockerSwarmClusterManager is TestList
   new make() =>
     None
 

--- a/lib/wallaroo/cluster_manager/_test_throughput_based_cluster_growth_trigger.pony
+++ b/lib/wallaroo/cluster_manager/_test_throughput_based_cluster_growth_trigger.pony
@@ -2,7 +2,7 @@ use "collections"
 use "sendence/connemara"
 use "wallaroo/metrics"
 
-actor TestThroughputBasedClusterGrowthTrigger is TestList
+actor _TestThroughputBasedClusterGrowthTrigger is TestList
   new make() =>
     None
 

--- a/lib/wallaroo/watermarking/_test.pony
+++ b/lib/wallaroo/watermarking/_test.pony
@@ -9,5 +9,5 @@ actor Main is TestList
     None
 
   fun tag tests(test: Connemara) =>
-    TestOutgoingToIncomingMessageTracker.make().tests(test)
-    TestWatermarker.make().tests(test)
+    _TestOutgoingToIncomingMessageTracker.make().tests(test)
+    _TestWatermarker.make().tests(test)

--- a/lib/wallaroo/watermarking/_test_outgoing_to_incoming_message_tracker.pony
+++ b/lib/wallaroo/watermarking/_test_outgoing_to_incoming_message_tracker.pony
@@ -2,7 +2,7 @@ use "sendence/connemara"
 use "wallaroo/topology"
 use "wallaroo/routing"
 
-actor TestOutgoingToIncomingMessageTracker is TestList
+actor _TestOutgoingToIncomingMessageTracker is TestList
   new make() =>
     None
 

--- a/lib/wallaroo/watermarking/_test_watermarker.pony
+++ b/lib/wallaroo/watermarking/_test_watermarker.pony
@@ -2,7 +2,7 @@ use "sendence/connemara"
 use "wallaroo/topology"
 use "wallaroo/routing"
 
-actor TestWatermarker is TestList
+actor _TestWatermarker is TestList
   new make() =>
     None
 


### PR DESCRIPTION
For "larger" test suites, we break the tests down into different files.
These test files are only accessed from a test class inside the package.
These "private tests" should have been package private. This commit
makes that change.