### PR TITLE
Support 1 to many Acker code

### DIFF
--- a/lib/wallaroo/routing/producer.pony
+++ b/lib/wallaroo/routing/producer.pony
@@ -34,6 +34,7 @@ trait tag Producer
     """
     _x_resilience_routes().flushed(low_watermark)
 
+  // TO DO: one to many. cut down method signature
   fun ref _bookkeeping(o_route_id: RouteId, o_seq_id: SeqId,
     i_origin: Producer, i_route_id: RouteId, i_seq_id: SeqId)
   =>
@@ -44,8 +45,7 @@ trait tag Producer
       @printf[I32]("Bookkeeping called for route %llu\n".cstring(), o_route_id)
     end
     ifdef "resilience" then
-      _x_resilience_routes().send(this, o_route_id, o_seq_id,
-        i_origin, i_route_id, i_seq_id)
+      _x_resilience_routes().sent(o_route_id, o_seq_id)
     end
 
   be update_watermark(route_id: RouteId, seq_id: SeqId) =>
@@ -62,4 +62,4 @@ trait tag Producer
       "\tseq_id: " + seq_id.string() + "\n\n").cstring())
     end
 
-    _x_resilience_routes().receive_ack(this, route_id, seq_id)
+    _x_resilience_routes().ack_received(this, route_id, seq_id)

--- a/lib/wallaroo/watermarking/acker.pony
+++ b/lib/wallaroo/watermarking/acker.pony
@@ -27,27 +27,28 @@ class Acker
   fun ref remove_route(route: Route) =>
     _watermarker.remove_route(route.id())
 
-  fun ref send(producer: Producer ref, o_route_id: RouteId, o_seq_id: SeqId,
-    i_origin: Producer, i_route_id: RouteId, i_seq_id: SeqId)
-  =>
+  fun ref sent(o_route_id: RouteId, o_seq_id: SeqId) =>
     _watermarker.sent(o_route_id, o_seq_id)
-    _add_incoming(producer, o_seq_id, i_origin, i_route_id, i_seq_id)
 
-  fun ref filter(producer: Producer ref, o_seq_id: SeqId,
-    i_origin: Producer, i_route_id: RouteId, i_seq_id: SeqId)
+  fun ref filtered(producer: Producer ref, o_seq_id: SeqId)
   =>
     """
     Filter out a message or otherwise have this be the end of the line
     """
     _watermarker.filtered(o_seq_id)
-    _add_incoming(producer, o_seq_id, i_origin, i_route_id, i_seq_id)
+    // TO DO: one to many. _maybe_ack feels weird here.
     _maybe_ack(producer)
 
-  fun ref receive_ack(producer: Producer ref, route_id: RouteId,
+  fun ref ack_received(producer: Producer ref, route_id: RouteId,
     seq_id: SeqId)
   =>
     _watermarker.ack_received(route_id, seq_id)
     _maybe_ack(producer)
+
+  fun ref track_incoming_to_outgoing(producer: Producer ref, o_seq_id: SeqId,
+    i_origin: Producer, i_route_id: RouteId, i_seq_id: SeqId)
+  =>
+    _add_incoming(producer, o_seq_id, i_origin, i_route_id, i_seq_id)
 
   fun ref flushed(up_to: SeqId) =>
     _flushing = false


### PR DESCRIPTION
With this change, our acking scheme now supports handling one incoming
message resulting in multiple output messages.

Next up is code that will allow a Wallaroo user to create many outgoing
messages from a single incoming message.