### PR TITLE
Remove unnecessary `trn` annotations

### DIFF
--- a/lib/sendence/dag/dag.pony
+++ b/lib/sendence/dag/dag.pony
@@ -57,7 +57,7 @@ class Dag[V: Any val]
   fun is_empty(): Bool => _nodes.size() == 0
 
   fun clone(): Dag[V] val ? =>
-    let c: Dag[V] trn = recover Dag[V] end
+    let c = recover trn Dag[V] end
     for (id, node) in _nodes.pairs() do
       c.add_node(node.value, node.id)
     end

--- a/lib/sendence/hub/hub_protocol.pony
+++ b/lib/sendence/hub/hub_protocol.pony
@@ -51,7 +51,7 @@ primitive HubProtocol
   fun payload_into_array(event: String, topic: String, data: Array[U8] iso):
     Array[ByteSeq] val
   =>
-    let encoded: Array[ByteSeq] trn = recover Array[ByteSeq](2) end
+    let encoded = recover trn Array[ByteSeq](2) end
 
     // Determine sizes
     let event_size = event.size().u32()

--- a/lib/sendence/options/options.pony
+++ b/lib/sendence/options/options.pony
@@ -116,7 +116,7 @@ class Options is Iterator[(ParsedOption | ParseError | None)]
     this will only include positional arguments, potentially unrecognised and
     ambiguous options and invalid arguments.
     """
-    let out: Array[String] trn = recover Array[String] end
+    let out = recover trn Array[String] end
     for arg in _arguments.values() do
       out.push(arg.clone())
     end

--- a/lib/sendence/rand/rand.pony
+++ b/lib/sendence/rand/rand.pony
@@ -61,7 +61,7 @@ class EnhancedRandom
     while idxs.size() < k do
       idxs.set(usize_between(0, a_size - 1))
     end
-    let result: Array[V] trn = recover Array[V] end
+    let result = recover trn Array[V] end
     for i in idxs.values() do
       result.push(a(i))
     end

--- a/lib/sendence/weighted/_test.pony
+++ b/lib/sendence/weighted/_test.pony
@@ -14,7 +14,7 @@ class iso _TestWeighted is UnitTest
   fun name(): String => "weighted/Weighted"
 
   fun apply(h: TestHelper) ? =>
-    let items: Array[(USize, USize)] trn = recover Array[(USize, USize)] end
+    let items = recover trn Array[(USize, USize)] end
     items.push((0, 1000))
     items.push((1, 150))
     items.push((2, 40))

--- a/lib/wallaroo/application.pony
+++ b/lib/wallaroo/application.pony
@@ -56,8 +56,7 @@ class Application
   =>
     default_state_name = default_name
 
-    let builders: Array[RunnerBuilder] trn =
-      recover Array[RunnerBuilder] end
+    let builders = recover trn Array[RunnerBuilder] end
 
     let pre_state_builder = PreStateRunnerBuilder[In, Out, In, U8, S](
       s_comp, default_name, SingleStepPartitionFunction[In],
@@ -90,9 +89,9 @@ class Application
 
   fun state_builder(state_name: String): PartitionBuilder ? =>
     _state_builders(state_name)
+
   fun state_builders(): Map[String, PartitionBuilder] val =>
-    let builders: Map[String, PartitionBuilder] trn =
-      recover Map[String, PartitionBuilder] end
+    let builders = recover trn Map[String, PartitionBuilder] end
     for (k, v) in _state_builders.pairs() do
       builders(k) = v
     end
@@ -210,7 +209,7 @@ class PipelineBuilder[In: Any val, Out: Any val, Last: Any val]
     let guid_gen = GuidGenerator
     let single_step_partition = Partition[Last, U8](
       SingleStepPartitionFunction[Last], recover [0] end)
-    let step_id_map: Map[U8, U128] trn = recover Map[U8, U128] end
+    let step_id_map = recover trn Map[U8, U128] end
 
     step_id_map(0) = guid_gen.u128()
 
@@ -245,7 +244,7 @@ class PipelineBuilder[In: Any val, Out: Any val, Last: Any val]
     ): PipelineBuilder[In, Out, Next]
   =>
     let guid_gen = GuidGenerator
-    let step_id_map: Map[Key, U128] trn = recover Map[Key, U128] end
+    let step_id_map = recover trn Map[Key, U128] end
 
     match partition.keys()
     | let wks: Array[WeightedKey[Key]] val =>

--- a/lib/wallaroo/broadcast/_test_broadcast_variables_map.pony
+++ b/lib/wallaroo/broadcast/_test_broadcast_variables_map.pony
@@ -20,7 +20,7 @@ class iso _TestExternalUpdateDecision is UnitTest
     // Incomparable timestamps mean we go by lexicographic ordering of
     // worker names.  In this case, the source of the external update
     // has a lower name, so we don't update.
-    let cur_ts1_map: Map[String, U64] trn = recover Map[String, U64] end
+    let cur_ts1_map = recover trn Map[String, U64] end
     cur_ts1_map("w1") = 0
     cur_ts1_map("w2") = 2
     cur_ts1_map("w3") = 1
@@ -29,7 +29,7 @@ class iso _TestExternalUpdateDecision is UnitTest
     map1("k1") = (cur_ts1, U64(0))
     map1("k2") = (cur_ts1, U64(0))
     map1("k4") = (cur_ts1, U64(0))
-    let ext_ts1_map: Map[String, U64] trn = recover Map[String, U64] end
+    let ext_ts1_map = recover trn Map[String, U64] end
     ext_ts1_map("w1") = 0
     ext_ts1_map("w2") = 2
     ext_ts1_map("w3") = 1
@@ -41,7 +41,7 @@ class iso _TestExternalUpdateDecision is UnitTest
     // Incomparable timestamps mean we go by lexicographic ordering of
     // worker names.  In this case, the source of the external update
     // has a higher name, so we do update.
-    let cur_ts2_map: Map[String, U64] trn = recover Map[String, U64] end
+    let cur_ts2_map = recover trn Map[String, U64] end
     cur_ts2_map("w1") = 0
     cur_ts2_map("w2") = 2
     cur_ts2_map("w3") = 1
@@ -50,7 +50,7 @@ class iso _TestExternalUpdateDecision is UnitTest
     map2("k1") = (cur_ts2, U64(0))
     map2("k2") = (cur_ts2, U64(0))
     map1("k4") = (cur_ts2, U64(0))
-    let ext_ts2_map: Map[String, U64] trn = recover Map[String, U64] end
+    let ext_ts2_map = recover trn Map[String, U64] end
     ext_ts2_map("w1") = 0
     ext_ts2_map("w2") = 3
     ext_ts2_map("w4") = 1
@@ -61,7 +61,7 @@ class iso _TestExternalUpdateDecision is UnitTest
 
     // If timestamps are comparable and the source of the external update
     // is greater, then update.
-    let cur_ts3_map: Map[String, U64] trn = recover Map[String, U64] end
+    let cur_ts3_map = recover trn Map[String, U64] end
     cur_ts3_map("w1") = 0
     cur_ts3_map("w2") = 2
     cur_ts3_map("w3") = 1
@@ -69,7 +69,7 @@ class iso _TestExternalUpdateDecision is UnitTest
     let map3 = Map[String, (VectorTimestamp, Any val)]
     map3("k1") = (cur_ts3, U64(0))
     map3("k2") = (cur_ts3, U64(0))
-    let ext_ts3_map: Map[String, U64] trn = recover Map[String, U64] end
+    let ext_ts3_map = recover trn Map[String, U64] end
     ext_ts3_map("w1") = 1
     ext_ts3_map("w2") = 2
     ext_ts3_map("w3") = 2
@@ -80,7 +80,7 @@ class iso _TestExternalUpdateDecision is UnitTest
 
     // If timestamps are comparable and the source of the external update
     // is <, then do not update.
-    let cur_ts4_map: Map[String, U64] trn = recover Map[String, U64] end
+    let cur_ts4_map = recover trn Map[String, U64] end
     cur_ts4_map("w1") = 3
     cur_ts4_map("w2") = 2
     cur_ts4_map("w3") = 4
@@ -88,7 +88,7 @@ class iso _TestExternalUpdateDecision is UnitTest
     let map4 = Map[String, (VectorTimestamp, Any val)]
     map4("k1") = (cur_ts4, U64(0))
     map4("k2") = (cur_ts4, U64(0))
-    let ext_ts4_map: Map[String, U64] trn = recover Map[String, U64] end
+    let ext_ts4_map = recover trn Map[String, U64] end
     ext_ts4_map("w1") = 1
     ext_ts4_map("w2") = 1
     ext_ts4_map("w3") = 1
@@ -100,7 +100,7 @@ class iso _TestExternalUpdateDecision is UnitTest
 
     // If timestamps are comparable and the source of the external update
     // is ==, then do not update.
-    let cur_ts5_map: Map[String, U64] trn = recover Map[String, U64] end
+    let cur_ts5_map = recover trn Map[String, U64] end
     cur_ts5_map("w1") = 1
     cur_ts5_map("w2") = 1
     cur_ts5_map("w3") = 1
@@ -108,7 +108,7 @@ class iso _TestExternalUpdateDecision is UnitTest
     let map5 = Map[String, (VectorTimestamp, Any val)]
     map5("k1") = (cur_ts5, U64(0))
     map5("k2") = (cur_ts5, U64(0))
-    let ext_ts5_map: Map[String, U64] trn = recover Map[String, U64] end
+    let ext_ts5_map = recover trn Map[String, U64] end
     ext_ts5_map("w1") = 1
     ext_ts5_map("w2") = 1
     ext_ts5_map("w3") = 1

--- a/lib/wallaroo/broadcast/_test_vector_ts.pony
+++ b/lib/wallaroo/broadcast/_test_vector_ts.pony
@@ -21,25 +21,25 @@ class iso _TestGreaterThanLessThan is UnitTest
     "vector_ts/GreaterThanLessThan"
 
   fun ref apply(h: TestHelper) =>
-    let v1_map: Map[String, U64] trn = recover Map[String, U64] end
+    let v1_map = recover trn Map[String, U64] end
     v1_map("w1") = 0
     v1_map("w2") = 2
     v1_map("w3") = 1
     let v1 = VectorTimestamp("w1", consume v1_map)
 
-    let v2_map: Map[String, U64] trn = recover Map[String, U64] end
+    let v2_map = recover trn Map[String, U64] end
     v2_map("w1") = 0
     v2_map("w2") = 3
     v2_map("w3") = 1
     let v2 = VectorTimestamp("w2", consume v2_map)
 
-    let v3_map: Map[String, U64] trn = recover Map[String, U64] end
+    let v3_map = recover trn Map[String, U64] end
     v3_map("w1") = 0
     v3_map("w2") = 1
     v3_map("w3") = 1
     let v3 = VectorTimestamp("w3", consume v3_map)
 
-    let v4_map: Map[String, U64] trn = recover Map[String, U64] end
+    let v4_map = recover trn Map[String, U64] end
     v4_map("w1") = 0
     v4_map("w2") = 2
     v4_map("w3") = 0
@@ -75,37 +75,37 @@ class iso _TestGreaterThanEqualLessThanEqual is UnitTest
     "vector_ts/GreaterThanEqualLessThanEqual"
 
   fun ref apply(h: TestHelper) =>
-    let v1_map: Map[String, U64] trn = recover Map[String, U64] end
+    let v1_map = recover trn Map[String, U64] end
     v1_map("w1") = 0
     v1_map("w2") = 2
     v1_map("w3") = 1
     let v1 = VectorTimestamp("w1", consume v1_map)
 
-    let v2_map: Map[String, U64] trn = recover Map[String, U64] end
+    let v2_map = recover trn Map[String, U64] end
     v2_map("w1") = 0
     v2_map("w2") = 3
     v2_map("w3") = 1
     let v2 = VectorTimestamp("w1", consume v2_map)
 
-    let v3_map: Map[String, U64] trn = recover Map[String, U64] end
+    let v3_map = recover trn Map[String, U64] end
     v3_map("w1") = 0
     v3_map("w2") = 1
     v3_map("w3") = 1
     let v3 = VectorTimestamp("w1", consume v3_map)
 
-    let v4_map: Map[String, U64] trn = recover Map[String, U64] end
+    let v4_map = recover trn Map[String, U64] end
     v4_map("w1") = 0
     v4_map("w2") = 2
     v4_map("w3") = 0
     let v4 = VectorTimestamp("w1", consume v4_map)
 
-    let v5_map: Map[String, U64] trn = recover Map[String, U64] end
+    let v5_map = recover trn Map[String, U64] end
     v5_map("w1") = 0
     v5_map("w2") = 3
     v5_map("w3") = 1
     let v5 = VectorTimestamp("w1", consume v5_map)
 
-    let v6_map: Map[String, U64] trn = recover Map[String, U64] end
+    let v6_map = recover trn Map[String, U64] end
     v6_map("w1") = 0
     v6_map("w2") = 2
     v6_map("w3") = 0
@@ -146,25 +146,25 @@ class iso _TestComparability is UnitTest
     "vector_ts/Comparability"
 
   fun ref apply(h: TestHelper) =>
-    let v1_map: Map[String, U64] trn = recover Map[String, U64] end
+    let v1_map = recover trn Map[String, U64] end
     v1_map("w1") = 0
     v1_map("w2") = 2
     v1_map("w3") = 1
     let v1 = VectorTimestamp("w1", consume v1_map)
 
-    let v2_map: Map[String, U64] trn = recover Map[String, U64] end
+    let v2_map = recover trn Map[String, U64] end
     v2_map("w1") = 0
     v2_map("w2") = 3
     v2_map("w3") = 1
     let v2 = VectorTimestamp("w2", consume v2_map)
 
-    let v3_map: Map[String, U64] trn = recover Map[String, U64] end
+    let v3_map = recover trn Map[String, U64] end
     v3_map("w1") = 1
     v3_map("w2") = 2
     v3_map("w3") = 2
     let v3 = VectorTimestamp("w3", consume v3_map)
 
-    let v4_map: Map[String, U64] trn = recover Map[String, U64] end
+    let v4_map = recover trn Map[String, U64] end
     v4_map("w1") = 0
     v4_map("w2") = 3
     v4_map("w3") = 0
@@ -199,25 +199,25 @@ class iso _TestIsSubset is UnitTest
     "vector_ts/IsSubset"
 
   fun ref apply(h: TestHelper) =>
-    let v1_map: Map[String, U64] trn = recover Map[String, U64] end
+    let v1_map = recover trn Map[String, U64] end
     v1_map("w1") = 0
     v1_map("w2") = 2
     let v1 = VectorTimestamp("w1", consume v1_map)
 
-    let v2_map: Map[String, U64] trn = recover Map[String, U64] end
+    let v2_map = recover trn Map[String, U64] end
     v2_map("w1") = 0
     v2_map("w2") = 3
     v2_map("w3") = 1
     let v2 = VectorTimestamp("w1", consume v2_map)
 
-    let v3_map: Map[String, U64] trn = recover Map[String, U64] end
+    let v3_map = recover trn Map[String, U64] end
     v3_map("w1") = 1
     v3_map("w2") = 2
     v3_map("w3") = 2
     v3_map("w4") = 3
     let v3 = VectorTimestamp("w1", consume v3_map)
 
-    let v4_map: Map[String, U64] trn = recover Map[String, U64] end
+    let v4_map = recover trn Map[String, U64] end
     v4_map("w3") = 0
     v4_map("w4") = 3
     let v4 = VectorTimestamp("w4", consume v4_map)

--- a/lib/wallaroo/broadcast/vector_ts.pony
+++ b/lib/wallaroo/broadcast/vector_ts.pony
@@ -13,7 +13,7 @@ class val VectorTimestamp
     _vs = vs
 
   fun inc(): VectorTimestamp =>
-    let new_map: Map[String, U64] trn = recover Map[String, U64] end
+    let new_map = recover trn Map[String, U64] end
     for (k, v) in _vs.pairs() do
       new_map(k) = v
     end
@@ -28,7 +28,7 @@ class val VectorTimestamp
     VectorTimestamp(w, _vs)
 
   fun merge(other: VectorTimestamp): VectorTimestamp =>
-    let new_map: Map[String, U64] trn = recover Map[String, U64] end
+    let new_map = recover trn Map[String, U64] end
     for (k, v) in _vs.pairs() do
       new_map(k) = v
     end

--- a/lib/wallaroo/initialization/_test.pony
+++ b/lib/wallaroo/initialization/_test.pony
@@ -68,8 +68,7 @@ primitive _DagGenerator
 
 primitive _StepMapGenerator
   fun apply(): Map[U128, (ProxyAddress | U128)] val =>
-    let m: Map[U128, (ProxyAddress | U128)] trn =
-      recover Map[U128, (ProxyAddress | U128)] end
+    let m = recover trn Map[U128, (ProxyAddress | U128)] end
     m(1) = ProxyAddress("w1", 10)
     m(2) = ProxyAddress("w2", 20)
     m(3) = ProxyAddress("w3", 30)
@@ -79,8 +78,7 @@ primitive _BaseStateBuildersGenerator
   fun apply(rb: RunnerBuilder, pf: PartitionFunction[String, String] val):
     Map[String, StateSubpartition] val
   =>
-    let m: Map[String, StateSubpartition] trn =
-      recover Map[String, StateSubpartition] end
+    let m = recover trn Map[String, StateSubpartition] end
     m("state") = _BaseStateSubpartitionGenerator(rb, pf)
     consume m
 
@@ -88,8 +86,7 @@ primitive _TargetStateBuildersGenerator
   fun apply(rb: RunnerBuilder, pf: PartitionFunction[String, String] val):
     Map[String, StateSubpartition] val
   =>
-    let m: Map[String, StateSubpartition] trn =
-      recover Map[String, StateSubpartition] end
+    let m = recover trn Map[String, StateSubpartition] end
     m("state") = _TargetStateSubpartitionGenerator(rb, pf)
     consume m
 
@@ -111,8 +108,7 @@ primitive _TargetStateSubpartitionGenerator
 
 primitive _BaseKeyedPartitionAddressesGenerator
   fun apply(): KeyedPartitionAddresses[String] val =>
-    let m: Map[String, ProxyAddress] trn =
-      recover Map[String, ProxyAddress] end
+    let m = recover trn Map[String, ProxyAddress] end
     m("k1") = ProxyAddress("w1", 10)
     m("k2") = ProxyAddress("w2", 20)
     m("k3") = ProxyAddress("w3", 30)
@@ -120,8 +116,7 @@ primitive _BaseKeyedPartitionAddressesGenerator
 
 primitive _TargetKeyedPartitionAddressesGenerator
   fun apply(): KeyedPartitionAddresses[String] val =>
-    let m: Map[String, ProxyAddress] trn =
-      recover Map[String, ProxyAddress] end
+    let m = recover trn Map[String, ProxyAddress] end
     m("k1") = ProxyAddress("w2", 10)
     m("k2") = ProxyAddress("w2", 20)
     m("k3") = ProxyAddress("w3", 30)
@@ -129,7 +124,7 @@ primitive _TargetKeyedPartitionAddressesGenerator
 
 primitive _IdMapGenerator
   fun apply(): Map[String, U128] val =>
-    let m: Map[String, U128] trn = recover Map[String, U128] end
+    let m = recover trn Map[String, U128] end
     m("k1") = 10
     m("k2") = 20
     m("k3") = 30

--- a/lib/wallaroo/initialization/application_distributor.pony
+++ b/lib/wallaroo/initialization/application_distributor.pony
@@ -54,7 +54,7 @@ actor ApplicationDistributor is Distributor
     @printf[I32]("vvvvvv|Initializing Topologies for Workers|vvvvvv\n\n".cstring())
 
     try
-      let all_workers_trn: Array[String] trn = recover Array[String] end
+      let all_workers_trn = recover trn Array[String] end
       all_workers_trn.push(initializer_name)
       for w in worker_names.values() do all_workers_trn.push(w) end
       let all_workers: Array[String] val = consume all_workers_trn
@@ -64,16 +64,14 @@ actor ApplicationDistributor is Distributor
       // directly to a source. For a sink, we don't keep a proxy address but
       // a step id (U128), since every worker will have its own instance of
       // that sink.
-      let step_map: Map[U128, (ProxyAddress | U128)] trn =
-        recover Map[U128, (ProxyAddress | U128)] end
+      let step_map = recover trn Map[U128, (ProxyAddress | U128)] end
 
       // Keep track of shared state so that it's only created once
-      let state_partition_map: Map[String, PartitionAddresses val] trn =
-        recover Map[String, PartitionAddresses val] end
+      let state_partition_map =
+        recover trn Map[String, PartitionAddresses val] end
 
       // Keep track of all prestate data so we can register routes
-      let pre_state_data: Array[PreStateData] trn =
-        recover Array[PreStateData] end
+      let pre_state_data = recover trn Array[PreStateData] end
 
       // This will be incremented as we move through pipelines
       var pipeline_id: USize = 0
@@ -88,8 +86,8 @@ actor ApplicationDistributor is Distributor
           = default_targets.create()
 
       // We use these graphs to build the local graphs for each worker
-      var local_graphs: Map[String, Dag[StepInitializer] trn] trn =
-        recover Map[String, Dag[StepInitializer] trn] end
+      var local_graphs =
+        recover trn Map[String, Dag[StepInitializer] trn] end
 
       // Initialize values for local graphs
       local_graphs(initializer_name) = Dag[StepInitializer]
@@ -108,8 +106,8 @@ actor ApplicationDistributor is Distributor
       end
 
       // Create StateSubpartitions
-      let ssb_trn: Map[String, StateSubpartition] trn =
-        recover Map[String, StateSubpartition] end
+
+      let ssb_trn = recover trn Map[String, StateSubpartition] end
       for (s_name, p_builder) in application.state_builders().pairs() do
         ssb_trn(s_name) = p_builder.state_subpartition(all_workers)
       end
@@ -182,19 +180,16 @@ actor ApplicationDistributor is Distributor
         // computations as we accumulate them to eventually turn into a
         // RunnerSequenceBuilder. When coalescing is off, we only put a
         // single runner builder here.
-        var source_runner_builders: Array[RunnerBuilder] trn =
-          recover Array[RunnerBuilder] end
+        var source_runner_builders = recover trn Array[RunnerBuilder] end
 
         // We'll use this array when creating StepInitializers
-        let step_runner_builders: Array[RunnerBuilder] trn =
-          recover Array[RunnerBuilder] end
+        let step_runner_builders = recover trn Array[RunnerBuilder] end
 
         // Used to temporarily store contiguous stateless computations as
         // we accumulate them to eventually turn into a RunnerSequenceBuilder.
         // When coalescing is off, we do not use this since each computation
         // will correspond to a step.
-        var latest_runner_builders: Array[RunnerBuilder] trn =
-          recover Array[RunnerBuilder] end
+        var latest_runner_builders = recover trn Array[RunnerBuilder] end
 
         // If any in a series of contiguous stateless computations is
         // to be parallelized and coalescing is on, we coalesce and
@@ -624,12 +619,12 @@ actor ApplicationDistributor is Distributor
                 // local graphs.
                 let pony_thread_count = @ponyint_sched_cores[I32]().usize()
                 let partition_count = worker_count * pony_thread_count
-                let partition_id_to_worker_trn: Map[U64, String] trn =
-                  recover Map[U64, String] end
-                let partition_id_to_step_id_trn: Map[U64, U128] trn =
-                  recover Map[U64, U128] end
-                let worker_to_step_id_trn: Map[String, Array[U128] trn] trn =
-                  recover Map[String, Array[U128] trn] end
+                let partition_id_to_worker_trn =
+                  recover trn Map[U64, String] end
+                let partition_id_to_step_id_trn =
+                  recover trn Map[U64, U128] end
+                let worker_to_step_id_trn =
+                  recover trn Map[String, Array[U128] trn] end
                 for w in all_workers.values() do
                   worker_to_step_id_trn(w) = recover Array[U128] end
                 end
@@ -644,9 +639,8 @@ actor ApplicationDistributor is Distributor
                   consume partition_id_to_worker_trn
                 let partition_id_to_step_id: Map[U64, U128] val =
                   consume partition_id_to_step_id_trn
-                let worker_to_step_id_collector:
-                  Map[String, Array[U128] val] trn =
-                  recover Map[String, Array[U128] val] end
+                let worker_to_step_id_collector =
+                  recover trn Map[String, Array[U128] val] end
                 for (k, v) in worker_to_step_id_trn.pairs() do
                   match worker_to_step_id_trn(k) = recover Array[U128] end
                   | let arr: Array[U128] trn =>
@@ -921,8 +915,7 @@ actor ApplicationDistributor is Distributor
               steps(pre_state_id) = pipeline_default_target_worker
               steps(state_id) = pipeline_default_target_worker
 
-              let next_default_targets: Array[StepBuilder] trn =
-                recover Array[StepBuilder] end
+              let next_default_targets = recover trn Array[StepBuilder] end
 
               next_default_targets.push(pre_state_builder)
               next_default_targets.push(state_builder)
@@ -961,8 +954,7 @@ actor ApplicationDistributor is Distributor
 
       // Keep track of LocalTopologies that we need to send to other
       // (non-"initializer") workers
-      let other_local_topologies: Map[String, LocalTopology] trn =
-        recover Map[String, LocalTopology] end
+      let other_local_topologies = recover trn Map[String, LocalTopology] end
 
       // Add unbuilt edges
       for (w, edges) in unbuilt_edges.pairs() do
@@ -1003,7 +995,7 @@ actor ApplicationDistributor is Distributor
 
       // For each worker, generate a LocalTopology from its LocalGraph
       for (w, g) in local_graphs.pairs() do
-        let p_ids: Map[String, U128] trn = recover Map[String, U128] end
+        let p_ids = recover trn Map[String, U128] end
         for (target, p_id) in proxy_ids(w).pairs() do
           p_ids(target) = p_id
         end

--- a/lib/wallaroo/initialization/cluster_initializer.pony
+++ b/lib/wallaroo/initialization/cluster_initializer.pony
@@ -113,7 +113,7 @@ actor ClusterInitializer
       _connections_ready_workers.set(worker_name)
       _interconnected = _interconnected + 1
       if _interconnected == _expected then
-        let names: Array[String] trn = recover Array[String] end
+        let names = recover trn Array[String] end
         for name in _worker_names.values() do
           names.push(name)
         end
@@ -148,7 +148,7 @@ actor ClusterInitializer
   //   _connections.register_proxy(worker, proxy)
 
   fun _create_data_channel_listeners() =>
-    let ws: Array[String] trn = recover Array[String] end
+    let ws = recover trn Array[String] end
 
     if not _worker_names.contains(_initializer_name) then
       ws.push(_initializer_name)
@@ -192,15 +192,12 @@ actor ClusterInitializer
   fun _generate_addresses_map(): (Map[String, (String, String)] val,
     Map[String, (String, String)] val)
   =>
-    let map: Map[String, Map[String, (String, String)]] trn =
-      recover Map[String, Map[String, (String, String)]] end
-    let control_map: Map[String, (String, String)] trn =
-      recover Map[String, (String, String)] end
+    let map = recover trn Map[String, Map[String, (String, String)]] end
+    let control_map = recover trn Map[String, (String, String)] end
     for (key, value) in _control_addrs.pairs() do
       control_map(key) = value
     end
-    let data_map: Map[String, (String, String)] trn =
-      recover Map[String, (String, String)] end
+    let data_map = recover trn Map[String, (String, String)] end
     for (key, value) in _data_addrs.pairs() do
       data_map(key) = value
     end

--- a/lib/wallaroo/initialization/local_topology.pony
+++ b/lib/wallaroo/initialization/local_topology.pony
@@ -114,8 +114,7 @@ class val LocalTopology
     state_name: String, key: Key, pa: ProxyAddress): LocalTopology ?
   =>
     let new_subpartition = _state_builders(state_name).update_key[Key](key, pa)
-    let new_state_builders: Map[String, StateSubpartition] trn =
-      recover Map[String, StateSubpartition] end
+    let new_state_builders = recover trn Map[String, StateSubpartition] end
     for (k, v) in _state_builders.pairs() do
       new_state_builders(k) = v
     end
@@ -126,7 +125,7 @@ class val LocalTopology
 
   fun val add_worker_name(w: String): LocalTopology =>
     if not worker_names.contains(w) then
-      let new_worker_names: Array[String] trn = recover Array[String] end
+      let new_worker_names = recover trn Array[String] end
       for n in worker_names.values() do
         new_worker_names.push(n)
       end
@@ -306,16 +305,14 @@ actor LocalTopologyInitializer is LayoutInitializer
     builder: OutgoingBoundaryBuilder)
   =>
     // Boundaries
-    let bs: Map[String, OutgoingBoundary] trn =
-      recover Map[String, OutgoingBoundary] end
+    let bs = recover trn Map[String, OutgoingBoundary] end
     for (w, b) in _outgoing_boundaries.pairs() do
       bs(w) = b
     end
     bs(target_worker) = boundary
 
     // Boundary builders
-    let bbs: Map[String, OutgoingBoundaryBuilder] trn =
-      recover Map[String, OutgoingBoundaryBuilder] end
+    let bbs = recover trn Map[String, OutgoingBoundaryBuilder] end
     for (w, b) in _outgoing_boundary_builders.pairs() do
       bbs(w) = b
     end
@@ -576,8 +573,7 @@ actor LocalTopologyInitializer is LayoutInitializer
 
         // Keep track of all Consumers by id so we can create a
         // DataRouter for the data channel boundary
-        var data_routes: Map[U128, Consumer] trn =
-          recover Map[U128, Consumer] end
+        var data_routes = recover trn Map[U128, Consumer] end
 
         // Update the step ids for all OutgoingBoundaries
         if _worker_count > 1 then
@@ -595,8 +591,7 @@ actor LocalTopologyInitializer is LayoutInitializer
         // Keep track of steps we've built that we'll use for the OmniRouter.
         // Unlike data_routes, these will not include state steps, which will
         // never be direct targets for state computation outputs.
-        let built_stateless_steps: Map[U128, Consumer] trn =
-          recover Map[U128, Consumer] end
+        let built_stateless_steps = recover trn Map[U128, Consumer] end
 
         // TODO: Replace this when we move past the temporary POC based default
         // target strategy. There can currently only be one partition default
@@ -1015,9 +1010,8 @@ actor LocalTopologyInitializer is LayoutInitializer
                   // Populate partition routes with all local steps in
                   // the partition and proxy routers for any steps that
                   // exist on other workers.
-                  let partition_routes:
-                    Map[U64, (Step | ProxyRouter)] trn =
-                    recover Map[U64, (Step | ProxyRouter)] end
+                  let partition_routes =
+                    recover trn Map[U64, (Step | ProxyRouter)] end
 
                   for (p_id, step_id) in
                     pre_stateless_data.partition_id_to_step_id.pairs()
@@ -1312,10 +1306,8 @@ actor LocalTopologyInitializer is LayoutInitializer
     @printf[I32]("|v|v|v|Initializing Joining Worker Local Topology|v|v|v|\n\n".cstring())
     try
       let built_routers = Map[U128, Router]
-      let data_routes: Map[U128, Consumer] trn =
-        recover Map[U128, Consumer] end
-      let built_stateless_steps: Map[U128, Consumer] trn =
-        recover Map[U128, Consumer] end
+      let data_routes = recover trn Map[U128, Consumer] end
+      let built_stateless_steps = recover trn Map[U128, Consumer] end
 
       match _topology
       | let t: LocalTopology =>

--- a/lib/wallaroo/messages/channel_messages.pony
+++ b/lib/wallaroo/messages/channel_messages.pony
@@ -553,7 +553,7 @@ class val ReplayMsg is ChannelMsg
       size = size + bytes.size()
     end
 
-    let buffer: Array[U8] trn = recover Array[U8](size) end
+    let buffer = recover trn Array[U8](size) end
     for bytes in data_bytes.values() do
       buffer.append(bytes)
     end

--- a/lib/wallaroo/network/connections.pony
+++ b/lib/wallaroo/network/connections.pony
@@ -314,15 +314,13 @@ actor Connections is Cluster
   fun _update_boundaries(layout_initializer: LayoutInitializer,
     recovering: Bool = false)
   =>
-    let out_bs: Map[String, OutgoingBoundary] trn =
-      recover Map[String, OutgoingBoundary] end
+    let out_bs = recover trn Map[String, OutgoingBoundary] end
 
     for (target, boundary) in _data_conns.pairs() do
       out_bs(target) = boundary
     end
 
-    let out_bbs: Map[String, OutgoingBoundaryBuilder] trn =
-      recover Map[String, OutgoingBoundaryBuilder] end
+    let out_bbs = recover trn Map[String, OutgoingBoundaryBuilder] end
 
     for (target, builder) in _data_conn_builders.pairs() do
       out_bbs(target) = builder
@@ -387,15 +385,12 @@ actor Connections is Cluster
   =>
     @printf[I32]("Saving connection addresses!\n".cstring())
 
-    let map: Map[String, Map[String, (String, String)]] trn =
-      recover Map[String, Map[String, (String, String)]] end
-    let control_map: Map[String, (String, String)] trn =
-      recover Map[String, (String, String)] end
+    let map = recover trn Map[String, Map[String, (String, String)]] end
+    let control_map = recover trn Map[String, (String, String)] end
     for (key, value) in control_addrs.pairs() do
       control_map(key) = value
     end
-    let data_map: Map[String, (String, String)] trn =
-      recover Map[String, (String, String)] end
+    let data_map = recover trn Map[String, (String, String)] end
     for (key, value) in data_addrs.pairs() do
       data_map(key) = value
     end
@@ -545,15 +540,13 @@ actor Connections is Cluster
   be inform_joining_worker(conn: TCPConnection, worker: String,
     local_topology: LocalTopology)
   =>
-    let c_addrs: Map[String, (String, String)] trn =
-      recover Map[String, (String, String)] end
+    let c_addrs = recover trn Map[String, (String, String)] end
     for (w, addr) in _control_addrs.pairs() do
       c_addrs(w) = addr
     end
     c_addrs(_worker_name) = _my_control_addr
 
-    let d_addrs: Map[String, (String, String)] trn =
-      recover Map[String, (String, String)] end
+    let d_addrs = recover trn Map[String, (String, String)] end
     for (w, addr) in _data_addrs.pairs() do
       d_addrs(w) = addr
     end

--- a/lib/wallaroo/recovery/recovery.pony
+++ b/lib/wallaroo/recovery/recovery.pony
@@ -40,7 +40,7 @@ actor Recovery
     initializer: (LocalTopologyInitializer | WActorInitializer),
     workers: Array[String] val)
   =>
-    let other_workers: Array[String] trn = recover Array[String] end
+    let other_workers = recover trn Array[String] end
     for w in workers.values() do
       if w != _worker_name then other_workers.push(w) end
     end

--- a/lib/wallaroo/startup.pony
+++ b/lib/wallaroo/startup.pony
@@ -468,10 +468,8 @@ actor Startup
       // Prepare control and data addresses, but sub in correct host for
       // the worker that sent inform message (since it didn't know its
       // host string as seen externally)
-      let control_addrs: Map[String, (String, String)] trn =
-        recover Map[String, (String, String)] end
-      let data_addrs: Map[String, (String, String)] trn =
-        recover Map[String, (String, String)] end
+      let control_addrs = recover trn Map[String, (String, String)] end
+      let data_addrs = recover trn Map[String, (String, String)] end
       for (worker, addr) in m.control_addrs.pairs() do
         if m.sender_name == worker then
           control_addrs(worker) = (info_sending_host, addr._2)
@@ -531,7 +529,7 @@ actor Startup
     """
     Read in a list of the names of all workers after recovery.
     """
-    let ws: Array[String] trn = recover Array[String] end
+    let ws = recover trn Array[String] end
 
     let file = File(worker_names_filepath)
     for worker_name in file.lines() do

--- a/lib/wallaroo/tcp_source/tcp_source_listener.pony
+++ b/lib/wallaroo/tcp_source/tcp_source_listener.pony
@@ -148,8 +148,7 @@ actor TCPSourceListener is SourceListener
   be add_boundary_builders(
     boundary_builders: Map[String, OutgoingBoundaryBuilder] val)
   =>
-    let new_builders: Map[String, OutgoingBoundaryBuilder] trn =
-      recover Map[String, OutgoingBoundaryBuilder] end
+    let new_builders = recover trn Map[String, OutgoingBoundaryBuilder] end
     // TODO: A persistent map on the field would be much more efficient here
     for (target_worker_name, builder) in _outgoing_boundary_builders.pairs() do
       new_builders(target_worker_name) = builder

--- a/lib/wallaroo/topology/_test_router_equality.pony
+++ b/lib/wallaroo/topology/_test_router_equality.pony
@@ -40,15 +40,15 @@ class iso _TestLocalPartitionRouterEquality is UnitTest
     let boundary2 = _BoundaryGenerator("w1", auth)
     let boundary3 = _BoundaryGenerator("w1", auth)
 
-    let base_local_map: Map[U128, Step] trn = recover Map[U128, Step] end
+    let base_local_map = recover trn Map[U128, Step] end
     base_local_map(1) = step1
     let target_local_map: Map[U128, Step] val = recover Map[U128, Step] end
 
-    let base_step_ids: Map[String, U128] trn = recover Map[String, U128] end
+    let base_step_ids = recover trn Map[String, U128] end
     base_step_ids("k1") = 1
     base_step_ids("k2") = 2
     base_step_ids("k3") = 3
-    let target_step_ids: Map[String, U128] trn = recover Map[String, U128] end
+    let target_step_ids = recover trn Map[String, U128] end
     target_step_ids("k1") = 1
     target_step_ids("k2") = 2
     target_step_ids("k3") = 3
@@ -97,30 +97,24 @@ class iso _TestOmniRouterEquality is UnitTest
     let boundary2 = _BoundaryGenerator("w1", auth)
     let boundary3 = _BoundaryGenerator("w1", auth)
 
-    let base_data_routes: Map[U128, Consumer] trn =
-      recover Map[U128, Consumer] end
+    let base_data_routes = recover trn Map[U128, Consumer] end
     base_data_routes(1) = step1
 
-    let target_data_routes: Map[U128, Consumer] trn =
-      recover Map[U128, Consumer] end
+    let target_data_routes = recover trn Map[U128, Consumer] end
     target_data_routes(2) = step2
 
-    let base_step_map: Map[U128, (ProxyAddress | U128)] trn =
-      recover Map[U128, (ProxyAddress | U128)] end
+    let base_step_map = recover trn Map[U128, (ProxyAddress | U128)] end
     base_step_map(1) = ProxyAddress("w1", 1)
     base_step_map(2) = ProxyAddress("w2", 2)
 
-    let target_step_map: Map[U128, (ProxyAddress | U128)] trn =
-      recover Map[U128, (ProxyAddress | U128)] end
+    let target_step_map = recover trn Map[U128, (ProxyAddress | U128)] end
     target_step_map(1) = ProxyAddress("w2", 1)
     target_step_map(2) = ProxyAddress("w1", 2)
 
-    let base_boundaries: Map[String, OutgoingBoundary] trn =
-      recover Map[String, OutgoingBoundary] end
+    let base_boundaries = recover trn Map[String, OutgoingBoundary] end
     base_boundaries("w2") = boundary2
 
-    let target_boundaries: Map[String, OutgoingBoundary] trn =
-      recover Map[String, OutgoingBoundary] end
+    let target_boundaries = recover trn Map[String, OutgoingBoundary] end
     target_boundaries("w2") = boundary2
     target_boundaries("w3") = boundary3
 
@@ -157,13 +151,11 @@ class iso _TestDataRouterEqualityAfterRemove is UnitTest
     let step1 = _StepGenerator(event_log, recovery_replayer)
     let step2 = _StepGenerator(event_log, recovery_replayer)
 
-    let base_routes: Map[U128, Consumer] trn =
-      recover Map[U128, Consumer] end
+    let base_routes = recover trn Map[U128, Consumer] end
     base_routes(1) = step1
     base_routes(2) = step2
 
-    let target_routes: Map[U128, Consumer] trn =
-      recover Map[U128, Consumer] end
+    let target_routes = recover trn Map[U128, Consumer] end
     target_routes(1) = step1
 
     var base_router = DataRouter(consume base_routes)
@@ -192,12 +184,10 @@ class iso _TestDataRouterEqualityAfterAdd is UnitTest
     let step1 = _StepGenerator(event_log, recovery_replayer)
     let step2 = _StepGenerator(event_log, recovery_replayer)
 
-    let base_routes: Map[U128, Consumer] trn =
-      recover Map[U128, Consumer] end
+    let base_routes = recover trn Map[U128, Consumer] end
     base_routes(1) = step1
 
-    let target_routes: Map[U128, Consumer] trn =
-      recover Map[U128, Consumer] end
+    let target_routes = recover trn Map[U128, Consumer] end
     target_routes(1) = step1
     target_routes(2) = step2
 
@@ -215,8 +205,7 @@ primitive _BasePartitionRoutesGenerator
     boundary2: OutgoingBoundary, boundary3: OutgoingBoundary):
     Map[String, (Step | ProxyRouter)] val
   =>
-    let m: Map[String, (Step | ProxyRouter)] trn =
-      recover Map[String, (Step | ProxyRouter)] end
+    let m = recover trn Map[String, (Step | ProxyRouter)] end
     m("k1") = step1
     m("k2") = ProxyRouter("w1", boundary2,
       ProxyAddress("w2", 2), auth)
@@ -229,8 +218,7 @@ primitive _TargetPartitionRoutesGenerator
     new_proxy_router: ProxyRouter, boundary2: OutgoingBoundary,
     boundary3: OutgoingBoundary): Map[String, (Step | ProxyRouter)] val
   =>
-    let m: Map[String, (Step | ProxyRouter)] trn =
-      recover Map[String, (Step | ProxyRouter)] end
+    let m = recover trn Map[String, (Step | ProxyRouter)] end
     m("k1") = new_proxy_router
     m("k2") = ProxyRouter("w1", boundary2,
       ProxyAddress("w2", 2), auth)

--- a/lib/wallaroo/topology/partition.pony
+++ b/lib/wallaroo/topology/partition.pony
@@ -62,8 +62,7 @@ class KeyedPartitionAddresses[Key: (Hashable val & Equatable[Key] val)]
   fun update_key[K: (Hashable val & Equatable[K] val)](key: K,
     pa: ProxyAddress): PartitionAddresses val ?
   =>
-    let new_addresses: Map[Key, ProxyAddress] trn =
-      recover Map[Key, ProxyAddress] end
+    let new_addresses = recover trn Map[Key, ProxyAddress] end
     // TODO: This would be much more efficient with a persistent map, since
     // we wouldn't have to copy everything to make a small change.
     for (k, v) in _addresses.pairs() do
@@ -119,8 +118,7 @@ class KeyedStateAddresses[Key: (Hashable val & Equatable[Key] val)]
     end
 
   fun steps(): Array[Consumer] val =>
-    let ss: Array[Consumer] trn =
-      recover Array[Consumer] end
+    let ss = recover trn Array[Consumer] end
     for s in _addresses.values() do
       match s
       | let cfcs: Consumer =>
@@ -175,10 +173,9 @@ class val KeyedStateSubpartition[PIn: Any val,
     default_router: (Router | None) = None):
     LocalPartitionRouter[PIn, Key] val
   =>
-    let routes: Map[Key, (Step | ProxyRouter)] trn =
-      recover Map[Key, (Step | ProxyRouter)] end
+    let routes = recover trn Map[Key, (Step | ProxyRouter)] end
 
-    let m: Map[U128, Step] trn = recover Map[U128, Step] end
+    let m = recover trn Map[U128, Step] end
 
     var partition_count: USize = 0
 
@@ -254,8 +251,7 @@ primitive PartitionFileReader
   fun apply(filename: String, auth: AmbientAuth):
     Array[WeightedKey[String]] val
   =>
-    let keys: Array[WeightedKey[String]] trn =
-      recover Array[WeightedKey[String]] end
+    let keys = recover trn Array[WeightedKey[String]] end
 
     try
       let file = File(FilePath(auth, filename))

--- a/lib/wallaroo/topology/router.pony
+++ b/lib/wallaroo/topology/router.pony
@@ -322,8 +322,7 @@ class val StepIdRouter is OmniRouter
   fun val add_boundary(w: String, boundary: OutgoingBoundary): OmniRouter =>
     // TODO: Using persistent maps for our fields would make this more
     // efficient
-    let new_outgoing_boundaries: Map[String, OutgoingBoundary] trn =
-      recover Map[String, OutgoingBoundary] end
+    let new_outgoing_boundaries = recover trn Map[String, OutgoingBoundary] end
     for (k, v) in _outgoing_boundaries.pairs() do
       new_outgoing_boundaries(k) = v
     end
@@ -334,14 +333,11 @@ class val StepIdRouter is OmniRouter
   fun val update_route_to_proxy(id: U128, pa: ProxyAddress): OmniRouter =>
     // TODO: Using persistent maps for our fields would make this more
     // efficient
-    let new_data_routes: Map[U128, Consumer] trn =
-      recover Map[U128, Consumer] end
-    let new_step_map: Map[U128, (ProxyAddress | U128)] trn =
-      recover Map[U128, (ProxyAddress | U128)] end
+    let new_data_routes = recover trn Map[U128, Consumer] end
+    let new_step_map = recover trn Map[U128, (ProxyAddress | U128)] end
     for (k, v) in _data_routes.pairs() do
       if k != id then new_data_routes(k) = v end
     end
-
     for (k, v) in _step_map.pairs() do
       new_step_map(k) = v
     end
@@ -353,10 +349,8 @@ class val StepIdRouter is OmniRouter
   fun val update_route_to_step(id: U128, step: Consumer): OmniRouter =>
     // TODO: Using persistent maps for our fields would make this more
     // efficient
-    let new_data_routes: Map[U128, Consumer] trn =
-      recover Map[U128, Consumer] end
-    let new_step_map: Map[U128, (ProxyAddress | U128)] trn =
-      recover Map[U128, (ProxyAddress | U128)] end
+    let new_data_routes = recover trn Map[U128, Consumer] end
+    let new_step_map = recover trn Map[U128, (ProxyAddress | U128)] end
     for (k, v) in _data_routes.pairs() do
       if k != id then new_data_routes(k) = v end
     end
@@ -371,14 +365,14 @@ class val StepIdRouter is OmniRouter
       _outgoing_boundaries)
 
   fun routes(): Array[Consumer] val =>
-    let diff: Array[Consumer] trn = recover Array[Consumer] end
+    let diff = recover trn Array[Consumer] end
     for r in _data_routes.values() do
       diff.push(r)
     end
     consume diff
 
   fun routes_not_in(router: OmniRouter): Array[Consumer] val =>
-    let diff: Array[Consumer] trn = recover Array[Consumer] end
+    let diff = recover trn Array[Consumer] end
     let other_routes = router.routes()
     for r in _data_routes.values() do
       if not other_routes.contains(r) then diff.push(r) end
@@ -473,10 +467,8 @@ class val DataRouter is Equatable[DataRouter]
     _data_routes = data_routes
     var route_id: RouteId = 0
     let keys: Array[U128] = keys.create()
-    let tid_map: Map[U128, RouteId] trn =
-      recover Map[U128, RouteId] end
-    let rid_map: Map[RouteId, U128] trn =
-      recover Map[RouteId, U128] end
+    let tid_map = recover trn Map[U128, RouteId] end
+    let rid_map = recover trn Map[RouteId, U128] end
     for step_id in _data_routes.keys() do
       keys.push(step_id)
     end
@@ -589,7 +581,7 @@ class val DataRouter is Equatable[DataRouter]
     ids
 
   fun routes(): Array[Consumer] val =>
-    let rs: Array[Consumer] trn = recover Array[Consumer] end
+    let rs = recover trn Array[Consumer] end
     for step in _data_routes.values() do
       rs.push(step)
     end
@@ -598,18 +590,15 @@ class val DataRouter is Equatable[DataRouter]
   fun remove_route(id: U128): DataRouter =>
     // TODO: Using persistent maps for our fields would make this much more
     // efficient
-    let new_data_routes: Map[U128, Consumer] trn =
-      recover Map[U128, Consumer] end
+    let new_data_routes = recover trn Map[U128, Consumer] end
     for (k, v) in _data_routes.pairs() do
       if k != id then new_data_routes(k) = v end
     end
-    let new_tid_map: Map[U128, RouteId] trn =
-      recover Map[U128, RouteId] end
+    let new_tid_map = recover trn Map[U128, RouteId] end
     for (k, v) in _target_ids_to_route_ids.pairs() do
       if k != id then new_tid_map(k) = v end
     end
-    let new_rid_map: Map[RouteId, U128] trn =
-      recover Map[RouteId, U128] end
+    let new_rid_map = recover trn Map[RouteId, U128] end
     for (k, v) in _route_ids_to_target_ids.pairs() do
       if v != id then new_rid_map(k) = v end
     end
@@ -619,15 +608,13 @@ class val DataRouter is Equatable[DataRouter]
   fun add_route(id: U128, target: Consumer): DataRouter =>
     // TODO: Using persistent maps for our fields would make this much more
     // efficient
-    let new_data_routes: Map[U128, Consumer] trn =
-      recover Map[U128, Consumer] end
+    let new_data_routes = recover trn Map[U128, Consumer] end
     for (k, v) in _data_routes.pairs() do
       new_data_routes(k) = v
     end
     new_data_routes(id) = target
 
-    let new_tid_map: Map[U128, RouteId] trn =
-      recover Map[U128, RouteId] end
+    let new_tid_map = recover trn Map[U128, RouteId] end
     var highest_route_id: RouteId = 0
     for (k, v) in _target_ids_to_route_ids.pairs() do
       new_tid_map(k) = v
@@ -636,8 +623,7 @@ class val DataRouter is Equatable[DataRouter]
     let new_route_id = highest_route_id + 1
     new_tid_map(id) = new_route_id
 
-    let new_rid_map: Map[RouteId, U128] trn =
-      recover Map[RouteId, U128] end
+    let new_rid_map = recover trn Map[RouteId, U128] end
     for (k, v) in _route_ids_to_target_ids.pairs() do
       new_rid_map(k) = v
     end
@@ -814,8 +800,7 @@ class val LocalPartitionRouter[In: Any val,
     end
 
   fun routes(): Array[Consumer] val =>
-    let cs: Array[Consumer] trn =
-      recover Array[Consumer] end
+    let cs = recover trn Array[Consumer] end
 
     for s in _partition_routes.values() do
       match s
@@ -827,7 +812,7 @@ class val LocalPartitionRouter[In: Any val,
     consume cs
 
   fun routes_not_in(router: Router): Array[Consumer] val =>
-    let diff: Array[Consumer] trn = recover Array[Consumer] end
+    let diff = recover trn Array[Consumer] end
     let other_routes = router.routes()
     for r in routes().values() do
       if not other_routes.contains(r) then diff.push(r) end
@@ -844,9 +829,8 @@ class val LocalPartitionRouter[In: Any val,
     match raw_k
     | let key: Key =>
       let target_id = _step_ids(key)
-      let new_local_map: Map[U128, Step] trn = recover Map[U128, Step] end
-      let new_partition_routes: Map[Key, (Step | ProxyRouter)] trn =
-        recover Map[Key, (Step | ProxyRouter)] end
+      let new_local_map = recover trn Map[U128, Step] end
+      let new_partition_routes = recover trn Map[Key, (Step | ProxyRouter)] end
       match target
       | let step: Step =>
         for (id, s) in _local_map.pairs() do
@@ -885,8 +869,7 @@ class val LocalPartitionRouter[In: Any val,
   fun update_boundaries(ob: box->Map[String, OutgoingBoundary]):
     PartitionRouter
   =>
-    let new_partition_routes: Map[Key, (Step | ProxyRouter)] trn =
-      recover Map[Key, (Step | ProxyRouter)] end
+    let new_partition_routes = recover trn Map[Key, (Step | ProxyRouter)] end
     for (k, target) in _partition_routes.pairs() do
       match target
       | let pr: ProxyRouter =>
@@ -1062,7 +1045,7 @@ class val LocalStatelessPartitionRouter is StatelessPartitionRouter
       end
     end
 
-    let to_send: Array[Consumer] trn = recover Array[Consumer] end
+    let to_send = recover trn Array[Consumer] end
     for c in cs.values() do
       to_send.push(c)
     end
@@ -1070,7 +1053,7 @@ class val LocalStatelessPartitionRouter is StatelessPartitionRouter
     consume to_send
 
   fun routes_not_in(router: Router): Array[Consumer] val =>
-    let diff: Array[Consumer] trn = recover Array[Consumer] end
+    let diff = recover trn Array[Consumer] end
     let other_routes = router.routes()
     for r in routes().values() do
       if not other_routes.contains(r) then diff.push(r) end
@@ -1083,8 +1066,7 @@ class val LocalStatelessPartitionRouter is StatelessPartitionRouter
     // TODO: Using persistent maps for our fields would make this much more
     // efficient
     let target_id = _step_ids(partition_id)
-    let new_partition_routes: Map[U64, (Step | ProxyRouter)] trn =
-      recover Map[U64, (Step | ProxyRouter)] end
+    let new_partition_routes = recover trn Map[U64, (Step | ProxyRouter)] end
     match target
     | let step: Step =>
       for (p_id, t) in _partition_routes.pairs() do
@@ -1113,8 +1095,7 @@ class val LocalStatelessPartitionRouter is StatelessPartitionRouter
   fun update_boundaries(ob: box->Map[String, OutgoingBoundary]):
     StatelessPartitionRouter
   =>
-    let new_partition_routes: Map[U64, (Step | ProxyRouter)] trn =
-      recover Map[U64, (Step | ProxyRouter)] end
+    let new_partition_routes = recover trn Map[U64, (Step | ProxyRouter)] end
     for (p_id, target) in _partition_routes.pairs() do
       match target
       | let pr: ProxyRouter =>

--- a/lib/wallaroo/topology/router_registry.pony
+++ b/lib/wallaroo/topology/router_registry.pony
@@ -139,8 +139,7 @@ actor RouterRegistry
     bbs: Map[String, OutgoingBoundaryBuilder] val)
   =>
     // Boundaries
-    let new_boundaries: Map[String, OutgoingBoundary] trn =
-      recover Map[String, OutgoingBoundary] end
+    let new_boundaries = recover trn Map[String, OutgoingBoundary] end
     for (worker, boundary) in bs.pairs() do
       if not _outgoing_boundaries.contains(worker) then
         _outgoing_boundaries(worker) = boundary
@@ -163,8 +162,8 @@ actor RouterRegistry
     end
 
     // Boundary builders
-    let new_boundary_builders: Map[String, OutgoingBoundaryBuilder] trn =
-      recover Map[String, OutgoingBoundaryBuilder] end
+    let new_boundary_builders =
+      recover trn Map[String, OutgoingBoundaryBuilder] end
     for (worker, builder) in bbs.pairs() do
       // Boundary builders should always be registered after the canonical
       // boundary for each builder. The canonical is used on all Steps.

--- a/lib/wallaroo/topology/runner.pony
+++ b/lib/wallaroo/topology/runner.pony
@@ -393,8 +393,7 @@ class val PartitionedStateRunnerBuilder[PIn: Any val, S: State ref,
   fun partition_addresses(workers: (String | Array[String] val)):
     KeyedPartitionAddresses[Key] val
   =>
-    let m: Map[Key, ProxyAddress] trn =
-      recover Map[Key, ProxyAddress] end
+    let m = recover trn Map[Key, ProxyAddress] end
 
     match workers
     | let w: String =>

--- a/lib/wallaroo/w_actor/actor_system.pony
+++ b/lib/wallaroo/w_actor/actor_system.pony
@@ -106,15 +106,13 @@ class val LocalActorSystem
     LocalActorSystem
   =>
     //TODO: Use persistent vector once it's available to improve perf here
-    let arr: Array[WActorWrapperBuilder] trn =
-      recover Array[WActorWrapperBuilder] end
+    let arr = recover trn Array[WActorWrapperBuilder] end
     for a in _actor_builders.values() do
       arr.push(a)
     end
     arr.push(builder)
     //TODO: Use persistent map here to improve perf
-    let new_actor_to_worker: Map[U128, String] trn =
-      recover Map[U128, String] end
+    let new_actor_to_worker = recover trn Map[U128, String] end
     for (k, v) in _actor_to_worker_map.pairs() do
       new_actor_to_worker(k) = v
     end
@@ -125,8 +123,7 @@ class val LocalActorSystem
 
   fun register_as_role(role: String, id: U128): LocalActorSystem =>
     //TODO: Use persistent map to improve perf
-    let new_roles: Map[String, Role box] trn =
-      recover Map[String, Role box] end
+    let new_roles = recover trn Map[String, Role box] end
     for (k, v) in _roles.pairs() do
       if k == role then
         let old_role_actors = v.actors()

--- a/lib/wallaroo/w_actor/actor_system_distributor.pony
+++ b/lib/wallaroo/w_actor/actor_system_distributor.pony
@@ -47,8 +47,7 @@ actor ActorSystemDistributor is Distributor
       (worker_count / actor_count) actors. The last worker also gets the
       remaining actors after all those have been distributed.
       */
-      let actor_to_worker_map: Map[U128, String] trn =
-        recover Map[U128, String] end
+      let actor_to_worker_map = recover trn Map[U128, String] end
       let actor_builders = _system.actor_builders()
       let actor_count = actor_builders.size()
       let base_share = actor_count / worker_count
@@ -56,8 +55,7 @@ actor ActorSystemDistributor is Distributor
       var actor_idx: USize = 0
       var worker_idx: USize = 0
       var cur_worker_share: USize = 0
-      var cur_actors: Array[WActorWrapperBuilder] trn =
-        recover Array[WActorWrapperBuilder] end
+      var cur_actors = recover trn Array[WActorWrapperBuilder] end
       while actor_idx < actor_count do
         let next_actor = actor_builders(actor_idx)
         actor_to_worker_map(next_actor.id()) = workers(worker_idx)

--- a/lib/wallaroo/w_actor/w_actor_initializer.pony
+++ b/lib/wallaroo/w_actor/w_actor_initializer.pony
@@ -99,7 +99,7 @@ actor WActorInitializer is LayoutInitializer
 
   be update_local_actor_system(las: LocalActorSystem) =>
     _system = las
-    let sinks: Array[Sink] trn = recover Array[Sink] end
+    let sinks = recover trn Array[Sink] end
     for (idx, sink_builder) in las.sinks().pairs() do
       let empty_metrics_reporter =
         MetricsReporter(_app_name, "",

--- a/lib/wallaroo/w_actor/w_actor_registry.pony
+++ b/lib/wallaroo/w_actor/w_actor_registry.pony
@@ -50,8 +50,7 @@ class WActorRegistry
 
   fun ref register_actor_for_worker(id: U128, worker: String) =>
     //TODO: Use persistent map to improve perf
-    let new_actor_to_worker: Map[U128, String] trn =
-      recover Map[U128, String] end
+    let new_actor_to_worker = recover trn Map[U128, String] end
     for (k, v) in _actor_to_worker_map.pairs() do
       new_actor_to_worker(k) = v
     end
@@ -80,8 +79,7 @@ class WActorRegistry
     let new_builder = StatefulWActorWrapperBuilder(new_id, builder)
 
     //TODO: Use persistent map to improve perf
-    let new_actor_to_worker: Map[U128, String] trn =
-      recover Map[U128, String] end
+    let new_actor_to_worker = recover trn Map[U128, String] end
     for (k, v) in _actor_to_worker_map.pairs() do
       new_actor_to_worker(k) = v
     end
@@ -236,8 +234,7 @@ actor CentralWActorRegistry
 
   fun ref _remove_actor_from_worker_map(id: U128) =>
     //TODO: Use persistent map to improve perf
-    let new_actor_to_worker: Map[U128, String] trn =
-      recover Map[U128, String] end
+    let new_actor_to_worker = recover trn Map[U128, String] end
     for (k, v) in _actor_to_worker_map.pairs() do
       if k != id then
         new_actor_to_worker(k) = v
@@ -257,8 +254,7 @@ actor CentralWActorRegistry
         (_actor_to_worker_map(id) == worker))
       then
         //TODO: Use persistent map to improve perf
-        let new_actor_to_worker: Map[U128, String] trn =
-          recover Map[U128, String] end
+        let new_actor_to_worker = recover trn Map[U128, String] end
         for (k, v) in _actor_to_worker_map.pairs() do
           new_actor_to_worker(k) = v
         end
@@ -448,8 +444,7 @@ actor CentralWActorRegistry
     end
 
   be send_digest(worker: String) =>
-    let role_sets: Map[String, SetIs[U128]] trn =
-      recover Map[String, SetIs[U128]] end
+    let role_sets = recover trn Map[String, SetIs[U128]] end
     for (k, v) in _role_sets.pairs() do
       let next_set = recover SetIs[U128] end
       for id in v.values() do
@@ -457,8 +452,7 @@ actor CentralWActorRegistry
       end
       role_sets(k) = consume next_set
     end
-    let actor_to_worker_map: Map[U128, String] trn =
-      recover Map[U128, String] end
+    let actor_to_worker_map = recover trn Map[U128, String] end
     for (k, v) in _actor_to_worker_map.pairs() do
       actor_to_worker_map(k) = v
     end

--- a/lib/wallaroo/w_actor/w_actor_startup.pony
+++ b/lib/wallaroo/w_actor/w_actor_startup.pony
@@ -37,8 +37,6 @@ actor ActorSystemStartup
   var _control_channel_file: String = ""
   var _worker_names_file: String = ""
   var _connection_addresses_file: String = ""
-  var _o_addrs_write: Array[Array[String]] trn =
-    recover Array[Array[String]] end
   // DEMO fields
   var _iterations: USize = 100
 
@@ -305,7 +303,7 @@ actor ActorSystemStartup
     """
     Read in a list of the names of all workers after recovery.
     """
-    let ws: Array[String] trn = recover Array[String] end
+    let ws = recover trn Array[String] end
 
     let file = File(worker_names_filepath)
     for worker_name in file.lines() do

--- a/lib/wallaroo/wallaroo_config.pony
+++ b/lib/wallaroo/wallaroo_config.pony
@@ -82,8 +82,7 @@ primitive WallarooConfig
       match option
       | ("metrics", let arg: String) => so.m_arg = arg.split(":")
       | ("in", let arg: String) =>
-        let i_addrs_write: Array[Array[String]] trn =
-          recover Array[Array[String]] end
+        let i_addrs_write = recover trn Array[Array[String]] end
         for addr in arg.split(",").values() do
           i_addrs_write.push(addr.split(":"))
         end
@@ -94,7 +93,7 @@ primitive WallarooConfig
         so.c_service = so.c_addr(1)
       | ("data", let arg: String) =>
         let d_addr_ref = arg.split(":")
-        let d_addr_trn: Array[String] trn = recover Array[String] end
+        let d_addr_trn = recover trn Array[String] end
         d_addr_trn.push(d_addr_ref(0))
         d_addr_trn.push(d_addr_ref(1))
         so.d_addr = consume d_addr_trn

--- a/testing/performance/apps/market-spread-encode/market-spread.pony
+++ b/testing/performance/apps/market-spread-encode/market-spread.pony
@@ -98,8 +98,7 @@ actor Main
 
       let init_file = InitFile(initial_nbbo_file_path, 46)
 
-      let initial_report_msgs_trn: Array[Array[ByteSeq] val] trn =
-        recover Array[Array[ByteSeq] val] end
+      let initial_report_msgs_trn = recover trn Array[Array[ByteSeq] val] end
       let connect_msg = HubProtocol.connect()
       let join_msg = HubProtocol.join("reports:market-spread")
       initial_report_msgs_trn.push(connect_msg)
@@ -388,7 +387,7 @@ class LegalSymbols
   let symbols: Array[String] val
 
   new create() =>
-    let padded: Array[String] trn = recover Array[String] end
+    let padded = recover trn Array[String] end
     for symbol in RawSymbols().values() do
       padded.push(RawSymbols.pad_symbol(symbol))
     end

--- a/testing/performance/apps/market-spread/market-spread.pony
+++ b/testing/performance/apps/market-spread/market-spread.pony
@@ -93,8 +93,7 @@ actor Main
 
       let init_file = InitFile(initial_nbbo_file_path, 46)
 
-      let initial_report_msgs_trn: Array[Array[ByteSeq] val] trn =
-        recover Array[Array[ByteSeq] val] end
+      let initial_report_msgs_trn = recover trn Array[Array[ByteSeq] val] end
       let connect_msg = HubProtocol.connect()
       let join_msg = HubProtocol.join("reports:market-spread")
       initial_report_msgs_trn.push(connect_msg)
@@ -349,7 +348,7 @@ class LegalSymbols
   let symbols: Array[String] val
 
   new create() =>
-    let padded: Array[String] trn = recover Array[String] end
+    let padded = recover trn Array[String] end
     for symbol in RawSymbols().values() do
       padded.push(RawSymbols.pad_symbol(symbol))
     end

--- a/testing/performance/apps/one-stream-market/one-stream-market.pony
+++ b/testing/performance/apps/one-stream-market/one-stream-market.pony
@@ -75,8 +75,7 @@ actor Main
 
       let init_file = InitFile(initial_nbbo_file_path, 46)
 
-      let initial_report_msgs_trn: Array[Array[ByteSeq] val] trn =
-        recover Array[Array[ByteSeq] val] end
+      let initial_report_msgs_trn = recover trn Array[Array[ByteSeq] val] end
       let connect_msg = HubProtocol.connect()
       let join_msg = HubProtocol.join("reports:market-spread")
       initial_report_msgs_trn.push(connect_msg)
@@ -268,7 +267,7 @@ class LegalSymbols
   let symbols: Array[String] val
 
   new create() =>
-    let padded: Array[String] trn = recover Array[String] end
+    let padded = recover trn Array[String] end
     for symbol in RawSymbols().values() do
       padded.push(RawSymbols.pad_symbol(symbol))
     end

--- a/testing/runs/w_actor/main.pony
+++ b/testing/runs/w_actor/main.pony
@@ -166,7 +166,7 @@ class A is WActor
     wh.register_as_role(BasicRoles.ingress())
     _all_message_types =
       try
-        let ts: Array[AMsgBuilder val] trn = recover Array[AMsgBuilder val] end
+        let ts = recover trn Array[AMsgBuilder val] end
         ts.push(SetActorProbability as AMsgBuilder val)
         ts.push(SetNumberOfMessagesToSend as AMsgBuilder val)
         ts.push(ChangeMessageTypesToSend as AMsgBuilder val)

--- a/testing/runs/w_actor_crdt/main.pony
+++ b/testing/runs/w_actor_crdt/main.pony
@@ -260,7 +260,7 @@ class val PMap[K: (Hashable val & Equatable[K] val), V: Any val]
   fun apply(k: K): V ? => _s(k)
 
   fun val update(k: K, v: V): PMap[K, V] =>
-    let m: Map[K, V] trn = recover Map[K, V] end
+    let m = recover trn Map[K, V] end
     for (k', v') in _s.pairs() do
       m(k') = v'
     end


### PR DESCRIPTION
There was a lot of unnecessary noise in
the code that this simplifies by replacing
code of the form `a: X trn = recover X end`
with `a = recover trn X end`. X was
often a long type name.