### PR TITLE
Remove coalescing from Python API

### DIFF
--- a/book/python/api.md
+++ b/book/python/api.md
@@ -54,7 +54,7 @@ The `ApplicationBuilder` class in `wallaroo` is a utility for constructing appli
 
 Create a new application with the name `name`.
 
-##### `new_pipeline(name, decoder[, coalescing=True])`
+##### `new_pipeline(name, decoder`
 
 Create a new pipline with the name `name`, and a `decoder` instance of [SourceDecoder](#sourcedecoder).
 

--- a/machida/wallaroo.py
+++ b/machida/wallaroo.py
@@ -18,11 +18,11 @@ class ApplicationBuilder(object):
     def __init__(self, name):
         self._actions = [("name", name)]
 
-    def new_pipeline(self, name, decoder, coalescing=True):
+    def new_pipeline(self, name, decoder):
         if inspect.isclass(decoder):
             raise WallarooParameterError("Expecting a Decoder instance. Got a "
                                          "class instead.")
-        self._actions.append(("new_pipeline", name, decoder, coalescing))
+        self._actions.append(("new_pipeline", name, decoder))
         return self
 
     def to(self, computation):


### PR DESCRIPTION
The option to turn off coalescing was removed in #1109. This commit
removes it from the Python API. It was never added to the C++ API.

Closes #1154