### PR TITLE
Report source ingestion metrics

### DIFF
--- a/lib/wallaroo/source/kafka_source/kafka_source_notify.pony
+++ b/lib/wallaroo/source/kafka_source/kafka_source_notify.pony
@@ -51,6 +51,7 @@ class KafkaSourceNotify[In: Any val]
   fun ref received(src: KafkaSource[In] ref, msg: KafkaMessage val,
     network_received_timestamp: U64)
   =>
+    _metrics_reporter.pipeline_ingest(_pipeline_name, _source_name)
     let ingest_ts = Time.nanos()
     let pipeline_time_spent: U64 = 0
     var latest_metrics_id: U16 = 1

--- a/lib/wallaroo/tcp_source/framed_source_notify.pony
+++ b/lib/wallaroo/tcp_source/framed_source_notify.pony
@@ -67,6 +67,7 @@ class TCPFramedSourceNotify[In: Any val] is TCPSourceNotify
       end
       true
     else
+      _metrics_reporter.pipeline_ingest(_pipeline_name, _source_name)
       let ingest_ts = Time.nanos()
       let pipeline_time_spent: U64 = 0
       var latest_metrics_id: U16 = 1

--- a/lib/wallaroo/topology/steps.pony
+++ b/lib/wallaroo/topology/steps.pony
@@ -229,10 +229,10 @@ actor Step is (Producer & Consumer)
       msg_uid, frac_ids, i_seq_id, i_route_id,
       latest_ts, metrics_id, worker_ingress_ts)
 
-  fun ref _run[D: Any val](metric_name: String, pipeline_time_spent: U64, data: D,
-    i_origin: Producer, msg_uid: U128, frac_ids: FractionalMessageId,
-    i_seq_id: SeqId, i_route_id: RouteId,
-    latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64)
+  fun ref _run[D: Any val](metric_name: String, pipeline_time_spent: U64,
+    data: D, i_origin: Producer, msg_uid: U128, frac_ids: FractionalMessageId,
+    i_seq_id: SeqId, i_route_id: RouteId, latest_ts: U64, metrics_id: U16,
+    worker_ingress_ts: U64)
   =>
     _seq_id_generator.new_incoming_message()
 


### PR DESCRIPTION
Given that 1-to-many can lead to misleading
values for overall pipeline throughput,
we now report the throughput of ingestion at
the source per pipeline to provide more
context.

Closes #1142