### PR TITLE
Remove unnecessary `val` annotations

### DIFF
--- a/dagon/dagon-child/dagon-child.pony
+++ b/dagon/dagon-child/dagon-child.pony
@@ -167,10 +167,10 @@ class HomeConnectNotify is TCPConnectionNotify
       try
         let decoded = ExternalMsgDecoder(consume chunked)
         match decoded
-        | let m: ExternalStartMsg val =>
+        | let m: ExternalStartMsg =>
           _env.out.print("\t" + node_name + ": received start message")
           _child.start()
-        | let m: ExternalShutdownMsg val =>
+        | let m: ExternalShutdownMsg =>
          _env.out.print("\t" + node_name + ": received shutdown messages ")
          _child.send_done_shutdown()
          _child.shutdown()

--- a/dagon/dagon-notifier/dagon-notifier.pony
+++ b/dagon/dagon-notifier/dagon-notifier.pony
@@ -128,7 +128,7 @@ class DagonNotify is TCPConnectionNotify
       try
         let decoded = ExternalMsgDecoder(consume chunked)
         match decoded
-        | let m: ExternalGilesSendersStartedMsg val =>
+        | let m: ExternalGilesSendersStartedMsg =>
           _env.out.print("Giles Senders started")
           _notifier.shutdown()
         else

--- a/dagon/dagon.pony
+++ b/dagon/dagon.pony
@@ -315,19 +315,19 @@ class ConnectNotify is TCPConnectionNotify
       try
         let decoded = ExternalMsgDecoder(consume chunked)
         match decoded
-        | let m: ExternalReadyMsg val =>
+        | let m: ExternalReadyMsg =>
           _env.out.print("dagon: " + m.node_name + ": Ready")
           _p_mgr.received_ready(conn, m.node_name)
-        | let m: ExternalTopologyReadyMsg val =>
+        | let m: ExternalTopologyReadyMsg =>
           _env.out.print("dagon: " + m.node_name + ": TopologyReady")
           _p_mgr.received_topology_ready(conn, m.node_name)
-        | let m: ExternalDoneMsg val =>
+        | let m: ExternalDoneMsg =>
           _env.out.print("dagon: " + m.node_name + ": Done")
           _p_mgr.received_done(conn, m.node_name)
-        | let m: ExternalDoneShutdownMsg val =>
+        | let m: ExternalDoneShutdownMsg =>
           _env.out.print("dagon: " + m.node_name + ": DoneShutdown")
           _p_mgr.received_done_shutdown(conn, m.node_name)
-        | let m: ExternalStartGilesSendersMsg val =>
+        | let m: ExternalStartGilesSendersMsg =>
           _p_mgr.received_start_senders(conn)
         else
           _env.out.print("dagon: Unexpected message from child")

--- a/giles/receiver/giles-receiver.pony
+++ b/giles/receiver/giles-receiver.pony
@@ -225,7 +225,7 @@ class ToDagonNotify is TCPConnectionNotify
       try
         let decoded = ExternalMsgDecoder(consume data)
         match decoded
-        | let d: ExternalShutdownMsg val =>
+        | let d: ExternalShutdownMsg =>
           _coordinator.finished()
         else
           @printf[I32]("Unexpected data from Dagon\n".cstring())

--- a/giles/sender/giles-sender.pony
+++ b/giles/sender/giles-sender.pony
@@ -270,7 +270,7 @@ class ToDagonNotify is TCPConnectionNotify
       try
         let decoded = ExternalMsgDecoder(consume chunked)
         match decoded
-        | let m: ExternalStartMsg val =>
+        | let m: ExternalStartMsg =>
             _coordinator.go()
         else
           @printf[I32]("Unexpected message from Dagon\n".cstring())

--- a/lib/sendence/hub/hub_decoder.pony
+++ b/lib/sendence/hub/hub_decoder.pony
@@ -3,7 +3,7 @@ use "collections"
 use "wallaroo/metrics"
 
 primitive HubProtocolDecoder
-  fun apply(data: Array[U8 val] val): HubProtocolMsg val ? =>
+  fun apply(data: Array[U8 val] val): HubProtocolMsg ? =>
     match _decode(data)
     | (_Join(), let d: Array[U8 val] val) =>
       HubJoinMsg
@@ -56,7 +56,7 @@ primitive HubPayloadMsg is HubProtocolMsg
       HubOtherMsg
     end
 
-class HubMetricsMsg is HubProtocolMsg
+class val HubMetricsMsg is HubProtocolMsg
   var name: String = ""
   var category: String = ""
   var pipeline_name: String = ""

--- a/lib/sendence/messages/external_messages.pony
+++ b/lib/sendence/messages/external_messages.pony
@@ -100,7 +100,7 @@ class BufferedExternalMsgEncoder
     _buffer.done()
 
 primitive ExternalMsgDecoder
-  fun apply(data: Array[U8] val): ExternalMsg val ? =>
+  fun apply(data: Array[U8] val): ExternalMsg ? =>
     match _decode(data)
     | (_Data(), let s: String) =>
       ExternalDataMsg(s)
@@ -134,19 +134,19 @@ primitive ExternalMsgDecoder
 
 trait val ExternalMsg
 
-class ExternalDataMsg is ExternalMsg
+class val ExternalDataMsg is ExternalMsg
   let data: String
 
   new val create(d: String) =>
     data = d
 
-class ExternalReadyMsg is ExternalMsg
+class val ExternalReadyMsg is ExternalMsg
   let node_name: String
 
   new val create(n: String) =>
     node_name = n
 
-class ExternalTopologyReadyMsg is ExternalMsg
+class val ExternalTopologyReadyMsg is ExternalMsg
   let node_name: String
 
   new val create(n: String) =>
@@ -154,19 +154,19 @@ class ExternalTopologyReadyMsg is ExternalMsg
 
 primitive ExternalStartMsg is ExternalMsg
 
-class ExternalShutdownMsg is ExternalMsg
+class val ExternalShutdownMsg is ExternalMsg
   let node_name: String
 
   new val create(n: String) =>
     node_name = n
 
-class ExternalDoneShutdownMsg is ExternalMsg
+class val ExternalDoneShutdownMsg is ExternalMsg
   let node_name: String
 
   new val create(n: String) =>
     node_name = n
 
-class ExternalDoneMsg is ExternalMsg
+class val ExternalDoneMsg is ExternalMsg
   let node_name: String
 
   new val create(n: String) =>

--- a/lib/wallaroo/boundary/boundary.pony
+++ b/lib/wallaroo/boundary/boundary.pony
@@ -25,7 +25,7 @@ use @pony_asio_event_resubscribe_write[None](event: AsioEventID)
 use @pony_asio_event_destroy[None](event: AsioEventID)
 
 
-class OutgoingBoundaryBuilder
+class val OutgoingBoundaryBuilder
   let _auth: AmbientAuth
   let _worker_name: String
   let _reporter: MetricsReporter val
@@ -154,7 +154,7 @@ actor OutgoingBoundary is Consumer
     initializer.report_created(this)
 
   be application_created(initializer: LocalTopologyInitializer,
-    omni_router: OmniRouter val)
+    omni_router: OmniRouter)
   =>
     _connect_count = @pony_os_connect_tcp[U32](this,
       _host.cstring(), _service.cstring(),
@@ -257,7 +257,7 @@ actor OutgoingBoundary is Consumer
     Fail()
 
   // TODO: open question: how do we reconnect if our external system goes away?
-  be forward(delivery_msg: ReplayableDeliveryMsg val, pipeline_time_spent: U64,
+  be forward(delivery_msg: ReplayableDeliveryMsg, pipeline_time_spent: U64,
     i_origin: Producer, i_seq_id: SeqId, i_route_id: RouteId, latest_ts: U64,
     metrics_id: U16, worker_ingress_ts: U64)
   =>
@@ -314,7 +314,7 @@ actor OutgoingBoundary is Consumer
 
     _maybe_mute_or_unmute_upstreams()
 
-  be forward_actor_data(delivery_msg: ActorDeliveryMsg val) =>
+  be forward_actor_data(delivery_msg: ActorDeliveryMsg) =>
     ifdef "trace" then
       @printf[I32]("Rcvd actor message at OutgoingBoundary\n".cstring())
     end
@@ -380,7 +380,7 @@ actor OutgoingBoundary is Consumer
       Fail()
     end
 
-  be update_router(router: Router val) =>
+  be update_router(router: Router) =>
     """
     No-op: OutgoingBoundary has no router
     """
@@ -938,18 +938,18 @@ class BoundaryNotify is WallarooOutgoingNetworkActorNotify
         @printf[I32]("Rcvd msg at OutgoingBoundary\n".cstring())
       end
       match ChannelMsgDecoder(consume data, _auth)
-      | let ac: AckDataConnectMsg val =>
+      | let ac: AckDataConnectMsg =>
         ifdef "trace" then
           @printf[I32]("Received AckDataConnectMsg at Boundary\n".cstring())
         end
         conn.receive_connect_ack(ac.last_id_seen)
-      | let sn: StartNormalDataSendingMsg val =>
+      | let sn: StartNormalDataSendingMsg =>
         ifdef "trace" then
           @printf[I32]("Received StartNormalDataSendingMsg at Boundary\n"
             .cstring())
         end
         conn.start_normal_sending()
-      | let aw: AckWatermarkMsg val =>
+      | let aw: AckWatermarkMsg =>
         ifdef "trace" then
           @printf[I32]("Received AckWatermarkMsg at Boundary\n".cstring())
         end

--- a/lib/wallaroo/boundary/data_receiver.pony
+++ b/lib/wallaroo/boundary/data_receiver.pony
@@ -18,7 +18,7 @@ actor DataReceiver is Producer
   let _worker_name: String
   var _sender_name: String
   var _sender_step_id: U128 = 0
-  var _router: DataRouter val =
+  var _router: DataRouter =
     DataRouter(recover Map[U128, Consumer] end)
   var _last_id_seen: SeqId = 0
   var _last_id_acked: SeqId = 0
@@ -144,7 +144,7 @@ actor DataReceiver is Producer
       _watermarker.sent(route_id, seq_id)
     end
 
-  be update_router(router: DataRouter val) =>
+  be update_router(router: DataRouter) =>
     // TODO: This commented line conflicts with invariant downstream. The
     // idea is to unregister if we've registered but not otherwise.
     // The invariant says you can only call this method on a step if
@@ -163,7 +163,7 @@ actor DataReceiver is Producer
       _watermarker.add_route(id)
     end
 
-  be received(d: DeliveryMsg val, pipeline_time_spent: U64, seq_id: SeqId,
+  be received(d: DeliveryMsg, pipeline_time_spent: U64, seq_id: SeqId,
     latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64)
   =>
     _timer_init(this)
@@ -178,7 +178,7 @@ actor DataReceiver is Producer
       _maybe_ack()
     end
 
-  be received_actor_data(d: ActorDeliveryMsg val, seq_id: SeqId) =>
+  be received_actor_data(d: ActorDeliveryMsg, seq_id: SeqId) =>
     _timer_init(this)
     ifdef "trace" then
       @printf[I32]("Rcvd actor msg at DataReceiver\n".cstring())
@@ -199,7 +199,7 @@ actor DataReceiver is Producer
     _router.request_ack(_watermarker.unacked_route_ids())
     _last_request = _ack_counter
 
-  be replay_received(r: ReplayableDeliveryMsg val, pipeline_time_spent: U64,
+  be replay_received(r: ReplayableDeliveryMsg, pipeline_time_spent: U64,
     seq_id: SeqId, latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64)
   =>
     if seq_id > _last_id_seen then

--- a/lib/wallaroo/boundary/data_receivers.pony
+++ b/lib/wallaroo/boundary/data_receivers.pony
@@ -31,7 +31,7 @@ actor DataReceivers
 
   let _data_receivers: Map[_BoundaryId, DataReceiver] =
     _data_receivers.create()
-  var _data_router: DataRouter val =
+  var _data_router: DataRouter =
     DataRouter(recover Map[U128, Consumer] end)
   let _subscribers: SetIs[DataReceiversSubscriber tag] = _subscribers.create()
 
@@ -86,7 +86,7 @@ actor DataReceivers
       dr.start_normal_message_processing()
     end
 
-  be update_data_router(dr: DataRouter val) =>
+  be update_data_router(dr: DataRouter) =>
     _data_router = dr
     for data_receiver in _data_receivers.values() do
       data_receiver.update_router(_data_router)

--- a/lib/wallaroo/core/dummy_consumer.pony
+++ b/lib/wallaroo/core/dummy_consumer.pony
@@ -36,7 +36,7 @@ actor DummyConsumer is Consumer
     None
 
   be application_created(initializer: LocalTopologyInitializer,
-    omni_router: OmniRouter val)
+    omni_router: OmniRouter)
   =>
     None
 

--- a/lib/wallaroo/core/producer_consumer.pony
+++ b/lib/wallaroo/core/producer_consumer.pony
@@ -37,7 +37,7 @@ trait tag AckRequester
 trait tag Initializable
   be application_begin_reporting(initializer: LocalTopologyInitializer)
   be application_created(initializer: LocalTopologyInitializer,
-    omni_router: OmniRouter val)
+    omni_router: OmniRouter)
 
   be application_initialized(initializer: LocalTopologyInitializer)
   be application_ready_to_work(initializer: LocalTopologyInitializer)

--- a/lib/wallaroo/init_file.pony
+++ b/lib/wallaroo/init_file.pony
@@ -1,4 +1,4 @@
-class InitFile
+class val InitFile
   let filename: String
   let msg_size: (USize | None)
 

--- a/lib/wallaroo/initialization/_test.pony
+++ b/lib/wallaroo/initialization/_test.pony
@@ -41,69 +41,69 @@ class iso _TestLocalTopologyEquality is UnitTest
     h.assert_eq[Bool](true, base_topology == target_topology)
 
 primitive _BaseLocalTopologyGenerator
-  fun apply(dag: Dag[StepInitializer val] val,
-    psd: Array[PreStateData val] val,
-    default_target: (Array[StepBuilder val] val | ProxyAddress val | None),
+  fun apply(dag: Dag[StepInitializer] val,
+    psd: Array[PreStateData] val,
+    default_target: (Array[StepBuilder] val | ProxyAddress | None),
     pf: PartitionFunction[String, String] val,
-    rb: RunnerBuilder val): LocalTopology val
+    rb: RunnerBuilder): LocalTopology
   =>
     LocalTopology("test", "w1", dag, _StepMapGenerator(),
       _BaseStateBuildersGenerator(rb, pf), psd, _ProxyIdsGenerator(),
       default_target, "test-default", 1, _BaseWorkerNamesGenerator())
 
 primitive _TargetLocalTopologyGenerator
-  fun apply(dag: Dag[StepInitializer val] val,
-    psd: Array[PreStateData val] val,
-    default_target: (Array[StepBuilder val] val | ProxyAddress val | None),
+  fun apply(dag: Dag[StepInitializer] val,
+    psd: Array[PreStateData] val,
+    default_target: (Array[StepBuilder] val | ProxyAddress | None),
     pf: PartitionFunction[String, String] val,
-    rb: RunnerBuilder val): LocalTopology val
+    rb: RunnerBuilder): LocalTopology
   =>
     LocalTopology("test", "w1", dag, _StepMapGenerator(),
       _TargetStateBuildersGenerator(rb, pf), psd, _ProxyIdsGenerator(),
       default_target, "test-default", 1, _TargetWorkerNamesGenerator())
 
 primitive _DagGenerator
-  fun apply(): Dag[StepInitializer val] val =>
-    Dag[StepInitializer val]
+  fun apply(): Dag[StepInitializer] val =>
+    Dag[StepInitializer]
 
 primitive _StepMapGenerator
-  fun apply(): Map[U128, (ProxyAddress val | U128)] val =>
-    let m: Map[U128, (ProxyAddress val | U128)] trn =
-      recover Map[U128, (ProxyAddress val | U128)] end
+  fun apply(): Map[U128, (ProxyAddress | U128)] val =>
+    let m: Map[U128, (ProxyAddress | U128)] trn =
+      recover Map[U128, (ProxyAddress | U128)] end
     m(1) = ProxyAddress("w1", 10)
     m(2) = ProxyAddress("w2", 20)
     m(3) = ProxyAddress("w3", 30)
     consume m
 
 primitive _BaseStateBuildersGenerator
-  fun apply(rb: RunnerBuilder val, pf: PartitionFunction[String, String] val):
-    Map[String, StateSubpartition val] val
+  fun apply(rb: RunnerBuilder, pf: PartitionFunction[String, String] val):
+    Map[String, StateSubpartition] val
   =>
-    let m: Map[String, StateSubpartition val] trn =
-      recover Map[String, StateSubpartition val] end
+    let m: Map[String, StateSubpartition] trn =
+      recover Map[String, StateSubpartition] end
     m("state") = _BaseStateSubpartitionGenerator(rb, pf)
     consume m
 
 primitive _TargetStateBuildersGenerator
-  fun apply(rb: RunnerBuilder val, pf: PartitionFunction[String, String] val):
-    Map[String, StateSubpartition val] val
+  fun apply(rb: RunnerBuilder, pf: PartitionFunction[String, String] val):
+    Map[String, StateSubpartition] val
   =>
-    let m: Map[String, StateSubpartition val] trn =
-      recover Map[String, StateSubpartition val] end
+    let m: Map[String, StateSubpartition] trn =
+      recover Map[String, StateSubpartition] end
     m("state") = _TargetStateSubpartitionGenerator(rb, pf)
     consume m
 
 primitive _BaseStateSubpartitionGenerator
-  fun apply(rb: RunnerBuilder val, pf: PartitionFunction[String, String] val):
-    StateSubpartition val
+  fun apply(rb: RunnerBuilder, pf: PartitionFunction[String, String] val):
+    StateSubpartition
   =>
     KeyedStateSubpartition[String, String](
       _BaseKeyedPartitionAddressesGenerator(), _IdMapGenerator(),
       rb, pf, "pipeline")
 
 primitive _TargetStateSubpartitionGenerator
-  fun apply(rb: RunnerBuilder val, pf: PartitionFunction[String, String] val):
-    StateSubpartition val
+  fun apply(rb: RunnerBuilder, pf: PartitionFunction[String, String] val):
+    StateSubpartition
   =>
     KeyedStateSubpartition[String, String](
       _TargetKeyedPartitionAddressesGenerator(), _IdMapGenerator(),
@@ -111,8 +111,8 @@ primitive _TargetStateSubpartitionGenerator
 
 primitive _BaseKeyedPartitionAddressesGenerator
   fun apply(): KeyedPartitionAddresses[String] val =>
-    let m: Map[String, ProxyAddress val] trn =
-      recover Map[String, ProxyAddress val] end
+    let m: Map[String, ProxyAddress] trn =
+      recover Map[String, ProxyAddress] end
     m("k1") = ProxyAddress("w1", 10)
     m("k2") = ProxyAddress("w2", 20)
     m("k3") = ProxyAddress("w3", 30)
@@ -120,8 +120,8 @@ primitive _BaseKeyedPartitionAddressesGenerator
 
 primitive _TargetKeyedPartitionAddressesGenerator
   fun apply(): KeyedPartitionAddresses[String] val =>
-    let m: Map[String, ProxyAddress val] trn =
-      recover Map[String, ProxyAddress val] end
+    let m: Map[String, ProxyAddress] trn =
+      recover Map[String, ProxyAddress] end
     m("k1") = ProxyAddress("w2", 10)
     m("k2") = ProxyAddress("w2", 20)
     m("k3") = ProxyAddress("w3", 30)
@@ -140,16 +140,16 @@ primitive _PartitionFunctionGenerator
     {(s: String): String => s}
 
 primitive _PreStateDataArrayGenerator
-  fun apply(rb: RunnerBuilder val): Array[PreStateData val] val =>
+  fun apply(rb: RunnerBuilder): Array[PreStateData] val =>
     recover [_PreStateDataGenerator(rb), _PreStateDataGenerator(rb),
       _PreStateDataGenerator(rb)] end
 
 primitive _PreStateDataGenerator
-  fun apply(rb: RunnerBuilder val): PreStateData val =>
+  fun apply(rb: RunnerBuilder): PreStateData =>
     PreStateData(rb, 1000)
 
 primitive _RunnerBuilderGenerator
-  fun apply(): RunnerBuilder val =>
+  fun apply(): RunnerBuilder =>
     ComputationRunnerBuilder[U8, U8](_ComputationBuilderGenerator(),
       BoundaryOnlyRouteBuilder)
 
@@ -167,7 +167,7 @@ primitive _ProxyIdsGenerator
     recover Map[String, U128] end
 
 primitive _DefaultTargetGenerator
-  fun apply(): (Array[StepBuilder val] val | ProxyAddress val | None) =>
+  fun apply(): (Array[StepBuilder] val | ProxyAddress | None) =>
     None
 
 primitive _BaseWorkerNamesGenerator

--- a/lib/wallaroo/initialization/cluster_initializer.pony
+++ b/lib/wallaroo/initialization/cluster_initializer.pony
@@ -93,7 +93,7 @@ actor ClusterInitializer
       end
     end
 
-  be distribute_local_topologies(ts: Map[String, LocalTopology val] val) =>
+  be distribute_local_topologies(ts: Map[String, LocalTopology] val) =>
     if _worker_names.size() != ts.size() then
       @printf[I32]("We need one local topology for each worker\n".cstring())
     else

--- a/lib/wallaroo/initialization/init_file_reader.pony
+++ b/lib/wallaroo/initialization/init_file_reader.pony
@@ -9,7 +9,7 @@ class InitFileReader
   let _file: File
   let _auth: AmbientAuth
 
-  new create(init_file: InitFile val, auth: AmbientAuth) ? =>
+  new create(init_file: InitFile, auth: AmbientAuth) ? =>
     _filename = init_file.filename
     match init_file.msg_size
     | let ms: USize =>

--- a/lib/wallaroo/initialization/layout_initializer.pony
+++ b/lib/wallaroo/initialization/layout_initializer.pony
@@ -6,10 +6,10 @@ trait tag LayoutInitializer
   be initialize(cluster_initializer: (ClusterInitializer | None) = None,
     recovering: Bool)
 
-  be receive_immigrant_step(msg: StepMigrationMsg val)
+  be receive_immigrant_step(msg: StepMigrationMsg)
 
   be update_boundaries(bs: Map[String, OutgoingBoundary] val,
-    bbs: Map[String, OutgoingBoundaryBuilder val] val)
+    bbs: Map[String, OutgoingBoundaryBuilder] val)
 
   be create_data_channel_listener(ws: Array[String] val,
     host: String, service: String,

--- a/lib/wallaroo/messages/channel_messages.pony
+++ b/lib/wallaroo/messages/channel_messages.pony
@@ -11,7 +11,7 @@ use "wallaroo/topology"
 use "wallaroo/w_actor"
 
 primitive ChannelMsgEncoder
-  fun _encode(msg: ChannelMsg val, auth: AmbientAuth,
+  fun _encode(msg: ChannelMsg, auth: AmbientAuth,
     wb: Writer = Writer): Array[ByteSeq] val ?
   =>
     let serialised: Array[U8] val =
@@ -23,14 +23,14 @@ primitive ChannelMsgEncoder
     end
     wb.done()
 
-  fun data_channel(delivery_msg: ReplayableDeliveryMsg val,
+  fun data_channel(delivery_msg: ReplayableDeliveryMsg,
     pipeline_time_spent: U64, seq_id: SeqId, wb: Writer, auth: AmbientAuth,
     latest_ts: U64, metrics_id: U16, metric_name: String): Array[ByteSeq] val ?
   =>
     _encode(DataMsg(delivery_msg, pipeline_time_spent, seq_id, latest_ts,
       metrics_id, metric_name), auth, wb)
 
-  fun data_channel_actor(delivery_msg: ActorDeliveryMsg val, seq_id: SeqId,
+  fun data_channel_actor(delivery_msg: ActorDeliveryMsg, seq_id: SeqId,
     wb: Writer, auth: AmbientAuth): Array[ByteSeq] val ?
   =>
     _encode(ActorDataMsg(delivery_msg, seq_id), auth, wb)
@@ -76,7 +76,7 @@ primitive ChannelMsgEncoder
   fun delivery[D: Any val](target_id: U128,
     from_worker_name: String, msg_data: D,
     metric_name: String, auth: AmbientAuth,
-    proxy_address: ProxyAddress val, msg_uid: U128): Array[ByteSeq] val ?
+    proxy_address: ProxyAddress, msg_uid: U128): Array[ByteSeq] val ?
   =>
     _encode(ForwardMsg[D](target_id, from_worker_name,
       msg_data, metric_name, proxy_address, msg_uid), auth)
@@ -96,7 +96,7 @@ primitive ChannelMsgEncoder
   =>
     _encode(ReconnectDataPortMsg(worker_name), auth)
 
-  fun spin_up_local_topology(local_topology: LocalTopology val,
+  fun spin_up_local_topology(local_topology: LocalTopology,
     auth: AmbientAuth): Array[ByteSeq] val ?
   =>
     _encode(SpinUpLocalTopologyMsg(local_topology), auth)
@@ -106,7 +106,7 @@ primitive ChannelMsgEncoder
   =>
     _encode(SpinUpLocalActorSystemMsg(local_actor_system), auth)
 
-  fun spin_up_step(step_id: U64, step_builder: StepBuilder val,
+  fun spin_up_step(step_id: U64, step_builder: StepBuilder,
     auth: AmbientAuth): Array[ByteSeq] val ?
   =>
     _encode(SpinUpStepMsg(step_id, step_builder), auth)
@@ -172,7 +172,7 @@ primitive ChannelMsgEncoder
 
   // TODO: Update this once new workers become first class citizens
   fun inform_joining_worker(worker_name: String, metric_app_name: String,
-    l_topology: LocalTopology val, metric_host: String,
+    l_topology: LocalTopology, metric_host: String,
     metric_service: String, control_addrs: Map[String, (String, String)] val,
     data_addrs: Map[String, (String, String)] val,
     worker_names: Array[String] val, auth: AmbientAuth): Array[ByteSeq] val ?
@@ -251,11 +251,11 @@ primitive ChannelMsgEncoder
     _encode(WActorRegistryDigestMsg(digest), auth)
 
 primitive ChannelMsgDecoder
-  fun apply(data: Array[U8] val, auth: AmbientAuth): ChannelMsg val =>
+  fun apply(data: Array[U8] val, auth: AmbientAuth): ChannelMsg =>
     try
       match Serialised.input(InputSerialisedAuth(auth), data)(
         DeserialiseAuth(auth))
-      | let m: ChannelMsg val =>
+      | let m: ChannelMsg =>
         m
       else
         UnknownChannelMsg(data)
@@ -266,13 +266,13 @@ primitive ChannelMsgDecoder
 
 trait val ChannelMsg
 
-class UnknownChannelMsg is ChannelMsg
+class val UnknownChannelMsg is ChannelMsg
   let data: Array[U8] val
 
   new val create(d: Array[U8] val) =>
     data = d
 
-class IdentifyControlPortMsg is ChannelMsg
+class val IdentifyControlPortMsg is ChannelMsg
   let worker_name: String
   let service: String
 
@@ -280,7 +280,7 @@ class IdentifyControlPortMsg is ChannelMsg
     worker_name = name
     service = s
 
-class IdentifyDataPortMsg is ChannelMsg
+class val IdentifyDataPortMsg is ChannelMsg
   let worker_name: String
   let service: String
 
@@ -288,39 +288,39 @@ class IdentifyDataPortMsg is ChannelMsg
     worker_name = name
     service = s
 
-class ReconnectDataPortMsg is ChannelMsg
+class val ReconnectDataPortMsg is ChannelMsg
   let worker_name: String
 
   new val create(name: String) =>
     worker_name = name
 
-class SpinUpLocalTopologyMsg is ChannelMsg
-  let local_topology: LocalTopology val
+class val SpinUpLocalTopologyMsg is ChannelMsg
+  let local_topology: LocalTopology
 
-  new val create(lt: LocalTopology val) =>
+  new val create(lt: LocalTopology) =>
     local_topology = lt
 
-class SpinUpLocalActorSystemMsg is ChannelMsg
+class val SpinUpLocalActorSystemMsg is ChannelMsg
   let local_actor_system: LocalActorSystem val
 
   new val create(las: LocalActorSystem val) =>
     local_actor_system = las
 
-class SpinUpStepMsg is ChannelMsg
+class val SpinUpStepMsg is ChannelMsg
   let step_id: U64
-  let step_builder: StepBuilder val
+  let step_builder: StepBuilder
 
-  new val create(s_id: U64, s_builder: StepBuilder val) =>
+  new val create(s_id: U64, s_builder: StepBuilder) =>
     step_id = s_id
     step_builder = s_builder
 
-class TopologyReadyMsg is ChannelMsg
+class val TopologyReadyMsg is ChannelMsg
   let worker_name: String
 
   new val create(name: String) =>
     worker_name = name
 
-class CreateConnectionsMsg is ChannelMsg
+class val CreateConnectionsMsg is ChannelMsg
   let control_addrs: Map[String, (String, String)] val
   let data_addrs: Map[String, (String, String)] val
 
@@ -330,19 +330,19 @@ class CreateConnectionsMsg is ChannelMsg
     control_addrs = c_addrs
     data_addrs = d_addrs
 
-class ConnectionsReadyMsg is ChannelMsg
+class val ConnectionsReadyMsg is ChannelMsg
   let worker_name: String
 
   new val create(name: String) =>
     worker_name = name
 
-class CreateDataChannelListener is ChannelMsg
+class val CreateDataChannelListener is ChannelMsg
   let workers: Array[String] val
 
   new val create(ws: Array[String] val) =>
     workers = ws
 
-class DataConnectMsg is ChannelMsg
+class val DataConnectMsg is ChannelMsg
   let sender_name: String
   let sender_boundary_id: U128
 
@@ -350,7 +350,7 @@ class DataConnectMsg is ChannelMsg
     sender_name = sender_name'
     sender_boundary_id = sender_boundary_id'
 
-class AckDataConnectMsg is ChannelMsg
+class val AckDataConnectMsg is ChannelMsg
   let last_id_seen: SeqId
 
   new val create(last_id_seen': SeqId) =>
@@ -358,13 +358,13 @@ class AckDataConnectMsg is ChannelMsg
 
 primitive StartNormalDataSendingMsg is ChannelMsg
 
-class RequestBoundaryCountMsg is ChannelMsg
+class val RequestBoundaryCountMsg is ChannelMsg
   let sender_name: String
 
   new val create(from: String) =>
     sender_name = from
 
-class ReplayBoundaryCountMsg is ChannelMsg
+class val ReplayBoundaryCountMsg is ChannelMsg
   let sender_name: String
   let boundary_count: USize
 
@@ -372,7 +372,7 @@ class ReplayBoundaryCountMsg is ChannelMsg
     sender_name = from
     boundary_count = count
 
-class ReplayCompleteMsg is ChannelMsg
+class val ReplayCompleteMsg is ChannelMsg
   let sender_name: String
   let boundary_id: U128
 
@@ -428,14 +428,14 @@ class val RequestWActorRegistryDigestMsg is ChannelMsg
   new val create(sender': String) =>
     sender = sender'
 
-trait StepMigrationMsg is ChannelMsg
+trait val StepMigrationMsg is ChannelMsg
   fun state_name(): String
   fun step_id(): U128
   fun state(): ByteSeq val
   fun worker(): String
   fun update_router_registry(router_registry: RouterRegistry, target: Consumer)
 
-class KeyedStepMigrationMsg[K: (Hashable val & Equatable[K] val)] is
+class val KeyedStepMigrationMsg[K: (Hashable val & Equatable[K] val)] is
   StepMigrationMsg
   let _state_name: String
   let _key: K
@@ -461,35 +461,35 @@ class KeyedStepMigrationMsg[K: (Hashable val & Equatable[K] val)] is
     router_registry.move_proxy_to_stateful_step[K](_step_id, target, _key,
       _state_name, _worker)
 
-class MigrationBatchCompleteMsg is ChannelMsg
+class val MigrationBatchCompleteMsg is ChannelMsg
   let sender_name: String
 
   new val create(sender: String) =>
     sender_name = sender
 
-class AckMigrationBatchCompleteMsg is ChannelMsg
+class val AckMigrationBatchCompleteMsg is ChannelMsg
   let sender_name: String
 
   new val create(sender: String) =>
     sender_name = sender
 
-class MuteRequestMsg is ChannelMsg
+class val MuteRequestMsg is ChannelMsg
   let originating_worker: String
   new val create(worker: String) =>
     originating_worker = worker
 
-class UnmuteRequestMsg is ChannelMsg
+class val UnmuteRequestMsg is ChannelMsg
   let originating_worker: String
   new val create(worker: String) =>
     originating_worker = worker
 
-class StepMigrationCompleteMsg is ChannelMsg
+class val StepMigrationCompleteMsg is ChannelMsg
   let step_id: U128
   new val create(step_id': U128)
   =>
     step_id = step_id'
 
-class AckWatermarkMsg is ChannelMsg
+class val AckWatermarkMsg is ChannelMsg
   let sender_name: String
   let sender_step_id: U128
   let seq_id: SeqId
@@ -501,15 +501,15 @@ class AckWatermarkMsg is ChannelMsg
     sender_step_id = sender_step_id'
     seq_id = seq_id'
 
-class DataMsg is ChannelMsg
+class val DataMsg is ChannelMsg
   let pipeline_time_spent: U64
   let seq_id: SeqId
-  let delivery_msg: ReplayableDeliveryMsg val
+  let delivery_msg: ReplayableDeliveryMsg
   let latest_ts: U64
   let metrics_id: U16
   let metric_name: String
 
-  new val create(msg: ReplayableDeliveryMsg val, pipeline_time_spent': U64,
+  new val create(msg: ReplayableDeliveryMsg, pipeline_time_spent': U64,
     seq_id': SeqId, latest_ts': U64, metrics_id': U16, metric_name': String)
   =>
     seq_id = seq_id'
@@ -519,11 +519,11 @@ class DataMsg is ChannelMsg
     metrics_id = metrics_id'
     metric_name = metric_name'
 
-class ActorDataMsg is ChannelMsg
+class val ActorDataMsg is ChannelMsg
   let seq_id: SeqId
-  let delivery_msg: ActorDeliveryMsg val
+  let delivery_msg: ActorDeliveryMsg
 
-  new val create(msg: ActorDeliveryMsg val, seq_id': SeqId) =>
+  new val create(msg: ActorDeliveryMsg, seq_id': SeqId) =>
     seq_id = seq_id'
     delivery_msg = msg
 
@@ -541,13 +541,13 @@ class val BroadcastVariableMsg is ChannelMsg
     ts = ts'
     worker = worker'
 
-class ReplayMsg is ChannelMsg
+class val ReplayMsg is ChannelMsg
   let data_bytes: Array[ByteSeq] val
 
   new val create(db: Array[ByteSeq] val) =>
     data_bytes = db
 
-  fun data_msg(auth: AmbientAuth): (DataMsg val | ActorDataMsg val) ? =>
+  fun data_msg(auth: AmbientAuth): (DataMsg | ActorDataMsg) ? =>
     var size: USize = 0
     for bytes in data_bytes.values() do
       size = size + bytes.size()
@@ -562,9 +562,9 @@ class ReplayMsg is ChannelMsg
     buffer.trim_in_place(4)
 
     match ChannelMsgDecoder(consume buffer, auth)
-    | let r: DataMsg val =>
+    | let r: DataMsg =>
       r
-    | let a: ActorDataMsg val =>
+    | let a: ActorDataMsg =>
       a
     else
       @printf[I32]("Trouble reconstituting replayed data msg\n".cstring())
@@ -572,14 +572,14 @@ class ReplayMsg is ChannelMsg
     end
 
 
-trait DeliveryMsg is ChannelMsg
+trait val DeliveryMsg is ChannelMsg
   fun target_id(): U128
   fun sender_name(): String
   fun deliver(pipeline_time_spent: U64, target_step: Consumer,
     origin: Producer, seq_id: SeqId, route_id: RouteId, latest_ts: U64,
     metrics_id: U16, worker_ingress_ts: U64): Bool
 
-trait ReplayableDeliveryMsg is DeliveryMsg
+trait val ReplayableDeliveryMsg is DeliveryMsg
   fun replay_deliver(pipeline_time_spent: U64, target_step: Consumer,
     origin: Producer, seq_id: SeqId, route_id: RouteId, latest_ts: U64,
     metrics_id: U16, worker_ingress_ts: U64): Bool
@@ -587,12 +587,12 @@ trait ReplayableDeliveryMsg is DeliveryMsg
   fun metric_name(): String
   fun msg_uid(): U128
 
-class ForwardMsg[D: Any val] is ReplayableDeliveryMsg
+class val ForwardMsg[D: Any val] is ReplayableDeliveryMsg
   let _target_id: U128
   let _sender_name: String
   let _data: D
   let _metric_name: String
-  let _proxy_address: ProxyAddress val
+  let _proxy_address: ProxyAddress
   let _msg_uid: U128
 
   fun input(): Any val => _data
@@ -600,7 +600,7 @@ class ForwardMsg[D: Any val] is ReplayableDeliveryMsg
   fun msg_uid(): U128 => _msg_uid
 
   new val create(t_id: U128, from: String,
-    m_data: D, m_name: String, proxy_address: ProxyAddress val, msg_uid': U128)
+    m_data: D, m_name: String, proxy_address: ProxyAddress, msg_uid': U128)
   =>
     _target_id = t_id
     _sender_name = from
@@ -659,7 +659,7 @@ class val ActorDeliveryMsg is ChannelMsg
     end
     false
 
-class JoinClusterMsg is ChannelMsg
+class val JoinClusterMsg is ChannelMsg
   """
   This message is sent from a worker requesting to join a running cluster to
   any existing worker in the cluster.
@@ -669,13 +669,13 @@ class JoinClusterMsg is ChannelMsg
   new val create(w: String) =>
     worker_name = w
 
-class InformJoiningWorkerMsg is ChannelMsg
+class val InformJoiningWorkerMsg is ChannelMsg
   """
   This message is sent as a response to a JoinCluster message. Currently it
   only informs the new worker of metrics-related info
   """
   let sender_name: String
-  let local_topology: LocalTopology val
+  let local_topology: LocalTopology
   let metrics_app_name: String
   let metrics_host: String
   let metrics_service: String
@@ -683,7 +683,7 @@ class InformJoiningWorkerMsg is ChannelMsg
   let data_addrs: Map[String, (String, String)] val
   let worker_names: Array[String] val
 
-  new val create(sender: String, app: String, l_topology: LocalTopology val,
+  new val create(sender: String, app: String, l_topology: LocalTopology,
     m_host: String, m_service: String,
     c_addrs: Map[String, (String, String)] val,
     d_addrs: Map[String, (String, String)] val,
@@ -699,7 +699,7 @@ class InformJoiningWorkerMsg is ChannelMsg
     worker_names = w_names
 
 // TODO: Don't send host over since we need to determine that on receipt
-class JoiningWorkerInitializedMsg is ChannelMsg
+class val JoiningWorkerInitializedMsg is ChannelMsg
   let worker_name: String
   let control_addr: (String, String)
   let data_addr: (String, String)
@@ -711,11 +711,11 @@ class JoiningWorkerInitializedMsg is ChannelMsg
     control_addr = c_addr
     data_addr = d_addr
 
-trait AnnounceNewStatefulStepMsg is ChannelMsg
+trait val AnnounceNewStatefulStepMsg is ChannelMsg
   fun update_registry(r: RouterRegistry)
 
-class KeyedAnnounceNewStatefulStepMsg[K: (Hashable val & Equatable[K] val)] is
-  AnnounceNewStatefulStepMsg
+class val KeyedAnnounceNewStatefulStepMsg[
+  K: (Hashable val & Equatable[K] val)] is AnnounceNewStatefulStepMsg
   """
   This message is sent to notify another worker that a new stateful step has
   been created on this worker and that partition routers should be updated.

--- a/lib/wallaroo/network/connections.pony
+++ b/lib/wallaroo/network/connections.pony
@@ -27,7 +27,7 @@ actor Connections is Cluster
   let _control_addrs: Map[String, (String, String)] = _control_addrs.create()
   let _data_addrs: Map[String, (String, String)] = _data_addrs.create()
   let _control_conns: Map[String, TCPConnection] = _control_conns.create()
-  let _data_conn_builders: Map[String, OutgoingBoundaryBuilder val] =
+  let _data_conn_builders: Map[String, OutgoingBoundaryBuilder] =
     _data_conn_builders.create()
   let _data_conns: Map[String, OutgoingBoundary] = _data_conns.create()
   var _phone_home: (TCPConnection | None) = None
@@ -321,8 +321,8 @@ actor Connections is Cluster
       out_bs(target) = boundary
     end
 
-    let out_bbs: Map[String, OutgoingBoundaryBuilder val] trn =
-      recover Map[String, OutgoingBoundaryBuilder val] end
+    let out_bbs: Map[String, OutgoingBoundaryBuilder] trn =
+      recover Map[String, OutgoingBoundaryBuilder] end
 
     for (target, builder) in _data_conn_builders.pairs() do
       out_bbs(target) = builder
@@ -543,7 +543,7 @@ actor Connections is Cluster
     end
 
   be inform_joining_worker(conn: TCPConnection, worker: String,
-    local_topology: LocalTopology val)
+    local_topology: LocalTopology)
   =>
     let c_addrs: Map[String, (String, String)] trn =
       recover Map[String, (String, String)] end

--- a/lib/wallaroo/network/control_channel_tcp.pony
+++ b/lib/wallaroo/network/control_channel_tcp.pony
@@ -163,7 +163,7 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
       end
       let msg = ChannelMsgDecoder(consume data, _auth)
       match msg
-      | let m: IdentifyControlPortMsg val =>
+      | let m: IdentifyControlPortMsg =>
         ifdef "trace" then
           @printf[I32]("Received IdentifyControlPortMsg on Control Channel\n"
             .cstring())
@@ -176,7 +176,7 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
           end
           _connections.create_control_connection(m.worker_name, host, m.service)
         end
-      | let m: IdentifyDataPortMsg val =>
+      | let m: IdentifyDataPortMsg =>
         ifdef "trace" then
           @printf[I32]("Received IdentifyDataPortMsg on Control Channel\n"
             .cstring())
@@ -189,13 +189,13 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
           end
           _connections.create_data_connection(m.worker_name, host, m.service)
         end
-      | let m: RequestBoundaryCountMsg val =>
+      | let m: RequestBoundaryCountMsg =>
         ifdef "trace" then
           @printf[I32]("Received RequestBoundaryCountMsg on Control Channel\n"
             .cstring())
         end
         _router_registry.inform_worker_of_boundary_count(m.sender_name)
-      | let m: ReconnectDataPortMsg val =>
+      | let m: ReconnectDataPortMsg =>
         // Sending worker is telling us we need to reconnect all boundaries
         // to that worker
         ifdef "trace" then
@@ -204,14 +204,14 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
         end
         _connections.reconnect_data_connection(m.worker_name)
         _router_registry.reconnect_source_boundaries(m.worker_name)
-      | let m: ReplayBoundaryCountMsg val =>
+      | let m: ReplayBoundaryCountMsg =>
         ifdef "trace" then
           @printf[I32]("Received ReplayBoundaryCountMsg on Control Channel\n"
             .cstring())
         end
         _recovery_replayer.add_expected_boundary_count(m.sender_name,
           m.boundary_count)
-      | let m: SpinUpLocalTopologyMsg val =>
+      | let m: SpinUpLocalTopologyMsg =>
         ifdef "trace" then
           @printf[I32]("Received SpinUpLocalTopologyMsg on Control Channel\n"
             .cstring())
@@ -223,7 +223,7 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
         else
           Fail()
         end
-      | let m: SpinUpLocalActorSystemMsg val =>
+      | let m: SpinUpLocalActorSystemMsg =>
         ifdef "trace" then
           @printf[I32](("Received SpinUpLocalActorSystemMsg on Control" +
             "Channel\n").cstring())
@@ -235,24 +235,24 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
         else
           Fail()
         end
-      | let m: RegisterActorForWorkerMsg val =>
+      | let m: RegisterActorForWorkerMsg =>
         ifdef "trace" then
           @printf[I32](("Received RegisterActorForWorkerMsg on Control" +
             "Channel\n").cstring())
         end
         _router_registry.register_actor_for_worker(m.id, m.worker)
-      | let m: ForgetActorMsg val =>
+      | let m: ForgetActorMsg =>
         ifdef "trace" then
           @printf[I32]("Received ForgetActor on Control Channel\n".cstring())
         end
         _router_registry.forget_external_actor(m.id)
-      | let m: RegisterAsRoleMsg val =>
+      | let m: RegisterAsRoleMsg =>
         ifdef "trace" then
           @printf[I32](("Received RegisterAsRoleMsg on Control" +
             "Channel\n").cstring())
         end
         _router_registry.register_as_role(m.role, m.id)
-      | let m: BroadcastToActorsMsg val =>
+      | let m: BroadcastToActorsMsg =>
         ifdef "trace" then
           @printf[I32](("Received BroadcastToActorsMsg on Control" +
             "Channel\n").cstring())
@@ -272,7 +272,7 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
         else
           Fail()
         end
-      | let m: WActorRegistryDigestMsg val =>
+      | let m: WActorRegistryDigestMsg =>
         ifdef "trace" then
           @printf[I32](("Received WActorRegistryDigestMsg on Control" +
             "Channel\n").cstring())
@@ -281,13 +281,13 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
         // Assumption: We only receive this digest message during
         // registry recovery phase of Recovery
         _recovery.w_actor_registry_recovery_finished()
-      | let m: RequestWActorRegistryDigestMsg val =>
+      | let m: RequestWActorRegistryDigestMsg =>
         ifdef "trace" then
           @printf[I32](("Received RequestWActorRegistryDigestMsg on Control" +
             "Channel\n").cstring())
         end
         _router_registry.send_digest_to(m.sender)
-      | let m: TopologyReadyMsg val =>
+      | let m: TopologyReadyMsg =>
         ifdef "trace" then
           @printf[I32]("Received TopologyReadyMsg on Control Channel\n"
             .cstring())
@@ -302,14 +302,14 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
           end
           i.topology_ready(m.worker_name)
         end
-      | let m: CreateConnectionsMsg val =>
+      | let m: CreateConnectionsMsg =>
         ifdef "trace" then
           @printf[I32]("Received CreateConnectionsMsg on Control Channel\n"
             .cstring())
         end
         _connections.create_connections(m.control_addrs, m.data_addrs,
           _layout_initializer)
-      | let m: ConnectionsReadyMsg val =>
+      | let m: ConnectionsReadyMsg =>
         ifdef "trace" then
           @printf[I32]("Received ConnectionsReadyMsg on Control Channel\n"
             .cstring())
@@ -325,18 +325,18 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
         end
         _layout_initializer.create_data_channel_listener(m.workers,
           _d_host, _d_service)
-      | let m: JoinClusterMsg val =>
+      | let m: JoinClusterMsg =>
         match _layout_initializer
         | let lti: LocalTopologyInitializer =>
           lti.inform_joining_worker(conn, m.worker_name)
         else
           Fail()
         end
-      | let m: AnnounceNewStatefulStepMsg val =>
+      | let m: AnnounceNewStatefulStepMsg =>
         m.update_registry(_router_registry)
-      | let m: StepMigrationCompleteMsg val =>
+      | let m: StepMigrationCompleteMsg =>
         _router_registry.step_migration_complete(m.step_id)
-      | let m: JoiningWorkerInitializedMsg val =>
+      | let m: JoiningWorkerInitializedMsg =>
         try
           (let joining_host, _) = conn.remote_address().name()
           match _layout_initializer
@@ -349,21 +349,21 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
         else
           Fail()
         end
-      | let m: AckMigrationBatchCompleteMsg val =>
+      | let m: AckMigrationBatchCompleteMsg =>
         ifdef "trace" then
           @printf[I32](("Received AckMigrationBatchCompleteMsg on Control " +
             "Channel\n").cstring())
         end
         _router_registry.process_migrating_target_ack(m.sender_name)
-      | let m: MuteRequestMsg val =>
+      | let m: MuteRequestMsg =>
         @printf[I32]("Control Ch: Received Mute Request from %s\n".cstring(),
           m.originating_worker.cstring())
         _router_registry.remote_mute_request(m.originating_worker)
-      | let m: UnmuteRequestMsg val =>
+      | let m: UnmuteRequestMsg =>
         @printf[I32]("Control Ch: Received Unmute Request from %s\n".cstring(),
           m.originating_worker.cstring())
         _router_registry.remote_unmute_request(m.originating_worker)
-      | let m: UnknownChannelMsg val =>
+      | let m: UnknownChannelMsg =>
         @printf[I32]("Unknown channel message type.\n".cstring())
       else
         @printf[I32](("Incoming Channel Message type not handled by control " +
@@ -435,7 +435,7 @@ class JoiningControlSenderConnectNotifier is TCPConnectionNotify
     else
       let msg = ChannelMsgDecoder(consume data, _auth)
       match msg
-      | let m: InformJoiningWorkerMsg val =>
+      | let m: InformJoiningWorkerMsg =>
         try
           // We need to get the host here because the sender didn't know
           // how its host string appears externally. We'll use it to

--- a/lib/wallaroo/network/phone_home_tcp.pony
+++ b/lib/wallaroo/network/phone_home_tcp.pony
@@ -33,7 +33,7 @@ class HomeConnectNotify is TCPConnectionNotify
       try
         let external_msg = ExternalMsgDecoder(consume data)
         match external_msg
-        | let m: ExternalShutdownMsg val =>
+        | let m: ExternalShutdownMsg =>
           @printf[I32]("Received ExternalShutdownMsg\n".cstring())
           _connections.shutdown()
         end

--- a/lib/wallaroo/routing/boundary_route.pony
+++ b/lib/wallaroo/routing/boundary_route.pony
@@ -51,7 +51,7 @@ class BoundaryRoute is Route
     Fail()
     true
 
-  fun ref forward(delivery_msg: ReplayableDeliveryMsg val,
+  fun ref forward(delivery_msg: ReplayableDeliveryMsg,
     pipeline_time_spent: U64, cfp: Producer ref,
     msg_uid: U128, latest_ts: U64, metrics_id: U16,
     metric_name: String, worker_ingress_ts: U64): Bool
@@ -76,7 +76,7 @@ class BoundaryRoute is Route
       worker_ingress_ts)
     true
 
-  fun ref _send_message_on_route(delivery_msg: ReplayableDeliveryMsg val,
+  fun ref _send_message_on_route(delivery_msg: ReplayableDeliveryMsg,
     pipeline_time_spent: U64, cfp: Producer ref, msg_uid: U128,
     latest_ts: U64, metrics_id: U16, metric_name: String,
     worker_ingress_ts: U64)

--- a/lib/wallaroo/routing/route.pony
+++ b/lib/wallaroo/routing/route.pony
@@ -17,7 +17,7 @@ trait Route
     cfp: Producer ref, msg_uid: U128,
     latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64): Bool
 
-  fun ref forward(delivery_msg: ReplayableDeliveryMsg val,
+  fun ref forward(delivery_msg: ReplayableDeliveryMsg,
     pipeline_time_spent: U64, cfp: Producer ref,
     msg_uid: U128, latest_ts: U64, metrics_id: U16,
     metric_name: String, worker_ingress_ts: U64): Bool
@@ -84,7 +84,7 @@ class EmptyRoute is Route
     Fail()
     true
 
-  fun ref forward(delivery_msg: ReplayableDeliveryMsg val,
+  fun ref forward(delivery_msg: ReplayableDeliveryMsg,
     pipeline_time_spent: U64, cfp: Producer ref,
     msg_uid: U128, latest_ts: U64, metrics_id: U16,
     metric_name: String, worker_ingress_ts: U64): Bool

--- a/lib/wallaroo/routing/route_builder.pony
+++ b/lib/wallaroo/routing/route_builder.pony
@@ -4,7 +4,7 @@ use "wallaroo/core"
 use "wallaroo/metrics"
 use "wallaroo/topology"
 
-trait RouteBuilder
+trait val RouteBuilder
   fun apply(step: Producer ref, consumer: Consumer,
     metrics_reporter: MetricsReporter ref): Route
 

--- a/lib/wallaroo/routing/typed_route.pony
+++ b/lib/wallaroo/routing/typed_route.pony
@@ -68,7 +68,7 @@ class TypedRoute[In: Any val] is Route
       true
     end
 
-  fun ref forward(delivery_msg: ReplayableDeliveryMsg val,
+  fun ref forward(delivery_msg: ReplayableDeliveryMsg,
     pipeline_time_spent: U64, cfp: Producer ref,
     msg_uid: U128, latest_ts: U64, metrics_id: U16,
     metric_name: String, worker_ingress_ts: U64): Bool

--- a/lib/wallaroo/sink/empty_sink.pony
+++ b/lib/wallaroo/sink/empty_sink.pony
@@ -28,7 +28,7 @@ actor EmptySink is Consumer
     initializer.report_created(this)
 
   be application_created(initializer: LocalTopologyInitializer,
-    omni_router: OmniRouter val)
+    omni_router: OmniRouter)
   =>
     initializer.report_initialized(this)
 

--- a/lib/wallaroo/source/source.pony
+++ b/lib/wallaroo/source/source.pony
@@ -8,17 +8,17 @@ use "wallaroo/topology"
 
 trait val SourceBuilder
   fun name(): String
-  fun apply(event_log: EventLog, auth: AmbientAuth, target_router: Router val):
+  fun apply(event_log: EventLog, auth: AmbientAuth, target_router: Router):
     SourceNotify iso^
-  fun val update_router(router: Router val): SourceBuilder
+  fun val update_router(router: Router): SourceBuilder
 
 class val BasicSourceBuilder[In: Any val, SH: SourceHandler[In] val] is SourceBuilder
   let _app_name: String
   let _worker_name: String
   let _name: String
-  let _runner_builder: RunnerBuilder val
+  let _runner_builder: RunnerBuilder
   let _handler: SH
-  let _router: Router val
+  let _router: Router
   let _metrics_conn: MetricsSink
   let _pre_state_target_id: (U128 | None)
   let _metrics_reporter: MetricsReporter
@@ -26,9 +26,9 @@ class val BasicSourceBuilder[In: Any val, SH: SourceHandler[In] val] is SourceBu
 
   new val create(app_name: String, worker_name: String,
     name': String,
-    runner_builder: RunnerBuilder val,
+    runner_builder: RunnerBuilder,
     handler: SH,
-    router: Router val, metrics_conn: MetricsSink,
+    router: Router, metrics_conn: MetricsSink,
     pre_state_target_id: (U128 | None) = None,
     metrics_reporter: MetricsReporter iso,
     source_notify_builder: SourceNotifyBuilder[In, SH])
@@ -46,20 +46,20 @@ class val BasicSourceBuilder[In: Any val, SH: SourceHandler[In] val] is SourceBu
 
   fun name(): String => _name
 
-  fun apply(event_log: EventLog, auth: AmbientAuth, target_router: Router val):
+  fun apply(event_log: EventLog, auth: AmbientAuth, target_router: Router):
     SourceNotify iso^
   =>
     _source_notify_builder(_name, auth, _handler, _runner_builder, _router,
       _metrics_reporter.clone(), event_log, target_router, _pre_state_target_id)
 
-  fun val update_router(router: Router val): SourceBuilder =>
+  fun val update_router(router: Router): SourceBuilder =>
     BasicSourceBuilder[In, SH](_app_name, _worker_name, _name, _runner_builder,
       _handler, router, _metrics_conn, _pre_state_target_id,
       _metrics_reporter.clone(), _source_notify_builder)
 
 interface val SourceBuilderBuilder
   fun name(): String
-  fun apply(runner_builder: RunnerBuilder val, router: Router val,
+  fun apply(runner_builder: RunnerBuilder, router: Router,
     metrics_conn: MetricsSink, pre_state_target_id: (U128 | None) = None,
     worker_name: String,
     metrics_reporter: MetricsReporter iso):
@@ -72,14 +72,14 @@ interface val SourceConfig[In: Any val]
     SourceBuilderBuilder
 
 interface tag Source
-  be update_router(router: PartitionRouter val)
+  be update_router(router: PartitionRouter)
   be add_boundary_builders(
-    boundary_builders: Map[String, OutgoingBoundaryBuilder val] val)
+    boundary_builders: Map[String, OutgoingBoundaryBuilder] val)
   be reconnect_boundary(target_worker_name: String)
   be mute(c: Consumer)
   be unmute(c: Consumer)
 
 interface tag SourceListener
-  be update_router(router: PartitionRouter val)
+  be update_router(router: PartitionRouter)
   be add_boundary_builders(
-    boundary_builders: Map[String, OutgoingBoundaryBuilder val] val)
+    boundary_builders: Map[String, OutgoingBoundaryBuilder] val)

--- a/lib/wallaroo/source/source_listener.pony
+++ b/lib/wallaroo/source/source_listener.pony
@@ -12,12 +12,12 @@ interface val SourceListenerBuilder
   fun apply(): SourceListener
 
 interface val SourceListenerBuilderBuilder
-  fun apply(source_builder: SourceBuilder, router: Router val,
-    router_registry: RouterRegistry, route_builder: RouteBuilder val,
-    outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder val] val,
+  fun apply(source_builder: SourceBuilder, router: Router,
+    router_registry: RouterRegistry, route_builder: RouteBuilder,
+    outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val,
     event_log: EventLog, auth: AmbientAuth,
     layout_initializer: LayoutInitializer,
     metrics_reporter: MetricsReporter iso,
     default_target: (Step | None) = None,
-    default_in_route_builder: (RouteBuilder val | None) = None,
-    target_router: Router val = EmptyRouter): SourceListenerBuilder
+    default_in_route_builder: (RouteBuilder | None) = None,
+    target_router: Router = EmptyRouter): SourceListenerBuilder

--- a/lib/wallaroo/source/source_notify.pony
+++ b/lib/wallaroo/source/source_notify.pony
@@ -18,14 +18,14 @@ interface FramedSourceHandler[In: Any val]
 interface SourceNotify
   fun ref routes(): Array[Consumer] val
 
-  fun ref update_router(router: Router val)
+  fun ref update_router(router: Router)
 
   fun ref update_boundaries(obs: box->Map[String, OutgoingBoundary])
 
 interface val SourceNotifyBuilder[In: Any val, SH: SourceHandler[In] val]
   fun apply(pipeline_name: String, auth: AmbientAuth,
     handler: SH,
-    runner_builder: RunnerBuilder val, router: Router val,
+    runner_builder: RunnerBuilder, router: Router,
     metrics_reporter: MetricsReporter iso, event_log: EventLog,
-    target_router: Router val, pre_state_target_id: (U128 | None) = None):
+    target_router: Router, pre_state_target_id: (U128 | None) = None):
     SourceNotify iso^

--- a/lib/wallaroo/startup.pony
+++ b/lib/wallaroo/startup.pony
@@ -385,7 +385,7 @@ actor Startup
       StartupHelp(_env)
     end
 
-  be complete_join(info_sending_host: String, m: InformJoiningWorkerMsg val) =>
+  be complete_join(info_sending_host: String, m: InformJoiningWorkerMsg) =>
     try
       let auth = _env.root as AmbientAuth
 

--- a/lib/wallaroo/tcp_sink/tcp_sink.pony
+++ b/lib/wallaroo/tcp_sink/tcp_sink.pony
@@ -125,7 +125,7 @@ actor TCPSink is Consumer
     initializer.report_created(this)
 
   be application_created(initializer: LocalTopologyInitializer,
-    omni_router: OmniRouter val)
+    omni_router: OmniRouter)
   =>
     _mute_upstreams()
     initializer.report_initialized(this)
@@ -205,7 +205,7 @@ actor TCPSink is Consumer
     run[D](metric_name, pipeline_time_spent, data, i_origin, msg_uid,
       i_seq_id, i_route_id, latest_ts, metrics_id, worker_ingress_ts)
 
-  be update_router(router: Router val) =>
+  be update_router(router: Router) =>
     """
     No-op: TCPSink has no router
     """

--- a/lib/wallaroo/tcp_source/framed_source_notify.pony
+++ b/lib/wallaroo/tcp_source/framed_source_notify.pony
@@ -16,9 +16,9 @@ use "wallaroo/topology"
 primitive TCPFramedSourceNotifyBuilder[In: Any val]
   fun apply(pipeline_name: String, auth: AmbientAuth,
     handler: FramedSourceHandler[In] val,
-    runner_builder: RunnerBuilder val, router: Router val,
+    runner_builder: RunnerBuilder, router: Router,
     metrics_reporter: MetricsReporter iso, event_log: EventLog,
-    target_router: Router val, pre_state_target_id: (U128 | None) = None):
+    target_router: Router, pre_state_target_id: (U128 | None) = None):
     SourceNotify iso^
   =>
     TCPFramedSourceNotify[In](pipeline_name, auth, handler, runner_builder,
@@ -32,16 +32,16 @@ class TCPFramedSourceNotify[In: Any val] is TCPSourceNotify
   let _source_name: String
   let _handler: FramedSourceHandler[In] val
   let _runner: Runner
-  var _router: Router val
-  let _omni_router: OmniRouter val = EmptyOmniRouter
+  var _router: Router
+  let _omni_router: OmniRouter = EmptyOmniRouter
   let _metrics_reporter: MetricsReporter
   let _header_size: USize
 
   new iso create(pipeline_name: String, auth: AmbientAuth,
     handler: FramedSourceHandler[In] val,
-    runner_builder: RunnerBuilder val, router: Router val,
+    runner_builder: RunnerBuilder, router: Router,
     metrics_reporter: MetricsReporter iso, event_log: EventLog,
-    target_router: Router val, pre_state_target_id: (U128 | None) = None)
+    target_router: Router, pre_state_target_id: (U128 | None) = None)
   =>
     _pipeline_name = pipeline_name
     _source_name = pipeline_name + " source"
@@ -133,12 +133,12 @@ class TCPFramedSourceNotify[In: Any val] is TCPSourceNotify
       end
     end
 
-  fun ref update_router(router: Router val) =>
+  fun ref update_router(router: Router) =>
     _router = router
 
   fun ref update_boundaries(obs: box->Map[String, OutgoingBoundary]) =>
     match _router
-    | let p_router: PartitionRouter val =>
+    | let p_router: PartitionRouter =>
       _router = p_router.update_boundaries(obs)
     else
       ifdef debug then

--- a/lib/wallaroo/tcp_source/tcp_source.pony
+++ b/lib/wallaroo/tcp_source/tcp_source.pony
@@ -30,7 +30,7 @@ actor TCPSource is Producer
   """
   let _guid: GuidGenerator = GuidGenerator
   let _routes: MapIs[Consumer, Route] = _routes.create()
-  let _route_builder: RouteBuilder val
+  let _route_builder: RouteBuilder
   let _outgoing_boundaries: Map[String, OutgoingBoundary] =
     _outgoing_boundaries.create()
   let _layout_initializer: LayoutInitializer
@@ -64,11 +64,11 @@ actor TCPSource is Producer
   var _seq_id: SeqId = 1 // 0 is reserved for "not seen yet"
 
   new _accept(listen: TCPSourceListener, notify: TCPSourceNotify iso,
-    routes: Array[Consumer] val, route_builder: RouteBuilder val,
-    outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder val] val,
+    routes: Array[Consumer] val, route_builder: RouteBuilder,
+    outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val,
     layout_initializer: LayoutInitializer,
     fd: U32, default_target: (Consumer | None) = None,
-    forward_route_builder: (RouteBuilder val | None) = None,
+    forward_route_builder: (RouteBuilder | None) = None,
     init_size: USize = 64, max_size: USize = 16384,
     metrics_reporter: MetricsReporter iso)
   =>
@@ -119,7 +119,7 @@ actor TCPSource is Producer
     match default_target
     | let r: Consumer =>
       match forward_route_builder
-      | let frb: RouteBuilder val =>
+      | let frb: RouteBuilder =>
         _routes(r) = frb(this, r, _metrics_reporter)
       end
     end
@@ -137,12 +137,12 @@ actor TCPSource is Producer
 
     _mute()
 
-  be update_router(router: PartitionRouter val) =>
+  be update_router(router: PartitionRouter) =>
     let new_router = router.update_boundaries(_outgoing_boundaries)
     _notify.update_router(new_router)
 
   be add_boundary_builders(
-    boundary_builders: Map[String, OutgoingBoundaryBuilder val] val)
+    boundary_builders: Map[String, OutgoingBoundaryBuilder] val)
   =>
     """
     Build a new boundary for each builder that corresponds to a worker we

--- a/lib/wallaroo/tcp_source/tcp_source_config.pony
+++ b/lib/wallaroo/tcp_source/tcp_source_config.pony
@@ -53,7 +53,7 @@ class val TCPSourceConfig[In: Any val]
     _host = opts.host
     _service = opts.service
 
-  fun source_listener_builder_builder(): TCPSourceListenerBuilderBuilder val =>
+  fun source_listener_builder_builder(): TCPSourceListenerBuilderBuilder =>
     TCPSourceListenerBuilderBuilder(_host, _service)
 
   fun source_builder(app_name: String, name: String):

--- a/lib/wallaroo/tcp_source/tcp_source_listener.pony
+++ b/lib/wallaroo/tcp_source/tcp_source_listener.pony
@@ -17,15 +17,15 @@ class val TCPSourceListenerBuilderBuilder
     _host = host
     _service = service
 
-  fun apply(source_builder: SourceBuilder, router: Router val,
-    router_registry: RouterRegistry, route_builder: RouteBuilder val,
-    outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder val] val,
+  fun apply(source_builder: SourceBuilder, router: Router,
+    router_registry: RouterRegistry, route_builder: RouteBuilder,
+    outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val,
     event_log: EventLog, auth: AmbientAuth,
     layout_initializer: LayoutInitializer,
     metrics_reporter: MetricsReporter iso,
     default_target: (Step | None) = None,
-    default_in_route_builder: (RouteBuilder val | None) = None,
-    target_router: Router val = EmptyRouter): TCPSourceListenerBuilder val
+    default_in_route_builder: (RouteBuilder | None) = None,
+    target_router: Router = EmptyRouter): TCPSourceListenerBuilder
   =>
     TCPSourceListenerBuilder(source_builder, router, router_registry,
       route_builder,
@@ -33,31 +33,31 @@ class val TCPSourceListenerBuilderBuilder
       layout_initializer, consume metrics_reporter, default_target,
       default_in_route_builder, target_router, _host, _service)
 
-class TCPSourceListenerBuilder
+class val TCPSourceListenerBuilder
   let _source_builder: SourceBuilder
-  let _router: Router val
+  let _router: Router
   let _router_registry: RouterRegistry
-  let _route_builder: RouteBuilder val
-  let _default_in_route_builder: (RouteBuilder val | None)
-  let _outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder val] val
+  let _route_builder: RouteBuilder
+  let _default_in_route_builder: (RouteBuilder | None)
+  let _outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val
   let _layout_initializer: LayoutInitializer
   let _event_log: EventLog
   let _auth: AmbientAuth
   let _default_target: (Step | None)
-  let _target_router: Router val
+  let _target_router: Router
   let _host: String
   let _service: String
   let _metrics_reporter: MetricsReporter
 
-  new val create(source_builder: SourceBuilder, router: Router val,
-    router_registry: RouterRegistry, route_builder: RouteBuilder val,
-    outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder val] val,
+  new val create(source_builder: SourceBuilder, router: Router,
+    router_registry: RouterRegistry, route_builder: RouteBuilder,
+    outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val,
     event_log: EventLog, auth: AmbientAuth,
     layout_initializer: LayoutInitializer,
     metrics_reporter: MetricsReporter iso,
     default_target: (Step | None) = None,
-    default_in_route_builder: (RouteBuilder val | None) = None,
-    target_router: Router val = EmptyRouter,
+    default_in_route_builder: (RouteBuilder | None) = None,
+    target_router: Router = EmptyRouter,
     host: String = "", service: String = "0")
   =>
     _source_builder = source_builder
@@ -88,11 +88,11 @@ actor TCPSourceListener is SourceListener
   """
 
   var _notify: TCPSourceListenerNotify
-  let _router: Router val
+  let _router: Router
   let _router_registry: RouterRegistry
-  let _route_builder: RouteBuilder val
-  let _default_in_route_builder: (RouteBuilder val | None)
-  var _outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder val] val
+  let _route_builder: RouteBuilder
+  let _default_in_route_builder: (RouteBuilder | None)
+  var _outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val
   let _layout_initializer: LayoutInitializer
   let _default_target: (Step | None)
   var _fd: U32
@@ -104,15 +104,15 @@ actor TCPSourceListener is SourceListener
   var _max_size: USize
   let _metrics_reporter: MetricsReporter
 
-  new create(source_builder: SourceBuilder, router: Router val,
-    router_registry: RouterRegistry, route_builder: RouteBuilder val,
-    outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder val] val,
+  new create(source_builder: SourceBuilder, router: Router,
+    router_registry: RouterRegistry, route_builder: RouteBuilder,
+    outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val,
     event_log: EventLog, auth: AmbientAuth,
     layout_initializer: LayoutInitializer,
     metrics_reporter: MetricsReporter iso,
     default_target: (Step | None) = None,
-    default_in_route_builder: (RouteBuilder val | None) = None,
-    target_router: Router val = EmptyRouter,
+    default_in_route_builder: (RouteBuilder | None) = None,
+    target_router: Router = EmptyRouter,
     host: String = "", service: String = "0", limit: USize = 0,
     init_size: USize = 64, max_size: USize = 16384)
   =>
@@ -139,17 +139,17 @@ actor TCPSourceListener is SourceListener
       + host + ":" + service + "\n").cstring())
     _notify_listening()
 
-  be update_router(router: PartitionRouter val) =>
+  be update_router(router: PartitionRouter) =>
     _notify.update_router(router)
 
   be remove_route_for(moving_step: Consumer) =>
     None
 
   be add_boundary_builders(
-    boundary_builders: Map[String, OutgoingBoundaryBuilder val] val)
+    boundary_builders: Map[String, OutgoingBoundaryBuilder] val)
   =>
-    let new_builders: Map[String, OutgoingBoundaryBuilder val] trn =
-      recover Map[String, OutgoingBoundaryBuilder val] end
+    let new_builders: Map[String, OutgoingBoundaryBuilder] trn =
+      recover Map[String, OutgoingBoundaryBuilder] end
     // TODO: A persistent map on the field would be much more efficient here
     for (target_worker_name, builder) in _outgoing_boundary_builders.pairs() do
       new_builders(target_worker_name) = builder

--- a/lib/wallaroo/tcp_source/tcp_source_listener_notify.pony
+++ b/lib/wallaroo/tcp_source/tcp_source_listener_notify.pony
@@ -24,7 +24,7 @@ class val TypedTCPSourceBuilderBuilder[In: Any val]
 
   fun name(): String => _name
 
-  fun apply(runner_builder: RunnerBuilder val, router: Router val,
+  fun apply(runner_builder: RunnerBuilder, router: Router,
     metrics_conn: MetricsSink, pre_state_target_id: (U128 | None) = None,
     worker_name: String, metrics_reporter: MetricsReporter iso):
       SourceBuilder
@@ -62,16 +62,16 @@ interface TCPSourceListenerNotify
     newly established connection to the server.
     """
 
-  fun ref update_router(router: Router val)
+  fun ref update_router(router: Router)
 
 class SourceListenerNotify is TCPSourceListenerNotify
   var _source_builder: SourceBuilder
   let _event_log: EventLog
-  let _target_router: Router val
+  let _target_router: Router
   let _auth: AmbientAuth
 
   new iso create(builder: SourceBuilder, event_log: EventLog, auth: AmbientAuth,
-    target_router: Router val) =>
+    target_router: Router) =>
     _source_builder = builder
     _event_log = event_log
     _target_router = target_router
@@ -95,5 +95,5 @@ class SourceListenerNotify is TCPSourceListenerNotify
       error
     end
 
-  fun ref update_router(router: Router val) =>
+  fun ref update_router(router: Router) =>
     _source_builder = _source_builder.update_router(router)

--- a/lib/wallaroo/tcp_source/tcp_source_notify.pony
+++ b/lib/wallaroo/tcp_source/tcp_source_notify.pony
@@ -13,7 +13,7 @@ interface TCPSourceNotify
   // and it can then make routes available
   fun ref routes(): Array[Consumer] val
 
-  fun ref update_router(router: Router val)
+  fun ref update_router(router: Router)
 
   fun ref update_boundaries(obs: box->Map[String, OutgoingBoundary])
 

--- a/lib/wallaroo/topology/_test_router_equality.pony
+++ b/lib/wallaroo/topology/_test_router_equality.pony
@@ -61,11 +61,11 @@ class iso _TestLocalPartitionRouterEquality is UnitTest
     let target_partition_routes = _TargetPartitionRoutesGenerator(event_log, auth,
       new_proxy_router, boundary2, boundary3)
 
-    var base_router: PartitionRouter val =
+    var base_router: PartitionRouter =
       LocalPartitionRouter[String, String](consume base_local_map,
         consume base_step_ids, base_partition_routes,
       _PartitionFunctionGenerator(), _DefaultRouterGenerator())
-    var target_router: PartitionRouter val =
+    var target_router: PartitionRouter =
       LocalPartitionRouter[String, String](consume target_local_map,
         consume target_step_ids, target_partition_routes,
         _PartitionFunctionGenerator(), _DefaultRouterGenerator())
@@ -105,13 +105,13 @@ class iso _TestOmniRouterEquality is UnitTest
       recover Map[U128, Consumer] end
     target_data_routes(2) = step2
 
-    let base_step_map: Map[U128, (ProxyAddress val | U128)] trn =
-      recover Map[U128, (ProxyAddress val | U128)] end
+    let base_step_map: Map[U128, (ProxyAddress | U128)] trn =
+      recover Map[U128, (ProxyAddress | U128)] end
     base_step_map(1) = ProxyAddress("w1", 1)
     base_step_map(2) = ProxyAddress("w2", 2)
 
-    let target_step_map: Map[U128, (ProxyAddress val | U128)] trn =
-      recover Map[U128, (ProxyAddress val | U128)] end
+    let target_step_map: Map[U128, (ProxyAddress | U128)] trn =
+      recover Map[U128, (ProxyAddress | U128)] end
     target_step_map(1) = ProxyAddress("w2", 1)
     target_step_map(2) = ProxyAddress("w1", 2)
 
@@ -124,11 +124,11 @@ class iso _TestOmniRouterEquality is UnitTest
     target_boundaries("w2") = boundary2
     target_boundaries("w3") = boundary3
 
-    var base_router: OmniRouter val = StepIdRouter("w1",
+    var base_router: OmniRouter = StepIdRouter("w1",
       consume base_data_routes, consume base_step_map,
       consume base_boundaries)
 
-    let target_router: OmniRouter val = StepIdRouter("w1",
+    let target_router: OmniRouter = StepIdRouter("w1",
       consume target_data_routes, consume target_step_map,
       consume target_boundaries)
 
@@ -213,10 +213,10 @@ class iso _TestDataRouterEqualityAfterAdd is UnitTest
 primitive _BasePartitionRoutesGenerator
   fun apply(event_log: EventLog, auth: AmbientAuth, step1: Step,
     boundary2: OutgoingBoundary, boundary3: OutgoingBoundary):
-    Map[String, (Step | ProxyRouter val)] val
+    Map[String, (Step | ProxyRouter)] val
   =>
-    let m: Map[String, (Step | ProxyRouter val)] trn =
-      recover Map[String, (Step | ProxyRouter val)] end
+    let m: Map[String, (Step | ProxyRouter)] trn =
+      recover Map[String, (Step | ProxyRouter)] end
     m("k1") = step1
     m("k2") = ProxyRouter("w1", boundary2,
       ProxyAddress("w2", 2), auth)
@@ -226,11 +226,11 @@ primitive _BasePartitionRoutesGenerator
 
 primitive _TargetPartitionRoutesGenerator
   fun apply(event_log: EventLog, auth: AmbientAuth,
-    new_proxy_router: ProxyRouter val, boundary2: OutgoingBoundary,
-    boundary3: OutgoingBoundary): Map[String, (Step | ProxyRouter val)] val
+    new_proxy_router: ProxyRouter, boundary2: OutgoingBoundary,
+    boundary3: OutgoingBoundary): Map[String, (Step | ProxyRouter)] val
   =>
-    let m: Map[String, (Step | ProxyRouter val)] trn =
-      recover Map[String, (Step | ProxyRouter val)] end
+    let m: Map[String, (Step | ProxyRouter)] trn =
+      recover Map[String, (Step | ProxyRouter)] end
     m("k1") = new_proxy_router
     m("k2") = ProxyRouter("w1", boundary2,
       ProxyAddress("w2", 2), auth)
@@ -251,7 +251,7 @@ primitive _PartitionFunctionGenerator
     {(s: String): String => s}
 
 primitive _DefaultRouterGenerator
-  fun apply(): (Router val | None) =>
+  fun apply(): (Router | None) =>
     None
 
 primitive _StepGenerator

--- a/lib/wallaroo/topology/computations.pony
+++ b/lib/wallaroo/topology/computations.pony
@@ -31,7 +31,7 @@ trait StateProcessor[S: State ref] is BasicComputation
   // keep receiving data and the state change (or None if there was
   // no state change).
   fun apply(state: S, sc_repo: StateChangeRepository[S],
-    omni_router: OmniRouter val, metric_name: String, pipeline_time_spent: U64,
+    omni_router: OmniRouter, metric_name: String, pipeline_time_spent: U64,
     producer: Producer ref, i_msg_uid: U128,
     latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64):
     (Bool, Bool, (StateChange[S] ref | DirectStateChange | None), U64,
@@ -55,7 +55,7 @@ class StateComputationWrapper[In: Any val, Out: Any val, S: State ref]
   fun input(): Any val => _input
 
   fun apply(state: S, sc_repo: StateChangeRepository[S],
-    omni_router: OmniRouter val, metric_name: String, pipeline_time_spent: U64,
+    omni_router: OmniRouter, metric_name: String, pipeline_time_spent: U64,
     producer: Producer ref, i_msg_uid: U128,
     latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64):
     (Bool, Bool, (StateChange[S] ref | DirectStateChange | None), U64,

--- a/lib/wallaroo/topology/proxy.pony
+++ b/lib/wallaroo/topology/proxy.pony
@@ -1,4 +1,4 @@
-class ProxyAddress
+class val ProxyAddress
   let worker: String
   let step_id: U128
 

--- a/lib/wallaroo/topology/step_initializer.pony
+++ b/lib/wallaroo/topology/step_initializer.pony
@@ -14,22 +14,22 @@ use "wallaroo/sink"
 type StepInitializer is (StepBuilder | SourceData | EgressBuilder |
   PreStatelessData)
 
-class StepBuilder
+class val StepBuilder
   let _app_name: String
   let _worker_name: String
   let _pipeline_name: String
   let _state_name: String
-  let _runner_builder: RunnerBuilder val
+  let _runner_builder: RunnerBuilder
   let _id: U128
   let _pre_state_target_id: (U128 | None)
   let _is_stateful: Bool
-  let _forward_route_builder: RouteBuilder val
+  let _forward_route_builder: RouteBuilder
 
   new val create(app_name: String, worker_name: String,
-    pipeline_name': String, r: RunnerBuilder val, id': U128,
+    pipeline_name': String, r: RunnerBuilder, id': U128,
     is_stateful': Bool = false,
     pre_state_target_id': (U128 | None) = None,
-    forward_route_builder': RouteBuilder val = BoundaryOnlyRouteBuilder)
+    forward_route_builder': RouteBuilder = BoundaryOnlyRouteBuilder)
   =>
     _app_name = app_name
     _worker_name = worker_name
@@ -56,19 +56,19 @@ class StepBuilder
   fun is_prestate(): Bool => _runner_builder.is_prestate()
   fun is_stateful(): Bool => _is_stateful
   fun is_partitioned(): Bool => false
-  fun forward_route_builder(): RouteBuilder val => _forward_route_builder
-  fun in_route_builder(): (RouteBuilder val | None) =>
+  fun forward_route_builder(): RouteBuilder => _forward_route_builder
+  fun in_route_builder(): (RouteBuilder | None) =>
     _runner_builder.in_route_builder()
-  fun clone_router_and_set_input_type(r: Router val,
-    default_r: (Router val | None) = None): Router val
+  fun clone_router_and_set_input_type(r: Router,
+    default_r: (Router | None) = None): Router
   =>
     _runner_builder.clone_router_and_set_input_type(r, default_r)
 
-  fun apply(next: Router val, metrics_conn: MetricsSink, event_log: EventLog,
+  fun apply(next: Router, metrics_conn: MetricsSink, event_log: EventLog,
     recovery_replayer: RecoveryReplayer,
     auth: AmbientAuth, outgoing_boundaries: Map[String, OutgoingBoundary] val,
-    router: Router val = EmptyRouter,
-    omni_router: OmniRouter val = EmptyOmniRouter,
+    router: Router = EmptyRouter,
+    omni_router: OmniRouter = EmptyOmniRouter,
     default_target: (Step | None) = None): Step tag
   =>
     let runner = _runner_builder(where event_log = event_log, auth = auth, router = router,
@@ -80,19 +80,19 @@ class StepBuilder
     step.update_router(next)
     step
 
-class SourceData
+class val SourceData
   let _id: U128
   let _pipeline_name: String
   let _name: String
   let _state_name: String
-  let _builder: SourceBuilderBuilder val
-  let _runner_builder: RunnerBuilder val
-  let _route_builder: RouteBuilder val
+  let _builder: SourceBuilderBuilder
+  let _runner_builder: RunnerBuilder
+  let _route_builder: RouteBuilder
   let _source_listener_builder_builder: SourceListenerBuilderBuilder
   let _pre_state_target_id: (U128 | None)
 
-  new val create(id': U128, b: SourceBuilderBuilder val, r: RunnerBuilder val,
-    default_source_route_builder: RouteBuilder val,
+  new val create(id': U128, b: SourceBuilderBuilder, r: RunnerBuilder,
+    default_source_route_builder: RouteBuilder,
     s: SourceListenerBuilderBuilder,
     pre_state_target_id': (U128 | None) = None)
   =>
@@ -104,7 +104,7 @@ class SourceData
     _state_name = _runner_builder.state_name()
     _route_builder =
       match _runner_builder.route_builder()
-      | let e: BoundaryOnlyRouteBuilder val =>
+      | let e: BoundaryOnlyRouteBuilder =>
         default_source_route_builder
       else
         _runner_builder.route_builder()
@@ -114,8 +114,8 @@ class SourceData
     _pre_state_target_id = pre_state_target_id'
 
   fun builder(): SourceBuilderBuilder => _builder
-  fun runner_builder(): RunnerBuilder val => _runner_builder
-  fun route_builder(): RouteBuilder val => _route_builder
+  fun runner_builder(): RunnerBuilder => _runner_builder
+  fun route_builder(): RouteBuilder => _route_builder
 
   fun name(): String => _name
   fun state_name(): String => _state_name
@@ -132,10 +132,10 @@ class SourceData
   fun is_prestate(): Bool => _runner_builder.is_prestate()
   fun is_stateful(): Bool => false
   fun is_partitioned(): Bool => false
-  fun forward_route_builder(): RouteBuilder val =>
+  fun forward_route_builder(): RouteBuilder =>
     _runner_builder.forward_route_builder()
-  fun clone_router_and_set_input_type(r: Router val,
-    default_r: (Router val | None) = None): Router val
+  fun clone_router_and_set_input_type(r: Router,
+    default_r: (Router | None) = None): Router
   =>
     _runner_builder.clone_router_and_set_input_type(r, default_r)
 
@@ -143,22 +143,22 @@ class SourceData
     _source_listener_builder_builder
 
 
-class EgressBuilder
+class val EgressBuilder
   let _name: String
   let _pipeline_name: String
   let _id: U128
   // None if this is a sink to an external system
-  let _proxy_addr: (ProxyAddress val | None)
+  let _proxy_addr: (ProxyAddress | None)
   let _sink_builder: (SinkBuilder | None)
 
   new val create(pipeline_name': String, id': U128,
     sink_builder: (SinkBuilder | None) = None,
-    proxy_addr: (ProxyAddress val | None) = None)
+    proxy_addr: (ProxyAddress | None) = None)
   =>
     _pipeline_name = pipeline_name'
     _name =
       match proxy_addr
-      | let pa: ProxyAddress val =>
+      | let pa: ProxyAddress =>
         "Proxy to " + pa.worker
       else
         _pipeline_name + " sink"
@@ -176,11 +176,11 @@ class EgressBuilder
   fun is_prestate(): Bool => false
   fun is_stateful(): Bool => false
   fun is_partitioned(): Bool => false
-  fun forward_route_builder(): RouteBuilder val => BoundaryOnlyRouteBuilder
-  fun clone_router_and_set_input_type(r: Router val,
-    dr: (Router val | None) = None): Router val => r
+  fun forward_route_builder(): RouteBuilder => BoundaryOnlyRouteBuilder
+  fun clone_router_and_set_input_type(r: Router,
+    dr: (Router | None) = None): Router => r
 
-  fun target_address(): (ProxyAddress val | PartitionAddresses val | None) =>
+  fun target_address(): (ProxyAddress | PartitionAddresses val | None) =>
     _proxy_addr
 
   fun apply(worker_name: String, reporter: MetricsReporter ref,
@@ -189,7 +189,7 @@ class EgressBuilder
       recover Map[String, OutgoingBoundary] end): Consumer ?
   =>
     match _proxy_addr
-    | let p: ProxyAddress val =>
+    | let p: ProxyAddress =>
       try
         proxies(p.worker)
       else
@@ -209,15 +209,15 @@ class EgressBuilder
       error
     end
 
-class PreStateData
+class val PreStateData
   let _state_name: String
   let _pre_state_name: String
-  let _runner_builder: RunnerBuilder val
+  let _runner_builder: RunnerBuilder
   let _target_id: (U128 | None)
-  let _forward_route_builder: RouteBuilder val
+  let _forward_route_builder: RouteBuilder
   let _is_default_target: Bool
 
-  new val create(runner_builder: RunnerBuilder val, t_id: (U128 | None),
+  new val create(runner_builder: RunnerBuilder, t_id: (U128 | None),
     is_default_target': Bool = false) =>
     _runner_builder = runner_builder
     _state_name = runner_builder.state_name()
@@ -229,8 +229,8 @@ class PreStateData
   fun state_name(): String => _state_name
   fun pre_state_name(): String => _pre_state_name
   fun target_id(): (U128 | None) => _target_id
-  fun forward_route_builder(): RouteBuilder val => _forward_route_builder
-  fun clone_router_and_set_input_type(r: Router val): Router val =>
+  fun forward_route_builder(): RouteBuilder => _forward_route_builder
+  fun clone_router_and_set_input_type(r: Router): Router =>
     _runner_builder.clone_router_and_set_input_type(r)
   fun is_default_target(): Bool => _is_default_target
 
@@ -271,6 +271,6 @@ class val PreStatelessData
   fun is_prestate(): Bool => false
   fun is_stateful(): Bool => false
   fun is_partitioned(): Bool => false
-  fun forward_route_builder(): RouteBuilder val => BoundaryOnlyRouteBuilder
-  fun clone_router_and_set_input_type(r: Router val,
-    dr: (Router val | None) = None): Router val => r
+  fun forward_route_builder(): RouteBuilder => BoundaryOnlyRouteBuilder
+  fun clone_router_and_set_input_type(r: Router,
+    dr: (Router | None) = None): Router => r

--- a/lib/wallaroo/topology/steps.pony
+++ b/lib/wallaroo/topology/steps.pony
@@ -20,10 +20,10 @@ use "wallaroo/watermarking"
 actor Step is (Producer & Consumer)
   var _id: U128
   let _runner: Runner
-  var _router: Router val = EmptyRouter
+  var _router: Router = EmptyRouter
   // For use if this is a state step, otherwise EmptyOmniRouter
-  var _omni_router: OmniRouter val
-  var _route_builder: RouteBuilder val
+  var _omni_router: OmniRouter
+  var _route_builder: RouteBuilder
   let _metrics_reporter: MetricsReporter
   // If this is a state step and the state partition uses a default step,
   // then this is used to create a route to that step during initialization.
@@ -49,11 +49,11 @@ actor Step is (Producer & Consumer)
     _outgoing_boundaries.create()
 
   new create(runner: Runner iso, metrics_reporter: MetricsReporter iso,
-    id: U128, route_builder: RouteBuilder val, event_log: EventLog,
+    id: U128, route_builder: RouteBuilder, event_log: EventLog,
     recovery_replayer: RecoveryReplayer,
     outgoing_boundaries: Map[String, OutgoingBoundary] val,
-    router: Router val = EmptyRouter, default_target: (Step | None) = None,
-    omni_router: OmniRouter val = EmptyOmniRouter)
+    router: Router = EmptyRouter, default_target: (Step | None) = None,
+    omni_router: OmniRouter = EmptyOmniRouter)
   =>
     _runner = consume runner
     match _runner
@@ -83,7 +83,7 @@ actor Step is (Producer & Consumer)
     initializer.report_created(this)
 
   be application_created(initializer: LocalTopologyInitializer,
-    omni_router: OmniRouter val)
+    omni_router: OmniRouter)
   =>
     for consumer in _router.routes().values() do
       _routes(consumer) =
@@ -145,10 +145,10 @@ actor Step is (Producer & Consumer)
   be application_ready_to_work(initializer: LocalTopologyInitializer) =>
     None
 
-  be update_route_builder(route_builder: RouteBuilder val) =>
+  be update_route_builder(route_builder: RouteBuilder) =>
     _route_builder = route_builder
 
-  be register_routes(router: Router val, route_builder: RouteBuilder val) =>
+  be register_routes(router: Router, route_builder: RouteBuilder) =>
     for consumer in router.routes().values() do
       let next_route = route_builder(this, consumer, _metrics_reporter)
       if not _routes.contains(consumer) then
@@ -160,10 +160,10 @@ actor Step is (Producer & Consumer)
       end
     end
 
-  be update_router(router: Router val) =>
+  be update_router(router: Router) =>
     _update_router(router)
 
-  fun ref _update_router(router: Router val) =>
+  fun ref _update_router(router: Router) =>
     try
       let old_router = _router
       _router = router
@@ -182,7 +182,7 @@ actor Step is (Producer & Consumer)
       Fail()
     end
 
-  be update_omni_router(omni_router: OmniRouter val) =>
+  be update_omni_router(omni_router: OmniRouter) =>
     try
       let old_router = _omni_router
       _omni_router = omni_router

--- a/lib/wallaroo/w_actor/w_actor_initializer.pony
+++ b/lib/wallaroo/w_actor/w_actor_initializer.pony
@@ -39,8 +39,8 @@ actor WActorInitializer is LayoutInitializer
   var _outgoing_boundaries: Map[String, OutgoingBoundary] val =
     recover Map[String, OutgoingBoundary] end
   var _outgoing_boundary_builders:
-    Map[String, OutgoingBoundaryBuilder val] val =
-      recover Map[String, OutgoingBoundaryBuilder val] end
+    Map[String, OutgoingBoundaryBuilder] val =
+      recover Map[String, OutgoingBoundaryBuilder] end
   let _is_initializer: Bool
   let _connections: Connections
   let _router_registry: RouterRegistry
@@ -217,7 +217,7 @@ actor WActorInitializer is LayoutInitializer
     end
 
   be update_boundaries(bs: Map[String, OutgoingBoundary] val,
-    bbs: Map[String, OutgoingBoundaryBuilder val] val)
+    bbs: Map[String, OutgoingBoundaryBuilder] val)
   =>
     // This should only be called during initialization
     if (_outgoing_boundaries.size() > 0) or
@@ -380,7 +380,7 @@ actor WActorInitializer is LayoutInitializer
       _system = las.add_actor(b, _worker_name)
     end
 
-  be receive_immigrant_step(msg: StepMigrationMsg val) =>
+  be receive_immigrant_step(msg: StepMigrationMsg) =>
     None
 
 class val ActorSystemSourceBuilder is SourceBuilder
@@ -400,11 +400,11 @@ class val ActorSystemSourceBuilder is SourceBuilder
   fun name(): String =>
     _app_name + " source"
 
-  fun apply(event_log: EventLog, auth: AmbientAuth, target_router: Router val):
+  fun apply(event_log: EventLog, auth: AmbientAuth, target_router: Router):
     TCPSourceNotify iso^
   =>
     WActorSourceNotify(auth, _handler, _actor_router,
       _central_actor_registry, event_log)
 
-  fun val update_router(router: Router val): SourceBuilder =>
+  fun val update_router(router: Router): SourceBuilder =>
     this

--- a/lib/wallaroo/w_actor/w_actor_source_notify.pony
+++ b/lib/wallaroo/w_actor/w_actor_source_notify.pony
@@ -94,7 +94,7 @@ class WActorSourceNotify is TCPSourceNotify
       end
     end
 
-  fun ref update_router(router: Router val) =>
+  fun ref update_router(router: Router) =>
     None
 
   fun ref update_boundaries(obs: box->Map[String, OutgoingBoundary]) =>

--- a/lib/wallaroo/w_actor/w_actor_wrapper.pony
+++ b/lib/wallaroo/w_actor/w_actor_wrapper.pony
@@ -72,7 +72,7 @@ actor WActorWithState is WActorWrapper
   var _creating_actor: Bool = false
   var _actor_being_created: WActorWrapper tag
 
-  new create(worker: String, id: U128, w_actor_builder: WActorBuilder val,
+  new create(worker: String, id: U128, w_actor_builder: WActorBuilder,
     event_log: EventLog, r: CentralWActorRegistry,
     actor_to_worker_map: Map[U128, String] val, connections: Connections,
     broadcast_variables: BroadcastVariables,
@@ -285,9 +285,9 @@ interface val WActorWrapperBuilder
 
 class val StatefulWActorWrapperBuilder
   let _id: U128
-  let _w_actor_builder: WActorBuilder val
+  let _w_actor_builder: WActorBuilder
 
-  new val create(id': U128, wab: WActorBuilder val) =>
+  new val create(id': U128, wab: WActorBuilder) =>
     _id = id'
     _w_actor_builder = wab
 
@@ -415,7 +415,7 @@ actor _DummyActorProducer is Producer
   fun ref flush(low_watermark: SeqId) =>
     None
 
-  fun ref update_router(router: Router val) =>
+  fun ref update_router(router: Router) =>
     None
 
   be request_ack() =>

--- a/lib/wallaroo/watermarking/_test_outgoing_to_incoming_message_tracker.pony
+++ b/lib/wallaroo/watermarking/_test_outgoing_to_incoming_message_tracker.pony
@@ -397,7 +397,7 @@ actor _TestProducer is Producer
   fun ref flush(low_watermark: SeqId) =>
     None
 
-  fun ref update_router(router: Router val) =>
+  fun ref update_router(router: Router) =>
     None
 
   be request_ack() =>

--- a/testing/correctness/apps/step_migration_test/step_migration_test.pony
+++ b/testing/correctness/apps/step_migration_test/step_migration_test.pony
@@ -61,7 +61,7 @@ actor Main
     end
 
 primitive _RunnerBuilderGenerator
-  fun apply(): RunnerBuilder val =>
+  fun apply(): RunnerBuilder =>
 		let comp = CountComputation
     StateRunnerBuilder[CountState](
 			CountStateBuilder,

--- a/testing/runs/w_actor/main.pony
+++ b/testing/runs/w_actor/main.pony
@@ -104,26 +104,26 @@ primitive ARoles
   fun two(): String => "two"
   fun three(): String => "three"
 
-trait AMsg
+trait val AMsg
   fun string(): String
 
-trait AMsgBuilder
+trait val AMsgBuilder
 
 primitive SetActorProbability is AMsgBuilder
-  fun apply(prob: F64): SetActorProbabilityMsg val =>
+  fun apply(prob: F64): SetActorProbabilityMsg =>
     SetActorProbabilityMsg(prob)
 
 primitive SetNumberOfMessagesToSend is AMsgBuilder
-  fun apply(n: USize): SetNumberOfMessagesToSendMsg val =>
+  fun apply(n: USize): SetNumberOfMessagesToSendMsg =>
     SetNumberOfMessagesToSendMsg(n)
 
 primitive ChangeMessageTypesToSend is AMsgBuilder
   fun apply(types: Array[AMsgBuilder val] val):
-    ChangeMessageTypesToSendMsg val
+    ChangeMessageTypesToSendMsg
   =>
     ChangeMessageTypesToSendMsg(types)
 
-class SetActorProbabilityMsg is AMsg
+class val SetActorProbabilityMsg is AMsg
   let prob: F64
 
   new val create(prob': F64) =>
@@ -132,7 +132,7 @@ class SetActorProbabilityMsg is AMsg
   fun string(): String =>
     "SetActorProbabilityMsg"
 
-class SetNumberOfMessagesToSendMsg is AMsg
+class val SetNumberOfMessagesToSendMsg is AMsg
   let n: USize
 
   new val create(n': USize) =>
@@ -141,7 +141,7 @@ class SetNumberOfMessagesToSendMsg is AMsg
   fun string(): String =>
     "SetNumberOfMessagesToSendMsg"
 
-class ChangeMessageTypesToSendMsg is AMsg
+class val ChangeMessageTypesToSendMsg is AMsg
   let types: Array[AMsgBuilder val] val
 
   new val create(types': Array[AMsgBuilder val] val) =>
@@ -179,19 +179,19 @@ class A is WActor
 
   fun ref receive(sender: U128, payload: Any val, h: WActorHelper) =>
     match payload
-    | let m: SetActorProbabilityMsg val =>
+    | let m: SetActorProbabilityMsg =>
       ifdef debug then
         @printf[I32]("Received %s to %s\n".cstring(), m.string().cstring(),
           m.prob.string().cstring())
       end
       _emission_prob = m.prob
-    | let m: SetNumberOfMessagesToSendMsg val =>
+    | let m: SetNumberOfMessagesToSendMsg =>
       ifdef debug then
         @printf[I32]("Received %s to %lu msgs\n".cstring(),
           m.string().cstring(), m.n)
       end
       _n_messages = m.n
-    | let m: ChangeMessageTypesToSendMsg val =>
+    | let m: ChangeMessageTypesToSendMsg =>
       ifdef debug then
         @printf[I32]("Received %s\n".cstring(), m.string().cstring())
       end
@@ -231,7 +231,7 @@ class A is WActor
   fun ref select_role(h: WActorHelper): String ? =>
     _rand.pick[String]([ARoles.one(), ARoles.two(), ARoles.three()])
 
-  fun ref create_message(): AMsg val ? =>
+  fun ref create_message(): AMsg ? =>
     match _rand.pick[AMsgBuilder val](_message_types_to_send)
     | let blder: SetActorProbability val =>
       SetActorProbability(_rand.f64_between(0.1, 0.9))

--- a/testing/runs/w_actor_crdt/main.pony
+++ b/testing/runs/w_actor_crdt/main.pony
@@ -215,11 +215,11 @@ trait AMsg
 trait AMsgBuilder
 
 primitive IncrementsMsgBuilder is AMsgBuilder
-  fun apply(increments: USize): IncrementsMsg val =>
+  fun apply(increments: USize): IncrementsMsg =>
     IncrementsMsg(increments)
 
 primitive GossipMsgBuilder is AMsgBuilder
-  fun apply(data: PMap[U64, USize]): GossipMsg val =>
+  fun apply(data: PMap[U64, USize]): GossipMsg =>
     GossipMsg(data)
 
 class val IncrementsMsg is AMsg

--- a/testing/runs/w_actor_ping_pony/main.pony
+++ b/testing/runs/w_actor_ping_pony/main.pony
@@ -1,7 +1,6 @@
 use "assert"
 use "buffered"
 use "collections"
-use pers = "collections/persistent"
 use "debug"
 use "net"
 use "options"
@@ -13,7 +12,6 @@ use "sendence/guid"
 use "sendence/hub"
 use "sendence/new_fix"
 use "sendence/rand"
-use "sendence/wall_clock"
 use "wallaroo"
 use "wallaroo/fail"
 use "wallaroo/metrics"
@@ -51,7 +49,7 @@ class Ping is WActor
     _id = id
     h.register_as_role(_role)
 
-  fun ref receive(sender: WActorId, payload: Any val, h: WActorHelper) =>
+  fun ref receive(sender: U128, payload: Any val, h: WActorHelper) =>
     match payload
     | let hit: Hit =>
       @printf[I32]("Ping: hit\n".cstring())
@@ -80,7 +78,7 @@ class Pong is WActor
     _id = id
     h.register_as_role(_role)
 
-  fun ref receive(sender: WActorId, payload: Any val, h: WActorHelper) =>
+  fun ref receive(sender: U128, payload: Any val, h: WActorHelper) =>
     match payload
     | let hit: Hit =>
       @printf[I32]("Pong: hit\n".cstring())

--- a/testing/tools/merrick/merrick.pony
+++ b/testing/tools/merrick/merrick.pony
@@ -235,7 +235,7 @@ class ToDagonNotify is TCPConnectionNotify
       try
         let decoded = ExternalMsgDecoder(consume data)
         match decoded
-        | let d: ExternalShutdownMsg val =>
+        | let d: ExternalShutdownMsg =>
           _coordinator.finished()
         else
           @printf[I32]("Unexpected data from Dagon\n".cstring())

--- a/testing/tools/robson/robson.pony
+++ b/testing/tools/robson/robson.pony
@@ -50,11 +50,11 @@ actor MetricsCollector
   let _env: Env
   let _input_file_path: String
   let _output_file_path: String
-  let _overall_metrics_msgs: Map[String, Array[HubMetricsMsg val]] =
+  let _overall_metrics_msgs: Map[String, Array[HubMetricsMsg]] =
     _overall_metrics_msgs.create()
-  let _computation_metrics_msgs: Map[String, Array[HubMetricsMsg val]] =
+  let _computation_metrics_msgs: Map[String, Array[HubMetricsMsg]] =
     _computation_metrics_msgs.create()
-  let _worker_metrics_msgs: Map[String, Array[HubMetricsMsg val]] =
+  let _worker_metrics_msgs: Map[String, Array[HubMetricsMsg]] =
     _worker_metrics_msgs.create()
   let _overall_metrics_data: Map[String, MetricsData] =
     _overall_metrics_data.create()
@@ -69,7 +69,7 @@ actor MetricsCollector
     _output_file_path = output_file_path
     collect_metrics()
 
-  fun ref add_metrics(metrics_msg: HubMetricsMsg val) =>
+  fun ref add_metrics(metrics_msg: HubMetricsMsg) =>
     match metrics_msg.category
     | ("start-to-end") =>
       add_overall_metrics(metrics_msg)
@@ -82,24 +82,24 @@ actor MetricsCollector
         metrics_msg.category + "\n").cstring())
     end
 
-  fun ref add_overall_metrics(metrics_msg: HubMetricsMsg val) =>
+  fun ref add_overall_metrics(metrics_msg: HubMetricsMsg) =>
     let name = metrics_msg.name
     let metrics_array = _overall_metrics_msgs.get_or_else(name,
-      Array[HubMetricsMsg val])
+      Array[HubMetricsMsg])
     metrics_array.push(metrics_msg)
     _overall_metrics_msgs.update(name, metrics_array)
 
-  fun ref add_computation_metrics(metrics_msg: HubMetricsMsg val) =>
+  fun ref add_computation_metrics(metrics_msg: HubMetricsMsg) =>
     let name = metrics_msg.name
     let metrics_array = _computation_metrics_msgs.get_or_else(name,
-      Array[HubMetricsMsg val])
+      Array[HubMetricsMsg])
     metrics_array.push(metrics_msg)
     _computation_metrics_msgs.update(name, metrics_array)
 
-  fun ref add_worker_metrics(metrics_msg: HubMetricsMsg val) =>
+  fun ref add_worker_metrics(metrics_msg: HubMetricsMsg) =>
     let name = metrics_msg.name
     let metrics_array = _worker_metrics_msgs.get_or_else(name,
-      Array[HubMetricsMsg val])
+      Array[HubMetricsMsg])
     metrics_array.push(metrics_msg)
     _worker_metrics_msgs.update(name, metrics_array)
 
@@ -166,7 +166,7 @@ actor MetricsCollector
           | HubOtherMsg =>
             @printf[I32]("Decoded HubOtherMsg\n".cstring())
           else
-            add_metrics(hub_msg as HubMetricsMsg val)
+            add_metrics(hub_msg as HubMetricsMsg)
           end
 
         else
@@ -235,7 +235,7 @@ class MetricsData
   var latency_stats: ( LatencyStats | None ) = None
 
   new create(name': String, category': String, period': U64,
-    metrics_msgs: Array[HubMetricsMsg val])
+    metrics_msgs: Array[HubMetricsMsg])
   =>
     name = name'
     category = category'


### PR DESCRIPTION
There were many places in the codebase where we had a `val` annotation for classes/traits/interfaces that are always immutable. This updates those.  Going forward,
let's reserve `val` annotations for classes/traits/interfaces that can be mutable.