### PR TITLE
Apply Pony license to derived works

### DIFF
--- a/lib/sendence/connemara/_color.pony
+++ b/lib/sendence/connemara/_color.pony
@@ -1,3 +1,32 @@
+/*
+
+Copyright (C) 2016-2017, Sendence LLC
+Copyright (C) 2016-2017, The Pony Developers
+Copyright (c) 2014-2015, Causality Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
 primitive _Color
   """
   Strings to embedded in text to specify colours. These are copies of the

--- a/lib/sendence/connemara/_group.pony
+++ b/lib/sendence/connemara/_group.pony
@@ -1,3 +1,32 @@
+/*
+
+Copyright (C) 2016-2017, Sendence LLC
+Copyright (C) 2016-2017, The Pony Developers
+Copyright (c) 2014-2015, Causality Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
 trait tag _Group
   """
   Test exclusion is achieved by organising tests into groups. Each group can be

--- a/lib/sendence/connemara/_test_record.pony
+++ b/lib/sendence/connemara/_test_record.pony
@@ -1,3 +1,32 @@
+/*
+
+Copyright (C) 2016-2017, Sendence LLC
+Copyright (C) 2016-2017, The Pony Developers
+Copyright (c) 2014-2015, Causality Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
 class _TestRecord
   """
   Store and report the result and log from a single test.

--- a/lib/sendence/connemara/_test_runner.pony
+++ b/lib/sendence/connemara/_test_runner.pony
@@ -1,3 +1,32 @@
+/*
+
+Copyright (C) 2016-2017, Sendence LLC
+Copyright (C) 2016-2017, The Pony Developers
+Copyright (c) 2014-2015, Causality Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
 use "time"
 
 actor _TestRunner

--- a/lib/sendence/connemara/connemara.pony
+++ b/lib/sendence/connemara/connemara.pony
@@ -1,3 +1,32 @@
+/*
+
+Copyright (C) 2016-2017, Sendence LLC
+Copyright (C) 2016-2017, The Pony Developers
+Copyright (c) 2014-2015, Causality Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
 """
 # Connemara package
 

--- a/lib/sendence/connemara/test_helper.pony
+++ b/lib/sendence/connemara/test_helper.pony
@@ -1,3 +1,32 @@
+/*
+
+Copyright (C) 2016-2017, Sendence LLC
+Copyright (C) 2016-2017, The Pony Developers
+Copyright (c) 2014-2015, Causality Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
 interface ITest
   fun apply() ?
 

--- a/lib/sendence/connemara/test_list.pony
+++ b/lib/sendence/connemara/test_list.pony
@@ -1,3 +1,32 @@
+/*
+
+Copyright (C) 2016-2017, Sendence LLC
+Copyright (C) 2016-2017, The Pony Developers
+Copyright (c) 2014-2015, Causality Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
 trait TestList
   """
   Source of unit tests for a Connemara object.

--- a/lib/sendence/connemara/unit_test.pony
+++ b/lib/sendence/connemara/unit_test.pony
@@ -1,3 +1,32 @@
+/*
+
+Copyright (C) 2016-2017, Sendence LLC
+Copyright (C) 2016-2017, The Pony Developers
+Copyright (c) 2014-2015, Causality Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
 trait UnitTest
   """
   Each unit test class must provide this trait. Simple tests only need to

--- a/lib/sendence/options/_test.pony
+++ b/lib/sendence/options/_test.pony
@@ -1,3 +1,32 @@
+/*
+
+Copyright (C) 2016-2017, Sendence LLC
+Copyright (C) 2016-2017, The Pony Developers
+Copyright (c) 2014-2015, Causality Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
 use "sendence/connemara"
 
 actor Main is TestList

--- a/lib/sendence/options/options.pony
+++ b/lib/sendence/options/options.pony
@@ -1,3 +1,32 @@
+/*
+
+Copyright (C) 2016-2017, Sendence LLC
+Copyright (C) 2016-2017, The Pony Developers
+Copyright (c) 2014-2015, Causality Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
 """
 # Options package
 

--- a/lib/wallaroo/boundary/boundary.pony
+++ b/lib/wallaroo/boundary/boundary.pony
@@ -1,3 +1,32 @@
+/*
+
+Copyright (C) 2016-2017, Sendence LLC
+Copyright (C) 2016-2017, The Pony Developers
+Copyright (c) 2014-2015, Causality Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
 use "buffered"
 use "collections"
 use "net"

--- a/lib/wallaroo/data_channel/_test.pony
+++ b/lib/wallaroo/data_channel/_test.pony
@@ -1,3 +1,32 @@
+/*
+
+Copyright (C) 2016-2017, Sendence LLC
+Copyright (C) 2016-2017, The Pony Developers
+Copyright (c) 2014-2015, Causality Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
 use "sendence/connemara"
 use "wallaroo/boundary"
 use "wallaroo/metrics"

--- a/lib/wallaroo/data_channel/data_channel.pony
+++ b/lib/wallaroo/data_channel/data_channel.pony
@@ -1,3 +1,32 @@
+/*
+
+Copyright (C) 2016-2017, Sendence LLC
+Copyright (C) 2016-2017, The Pony Developers
+Copyright (c) 2014-2015, Causality Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
 use "buffered"
 use "collections"
 use "net"

--- a/lib/wallaroo/data_channel/data_channel_listener.pony
+++ b/lib/wallaroo/data_channel/data_channel_listener.pony
@@ -1,3 +1,32 @@
+/*
+
+Copyright (C) 2016-2017, Sendence LLC
+Copyright (C) 2016-2017, The Pony Developers
+Copyright (c) 2014-2015, Causality Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
 use "collections"
 use "net"
 use "wallaroo/boundary"

--- a/lib/wallaroo/data_channel/data_channel_listener_notify.pony
+++ b/lib/wallaroo/data_channel/data_channel_listener_notify.pony
@@ -1,3 +1,32 @@
+/*
+
+Copyright (C) 2016-2017, Sendence LLC
+Copyright (C) 2016-2017, The Pony Developers
+Copyright (c) 2014-2015, Causality Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
 use "collections"
 use "wallaroo/boundary"
 use "wallaroo/topology"

--- a/lib/wallaroo/data_channel/data_channel_notify.pony
+++ b/lib/wallaroo/data_channel/data_channel_notify.pony
@@ -1,3 +1,32 @@
+/*
+
+Copyright (C) 2016-2017, Sendence LLC
+Copyright (C) 2016-2017, The Pony Developers
+Copyright (c) 2014-2015, Causality Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
 use "collections"
 use "wallaroo/boundary"
 

--- a/lib/wallaroo/data_channel/data_channel_tcp.pony
+++ b/lib/wallaroo/data_channel/data_channel_tcp.pony
@@ -1,3 +1,32 @@
+/*
+
+Copyright (C) 2016-2017, Sendence LLC
+Copyright (C) 2016-2017, The Pony Developers
+Copyright (c) 2014-2015, Causality Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
 use "buffered"
 use "collections"
 use "time"

--- a/lib/wallaroo/tcp_sink/tcp_sink.pony
+++ b/lib/wallaroo/tcp_sink/tcp_sink.pony
@@ -1,3 +1,32 @@
+/*
+
+Copyright (C) 2016-2017, Sendence LLC
+Copyright (C) 2016-2017, The Pony Developers
+Copyright (c) 2014-2015, Causality Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
 use "buffered"
 use "collections"
 use "net"

--- a/lib/wallaroo/tcp_source/source_listener_notify.pony
+++ b/lib/wallaroo/tcp_source/source_listener_notify.pony
@@ -1,0 +1,38 @@
+use "wallaroo/fail"
+use "wallaroo/recovery"
+use "wallaroo/source"
+use "wallaroo/topology"
+
+class SourceListenerNotify is TCPSourceListenerNotify
+  var _source_builder: SourceBuilder
+  let _event_log: EventLog
+  let _target_router: Router
+  let _auth: AmbientAuth
+
+  new iso create(builder: SourceBuilder, event_log: EventLog, auth: AmbientAuth,
+    target_router: Router) =>
+    _source_builder = builder
+    _event_log = event_log
+    _target_router = target_router
+    _auth = auth
+
+  fun ref listening(listen: TCPSourceListener ref) =>
+    @printf[I32]((_source_builder.name() + " source is listening\n").cstring())
+
+  fun ref not_listening(listen: TCPSourceListener ref) =>
+    @printf[I32](
+      (_source_builder.name() + " source is unable to listen\n").cstring())
+    Fail()
+
+  fun ref connected(listen: TCPSourceListener ref): TCPSourceNotify iso^ ? =>
+    try
+      _source_builder(_event_log, _auth, _target_router) as TCPSourceNotify iso^
+    else
+      @printf[I32](
+        (_source_builder.name() + " could not create a TCPSourceNotify\n").cstring())
+      Fail()
+      error
+    end
+
+  fun ref update_router(router: Router) =>
+    _source_builder = _source_builder.update_router(router)

--- a/lib/wallaroo/tcp_source/tcp_source.pony
+++ b/lib/wallaroo/tcp_source/tcp_source.pony
@@ -1,3 +1,32 @@
+/*
+
+Copyright (C) 2016-2017, Sendence LLC
+Copyright (C) 2016-2017, The Pony Developers
+Copyright (c) 2014-2015, Causality Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
 use "buffered"
 use "collections"
 use "net"

--- a/lib/wallaroo/tcp_source/tcp_source_listener.pony
+++ b/lib/wallaroo/tcp_source/tcp_source_listener.pony
@@ -1,3 +1,32 @@
+/*
+
+Copyright (C) 2016-2017, Sendence LLC
+Copyright (C) 2016-2017, The Pony Developers
+Copyright (c) 2014-2015, Causality Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
 use "collections"
 use "wallaroo/boundary"
 use "wallaroo/core"
@@ -8,79 +37,6 @@ use "wallaroo/routing"
 use "wallaroo/source"
 use "wallaroo/tcp_sink"
 use "wallaroo/topology"
-
-class val TCPSourceListenerBuilderBuilder
-  let _host: String
-  let _service: String
-
-  new val create(host: String, service: String) =>
-    _host = host
-    _service = service
-
-  fun apply(source_builder: SourceBuilder, router: Router,
-    router_registry: RouterRegistry, route_builder: RouteBuilder,
-    outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val,
-    event_log: EventLog, auth: AmbientAuth,
-    layout_initializer: LayoutInitializer,
-    metrics_reporter: MetricsReporter iso,
-    default_target: (Step | None) = None,
-    default_in_route_builder: (RouteBuilder | None) = None,
-    target_router: Router = EmptyRouter): TCPSourceListenerBuilder
-  =>
-    TCPSourceListenerBuilder(source_builder, router, router_registry,
-      route_builder,
-      outgoing_boundary_builders, event_log, auth,
-      layout_initializer, consume metrics_reporter, default_target,
-      default_in_route_builder, target_router, _host, _service)
-
-class val TCPSourceListenerBuilder
-  let _source_builder: SourceBuilder
-  let _router: Router
-  let _router_registry: RouterRegistry
-  let _route_builder: RouteBuilder
-  let _default_in_route_builder: (RouteBuilder | None)
-  let _outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val
-  let _layout_initializer: LayoutInitializer
-  let _event_log: EventLog
-  let _auth: AmbientAuth
-  let _default_target: (Step | None)
-  let _target_router: Router
-  let _host: String
-  let _service: String
-  let _metrics_reporter: MetricsReporter
-
-  new val create(source_builder: SourceBuilder, router: Router,
-    router_registry: RouterRegistry, route_builder: RouteBuilder,
-    outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val,
-    event_log: EventLog, auth: AmbientAuth,
-    layout_initializer: LayoutInitializer,
-    metrics_reporter: MetricsReporter iso,
-    default_target: (Step | None) = None,
-    default_in_route_builder: (RouteBuilder | None) = None,
-    target_router: Router = EmptyRouter,
-    host: String = "", service: String = "0")
-  =>
-    _source_builder = source_builder
-    _router = router
-    _router_registry = router_registry
-    _route_builder = route_builder
-    _default_in_route_builder = default_in_route_builder
-    _outgoing_boundary_builders = outgoing_boundary_builders
-    _layout_initializer = layout_initializer
-    _event_log = event_log
-    _auth = auth
-    _default_target = default_target
-    _target_router = target_router
-    _host = host
-    _service = service
-    _metrics_reporter = consume metrics_reporter
-
-  fun apply(): SourceListener =>
-    TCPSourceListener(_source_builder, _router, _router_registry,
-      _route_builder, _outgoing_boundary_builders,
-      _event_log, _auth, _layout_initializer, _metrics_reporter.clone(),
-      _default_target, _default_in_route_builder, _target_router, _host,
-      _service)
 
 actor TCPSourceListener is SourceListener
   """

--- a/lib/wallaroo/tcp_source/tcp_source_listener_builder.pony
+++ b/lib/wallaroo/tcp_source/tcp_source_listener_builder.pony
@@ -1,0 +1,82 @@
+use "collections"
+use "wallaroo/boundary"
+use "wallaroo/initialization"
+use "wallaroo/metrics"
+use "wallaroo/recovery"
+use "wallaroo/routing"
+use "wallaroo/source"
+use "wallaroo/topology"
+
+class val TCPSourceListenerBuilder
+  let _source_builder: SourceBuilder
+  let _router: Router
+  let _router_registry: RouterRegistry
+  let _route_builder: RouteBuilder
+  let _default_in_route_builder: (RouteBuilder | None)
+  let _outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val
+  let _layout_initializer: LayoutInitializer
+  let _event_log: EventLog
+  let _auth: AmbientAuth
+  let _default_target: (Step | None)
+  let _target_router: Router
+  let _host: String
+  let _service: String
+  let _metrics_reporter: MetricsReporter
+
+  new val create(source_builder: SourceBuilder, router: Router,
+    router_registry: RouterRegistry, route_builder: RouteBuilder,
+    outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val,
+    event_log: EventLog, auth: AmbientAuth,
+    layout_initializer: LayoutInitializer,
+    metrics_reporter: MetricsReporter iso,
+    default_target: (Step | None) = None,
+    default_in_route_builder: (RouteBuilder | None) = None,
+    target_router: Router = EmptyRouter,
+    host: String = "", service: String = "0")
+  =>
+    _source_builder = source_builder
+    _router = router
+    _router_registry = router_registry
+    _route_builder = route_builder
+    _default_in_route_builder = default_in_route_builder
+    _outgoing_boundary_builders = outgoing_boundary_builders
+    _layout_initializer = layout_initializer
+    _event_log = event_log
+    _auth = auth
+    _default_target = default_target
+    _target_router = target_router
+    _host = host
+    _service = service
+    _metrics_reporter = consume metrics_reporter
+
+  fun apply(): SourceListener =>
+    TCPSourceListener(_source_builder, _router, _router_registry,
+      _route_builder, _outgoing_boundary_builders,
+      _event_log, _auth, _layout_initializer, _metrics_reporter.clone(),
+      _default_target, _default_in_route_builder, _target_router, _host,
+      _service)
+
+class val TCPSourceListenerBuilderBuilder
+  let _host: String
+  let _service: String
+
+  new val create(host: String, service: String) =>
+    _host = host
+    _service = service
+
+  fun apply(source_builder: SourceBuilder, router: Router,
+    router_registry: RouterRegistry, route_builder: RouteBuilder,
+    outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val,
+    event_log: EventLog, auth: AmbientAuth,
+    layout_initializer: LayoutInitializer,
+    metrics_reporter: MetricsReporter iso,
+    default_target: (Step | None) = None,
+    default_in_route_builder: (RouteBuilder | None) = None,
+    target_router: Router = EmptyRouter): TCPSourceListenerBuilder
+  =>
+    TCPSourceListenerBuilder(source_builder, router, router_registry,
+      route_builder,
+      outgoing_boundary_builders, event_log, auth,
+      layout_initializer, consume metrics_reporter, default_target,
+      default_in_route_builder, target_router, _host, _service)
+

--- a/lib/wallaroo/tcp_source/tcp_source_notify.pony
+++ b/lib/wallaroo/tcp_source/tcp_source_notify.pony
@@ -1,3 +1,32 @@
+/*
+
+Copyright (C) 2016-2017, Sendence LLC
+Copyright (C) 2016-2017, The Pony Developers
+Copyright (c) 2014-2015, Causality Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
 use "collections"
 use "wallaroo/boundary"
 use "wallaroo/core"

--- a/lib/wallaroo/tcp_source/typed_tcp_source_builder_builder.pony
+++ b/lib/wallaroo/tcp_source/typed_tcp_source_builder_builder.pony
@@ -1,0 +1,37 @@
+use "wallaroo/metrics"
+use "wallaroo/source"
+use "wallaroo/topology"
+
+class val TypedTCPSourceBuilderBuilder[In: Any val]
+  let _app_name: String
+  let _name: String
+  let _handler: FramedSourceHandler[In] val
+  let _host: String
+  let _service: String
+
+  new val create(app_name: String, name': String,
+    handler: FramedSourceHandler[In] val, host': String, service': String)
+  =>
+    _app_name = app_name
+    _name = name'
+    _handler = handler
+    _host = host'
+    _service = service'
+
+  fun name(): String => _name
+
+  fun apply(runner_builder: RunnerBuilder, router: Router,
+    metrics_conn: MetricsSink, pre_state_target_id: (U128 | None) = None,
+    worker_name: String, metrics_reporter: MetricsReporter iso):
+      SourceBuilder
+  =>
+    BasicSourceBuilder[In, FramedSourceHandler[In] val](_app_name, worker_name,
+      _name, runner_builder, _handler, router,
+      metrics_conn, pre_state_target_id, consume metrics_reporter,
+      TCPFramedSourceNotifyBuilder[In])
+
+  fun host(): String =>
+    _host
+
+  fun service(): String =>
+    _service


### PR DESCRIPTION
This breaks apart some files so that Sendence code that isn't derived
from Pony derived code live in different files. Also adds the
appropriate BSD-2 clause license to the Pony derived sources.