### PR TITLE
Fix Source Ingestion Metrics Reporting

### DIFF
--- a/lib/wallaroo/metrics/metrics.pony
+++ b/lib/wallaroo/metrics/metrics.pony
@@ -175,7 +175,7 @@ class MetricsReporter
         let reporter =
           _MetricsReporter(_metrics_conn, _app_name, _worker_name, pipeline,
             source_name, 0, "", PipelineIngestionCategory)
-        _pipeline_metrics_map(source_name) = reporter
+        _pipeline_ingestion_map(source_name) = reporter
         reporter
       end
 


### PR DESCRIPTION
- fixes map that _MetricsReporter is stored in when created in
  pipeline_ingest function so that a new _MetricsReporter is not
  created every time we report an ingested message metric.