### PR TITLE
Turn off OSX CI jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,6 @@ sudo: required
 
 matrix:
   include:
-    - os: osx
-      env:
-        - LLVM_VERSION="3.9.1"
-        - LLVM_CONFIG="llvm-config-3.9"
-        - CC1=clang-3.9
-        - CXX1=clang++-3.9
-        - lto=no
     - os: linux
       addons:
         apt:


### PR DESCRIPTION
Currently they fail often on integration tests due to the constrained
environment. OSX isnt a deployment platform, the real value in OSX CI is
making sure that we can build everything on OSX and not slow down
developers with uncaught errors.

Turning this off for now until we can split our tests into different
categories and only run required ones on OSX.