### PR TITLE
Add Python support for Kafka sources and sinks

### DIFF
--- a/book/examples/python/alphabet/alphabet.py
+++ b/book/examples/python/alphabet/alphabet.py
@@ -9,11 +9,10 @@ def application_setup(args):
     out_host, out_port = wallaroo.tcp_parse_output_addrs(args)[0]
 
     ab = wallaroo.ApplicationBuilder("alphabet")
-    ab.new_pipeline("alphabet", Decoder(),
-                    wallaroo.TCPSourceConfig(in_host, in_port))
+    ab.new_pipeline("alphabet",
+                    wallaroo.TCPSourceConfig(in_host, in_port, Decoder()))
     ab.to_stateful(AddVotes(), LetterStateBuilder(), "letter state")
-    ab.to_sink(Encoder(),
-               wallaroo.TCPSinkConfig(out_host, out_port))
+    ab.to_sink(wallaroo.TCPSinkConfig(out_host, out_port, Encoder()))
     return ab.build()
 
 

--- a/book/examples/python/alphabet_partitioned/alphabet_partitioned.py
+++ b/book/examples/python/alphabet_partitioned/alphabet_partitioned.py
@@ -11,12 +11,11 @@ def application_setup(args):
 
     letter_partitions = list(string.ascii_lowercase)
     ab = wallaroo.ApplicationBuilder("alphabet")
-    ab.new_pipeline("alphabet", Decoder(),
-                    wallaroo.TCPSourceConfig(in_host, in_port))
+    ab.new_pipeline("alphabet",
+                    wallaroo.TCPSourceConfig(in_host, in_port, Decoder()))
     ab.to_state_partition(AddVotes(), LetterStateBuilder(), "letter state",
                           LetterPartitionFunction(), letter_partitions)
-    ab.to_sink(Encoder(),
-               wallaroo.TCPSinkConfig(out_host, out_port))
+    ab.to_sink(wallaroo.TCPSinkConfig(out_host, out_port, Encoder()))
     return ab.build()
 
 

--- a/book/examples/python/celsius-kafka/.gitignore
+++ b/book/examples/python/celsius-kafka/.gitignore
@@ -1,0 +1,3 @@
+*.pyc
+celsius.out
+celsius.msg

--- a/book/examples/python/celsius-kafka/Makefile
+++ b/book/examples/python/celsius-kafka/Makefile
@@ -1,0 +1,40 @@
+# include root makefile
+ifndef ROOT_MAKEFILE_MK
+include ../../../../Makefile
+endif
+
+# prevent rules from being evaluated/included multiple times
+ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
+$(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
+
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
+# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
+PONY_TARGET := false
+
+# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
+EXS_TARGET := false
+
+# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
+DOCKER_TARGET := false
+
+# uncomment to disable generate recursing into Makefiles of subdirectories
+RECURSE_SUBMAKEFILES := false
+
+CELSIUS_KAFKA_PY_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+# standard rules generation makefile
+include $(rules_mk_path)
+
+# args to RUN_DAGON and RUN_DAGON_SPIKE: $1 = test name; $2 = ini file; $3 = timeout; $4 = wesley test command, $5 = include in CI
+# NOTE: all paths must be relative to buffy directory (use buffy_path variable)
+
+##<NAME OF TARGET>: #used as part of `make help` command ## <DESCRIPTION OF TARGET>
+#$(eval $(call RUN_DAGON\
+#,<NAME OF TARGET> \
+#,$(buffy_path)/<PATH TO INI FILE> \
+#,<TIMEOUT VALUE> \
+#,<WESLEY TEST COMMAND> \
+#,<INCLUDE IN CI>))
+endif

--- a/book/examples/python/celsius-kafka/README.md
+++ b/book/examples/python/celsius-kafka/README.md
@@ -1,0 +1,40 @@
+# Celsius
+
+This is an example of a stateless Python application that takes a floating point Celsius value from Kafka and sends out a floating point Fahrenheit value to Kafka.
+
+
+## Prerequisites
+
+- ponyc
+- pony-stable
+- Wallaroo
+- Machida
+
+See [Wallaroo Environment Setup Instructions](https://github.com/sendence/wallaroo/book/getting-started/setup.md).
+
+## Running Celsius-kafka
+
+In a separate shell, each:
+
+1. In a shell, start up the Metrics UI if you don't already have it running:
+
+```bash
+docker start mui
+```
+
+2. Start the application
+
+```bash
+./machida --application-module celsius \
+  --kafka_source_topic test-in --kafka_source_brokers 127.0.0.1:9092 \
+  --kafka_sink_topic test-out --kafka_sink_brokers 127.0.0.1:9092 \
+  --kafka_sink_max_message_size 100000 --kafka_sink_max_produce_buffer_ms 10
+  --metrics 127.0.0.1:5001 --control 127.0.0.1:12500 --data 127.0.0.1:12501 \
+  --ponythreads=1
+```
+
+`kafka_sink_max_message_size` controls maximum size of message sent to kafka in a single produce request. Kafka will return errors if this is bigger than server is configured to accept.
+
+`kafka_sink_max_produce_buffer_ms` controls maximum time (in ms) to buffer messages before sending to kafka. Either don't specify it or set it to `0` to disable batching on produce.
+
+3. Send data into kafka using kafkacat or some other mechanism

--- a/book/examples/python/celsius-kafka/celsius.py
+++ b/book/examples/python/celsius-kafka/celsius.py
@@ -1,0 +1,53 @@
+import struct
+
+import wallaroo
+
+
+def application_setup(args):
+    (in_topic, in_brokers,
+     in_log_level) = wallaroo.kafka_parse_source_options(args)
+
+    (out_topic, out_brokers, out_log_level, out_max_produce_buffer_ms,
+     out_max_message_size) = wallaroo.kafka_parse_sink_options(args)
+
+    ab = wallaroo.ApplicationBuilder("Celsius to Fahrenheit with Kafka")
+
+    ab.new_pipeline("convert",
+                    wallaroo.KafkaSourceConfig(in_topic, in_brokers, in_log_level,
+                                               Decoder()))
+
+    ab.to(Multiply)
+    ab.to(Add)
+
+    ab.to_sink(wallaroo.KafkaSinkConfig(out_topic, out_brokers, out_log_level,
+                                        out_max_produce_buffer_ms,
+                                        out_max_message_size,
+                                        Encoder()))
+    return ab.build()
+
+
+class Decoder(object):
+    def decode(self, bs):
+        return struct.unpack('>f', bs)[0]
+
+
+class Multiply(object):
+    def name(self):
+        return "multiply by 1.8"
+
+    def compute(self, data):
+        return data * 1.8
+
+
+class Add(object):
+    def name(self):
+        return "add 32"
+
+    def compute(self, data):
+        return data + 32
+
+
+class Encoder(object):
+    def encode(self, data):
+        # data is a float
+        return (struct.pack('>f', data), None)

--- a/book/examples/python/celsius/celsius.py
+++ b/book/examples/python/celsius/celsius.py
@@ -8,12 +8,11 @@ def application_setup(args):
     out_host, out_port = wallaroo.tcp_parse_output_addrs(args)[0]
 
     ab = wallaroo.ApplicationBuilder("Celsius to Fahrenheit")
-    ab.new_pipeline("convert", Decoder(),
-                    wallaroo.TCPSourceConfig(in_host, in_port))
+    ab.new_pipeline("convert",
+                    wallaroo.TCPSourceConfig(in_host, in_port, Decoder()))
     ab.to(Multiply)
     ab.to(Add)
-    ab.to_sink(Encoder(),
-               wallaroo.TCPSinkConfig(out_host, out_port))
+    ab.to_sink(wallaroo.TCPSinkConfig(out_host, out_port, Encoder()))
     return ab.build()
 
 

--- a/book/examples/python/market_spread/market_spread.py
+++ b/book/examples/python/market_spread/market_spread.py
@@ -40,17 +40,17 @@ def application_setup(args):
 
     ab = wallaroo.ApplicationBuilder("market-spread")
     ab.new_pipeline(
-            "Orders", OrderDecoder(),
-            wallaroo.TCPSourceConfig(order_host, order_port)
+            "Orders",
+            wallaroo.TCPSourceConfig(order_host, order_port, OrderDecoder())
         ).to_state_partition_u64(
             CheckOrder(), SymbolDataBuilder(), "symbol-data",
             SymbolPartitionFunction(), symbol_partitions
-       ).to_sink(
-            OrderResultEncoder(),
-            wallaroo.TCPSinkConfig(out_host, out_port)
+       ).to_sink(wallaroo.TCPSinkConfig(out_host, out_port,
+                                        OrderResultEncoder())
        ).new_pipeline(
-            "Market Data", MarketDataDecoder(),
-            wallaroo.TCPSourceConfig(nbbo_host, nbbo_port)
+            "Market Data",
+            wallaroo.TCPSourceConfig(nbbo_host, nbbo_port,
+                                     MarketDataDecoder())
         ).to_state_partition_u64(
             UpdateMarketData(), SymbolDataBuilder(), "symbol-data",
             SymbolPartitionFunction(), symbol_partitions

--- a/book/examples/python/reverse/reverse.py
+++ b/book/examples/python/reverse/reverse.py
@@ -8,11 +8,10 @@ def application_setup(args):
     out_host, out_port = wallaroo.tcp_parse_output_addrs(args)[0]
 
     ab = wallaroo.ApplicationBuilder("Reverse Word")
-    ab.new_pipeline("reverse", Decoder(),
-                    wallaroo.TCPSourceConfig(in_host, in_port))
+    ab.new_pipeline("reverse",
+                    wallaroo.TCPSourceConfig(in_host, in_port, Decoder()))
     ab.to(Reverse)
-    ab.to_sink(Encoder(),
-               wallaroo.TCPSinkConfig(out_host, out_port))
+    ab.to_sink(wallaroo.TCPSinkConfig(out_host, out_port, Encoder()))
     return ab.build()
 
 

--- a/book/examples/python/sequence/sequence.py
+++ b/book/examples/python/sequence/sequence.py
@@ -9,12 +9,11 @@ def application_setup(args):
     out_host, out_port = wallaroo.tcp_parse_output_addrs(args)[0]
 
     ab = wallaroo.ApplicationBuilder("Sequence Window")
-    ab.new_pipeline("Sequence Window", Decoder(),
-                    wallaroo.TCPSourceConfig(in_host, in_port))
+    ab.new_pipeline("Sequence Window",
+                    wallaroo.TCPSourceConfig(in_host, in_port, Decoder()))
     ab.to_stateful(ObserveNewValue(), SequenceWindowStateBuilder(),
                    "Sequence Window")
-    ab.to_sink(Encoder(),
-               wallaroo.TCPSinkConfig(out_host, out_port))
+    ab.to_sink(wallaroo.TCPSinkConfig(out_host, out_port, Encoder()))
     return ab.build()
 
 

--- a/book/examples/python/sequence_partitioned/sequence_partitioned.py
+++ b/book/examples/python/sequence_partitioned/sequence_partitioned.py
@@ -11,13 +11,12 @@ def application_setup(args):
     print "args = {}".format(args)
     sequence_partitions = [0, 1]
     ab = wallaroo.ApplicationBuilder("Sequence Window")
-    ab.new_pipeline("Sequence Window", Decoder(),
-                    wallaroo.TCPSourceConfig(in_host, in_port))
+    ab.new_pipeline("Sequence Window",
+                    wallaroo.TCPSourceConfig(in_host, in_port, Decoder()))
     ab.to_state_partition(ObserveNewValue(), SequenceWindowStateBuilder(),
                           "Sequence Window", SequencePartitionFunction(),
                           sequence_partitions)
-    ab.to_sink(Encoder(),
-               wallaroo.TCPSinkConfig(out_host, out_port))
+    ab.to_sink(wallaroo.TCPSinkConfig(out_host, out_port, Encoder()))
     return ab.build()
 
 

--- a/book/examples/python/word_count/word_count.py
+++ b/book/examples/python/word_count/word_count.py
@@ -11,13 +11,12 @@ def application_setup(args):
     word_partitions.append("!")
 
     ab = wallaroo.ApplicationBuilder("Word Count Application")
-    ab.new_pipeline("Split and Count", Decoder(),
-                    wallaroo.TCPSourceConfig(in_host, in_port))
+    ab.new_pipeline("Split and Count",
+                    wallaroo.TCPSourceConfig(in_host, in_port, Decoder()))
     ab.to_parallel(Split)
     ab.to_state_partition(CountWord(), WordTotalsBuilder(), "word totals",
         WordPartitionFunction(), word_partitions)
-    ab.to_sink(Encoder(),
-               wallaroo.TCPSinkConfig(out_host, out_port))
+    ab.to_sink(wallaroo.TCPSinkConfig(out_host, out_port, Encoder()))
     return ab.build()
 
 

--- a/lib/wallaroo/initialization/local_topology.pony
+++ b/lib/wallaroo/initialization/local_topology.pony
@@ -470,9 +470,10 @@ actor LocalTopologyInitializer is LayoutInitializer
         // Clear contents of file.
         file.set_length(0)
         let wb = Writer
-        let serialised_topology: Array[U8] val =
-          Serialised(SerialiseAuth(_auth), t).output(
-            OutputSerialisedAuth(_auth))
+        let sa = SerialiseAuth(_auth)
+        let s = Serialised(sa, t)
+        let osa = OutputSerialisedAuth(_auth)
+        let serialised_topology: Array[U8] val = s.output(osa)
         wb.write(serialised_topology)
         file.writev(recover val wb.done() end)
         file.sync()

--- a/machida/bundle.json
+++ b/machida/bundle.json
@@ -1,7 +1,11 @@
 {
   "deps": [
-    { "type": "local",
-      "local-path": "../lib/"
-    }
+      { "type": "local",
+        "local-path": "../lib/"
+      },
+      { "type": "github",
+        "repo": "Sendence/pony-kafka",
+        "tag": "0.0.0.0.0.0.0.0.0.3"
+      }
   ]
 }

--- a/machida/main.pony
+++ b/machida/main.pony
@@ -35,9 +35,7 @@ actor Main
           let application_setup =
             Machida.application_setup(module, options.remaining())
           let application = recover val
-            let tcp_sources = TCPSourceConfigCLIParser(env.args)
-            let tcp_sinks = TCPSinkConfigCLIParser(env.args)
-            Machida.apply_application_setup(application_setup, tcp_sources, tcp_sinks)
+            Machida.apply_application_setup(application_setup, env)
           end
           Startup(env, application, module_name)
         else

--- a/machida/wallaroo.py
+++ b/machida/wallaroo.py
@@ -19,11 +19,8 @@ class ApplicationBuilder(object):
     def __init__(self, name):
         self._actions = [("name", name)]
 
-    def new_pipeline(self, name, decoder, source_config):
-        if inspect.isclass(decoder):
-            raise WallarooParameterError("Expecting a Decoder instance. Got a "
-                                         "class instead.")
-        self._actions.append(("new_pipeline", name, decoder,
+    def new_pipeline(self, name, source_config):
+        self._actions.append(("new_pipeline", name,
                               source_config.to_tuple()))
         return self
 
@@ -81,11 +78,8 @@ class ApplicationBuilder(object):
                               state_name, partition_function, partition_keys))
         return self
 
-    def to_sink(self, encoder, sink_config):
-        if inspect.isclass(encoder):
-            raise WallarooParameterError("Expecting an Encoder instance. Got a"
-                                         " class instead.")
-        self._actions.append(("to_sink", encoder, sink_config.to_tuple()))
+    def to_sink(self, sink_config):
+        self._actions.append(("to_sink", sink_config.to_tuple()))
         return self
 
     def done(self):
@@ -97,21 +91,55 @@ class ApplicationBuilder(object):
 
 
 class TCPSourceConfig(object):
-    def __init__(self, host, port):
+    def __init__(self, host, port, encoder):
         self._host = host
         self._port = port
+        self._encoder = encoder
 
     def to_tuple(self):
-        return ("tcp", self._host, self._port)
+        return ("tcp", self._host, self._port, self._encoder)
 
 
 class TCPSinkConfig(object):
-    def __init__(self, host, port):
+    def __init__(self, host, port, decoder):
         self._host = host
         self._port = port
+        self._decoder = decoder
 
     def to_tuple(self):
-        return ("tcp", self._host, self._port)
+        return ("tcp", self._host, self._port, self._decoder)
+
+
+class KafkaSourceConfig(object):
+    def __init__(self, topic, brokers, log_level, decoder):
+        """
+        topic: string
+        brokers: list of (string, int) tuples with values (HOST, PORT)
+        log_level: string of "Fine", "Info", "Warn", or "Error"
+        decoder: decoder
+        """
+        self.topic = topic
+        self.brokers = brokers
+        self.log_level = log_level
+        self.decoder = decoder
+
+    def to_tuple(self):
+        return ("kafka", self.topic, self.brokers, self.log_level, self.decoder)
+
+
+class KafkaSinkConfig(object):
+    def __init__(self, topic, brokers, log_level, max_produce_buffer_ms,
+                 max_message_size, encoder):
+        self.topic = topic
+        self.brokers = brokers
+        self.log_level = log_level
+        self.max_produce_buffer_ms = max_produce_buffer_ms
+        self.max_message_size = max_message_size
+        self.encoder = encoder
+
+    def to_tuple(self):
+        return ("kafka", self.topic, self.brokers, self.log_level,
+                self.max_produce_buffer_ms, self.max_message_size, self.encoder)
 
 
 def tcp_parse_input_addrs(args):
@@ -128,3 +156,60 @@ def tcp_parse_output_addrs(args):
     output_addrs = parser.parse_known_args(args)[0].output_addrs
     # split H1:P1,H2:P2... into [(H1, P1), (H2, P2), ...]
     return [tuple(x.split(':')) for x in output_addrs.split(',')]
+
+
+def kafka_parse_source_options(args):
+    parser = argparse.ArgumentParser(prog="wallaroo")
+    parser.add_argument('--kafka_source_topic', dest="topic",
+                        default="")
+    parser.add_argument('--kafka_source_brokers', dest="brokers",
+                        default="")
+    parser.add_argument('--kafka_source_log_level', dest="log_level",
+                        default="Warn",
+                        choices=["Fine", "Info", "Warn", "Error"])
+
+    known_args = parser.parse_known_args(args)[0]
+
+    brokers = [_kafka_parse_broker(b) for b in known_args.brokers.split(",")]
+
+    return (known_args.topic, brokers, known_args.log_level)
+
+
+def kafka_parse_sink_options(args):
+    parser = argparse.ArgumentParser(prog="wallaroo")
+    parser.add_argument('--kafka_sink_topic', dest="topic",
+                        default="")
+    parser.add_argument('--kafka_sink_brokers', dest="brokers",
+                        default="")
+    parser.add_argument('--kafka_sink_log_level', dest="log_level",
+                        default="Warn",
+                        choices=["Fine", "Info", "Warn", "Error"])
+    parser.add_argument('--kafka_sink_max_produce_buffer_ms',
+                        dest="max_produce_buffer_ms",
+                        type=int,
+                        default=0)
+    parser.add_argument('--kafka_sink_max_message_size',
+                        dest="max_message_size",
+                        type=int,
+                        default=100000)
+
+    known_args = parser.parse_known_args(args)[0]
+
+    brokers = [_kafka_parse_broker(b) for b in known_args.brokers.split(",")]
+
+    return (known_args.topic, brokers, known_args.log_level,
+            known_args.max_produce_buffer_ms, known_args.max_message_size)
+
+def _kafka_parse_broker(broker):
+    """
+    `broker` is a string of `host[:port]`, return a tuple of `(host, port)`
+    """
+    host_and_port = broker.split(":")
+
+    host = host_and_port[0]
+    port = "9092"
+
+    if len(host_and_port) == 2:
+        port = host_and_port[1]
+
+    return (host, port)


### PR DESCRIPTION
Kafka sources and sinks are now supported in Python applications. This
allows Python application to use these sinks and sources in addition
to the exiting TCP sinks and sources.

The Python API was updated so that decoders are passed as arguments to
the source configation objects and encoders are passed as arguments to
the sink configuration objects. This reflects the way the Pony API is
arranged, and also results in less casting of different kinds of
objects.

In order to make it easier to create the `KafkaConfig` objects for the
sink and source, the Pony API was modified and the creation of the the
config objects was moved into factory classes. This made it easier to
use independent of the Pony CLI parser classes.

The documentation has been updated to reflect the API changes.

There is an example called `celsius-kafka` in `book/examples/python`.

Closes #1025