### PR TITLE
Add KafkaSource and KafkaSink

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ matrix:
         - CXX1=g++-5
         - lto=no
 
+before_install:
+- echo -e "machine github.com\n  login $CI_USER_TOKEN" >> ~/.netrc
+
 install:
   # Based on how travis-ci works, when this is run, we are in the source
   # directory for Buffy. This means, when we go to git clone and install
@@ -88,6 +91,16 @@ install:
     cd pony-stable;
     git checkout 0054b429a54818d187100ed40f5525ec7931b31b;
     sudo make install;
+  - echo "Installing snappy and lz4";
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ];
+    then
+      sudo apt-get install libsnappy-dev;
+      cd /tmp;
+      wget -O liblz4-1.7.5.tar.gz https://github.com/lz4/lz4/archive/v1.7.5.tar.gz;
+      tar zxvf liblz4-1.7.5.tar.gz;
+      cd lz4-1.7.5;
+      sudo make install;
+    fi
   - cd $INSTALL_STARTED_AT
   - if [ "${TRAVIS_OS_NAME}" = "osx" ];
     then

--- a/book/examples/pony/celsius-kafka/.gitignore
+++ b/book/examples/pony/celsius-kafka/.gitignore
@@ -1,0 +1,3 @@
+celsius-kafka
+celsius-kafka.o
+celsius-kafka.d

--- a/book/examples/pony/celsius-kafka/Makefile
+++ b/book/examples/pony/celsius-kafka/Makefile
@@ -1,0 +1,43 @@
+# include root makefile
+ifndef ROOT_MAKEFILE_MK
+include ../../../../Makefile
+endif
+
+# prevent rules from being evaluated/included multiple times
+ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
+$(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
+
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
+# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
+#PONY_TARGET := false
+
+# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
+EXS_TARGET := false
+
+# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
+DOCKER_TARGET := false
+
+# uncomment to disable generate recursing into Makefiles of subdirectories
+#RECURSE_SUBMAKEFILES := false
+
+
+CELSIUS_PONY_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+# standard rules generation makefile
+include $(rules_mk_path)
+
+# args to RUN_DAGON and RUN_DAGON_SPIKE: $1 = test name; $2 = ini file; $3 = timeout; $4 = wesley test command, $5 = include in CI
+# NOTE: all paths must be relative to buffy directory (use buffy_path variable)
+
+##<NAME OF TARGET>: #used as part of `make help` command ## <DESCRIPTION OF TARGET>
+#$(eval $(call RUN_DAGON\
+#,<NAME OF TARGET> \
+#,$(buffy_path)/<PATH TO INI FILE> \
+#,<TIMEOUT VALUE> \
+#,<WESLEY TEST COMMAND> \
+#,<INCLUDE IN CI>))
+
+# end of prevent rules from being evaluated/included multiple times
+endif

--- a/book/examples/pony/celsius-kafka/README.md
+++ b/book/examples/pony/celsius-kafka/README.md
@@ -1,0 +1,58 @@
+# Celsius-kafka
+
+This is an example of a stateless application that takes a floating point
+Celsius value from Kafka and sends out a floating point Fahrenheit value to
+Kafka.
+
+## Prerequisites
+
+- ponyc
+- pony-stable
+- Wallaroo
+
+See [Wallaroo Environment Setup Instructions](https://github.com/sendence/wallaroo/book/getting-started/setup.md).
+
+## Building
+
+Build Celsius-kafka with
+
+```bash
+stable env ponyc
+```
+
+## Celsius-kafka argument
+
+In a shell, run the following to get help on arguments to the application:
+
+```bash
+./celsius-kafka --help
+```
+
+## Running Celsius-kafka
+
+In a separate shell, each:
+
+0. In a shell, start up the Metrics UI if you don't already have it running:
+
+```bash
+docker start mui
+```
+
+1. Start the application
+
+```bash
+./celsius-kafka --kafka_source_topic test --kafka_source_brokers 127.0.0.1 \
+  --kafka_sink_topic test --kafka_sink_brokers 127.0.0.1 \
+  --metrics 127.0.0.1:5001   --control 127.0.0.1:12500 --data 127.0.0.1:12501 \
+  --kafka_sink_max_message_size 100000 --kafka_sink_max_produce_buffer_ms 10
+```
+
+`kafka_sink_max_message_size` controls maximum size of message sent to kafka in
+a single produce request. Kafka will return errors if this is bigger than server
+is configured to accept.
+
+`kafka_sink_max_produce_buffer_ms` controls maximum time (in ms) to buffer
+messages before sending to kafka. Either don't specify it or set it to `0` to
+disable batching on produce.
+
+2. Send data into kafka using kafkacat or some other mechanism

--- a/book/examples/pony/celsius-kafka/bundle.json
+++ b/book/examples/pony/celsius-kafka/bundle.json
@@ -1,0 +1,11 @@
+{
+  "deps": [
+      { "type": "local",
+        "local-path": "../../../../lib/"
+      },
+      { "type": "github",
+        "repo": "Sendence/pony-kafka",
+        "tag": "0.0.0.0.0.0.0.0.0.2"
+      }
+  ]
+}

--- a/book/examples/pony/celsius-kafka/celsius.pony
+++ b/book/examples/pony/celsius-kafka/celsius.pony
@@ -1,0 +1,59 @@
+use "buffered"
+use "wallaroo"
+use "wallaroo/source"
+use "wallaroo/source/kafka_source"
+use "wallaroo/sink/kafka_sink"
+use "wallaroo/topology"
+
+actor Main
+  new create(env: Env) =>
+    try
+      if (env.args(1) == "--help") or (env.args(1) == "-h") then
+        KafkaSourceConfigCLIParser.print_usage(env.out)
+        KafkaSinkConfigCLIParser.print_usage(env.out)
+        return
+      end
+    else
+      KafkaSourceConfigCLIParser.print_usage(env.out)
+      KafkaSinkConfigCLIParser.print_usage(env.out)
+      return
+    end
+
+    try
+      let application = recover val
+        Application("Celsius Conversion App")
+          .new_pipeline[F32, F32]("Celsius Conversion",
+            KafkaSourceConfig[F32](KafkaSourceConfigCLIParser(env.args, env.out)
+              , env.root as AmbientAuth, CelsiusKafkaDecoder))
+            .to[F32]({(): Multiply => Multiply})
+            .to[F32]({(): Add => Add})
+            .to_sink(KafkaSinkConfig[F32](FahrenheitEncoder,
+              KafkaSinkConfigCLIParser(env.args, env.out), env.root as AmbientAuth))
+      end
+      Startup(env, application, "celsius-conversion")
+    else
+      @printf[I32]("Couldn't build topology\n".cstring())
+    end
+
+primitive Multiply is Computation[F32, F32]
+  fun apply(input: F32): F32 =>
+    input * 1.8
+
+  fun name(): String => "Multiply by 1.8"
+
+primitive Add is Computation[F32, F32]
+  fun apply(input: F32): F32 =>
+    input + 32
+
+  fun name(): String => "Add 32"
+
+primitive FahrenheitEncoder
+  fun apply(f: F32, wb: Writer): Array[ByteSeq] val =>
+    wb.f32_be(f)
+    wb.done()
+
+primitive CelsiusKafkaDecoder is SourceHandler[F32]
+  fun decode(a: Array[U8] val): F32 ? =>
+    let r = Reader
+    r.append(a)
+    r.f32_be()

--- a/lib/wallaroo/sink/kafka_sink/kafka_sink.pony
+++ b/lib/wallaroo/sink/kafka_sink/kafka_sink.pony
@@ -1,0 +1,282 @@
+use "buffered"
+use "collections"
+use "net"
+use "pony-kafka"
+use "pony-kafka/customlogger"
+use "time"
+use "wallaroo/core"
+use "wallaroo/fail"
+use "wallaroo/initialization"
+use "wallaroo/invariant"
+use "wallaroo/messages"
+use "wallaroo/metrics"
+use "wallaroo/routing"
+use "wallaroo/topology"
+use "wallaroo/ent/watermarking"
+
+
+actor KafkaSink is (Consumer & KafkaClientManager & KafkaProducer)
+  // Steplike
+  let _encoder: EncoderWrapper
+  let _wb: Writer = Writer
+  let _metrics_reporter: MetricsReporter
+  var _initializer: (LocalTopologyInitializer | None) = None
+
+  // Consumer
+  var _upstreams: SetIs[Producer] = _upstreams.create()
+  var _mute_outstanding: Bool = false
+
+  var _kc: (KafkaClient tag | None) = None
+  let _conf: KafkaConfig val
+  let _auth: TCPConnectionAuth
+
+  // Origin (Resilience)
+  let _terminus_route: TerminusRoute = TerminusRoute
+
+  // variable to hold producer mapping for sending requests to broker
+  //  connections
+  var _kafka_producer_mapping: (KafkaProducerMapping ref | None) = None
+
+  var _ready_to_produce: Bool = false
+  var _application_initialized: Bool = false
+
+  let _topic: String
+
+  // Items in tuple are: metric_name, metrics_id, send_ts, worker_ingress_ts,
+  //   pipeline_time_spent, tracking_id
+  let _pending_delivery_report: MapIs[Any tag, (String, U16, U64, U64, U64,
+    (U64 | None))] = _pending_delivery_report.create()
+
+  new create(encoder_wrapper: EncoderWrapper,
+    metrics_reporter: MetricsReporter iso, conf: KafkaConfig val,
+    auth: TCPConnectionAuth)
+  =>
+    _encoder = encoder_wrapper
+    _metrics_reporter = consume metrics_reporter
+    _conf = conf
+    _auth = auth
+
+    _topic = try
+               _conf.topics.keys().next()
+             else
+               Fail()
+               ""
+             end
+
+  fun ref update_producer_mapping(mapping: KafkaProducerMapping):
+    (KafkaProducerMapping | None)
+  =>
+    _kafka_producer_mapping = mapping
+
+  fun ref producer_mapping(): (KafkaProducerMapping | None) =>
+    _kafka_producer_mapping
+
+  be receive_kafka_topics_partitions(new_topic_partitions: Map[String, 
+    (KafkaTopicType, Set[I32])] val)
+  =>
+    None
+
+  be kafka_producer_ready() =>
+    _ready_to_produce = true
+
+    // we either signal back to intializer that we're ready to work here or in
+    //  application_ready_to_work depending on which one is called second.
+    if _application_initialized then
+      match _initializer
+      | let initializer: LocalTopologyInitializer =>
+        initializer.report_ready_to_work(this)
+        _initializer = None
+      else
+        // kafka_producer_ready should never be called twice
+        Fail()
+      end
+
+      _unmute_upstreams()
+    end
+
+  be kafka_message_delivery_report(delivery_report: KafkaProducerDeliveryReport)
+  =>
+    try
+      if not _pending_delivery_report.contains(delivery_report.opaque) then
+        @printf[I32](("Kafka Sink: Error kafka delivery report opaque doesn't"
+          + " exist in _pending_delivery_report\n").cstring())
+        error
+      end
+
+      (_, (let metric_name, let metrics_id, let send_ts, let worker_ingress_ts,
+        let pipeline_time_spent, let tracking_id)) = 
+        _pending_delivery_report.remove(delivery_report.opaque)
+
+      if delivery_report.status isnt ErrorNone then
+        @printf[I32](("Kafka Sink: Error reported in kafka delivery report: "
+          + delivery_report.status.string() + "\n").cstring())
+        error
+      end
+
+      ifdef "resilience" then
+        match tracking_id
+        | let sent: SeqId =>
+          _terminus_route.receive_ack(sent)
+        end
+      end
+
+      let end_ts = Time.nanos()
+      _metrics_reporter.step_metric(metric_name, "Kafka send time", metrics_id,
+        send_ts, end_ts)
+
+      let final_ts = Time.nanos()
+      let time_spent = final_ts - worker_ingress_ts
+
+      ifdef "detailed-metrics" then
+        _metrics_reporter.step_metric(metric_name, "Before end at sink", 9999,
+          end_ts, final_ts)
+      end
+
+      _metrics_reporter.pipeline_metric(metric_name,
+        time_spent + pipeline_time_spent)
+      _metrics_reporter.worker_metric(metric_name, time_spent)
+    else
+      // TODO: How are we supposed to handle errors?
+      @printf[I32]("Error handling kafka delivery report in Kakfa Sink\n"
+        .cstring())
+    end
+
+  fun ref _kafka_producer_throttled(topic_mapping: Map[String, Map[I32, I32]]
+    val)
+  =>
+    if not _mute_outstanding then
+      _mute_upstreams()
+    end
+
+  fun ref _kafka_producer_unthrottled(topic_mapping: Map[String, Map[I32, I32]]
+    val, fully_unthrottled: Bool)
+  =>
+    if fully_unthrottled and _mute_outstanding then
+      _unmute_upstreams()
+    end
+
+  fun ref _mute_upstreams() =>
+    for u in _upstreams.values() do
+      u.mute(this)
+    end
+    _mute_outstanding = true
+
+  fun ref _unmute_upstreams() =>
+    for u in _upstreams.values() do
+      u.unmute(this)
+    end
+    _mute_outstanding = false
+
+  be application_begin_reporting(initializer: LocalTopologyInitializer) =>
+    _initializer = initializer
+    initializer.report_created(this)
+
+  be application_created(initializer: LocalTopologyInitializer,
+    omni_router: OmniRouter)
+  =>
+    _mute_upstreams()
+
+    initializer.report_initialized(this)
+
+    // create kafka client
+    let kc = KafkaClient(_auth, _conf, this)
+    _kc = kc
+    kc.register_producer(this)
+
+  be application_initialized(initializer: LocalTopologyInitializer) =>
+    _application_initialized = true
+
+    if _ready_to_produce then
+      initializer.report_ready_to_work(this)
+      _initializer = None
+
+      _unmute_upstreams()
+    end
+
+  be application_ready_to_work(initializer: LocalTopologyInitializer) =>
+    None
+
+  be request_ack() =>
+    _terminus_route.request_ack()
+
+  fun ref _next_tracking_id(i_origin: Producer, i_route_id: RouteId,
+    i_seq_id: SeqId): (U64 | None)
+  =>
+    ifdef "resilience" then
+      return _terminus_route.terminate(i_origin, i_route_id, i_seq_id)
+    end
+
+    None
+
+  be register_producer(producer: Producer) =>
+    _upstreams.set(producer)
+
+  be unregister_producer(producer: Producer) =>
+    ifdef debug then
+      Invariant(_upstreams.contains(producer))
+    end
+
+    _upstreams.unset(producer)
+
+  be run[D: Any val](metric_name: String, pipeline_time_spent: U64, data: D,
+    i_origin: Producer, msg_uid: U128, frac_ids: FractionalMessageId,
+    i_seq_id: SeqId, i_route_id: RouteId,
+    latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64)
+  =>
+    var my_latest_ts: U64 = latest_ts
+    var my_metrics_id = ifdef "detailed-metrics" then
+      my_latest_ts = Time.nanos()
+      _metrics_reporter.step_metric(metric_name, "Before receive at sink",
+        metrics_id, latest_ts, my_latest_ts)
+        metrics_id + 1
+      else
+        metrics_id
+      end
+
+
+    ifdef "trace" then
+      @printf[I32]("Rcvd msg at KafkaSink\n".cstring())
+    end
+    try
+      let encoded = _encoder.encode[D](data, _wb)
+      my_metrics_id = ifdef "detailed-metrics" then
+          var old_ts = my_latest_ts = Time.nanos()
+          _metrics_reporter.step_metric(metric_name, "Sink encoding time", 9998,
+          old_ts, my_latest_ts)
+          metrics_id + 1
+        else
+          metrics_id
+        end
+
+      try
+        // `any` is required because if `data` is used directly, there are
+        // issues with the items not being found in `_pending_delivery_report`.
+        let any: Any tag = data
+        let ret = (_kafka_producer_mapping as KafkaProducerMapping ref)
+          .send_topic_message(_topic, any, encoded)
+        if ret isnt None then error end
+        let next_tracking_id = _next_tracking_id(i_origin, i_route_id, i_seq_id)
+        _pending_delivery_report(any) = (metric_name, my_metrics_id,
+          my_latest_ts, worker_ingress_ts, pipeline_time_spent,
+          next_tracking_id)
+      else
+        // TODO: How are we supposed to handle errors?
+        @printf[I32]("Error sending message to Kafka via Kakfa Sink\n"
+          .cstring())
+      end
+
+    else
+      Fail()
+    end
+
+  be replay_run[D: Any val](metric_name: String, pipeline_time_spent: U64,
+    data: D, i_origin: Producer, msg_uid: U128, frac_ids: FractionalMessageId,
+    i_seq_id: SeqId, i_route_id: RouteId,
+    latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64)
+  =>
+    // TODO: implement this once state save/recover is handled
+    Fail()
+
+  be receive_state(state: ByteSeq val) =>
+    // TODO: implement state recovery
+    Fail()

--- a/lib/wallaroo/sink/kafka_sink/kafka_sink_config.pony
+++ b/lib/wallaroo/sink/kafka_sink/kafka_sink_config.pony
@@ -1,0 +1,163 @@
+use "net"
+use "options"
+use "pony-kafka"
+use "pony-kafka/customlogger"
+use "wallaroo/messages"
+use "wallaroo/metrics"
+use "wallaroo/sink"
+
+primitive KafkaSinkConfigCLIParser
+  fun opts(): Array[(String, (None | String), ArgumentType, (Required |
+    Optional), String)]
+  =>
+    // items in the tuple are: Argument Name, Argument Short Name,
+    //   Argument Type, Required or Optional, Help Text
+    let opts_array = Array[(String, (None | String), ArgumentType, (Required |
+      Optional), String)]
+
+    opts_array.push(("kafka_sink_topic", None, StringArgument, Required,
+      "Kafka topic to consume from"))
+    opts_array.push(("kafka_sink_brokers", None, StringArgument, Required,
+      "Initial brokers to connect to. Format: 'host:port,host:port,...'"))
+    opts_array.push(("kafka_sink_log_level", None, StringArgument, Required,
+      "Log Level (Fine, Info, Warn, Error)"))
+    opts_array.push(("kafka_sink_max_produce_buffer_ms", None, I64Argument,
+      Required, "# ms to buffer for producing to kafka"))
+    opts_array.push(("kafka_sink_max_message_size", None, I64Argument, Required,
+      "Max message size in bytes for producing to kafka"))
+
+    opts_array
+
+  fun print_usage(out: OutStream) =>
+    for (long, short, arg_type, arg_req, help) in opts().values() do
+      let short_str = match short
+             | let s: String => "/-" + s
+             else "" end
+
+      let arg_type_str = match arg_type
+             | StringArgument => "(String)"
+             | I64Argument => "(Integer)"
+             | F64Argument => "(Float)"
+             else "" end
+
+      out.print("--" + long + short_str + "       " + arg_type_str + "    "
+        + help)
+    end
+
+  fun apply(args: Array[String] val, out: OutStream): KafkaConfig val ? =>
+    var log_level: LogLevel = Warn
+
+    var topic: String = ""
+    var brokers = recover val Array[(String, I32)] end
+
+    var max_message_size: I32 = 1000000
+    var max_produce_buffer_ms: U64 = 0
+
+    let options = Options(args, false)
+
+    for (long, short, arg_type, arg_req, _) in opts().values() do
+      options.add(long, short, arg_type, arg_req)
+    end
+
+    // TODO: implement all the other options that kafka client supports
+    for option in options do
+      match option
+      | ("kafka_sink_max_produce_buffer_ms", let input: I64) =>
+        max_produce_buffer_ms = input.u64()
+      | ("kafka_sink_max_message_size", let input: I64) =>
+        max_message_size = input.i32()
+      | ("kafka_sink_topic", let input: String) =>
+        topic = input
+      | ("kafka_sink_brokers", let input: String) =>
+        brokers = _brokers_from_input_string(input)
+      | ("kafka_sink_log_level", let input: String) =>
+        log_level = match input
+          | "Fine" => Fine
+          | "Info" => Info
+          | "Warn" => Warn
+          | "Error" => Error
+          else
+            let l = StringLogger(log_level, out)
+            l(Error) and
+              l.log(Error, "Error! Invalid kafka_sink_log_level: " + input)
+            error
+          end
+      end
+    end
+
+    let logger = StringLogger(log_level, out)
+
+    if (brokers.size() == 0) or (topic == "") then
+      logger(Error) and
+        logger.log(Error, "Error! Either brokers is empty or topics is empty!")
+      error
+    end
+
+    // create kafka config
+    recover val
+      let kc = KafkaConfig(logger, "Wallaroo Kafka Sink " + topic where 
+        max_message_size' = max_message_size, max_produce_buffer_ms' = 
+        max_produce_buffer_ms)
+
+      // add topic config to consumer
+      kc.add_topic_config(topic, KafkaProduceOnly)
+
+      for (host, port) in brokers.values() do
+        kc.add_broker(host, port)
+      end
+
+      kc
+    end
+
+  fun _brokers_from_input_string(inputs: String): Array[(String, I32)] val ? =>
+    let brokers = recover trn Array[(String, I32)] end
+
+    for input in inputs.split(",").values() do
+      let i = input.split(":")
+      let host = i(0)
+      let port: I32 = try i(1).i32() else 9092 end
+      brokers.push((host, port))
+    end
+
+    consume brokers
+
+  fun _topics_from_input_string(inputs: String): Array[String] val =>
+    let topics = recover trn Array[String] end
+
+    for input in inputs.split(",").values() do
+      topics.push(input)
+    end
+
+    consume topics
+
+class val KafkaSinkConfig[Out: Any val] is SinkConfig[Out]
+  let _encoder: SinkEncoder[Out]
+  let _conf: KafkaConfig val
+  let _auth: TCPConnectionAuth
+
+  new val create(encoder: SinkEncoder[Out], conf: KafkaConfig val,
+    auth: TCPConnectionAuth)
+  =>
+    _encoder = encoder
+    _conf = conf
+    _auth = auth
+
+  fun apply(): SinkBuilder =>
+    KafkaSinkBuilder(TypedEncoderWrapper[Out](_encoder), _conf, _auth)
+
+class val KafkaSinkBuilder
+  let _encoder_wrapper: EncoderWrapper
+  let _conf: KafkaConfig val
+  let _auth: TCPConnectionAuth
+
+  new val create(encoder_wrapper: EncoderWrapper, conf: KafkaConfig val,
+    auth: TCPConnectionAuth)
+  =>
+    _encoder_wrapper = encoder_wrapper
+    _conf = conf
+    _auth = auth
+
+  fun apply(reporter: MetricsReporter iso): Sink =>
+    @printf[I32]("Creating Kafka Sink\n".cstring())
+
+    KafkaSink(_encoder_wrapper, consume reporter, _conf, _auth)

--- a/lib/wallaroo/source/kafka_source/kafka_source.pony
+++ b/lib/wallaroo/source/kafka_source/kafka_source.pony
@@ -1,0 +1,217 @@
+use "collections"
+use "pony-kafka"
+use "sendence/guid"
+use "wallaroo/boundary"
+use "wallaroo/core"
+use "wallaroo/fail"
+use "wallaroo/initialization"
+use "wallaroo/metrics"
+use "wallaroo/routing"
+use "wallaroo/topology"
+use "wallaroo/ent/watermarking"
+
+actor KafkaSource[In: Any val] is (Producer & KafkaConsumer)
+  let _guid: GuidGenerator = GuidGenerator
+  let _routes: MapIs[Consumer, Route] = _routes.create()
+  let _route_builder: RouteBuilder
+  let _outgoing_boundaries: Map[String, OutgoingBoundary] =
+    _outgoing_boundaries.create()
+  let _layout_initializer: LayoutInitializer
+  var _unregistered: Bool = false
+
+  let _metrics_reporter: MetricsReporter
+
+  let _listen: KafkaSourceListener[In]
+  let _notify: KafkaSourceNotify[In]
+
+  var _muted: Bool = true
+  let _muted_downstream: SetIs[Any tag] = _muted_downstream.create()
+
+  // Origin (Resilience)
+  var _seq_id: SeqId = 1 // 0 is reserved for "not seen yet"
+
+  let _topic: String
+  let _partition_id: I32
+  let _kc: KafkaClient tag
+
+  new create(listen: KafkaSourceListener[In], notify: KafkaSourceNotify[In] iso,
+    routes: Array[Consumer] val, route_builder: RouteBuilder,
+    outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val,
+    layout_initializer: LayoutInitializer,
+    default_target: (Consumer | None) = None,
+    forward_route_builder: (RouteBuilder | None) = None,
+    metrics_reporter: MetricsReporter iso,
+    topic: String, partition_id: I32, kafka_client: KafkaClient tag)
+  =>
+    _topic = topic
+    _partition_id = partition_id
+    _kc = kafka_client
+
+    _metrics_reporter = consume metrics_reporter
+    _listen = listen
+    _notify = consume notify
+
+    _layout_initializer = layout_initializer
+
+    _route_builder = route_builder
+    for (target_worker_name, builder) in outgoing_boundary_builders.pairs() do
+      _outgoing_boundaries(target_worker_name) = builder.build_and_initialize(
+        _guid.u128(), _layout_initializer)
+    end
+
+    for consumer in routes.values() do
+      _routes(consumer) =
+        _route_builder(this, consumer, _metrics_reporter)
+    end
+
+    for (worker, boundary) in _outgoing_boundaries.pairs() do
+      _routes(boundary) =
+        _route_builder(this, boundary, _metrics_reporter)
+    end
+
+    _notify.update_boundaries(_outgoing_boundaries)
+
+    match default_target
+    | let r: Consumer =>
+      match forward_route_builder
+      | let frb: RouteBuilder =>
+        _routes(r) = frb(this, r, _metrics_reporter)
+      end
+    end
+
+    for r in _routes.values() do
+      // TODO: this is a hack, we shouldn't be calling application events
+      // directly. route lifecycle needs to be broken out better from
+      // application lifecycle
+      r.application_created()
+    end
+
+    for r in _routes.values() do
+      r.application_initialized("KafkaSource-" + topic + "-"
+        + partition_id.string())
+    end
+
+    _mute()
+
+  be update_router(router: PartitionRouter) =>
+    let new_router = router.update_boundaries(_outgoing_boundaries)
+    _notify.update_router(new_router)
+
+  be add_boundary_builders(
+    boundary_builders: Map[String, OutgoingBoundaryBuilder] val)
+  =>
+    """
+    Build a new boundary for each builder that corresponds to a worker we
+    don't yet have a boundary to. Each KafkaSource has its own
+    OutgoingBoundary to each worker to allow for higher throughput.
+    """
+    for (target_worker_name, builder) in boundary_builders.pairs() do
+      if not _outgoing_boundaries.contains(target_worker_name) then
+        let boundary = builder.build_and_initialize(_guid.u128(),
+          _layout_initializer)
+        _outgoing_boundaries(target_worker_name) = boundary
+        _routes(boundary) =
+          _route_builder(this, boundary, _metrics_reporter)
+      end
+    end
+    _notify.update_boundaries(_outgoing_boundaries)
+
+  be reconnect_boundary(target_worker_name: String) =>
+    try
+      _outgoing_boundaries(target_worker_name).reconnect()
+    else
+      Fail()
+    end
+
+  be remove_route_for(step: Consumer) =>
+    try
+      _routes.remove(step)
+    else
+      Fail()
+    end
+
+  //////////////
+  // ORIGIN (resilience)
+  be request_ack() =>
+    None
+
+  fun ref _acker(): Acker =>
+    // TODO: we don't really need this
+    // Because we dont actually do any resilience work
+    Acker
+
+  // Override these for KafkaSource as we are currently
+  // not resilient.
+  fun ref flush(low_watermark: U64) =>
+    None
+
+  be log_flushed(low_watermark: SeqId) =>
+    None
+
+  be update_watermark(route_id: RouteId, seq_id: SeqId) =>
+    ifdef "trace" then
+      @printf[I32]("KafkaSource received update_watermark\n".cstring())
+    end
+
+  fun ref _update_watermark(route_id: RouteId, seq_id: SeqId) =>
+    None
+
+  fun ref route_to(c: Consumer): (Route | None) =>
+    try
+      _routes(c)
+    else
+      None
+    end
+
+  fun ref next_sequence_id(): SeqId =>
+    _seq_id = _seq_id + 1
+
+  fun ref current_sequence_id(): SeqId =>
+    _seq_id
+
+  fun ref _mute() =>
+    ifdef "credit_trace" then
+      @printf[I32]("MUTE SOURCE\n".cstring())
+    end
+
+    _kc.consumer_pause(_topic, _partition_id)
+
+    _muted = true
+
+  fun ref _unmute() =>
+    ifdef "credit_trace" then
+      @printf[I32]("UNMUTE SOURCE\n".cstring())
+    end
+
+    _kc.consumer_resume(_topic, _partition_id)
+
+    _muted = false
+
+  be mute(c: Consumer) =>
+    @printf[I32]("MUTE\n".cstring())
+    _muted_downstream.set(c)
+    _mute()
+
+  be unmute(c: Consumer) =>
+    @printf[I32]("UNMUTE\n".cstring())
+    _muted_downstream.unset(c)
+
+    if _muted_downstream.size() == 0 then
+      _unmute()
+    end
+
+  fun ref is_muted(): Bool =>
+    _muted
+
+  be receive_kafka_message(msg: KafkaMessage val,
+    network_received_timestamp: U64)
+  =>
+    if (msg.get_topic() != _topic)
+      or (msg.get_partition_id() != _partition_id) then
+      @printf[I32](("Msg topic: " + msg.get_topic() + " != _topic: " + _topic
+        + " or Msg partition: " + msg.get_partition_id().string() + " != "
+        + " _partition_id: " + _partition_id.string() + "!").cstring())
+      Fail()
+    end
+    _notify.received(this, msg, network_received_timestamp)
+

--- a/lib/wallaroo/source/kafka_source/kafka_source_config.pony
+++ b/lib/wallaroo/source/kafka_source/kafka_source_config.pony
@@ -1,0 +1,140 @@
+use "net"
+use "options"
+use "pony-kafka"
+use "pony-kafka/customlogger"
+use "wallaroo/source"
+
+
+primitive KafkaSourceConfigCLIParser
+  fun opts(): Array[(String, (None | String), ArgumentType,
+    (Required | Optional), String)]
+  =>
+    // items in the tuple are: Argument Name, Argument Short Name,
+    //   Argument Type, Required or Optional, Help Text
+    let opts_array = Array[(String, (None | String), ArgumentType,
+      (Required | Optional), String)]
+
+    opts_array.push(("kafka_source_topic", None, StringArgument, Required,
+      "Kafka topic to consume from"))
+    opts_array.push(("kafka_source_brokers", None, StringArgument, Required,
+      "Initial brokers to connect to. Format: 'host:port,host:port,...'"))
+    opts_array.push(("kafka_source_log_level", None, StringArgument, Required,
+      "Log Level (Fine, Info, Warn, Error)"))
+
+    opts_array
+
+  fun print_usage(out: OutStream) =>
+    for (long, short, arg_type, arg_req, help) in opts().values() do
+      let short_str = match short
+             | let s: String => "/-" + s
+             else "" end
+
+      let arg_type_str = match arg_type
+             | StringArgument => "(String)"
+             | I64Argument => "(Integer)"
+             | F64Argument => "(Float)"
+             else "" end
+
+      out.print("--" + long + short_str + "       " + arg_type_str + "    "
+        + help)
+    end
+
+  fun apply(args: Array[String] val, out: OutStream): KafkaConfig val ? =>
+    var log_level: LogLevel = Warn
+
+    var topic: String = ""
+    var brokers = recover val Array[(String, I32)] end
+
+    let options = Options(args, false)
+
+    for (long, short, arg_type, arg_req, _) in opts().values() do
+      options.add(long, short, arg_type, arg_req)
+    end
+
+    // TODO: implement all the other options that kafka client supports
+    for option in options do
+      match option
+      | ("kafka_source_topic", let input: String) =>
+        topic = input
+      | ("kafka_source_brokers", let input: String) =>
+        brokers = _brokers_from_input_string(input)
+      | ("kafka_source_log_level", let input: String) =>
+        log_level = match input
+          | "Fine" => Fine
+          | "Info" => Info
+          | "Warn" => Warn
+          | "Error" => Error
+          else
+            let l = StringLogger(log_level, out)
+            l(Error) and
+              l.log(Error, "Error! Invalid kafka_source_log_level: " + input)
+            error
+          end
+      end
+    end
+
+    let logger = StringLogger(log_level, out)
+
+    if (brokers.size() == 0) or (topic == "") then
+      logger(Error) and
+        logger.log(Error, "Error! Either brokers is empty or topics is empty!")
+      error
+    end
+
+    // create kafka config
+    recover val
+      let kc = KafkaConfig(logger, "Kafka Wallaroo Source " + topic)
+
+      // add topic config to consumer
+      kc.add_topic_config(topic, KafkaConsumeOnly)
+
+      for (host, port) in brokers.values() do
+        kc.add_broker(host, port)
+      end
+
+      kc
+    end
+
+  fun _brokers_from_input_string(inputs: String): Array[(String, I32)] val ? =>
+    let brokers = recover trn Array[(String, I32)] end
+
+    for input in inputs.split(",").values() do
+      let i = input.split(":")
+      let host = i(0)
+      let port: I32 = try i(1).i32() else 9092 end
+      brokers.push((host, port))
+    end
+
+    consume brokers
+
+  fun _topics_from_input_string(inputs: String): Array[String] val =>
+    let topics = recover trn Array[String] end
+
+    for input in inputs.split(",").values() do
+      topics.push(input)
+    end
+
+    consume topics
+
+
+class val KafkaSourceConfig[In: Any val] is SourceConfig[In]
+  let _conf: KafkaConfig val
+  let _auth: TCPConnectionAuth
+  let _handler: SourceHandler[In] val
+
+  new val create(conf: KafkaConfig val, auth: TCPConnectionAuth,
+    handler: SourceHandler[In] val)
+  =>
+    _handler = handler
+    _auth = auth
+    _conf = conf
+
+  fun source_listener_builder_builder(): KafkaSourceListenerBuilderBuilder[In]
+  =>
+    KafkaSourceListenerBuilderBuilder[In](_conf, _auth)
+
+  fun source_builder(app_name: String, name: String):
+    KafkaSourceBuilderBuilder[In]
+  =>
+    KafkaSourceBuilderBuilder[In](app_name, name, _handler)
+

--- a/lib/wallaroo/source/kafka_source/kafka_source_listener.pony
+++ b/lib/wallaroo/source/kafka_source/kafka_source_listener.pony
@@ -1,0 +1,234 @@
+use "collections"
+use "net"
+use "pony-kafka"
+use "wallaroo/boundary"
+use "wallaroo/core"
+use "wallaroo/fail"
+use "wallaroo/initialization"
+use "wallaroo/metrics"
+use "wallaroo/recovery"
+use "wallaroo/routing"
+use "wallaroo/source"
+use "wallaroo/topology"
+
+class val KafkaSourceListenerBuilderBuilder[In: Any val]
+  let _conf: KafkaConfig val
+  let _auth: TCPConnectionAuth
+
+  new val create(conf: KafkaConfig val, auth: TCPConnectionAuth) =>
+    _conf = conf
+    _auth = auth
+
+  fun apply(source_builder: SourceBuilder, router: Router,
+    router_registry: RouterRegistry, route_builder: RouteBuilder,
+    outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val,
+    event_log: EventLog, auth: AmbientAuth,
+    layout_initializer: LayoutInitializer,
+    metrics_reporter: MetricsReporter iso,
+    default_target: (Step | None) = None,
+    default_in_route_builder: (RouteBuilder | None) = None,
+    target_router: Router = EmptyRouter): KafkaSourceListenerBuilder[In]
+  =>
+    KafkaSourceListenerBuilder[In](source_builder, router, router_registry,
+      route_builder,
+      outgoing_boundary_builders, event_log, auth,
+      layout_initializer, consume metrics_reporter, default_target,
+      default_in_route_builder, target_router, _conf, _auth)
+
+class val KafkaSourceListenerBuilder[In: Any val]
+  let _source_builder: SourceBuilder
+  let _router: Router
+  let _router_registry: RouterRegistry
+  let _route_builder: RouteBuilder
+  let _default_in_route_builder: (RouteBuilder | None)
+  let _outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val
+  let _layout_initializer: LayoutInitializer
+  let _event_log: EventLog
+  let _auth: AmbientAuth
+  let _default_target: (Step | None)
+  let _target_router: Router
+  let _metrics_reporter: MetricsReporter
+  let _conf: KafkaConfig val
+  let _tcp_auth: TCPConnectionAuth
+
+  new val create(source_builder: SourceBuilder, router: Router,
+    router_registry: RouterRegistry, route_builder: RouteBuilder,
+    outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val,
+    event_log: EventLog, auth: AmbientAuth,
+    layout_initializer: LayoutInitializer,
+    metrics_reporter: MetricsReporter iso,
+    default_target: (Step | None) = None,
+    default_in_route_builder: (RouteBuilder | None) = None,
+    target_router: Router = EmptyRouter,
+    conf: KafkaConfig val, tcp_auth: TCPConnectionAuth)
+  =>
+    _source_builder = source_builder
+    _router = router
+    _router_registry = router_registry
+    _route_builder = route_builder
+    _default_in_route_builder = default_in_route_builder
+    _outgoing_boundary_builders = outgoing_boundary_builders
+    _layout_initializer = layout_initializer
+    _event_log = event_log
+    _auth = auth
+    _default_target = default_target
+    _target_router = target_router
+    _metrics_reporter = consume metrics_reporter
+    _conf = conf
+    _tcp_auth = tcp_auth
+
+  fun apply(): SourceListener =>
+    KafkaSourceListener[In](_source_builder, _router, _router_registry,
+      _route_builder, _outgoing_boundary_builders,
+      _event_log, _auth, _layout_initializer, _metrics_reporter.clone(),
+      _default_target, _default_in_route_builder, _target_router, _conf,
+      _tcp_auth)
+
+
+class MapPartitionConsumerMessageHandler is KafkaConsumerMessageHandler
+  let _consumers: Map[I32, KafkaConsumer tag] val
+
+  new create(consumers: Map[I32, KafkaConsumer tag] val) =>
+    _consumers = consumers
+
+  fun ref apply(consumers: Array[KafkaConsumer tag] val,
+    msg: KafkaMessage val): (KafkaConsumer tag | None)
+  =>
+    try _consumers(msg.get_partition_id()) end
+
+  fun clone(): KafkaConsumerMessageHandler iso^ =>
+    recover iso MapPartitionConsumerMessageHandler(_consumers) end
+
+
+actor KafkaSourceListener[In: Any val] is (SourceListener & KafkaClientManager)
+  let _notify: KafkaSourceListenerNotify[In]
+  let _router: Router
+  let _router_registry: RouterRegistry
+  let _route_builder: RouteBuilder
+  let _default_in_route_builder: (RouteBuilder | None)
+  var _outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val
+  let _layout_initializer: LayoutInitializer
+  let _default_target: (Step | None)
+  let _metrics_reporter: MetricsReporter
+  let _array: Array[Array[U8] val] val
+  let _emit_gap: U64
+  let _conf: KafkaConfig val
+  let _tcp_auth: TCPConnectionAuth
+  let _kc: KafkaClient tag
+  let _kafka_topic_partition_sources: Map[String, Map[I32, KafkaSource[In]]] =
+    _kafka_topic_partition_sources.create()
+
+  new create(source_builder: SourceBuilder, router: Router,
+    router_registry: RouterRegistry, route_builder: RouteBuilder,
+    outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val,
+    event_log: EventLog, auth: AmbientAuth,
+    layout_initializer: LayoutInitializer,
+    metrics_reporter: MetricsReporter iso,
+    default_target: (Step | None) = None,
+    default_in_route_builder: (RouteBuilder | None) = None,
+    target_router: Router = EmptyRouter,
+    conf: KafkaConfig val, tcp_auth: TCPConnectionAuth)
+  =>
+    _notify = KafkaSourceListenerNotify[In](source_builder, event_log, auth,
+      target_router)
+    _router = router
+    _router_registry = router_registry
+    _route_builder = route_builder
+    _default_in_route_builder = default_in_route_builder
+    _outgoing_boundary_builders = outgoing_boundary_builders
+    _layout_initializer = layout_initializer
+    _default_target = default_target
+    _metrics_reporter = consume metrics_reporter
+
+    _conf = conf
+    _tcp_auth = tcp_auth
+    _array = recover val Array[Array[U8] val] end
+    _emit_gap = 0
+
+
+    for topic in _conf.consumer_topics.values() do
+      _kafka_topic_partition_sources(topic) = Map[I32, KafkaSource[In]]
+    end
+
+    // create kafka client
+    _kc = KafkaClient(_tcp_auth, _conf, this)
+
+  be receive_kafka_topics_partitions(new_topic_partitions: Map[String,
+    (KafkaTopicType, Set[I32])] val)
+  =>
+    var partitions_changed: Bool = false
+
+    for (topic, (ktt, new_partitions)) in new_topic_partitions.pairs() do
+      if (ktt isnt KafkaConsumeOnly) and (ktt isnt KafkaProduceAndConsume) then
+        continue
+      end
+      let partitions_sources = try
+             _kafka_topic_partition_sources(topic)
+           else
+             let m = Map[I32, KafkaSource[In]]
+             _kafka_topic_partition_sources(topic) = m
+             m
+           end
+      if new_partitions.size() != partitions_sources.size() then
+        partitions_changed = true
+      end
+
+      for part_id in new_partitions.values() do
+        if not partitions_sources.contains(part_id) then
+          partitions_changed = true
+
+          try
+            let source = KafkaSource[In](this, _notify.build_source(),
+              _router.routes(), _route_builder, _outgoing_boundary_builders,
+              _layout_initializer, _default_target,
+              _default_in_route_builder,
+              _metrics_reporter.clone(), topic, part_id, _kc)
+            partitions_sources(part_id) = source
+            _router_registry.register_source(source)
+          else
+            @printf[I32](("Error creating KafkaSource for topic: " + topic
+              + " and partition: " + part_id.string() + "!").cstring())
+            Fail()
+          end
+        end
+      end
+    end
+
+    if partitions_changed then
+      // Replace consumer_message_handler with KafkaClient with one that knows
+      // about the latest mappings
+      // TODO: add logic to update starting offsets to consume from kafka
+      for (topic, consumers) in _kafka_topic_partition_sources.pairs() do
+        let my_consumers: Map[I32, KafkaConsumer tag] iso = recover iso 
+          Map[I32, KafkaConsumer tag] end
+        for (part_id, consumer) in consumers.pairs() do
+          my_consumers(part_id) = consumer
+        end
+
+        _kc.update_consumer_message_handler(topic, recover val 
+          MapPartitionConsumerMessageHandler(consume my_consumers) end)
+      end
+    end
+
+  be update_router(router: PartitionRouter) =>
+    _notify.update_router(router)
+
+  be remove_route_for(moving_step: Consumer) =>
+    None
+
+  be add_boundary_builders(
+    boundary_builders: Map[String, OutgoingBoundaryBuilder] val)
+  =>
+    let new_builders: Map[String, OutgoingBoundaryBuilder val] trn =
+      recover Map[String, OutgoingBoundaryBuilder val] end
+    // TODO: A persistent map on the field would be much more efficient here
+    for (target_worker_name, builder) in _outgoing_boundary_builders.pairs() do
+      new_builders(target_worker_name) = builder
+    end
+    for (target_worker_name, builder) in boundary_builders.pairs() do
+      if not new_builders.contains(target_worker_name) then
+        new_builders(target_worker_name) = builder
+      end
+    end
+    _outgoing_boundary_builders = consume new_builders
+

--- a/lib/wallaroo/source/kafka_source/kafka_source_listener_notify.pony
+++ b/lib/wallaroo/source/kafka_source/kafka_source_listener_notify.pony
@@ -1,0 +1,58 @@
+use "wallaroo/fail"
+use "wallaroo/metrics"
+use "wallaroo/source"
+use "wallaroo/topology"
+use "wallaroo/recovery"
+
+class KafkaSourceListenerNotify[In: Any val]
+  var _source_builder: SourceBuilder
+  let _event_log: EventLog
+  let _target_router: Router
+  let _auth: AmbientAuth
+
+  new iso create(builder: SourceBuilder, event_log: EventLog,
+    auth: AmbientAuth, target_router: Router) =>
+    _source_builder = builder
+    _event_log = event_log
+    _target_router = target_router
+    _auth = auth
+
+  fun ref build_source(): KafkaSourceNotify[In] iso^ ? =>
+    try
+      _source_builder(_event_log, _auth, _target_router) as
+        KafkaSourceNotify[In] iso^
+    else
+      @printf[I32](
+        (_source_builder.name()
+          + " could not create a KafkaSourceNotify\n").cstring())
+      Fail()
+      error
+    end
+
+  fun ref update_router(router: Router) =>
+    _source_builder = _source_builder.update_router(router)
+
+class val KafkaSourceBuilderBuilder[In: Any val]
+  let _app_name: String
+  let _name: String
+  let _handler: SourceHandler[In] val
+
+  new val create(app_name: String, name': String,
+    handler: SourceHandler[In] val)
+  =>
+    _app_name = app_name
+    _name = name'
+    _handler = handler
+
+  fun name(): String => _name
+
+  fun apply(runner_builder: RunnerBuilder, router: Router,
+    metrics_conn: MetricsSink, pre_state_target_id: (U128 | None) = None,
+    worker_name: String, metrics_reporter: MetricsReporter iso):
+      SourceBuilder
+  =>
+    BasicSourceBuilder[In, SourceHandler[In] val](_app_name, worker_name,
+      _name, runner_builder, _handler, router,
+      metrics_conn, pre_state_target_id, consume metrics_reporter,
+      KafkaSourceNotifyBuilder[In])
+

--- a/lib/wallaroo/source/kafka_source/kafka_source_notify.pony
+++ b/lib/wallaroo/source/kafka_source/kafka_source_notify.pony
@@ -1,0 +1,133 @@
+use "collections"
+use "pony-kafka"
+use "time"
+use "sendence/guid"
+use "wallaroo/boundary"
+use "wallaroo/core"
+use "wallaroo/fail"
+use "wallaroo/metrics"
+use "wallaroo/recovery"
+use "wallaroo/source"
+use "wallaroo/topology"
+
+primitive KafkaSourceNotifyBuilder[In: Any val]
+  fun apply(pipeline_name: String, auth: AmbientAuth,
+    handler: SourceHandler[In] val,
+    runner_builder: RunnerBuilder, router: Router,
+    metrics_reporter: MetricsReporter iso, event_log: EventLog,
+    target_router: Router, pre_state_target_id: (U128 | None) = None):
+    SourceNotify iso^
+  =>
+    KafkaSourceNotify[In](pipeline_name, auth, handler, runner_builder, router,
+      consume metrics_reporter, event_log, target_router, pre_state_target_id)
+
+class KafkaSourceNotify[In: Any val]
+  let _guid_gen: GuidGenerator = GuidGenerator
+  let _pipeline_name: String
+  let _source_name: String
+  let _handler: SourceHandler[In] val
+  let _runner: Runner
+  var _router: Router
+  let _omni_router: OmniRouter = EmptyOmniRouter
+  let _metrics_reporter: MetricsReporter
+
+  new iso create(pipeline_name: String, auth: AmbientAuth,
+    handler: SourceHandler[In] val,
+    runner_builder: RunnerBuilder, router: Router,
+    metrics_reporter: MetricsReporter iso, event_log: EventLog,
+    target_router: Router, pre_state_target_id: (U128 | None) = None)
+  =>
+    _pipeline_name = pipeline_name
+    _source_name = pipeline_name + " source"
+    _handler = handler
+    _runner = runner_builder(event_log, auth, None,
+      target_router, pre_state_target_id)
+    _router = _runner.clone_router_and_set_input_type(router)
+    _metrics_reporter = consume metrics_reporter
+
+  fun routes(): Array[Consumer] val =>
+    _router.routes()
+
+  fun ref received(src: KafkaSource[In] ref, msg: KafkaMessage val,
+    network_received_timestamp: U64)
+  =>
+    let ingest_ts = Time.nanos()
+    let pipeline_time_spent: U64 = 0
+    var latest_metrics_id: U16 = 1
+
+    ifdef "detailed-metrics" then
+      _metrics_reporter.step_metric(_pipeline_name,
+        "Kafka Client decode time (before wallaroo)", latest_metrics_id,
+        network_received_timestamp, ingest_ts)
+      latest_metrics_id = latest_metrics_id + 1
+    end
+
+    let data = msg.get_value()
+
+    ifdef "trace" then
+      @printf[I32](("Rcvd msg at " + _pipeline_name + " source\n").cstring())
+    end
+
+    (let is_finished, let keep_sending, let last_ts) =
+      try
+        src.next_sequence_id()
+        let decoded =
+          try
+            _handler.decode(consume data)
+          else
+            ifdef debug then
+              @printf[I32]("Error decoding message at source\n".cstring())
+            end
+            error
+          end
+        let decode_end_ts = Time.nanos()
+        _metrics_reporter.step_metric(_pipeline_name,
+          "Decode Time in Kafka Source", latest_metrics_id, ingest_ts,
+          decode_end_ts)
+        latest_metrics_id = latest_metrics_id + 1
+
+        ifdef "trace" then
+          @printf[I32](("Msg decoded at " + _pipeline_name +
+            " source\n").cstring())
+        end
+        _runner.run[In](_pipeline_name, pipeline_time_spent, decoded,
+          src, _router, _omni_router, _guid_gen.u128(), None,
+          decode_end_ts, latest_metrics_id, ingest_ts, _metrics_reporter)
+      else
+        @printf[I32](("Unable to decode message at " + _pipeline_name +
+          " source\n").cstring())
+        ifdef debug then
+          Fail()
+        end
+        (true, true, ingest_ts)
+      end
+
+    if is_finished then
+      let end_ts = Time.nanos()
+      let time_spent = end_ts - ingest_ts
+
+      ifdef "detailed-metrics" then
+        _metrics_reporter.step_metric(_pipeline_name,
+          "Before end at Kafka Source", 9999,
+          last_ts, end_ts)
+      end
+
+      _metrics_reporter.pipeline_metric(_pipeline_name, time_spent +
+        pipeline_time_spent)
+      _metrics_reporter.worker_metric(_pipeline_name, time_spent)
+    end
+
+  fun ref update_router(router: Router) =>
+    _router = router
+
+  fun ref update_boundaries(obs: box->Map[String, OutgoingBoundary]) =>
+    match _router
+    | let p_router: PartitionRouter =>
+      _router = p_router.update_boundaries(obs)
+    else
+      ifdef debug then
+        @printf[I32](("KafkaSourceNotify doesn't have PartitionRouter. " +
+          "Updating boundaries is a noop for this kind of Source.\n").cstring())
+      end
+    end
+


### PR DESCRIPTION
Initial version of KafkaSource and KafkaSink with a sample `celsius-kafka` app that uses them both.

Many things outstanding still:

* Failure recovery (save state and reload on start)
* Error handling (what to do when Kafka Client encounters an error)
* Performance tuning
* Exposing more Kafka Client options via CLI parser
* Other stuff I'm forgetting along with stuff in Kafka Client that's in #998 

I've been using the following for a local kafka setup for basic manual testing:

https://github.com/andreas-schroeder/local-kafka-cluster

With commands:

```bash
./cluster up 1 # change 1 to however many brokers are desired to be started
```
```bash
docker exec -it local_kafka_1_1 /kafka/bin/kafka-topics.sh --zookeeper \
  zookeeper:2181 --create --partitions 4 --topic test --replication-factor \
  1 # to create a topic; change arguments as desired
```
```bash
./cluster down # shut down cluster
```
