### PR TITLE
Remove C++ documentation from book

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -20,6 +20,7 @@
 * [Run a Wallaroo Application](book/getting-started/run-a-application.md)
 * [Conclusion](book/getting-started/conclusion.md)
 
+<!--
 ### Wallaroo C++ API
 * [C++ API Introduction](book/cpp/intro.md)
 * [C++ Sample Application](book/cpp/sample-application.md)
@@ -45,6 +46,7 @@
    * [StateComputation](book/cpp/api/state-computation.md)
    * [State](book/cpp/api/state.md)
    * [UserFunctions](book/cpp/api/user-functions.md)
+-->
 
 ### Wallaroo Python API
 * [Python API Introduction](book/python/intro.md)

--- a/book/core-concepts/intro.md
+++ b/book/core-concepts/intro.md
@@ -1,5 +1,3 @@
 # Core Concepts
 
 In this section, we are going to introduce you to the core concepts of Wallaroo that you will be working with when you use our APIs. This section is designed to get you "thinking in Wallaroo".
-
-We've tried to keep "Core Concepts" as language agnostic as possible. There are times when a problem is best illustrated by example code. When code is used, we've opted to go for examples in Pony rather than C++ or Python. We feel that C++ code could be hard for Python developers to following along with and Python examples would omit type information that can be helpful and would otherwise have to be supplied in text.

--- a/book/core-concepts/state.md
+++ b/book/core-concepts/state.md
@@ -22,10 +22,11 @@ So what is a state object? Let's explain via an example. Imagine we are writing 
 
 Wallaroo allows you to define your own state objects that match your domain. For example, our example application might define a state object as:
 
-```pony
-class Stock
-  var symbol: String
-  var latest_price: Float
+```python
+class Stock(object):
+    def __init__(self, symbol, price):
+        self.symbol = symbol
+        self.price = price
 ```
 
 State objects can be arbitrarily complex. Our example is two fields. If your application required it, you could build a deeply nested series of objects.

--- a/book/core-concepts/working-with-state.md
+++ b/book/core-concepts/working-with-state.md
@@ -7,9 +7,10 @@ Wallaroo's state objects allow developers to define their own domain-specific da
 Imagine a word counting application. We'll have a state object for each different word. Each word and count object would look something like:
 
 ```pony
-class WordAndCount
-  var word: String = ""
-  var count: U64 = 0
+class WordAndCount(object):
+    def __init__(self, word="", count=0):
+        self.word = word
+        self.count = count
 ```
 
 State computations allow you to read and write data to state objects. State computations have 3 inputs and 2 outputs. 
@@ -26,6 +27,4 @@ For the duration of this document, we're going to ignore the "state change repos
 
 ## Thread Safety
 
-When a state computation is running, one of the parameters it is provided is the state to operate on. That state will only be provided to a single state computation at a time. Within the state computation, you don't have to worry about thread synchronization issues[^threading]. 
-
-[^threading] Depending on your language, you may have to follow certain best practices. Check the best practices section for your language of choice for any caveats that might apply.
+When a state computation is running, one of the parameters it is provided is the state to operate on. That state will only be provided to a single state computation at a time. Within the state computation, you don't have to worry about thread synchronization issues. 

--- a/intro.md
+++ b/intro.md
@@ -17,13 +17,12 @@ This document is has been written to take an application developer from zero kno
 
 We designed this document for programmers that want to jump right in and get started using Wallaroo.  Starting with installing all of the necessary components required for Wallaroo and launching an example application in a local development environment.
 
-Although not required, you will get the most out of this tutorial if you have previous experience with an object-oriented language such as Java or C++.  Additionally, experience with stream processing and distributed computing systems and concepts would be helpful.
-
-The language specific portions of the document, for example, the C++ guide, assume that you have previously developed using the language and are comfortable with setting up a development environment for it.
+Although not required, you will get the most out of this tutorial if you have previous experience with Python.  Additionally, experience with stream processing and distributed computing systems and concepts would be helpful.
 
 ## Supported development environments
 
 It is currently possible to develop Wallaroo applications on MacOS, Linux or Windows. This guide has installation instructions for MacOS, Ubuntu Linux, and Windows 10 Pro via Bash/WSL. It's assumed if you are using a different Linux distribution that you are able to translate the Ubuntu instructions to your distribution of choice.
+
 ## What to Expect
 
 This document is organized into a number of sections. We recommend that you start in a linear fashion through this book. To that end, please consider reading in order:
@@ -40,13 +39,9 @@ Covers the concepts you'll need to understand in order to build a Wallaroo appli
 
 ### Developing with Wallaroo
 
-The "Getting Started" section is all about getting your development environment setup and then compiling and running a Wallaroo application. The tools you will install then are useful when developing a Wallaroo application regardless of which language you are using. You may have to install additional tools later to support your language of choice.
+The "Getting Started" section is all about getting your development environment setup and then compiling and running a Wallaroo application. The tools you will install then are useful when developing a Wallaroo application.
 
-By the time you are done with this, you will have touched many of the tools you'll use with Wallaroo as well has having run a Wallaroo application locally and shaken out any issues related to getting one setup. From there, you can proceed to documentation for your language of choice.
-
-### Wallaroo C++ API
-
-How to develop Wallaroo applications using C++.
+By the time you are done with this, you will have touched many of the tools you'll use with Wallaroo as well has having run a Wallaroo application locally and shaken out any issues related to getting one setup.
 
 ### Wallaroo Python API
 


### PR DESCRIPTION
We are going out the door with just Python. This removes C++
documentation from our index and as we only have a single supported
langauge, switches from Pony to Python for code examples.