### PR TITLE
Disable `make arch=amd64`

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -26,7 +26,7 @@ All of these must be run from the Wallaroo root directory.
 
 To build for x86_64 for AWS/Vagrant, run:
 
-`make arch=amd64`
+`make`
 
 This will use a docker container based `ponyc` to compile for x86_64 based on the Sendence fork of the Pony repository.
 

--- a/rules.mk
+++ b/rules.mk
@@ -182,7 +182,7 @@ ifeq ($(shell uname -s),Linux)
   docker_user_arg := -u `id -u`
   extra_awk_arg := \\
   host_ip_src = $(shell ifconfig `route -n | grep '^0.0.0.0' | awk '{print $$8}'` | egrep -o 'inet addr:[^ ]+' | awk -F: '{print $$2}')
-  system_cpus := $(shell sudo cset set -l -r | grep '/system' | awk '{print $$2}')
+  system_cpus := $(shell which cset && sudo cset set -l -r | grep '/system' | awk '{print $$2}')
   ifneq (,$(system_cpus))
     docker_cpu_arg := --cpuset-cpus $(system_cpus)
   endif
@@ -201,9 +201,12 @@ endif
 
 # validation of variable
 ifdef arch
-  ifeq (,$(filter $(arch),amd64 armhf native))
-    $(error Unknown architecture "$(arch)". Valid values are "amd64 armhf native")
+  ifeq (,$(filter $(arch),native))
+    $(error Unknown architecture "$(arch)". Valid value is "native")
   endif
+#  ifeq (,$(filter $(arch),amd64 armhf native))
+#    $(error Unknown architecture "$(arch)". Valid values are "amd64 armhf native")
+#  endif
 endif
 
 # validation of variable
@@ -647,7 +650,7 @@ help: ## this help message
           'BEGIN {FS = "$(extra_awk_arg)?="}; {printf "\033[36m%-40s\033[0m ##%s\n", $$1, \
           $$2}' | awk 'BEGIN {FS = "## "}; {printf "%s%s \033[36m(Default:\
  %s)\033[0m\n", $$1, $$3, $$2}'
-	$(QUIET)grep -h -E 'ifeq.*filter.*\)$$' $(MAKEFILE_LIST) | sort -u | awk \
+	$(QUIET)grep -h -E '^[^#]*ifeq.*filter.*\)$$' $(MAKEFILE_LIST) | sort -u | awk \
           'BEGIN {FS = "[(),]"}; {printf "\033[36m%-40s\033[0m %s\n", \
           " Valid values for " $$5 ":", $$7}'
 	$(QUIET)echo ''

--- a/testing/performance/apps/WALLAROO_PERFORMANCE_TESTING.md
+++ b/testing/performance/apps/WALLAROO_PERFORMANCE_TESTING.md
@@ -84,19 +84,19 @@ git clone https://github.com/sendence/buffy.git
 To build Market Spread:
 
 ```bash
-make arch=amd64 build-apps-market-spread
+make build-apps-market-spread
 ```
 
 To build Giles Sender:
 
 ```bash
-make build-giles-sender arch=amd64
+make build-giles-sender
 ```
 
 To build Giles Receiver:
 
 ```bash
-make build-giles-receiver arch=amd64
+make build-giles-receiver
 ```
 
 ### AWS

--- a/testing/performance/apps/market-spread/PERFORMANCE_TESTING_MARKET_SPREAD.md
+++ b/testing/performance/apps/market-spread/PERFORMANCE_TESTING_MARKET_SPREAD.md
@@ -89,21 +89,21 @@ To build Market Spread:
 
 ```bash
 cd ~/wallaroo
-make arch=amd64 build-testing-performance-apps-market-spread
+make build-testing-performance-apps-market-spread
 ```
 
 To build Giles Sender:
 
 ```bash
 cd ~/wallaroo
-make arch=amd64 build-giles-sender
+make build-giles-sender
 ```
 
 To build Giles Receiver:
 
 ```bash
 cd ~/wallaroo
-make arch=amd64 build-giles-receiver
+make build-giles-receiver
 ```
 
 ### SINGLE WORKER market spread:

--- a/testing/tools/dagon/docker-topology-for-double-divide.org
+++ b/testing/tools/dagon/docker-topology-for-double-divide.org
@@ -1176,9 +1176,9 @@ docker -H tcp://52.87.211.240:2378 login docker.sendence.com:5043
 Build and publish containers.
 #+BEGIN_SRC sh
 cd buffy
-make arch=amd64 debug=true
-make arch=amd64 debug=true build-docker
-make arch=amd64 debug=true push-docker
+make debug=true
+make debug=true build-docker
+make debug=true push-docker
 #+END_SRC
 
 ** Build Dagon
@@ -1338,7 +1338,7 @@ local Docker host. Build the AMD64 binaries.
 DOCKER_HOST=tcp://192.168.99.100:2376 # change this as needed
 cd buffy
 make clean;make clean
-make arch=amd64 debug=true
+make debug=true
 #+END_SRC
 
 Make sure your =DOCKER_HOST= shell environment is pointing to the
@@ -1346,7 +1346,7 @@ Make sure your =DOCKER_HOST= shell environment is pointing to the
 host.
 #+BEGIN_SRC sh
 export DOCKER_HOST=tcp://10.0.1.200:2375
-make arch=amd64 debug=true build-docker
+make debug=true build-docker
 #+END_SRC
 
 ** Update Configurations
@@ -1552,9 +1552,9 @@ Change into the main Buffy directory and build the binaries and
 container images:
 #+BEGIN_SRC sh
 cd buffy
-make arch=amd64 debug=true
-make arch=amd64 debug=true build-docker
-make arch=amd64 debug=true push-docker
+make debug=true
+make debug=true build-docker
+make debug=true push-docker
 #+END_SRC
 
 List the container images and note down the latest tag:
@@ -1666,8 +1666,8 @@ The following are the steps:
 1. create & configure cluster (with makefile)
 2. ssh into leader node
 3. git clone buffy repo
-4. build binaries using make arch=amd64
-5. build/push docker containers using make arch=amd64 push-docker
+4. build binaries using make
+5. build/push docker containers using make push-docker
 6. copy relevant files (ini, etc) to /tmp on leader node (use latest
    in repo with edits for image tag as necessary)
 7. exit ssh
@@ -1834,8 +1834,8 @@ default VirtualBox VM that comes with the default Docker install.
 ** Build
 #+BEGIN_SRC sh
 cd buffy
-make arch=amd64
-make arch=amd64 build-docker
+make
+make build-docker
 #+END_SRC
 
 ** Prepare

--- a/testing/tools/dagon/howto-run-double-divide-with-docker.org
+++ b/testing/tools/dagon/howto-run-double-divide-with-docker.org
@@ -38,8 +38,8 @@ Start the test like this:
 
 ** Build
 1. Checkout buffy and switch to branch "dagon-docker-reanimator"
-2. run "make arch=amd64"
-3. run "make arch=amd64 build-docker"
+2. run "make"
+3. run "make build-docker"
 4. cd dagon
 5. run "stable env ponyc --debug"
 

--- a/testing/tools/dagon/howto-test-buffy-performance-in-AWS.org
+++ b/testing/tools/dagon/howto-test-buffy-performance-in-AWS.org
@@ -205,18 +205,18 @@ git clone https://github.com/Sendence/buffy.git buffy
 We are using the pre-build ponyc container to build the binaries:
 #+BEGIN_SRC sh
 cd buffy
-make arch=amd64
+make
 #+END_SRC
 
 Build the container images if you intend to use them later:
 #+BEGIN_SRC sh
-make arch=amd64 build-docker
+make build-docker
 #+END_SRC
 
 This will build the container images and publish them to the local Docker registry.
 If you want to publish the resulting images to the Sendence registry you will need to run he publish command:
 #+BEGIN_SRC sh
-make arch=amd64 push-docker
+make push-docker
 #+END_SRC
 
 * Run Performance Tests


### PR DESCRIPTION
This PR disables the `make arch=amd64`/`make arch=armhf` functionality which uses docker containers behind the scenes to compile applications for the desired target architecture. I've changed all references of `make arch=amd64 <other stuff>` to `make <other stuff>` however this doesn't address other references to building with docker/building docker containers using `make`.