### PR TITLE
Check before creating a duplicate OutgoingBoundary

### DIFF
--- a/lib/wallaroo/tcp_source/tcp_source.pony
+++ b/lib/wallaroo/tcp_source/tcp_source.pony
@@ -126,8 +126,10 @@ actor TCPSource is Producer
 
     _route_builder = route_builder
     for (target_worker_name, builder) in outgoing_boundary_builders.pairs() do
-      _outgoing_boundaries(target_worker_name) = builder.build_and_initialize(
-        _guid.u128(), _layout_initializer)
+      if not _outgoing_boundaries.contains(target_worker_name) then
+        _outgoing_boundaries(target_worker_name) = builder.build_and_initialize(
+          _guid.u128(), _layout_initializer)
+      end
     end
 
     //TODO: either only accept when we are done recovering or don't start


### PR DESCRIPTION
This fixes issue #1137 by making sure that when a source reconnects we are not
blindly recreating all OutgoingBoundary entries, which not only leads to new
ones being created and replacing the old ones, but the old ones still have
references being held to them somewhere which means that we now have duplicates.