### PR TITLE
Make OutgoingToIncomingMessageTracker package private

### DIFF
--- a/lib/wallaroo/ent/watermarking/_test_outgoing_to_incoming_message_tracker.pony
+++ b/lib/wallaroo/ent/watermarking/_test_outgoing_to_incoming_message_tracker.pony
@@ -27,7 +27,7 @@ class iso _TestEmptyIndexFor is UnitTest
     "outgoing_to_incoming_message_tracker/EmptyIndexFor"
 
   fun ref apply(h: TestHelper) =>
-    let t = OutgoingToIncomingMessageTracker
+    let t = _OutgoingToIncomingMessageTracker
 
     h.assert_eq[USize](-1, t._index_for(1))
 
@@ -36,7 +36,7 @@ class iso _TestBelowFirstIndex is UnitTest
     "outgoing_to_incoming_message_tracker/BelowFirstIndex"
 
   fun ref apply(h: TestHelper) =>
-    let t = OutgoingToIncomingMessageTracker
+    let t = _OutgoingToIncomingMessageTracker
 
     t.add(SeqId(2), _TestProducer, RouteId(1), SeqId(1))
 
@@ -47,7 +47,7 @@ class iso _TestIndexFor1 is UnitTest
     "outgoing_to_incoming_message_tracker/IndexFor1"
 
   fun ref apply(h: TestHelper) =>
-    let t = OutgoingToIncomingMessageTracker
+    let t = _OutgoingToIncomingMessageTracker
 
     t.add(SeqId(1), _TestProducer, RouteId(1), SeqId(1))
     t.add(SeqId(2), _TestProducer, RouteId(1), SeqId(2))
@@ -68,7 +68,7 @@ class iso _TestIndexFor2 is UnitTest
     "outgoing_to_incoming_message_tracker/IndexFor2"
 
   fun ref apply(h: TestHelper) =>
-    let t = OutgoingToIncomingMessageTracker
+    let t = _OutgoingToIncomingMessageTracker
 
     t.add(SeqId(505), _TestProducer, RouteId(1), SeqId(10))
     t.add(SeqId(506), _TestProducer, RouteId(1), SeqId(11))
@@ -89,7 +89,7 @@ class iso _TestIndexForWithGaps is UnitTest
     "outgoing_to_incoming_message_tracker/IndexForWithGaps"
 
   fun ref apply(h: TestHelper) =>
-    let t = OutgoingToIncomingMessageTracker
+    let t = _OutgoingToIncomingMessageTracker
 
     t.add(SeqId(505), _TestProducer, RouteId(1), SeqId(10))
     t.add(SeqId(516), _TestProducer, RouteId(1), SeqId(11))
@@ -115,7 +115,7 @@ class iso _TestIndexForWithGaps2 is UnitTest
     "outgoing_to_incoming_message_tracker/IndexForWithGaps2"
 
   fun ref apply(h: TestHelper) =>
-    let t = OutgoingToIncomingMessageTracker
+    let t = _OutgoingToIncomingMessageTracker
 
     t.add(SeqId(505), _TestProducer, RouteId(1), SeqId(10))
     t.add(SeqId(516), _TestProducer, RouteId(1), SeqId(11))
@@ -144,7 +144,7 @@ class iso _TestOriginHighsBelow1 is UnitTest
     let o1route = RouteId(1)
     let o2 = _TestProducer
     let o2route = RouteId(3)
-    let t = OutgoingToIncomingMessageTracker
+    let t = _OutgoingToIncomingMessageTracker
 
     t.add(SeqId(1), o1, o1route, SeqId(1))
     t.add(SeqId(2), o2, o2route, SeqId(1))
@@ -177,7 +177,7 @@ class iso _TestOriginHighsBelow2 is UnitTest
     let o1route = RouteId(1)
     let o2 = _TestProducer
     let o2route = RouteId(3)
-    let t = OutgoingToIncomingMessageTracker
+    let t = _OutgoingToIncomingMessageTracker
 
     t.add(SeqId(1), o1, o1route, SeqId(1))
     t.add(SeqId(2), o2, o2route, SeqId(1))
@@ -205,7 +205,7 @@ class iso _TestOriginHighsBelowWithOneToManyPartiallyAcked is UnitTest
     let o1route = RouteId(1)
     let o2 = _TestProducer
     let o2route = RouteId(3)
-    let t = OutgoingToIncomingMessageTracker
+    let t = _OutgoingToIncomingMessageTracker
 
     t.add(SeqId(1), o1, o1route, SeqId(1))
     // this incoming message is 1 to many
@@ -236,7 +236,7 @@ class iso _TestOriginHighsBelowWithOneToManyFullyAcked1 is UnitTest
     let o1route = RouteId(1)
     let o2 = _TestProducer
     let o2route = RouteId(3)
-    let t = OutgoingToIncomingMessageTracker
+    let t = _OutgoingToIncomingMessageTracker
 
     t.add(SeqId(1), o1, o1route, SeqId(1))
     // this incoming message is 1 to many
@@ -268,7 +268,7 @@ class iso _TestOriginHighsBelowWithOneToManyFullyAcked2 is UnitTest
     let o1route = RouteId(1)
     let o2 = _TestProducer
     let o2route = RouteId(3)
-    let t = OutgoingToIncomingMessageTracker
+    let t = _OutgoingToIncomingMessageTracker
 
     t.add(SeqId(1), o1, o1route, SeqId(1))
     // this incoming message is 1 to many
@@ -301,7 +301,7 @@ class iso _TestOriginHighsBelowWithOneToManyFullyAcked3 is UnitTest
     let o1route = RouteId(1)
     let o2 = _TestProducer
     let o2route = RouteId(3)
-    let t = OutgoingToIncomingMessageTracker
+    let t = _OutgoingToIncomingMessageTracker
 
     t.add(SeqId(1), o1, o1route, SeqId(1))
     // this incoming message is 1 to many
@@ -333,7 +333,7 @@ class iso _TestOutgoingToIncomingEviction is UnitTest
     let o1route = RouteId(1)
     let o2 = _TestProducer
     let o2route = RouteId(3)
-    let t = OutgoingToIncomingMessageTracker
+    let t = _OutgoingToIncomingMessageTracker
 
     t.add(SeqId(1), o1, o1route, SeqId(1))
     t.add(SeqId(2), o2, o2route, SeqId(1))
@@ -362,7 +362,7 @@ class iso _TestOutgoingToIncomingEvictionBelow is UnitTest
     let o1route = RouteId(1)
     let o2 = _TestProducer
     let o2route = RouteId(3)
-    let t = OutgoingToIncomingMessageTracker
+    let t = _OutgoingToIncomingMessageTracker
 
 
     t.add(SeqId(5), o2, o2route, SeqId(2))

--- a/lib/wallaroo/ent/watermarking/acker.pony
+++ b/lib/wallaroo/ent/watermarking/acker.pony
@@ -13,13 +13,13 @@ class Acker
   let _ack_batch_size: USize
   var _ack_next_time: Bool = false
   var _last_proposed_watermark: SeqId = 0
-  let _outgoing_to_incoming: OutgoingToIncomingMessageTracker
+  let _outgoing_to_incoming: _OutgoingToIncomingMessageTracker
   let _watermarker: Watermarker
 
   // TODO: Change this to a reasonable value!
   new create(ack_batch_size': USize = 100) =>
     _ack_batch_size = ack_batch_size'
-    _outgoing_to_incoming = OutgoingToIncomingMessageTracker(_ack_batch_size)
+    _outgoing_to_incoming = _OutgoingToIncomingMessageTracker(_ack_batch_size)
     _watermarker = Watermarker
 
   fun ref add_route(route: Route) =>

--- a/lib/wallaroo/ent/watermarking/outgoing_to_incoming_message_tracker.pony
+++ b/lib/wallaroo/ent/watermarking/outgoing_to_incoming_message_tracker.pony
@@ -4,13 +4,13 @@ use "wallaroo/fail"
 use "wallaroo/invariant"
 use "wallaroo/routing"
 
-type ProducerRouteSeqId is (Producer, RouteId, SeqId)
+type _ProducerRouteSeqId is (Producer, RouteId, SeqId)
 
-class ref OutgoingToIncomingMessageTracker
-  let _seq_id_to_incoming: Array[(SeqId, ProducerRouteSeqId)]
+class ref _OutgoingToIncomingMessageTracker
+  let _seq_id_to_incoming: Array[(SeqId, _ProducerRouteSeqId)]
 
   new create(size': USize = 0) =>
-    _seq_id_to_incoming = Array[(SeqId, ProducerRouteSeqId)](size')
+    _seq_id_to_incoming = Array[(SeqId, _ProducerRouteSeqId)](size')
 
   fun ref add(o_seq_id: SeqId, i_origin: Producer, i_route_id: RouteId,
     i_seq_id: SeqId)

--- a/lib/wallaroo/ent/watermarking/terminus_route.pony
+++ b/lib/wallaroo/ent/watermarking/terminus_route.pony
@@ -18,14 +18,15 @@ class TerminusRoute
   var _highest_tracking_id_acked: U64 = 0
   let _ack_batch_size: USize
   var _tracking_id: U64 = 0
-  let _tracking_id_to_incoming: OutgoingToIncomingMessageTracker
+  let _tracking_id_to_incoming: _OutgoingToIncomingMessageTracker
   var _acked_watermark: U64 = 0
   var _ack_next_time: Bool = false
 
   // TODO: Change this to a reasonable value!
   new create(ack_batch_size': USize = 100) =>
     _ack_batch_size = ack_batch_size'
-    _tracking_id_to_incoming = OutgoingToIncomingMessageTracker(_ack_batch_size)
+    _tracking_id_to_incoming =
+      _OutgoingToIncomingMessageTracker(_ack_batch_size)
 
   fun ref terminate(i_origin: Producer, i_route_id: RouteId,
     i_seq_id: SeqId): SeqId

--- a/lib/wallaroo/ent/watermarking/watermarking.pony
+++ b/lib/wallaroo/ent/watermarking/watermarking.pony
@@ -30,7 +30,7 @@ back to the source.
 To chain acknowledgements in this fashion, a Step like A needs to know what
 incoming message from an upstream `Producer` corresponds to what message that
 was sent to a downstream `Consumer`. This incoming to outgoing tracking is done
-in the `OutgoingToIncomingMessageTracker` class.
+in the `_OutgoingToIncomingMessageTracker` class.
 
 Acknowledged messages are recorded in the `Watermarker` class on a per route
 basis. A `Route` is a point between two steps. For example, A --> B results
@@ -40,7 +40,7 @@ messages can be acknowledged by a step at any given point in time. Each step's
 any messages that entered the step but had no corresponding output message.
 
 The `Acker` class is responsible for coordinating between the `Watermarker`
-and the `OutgoingToIncomingMessageTracker`. The `Acker` receives acks from
+and the `_OutgoingToIncomingMessageTracker`. The `Acker` receives acks from
 downstream consumers and will periodically check to see if it can acknowledge
 anything back to any of it's upstream producers.
 


### PR DESCRIPTION
It's only used in `ent/watermarking`.