### PR TITLE
Use "debug" flag when building Wallaroo for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,4 +119,4 @@ install:
   - echo "Installing pytest";
     python2 -m pip install pytest==3.1.0
 script:
-  - make test
+  - make test debug=true


### PR DESCRIPTION
Debug will allow us to catch errors we might not otherwise get.
We have various "shouldn't happen" invariants in ifdef debug blocks.

Closes #1129