### PR TITLE
Create a package for "kill this program" exit conditions

### DIFF
--- a/lib/sendence/mort/fail.pony
+++ b/lib/sendence/mort/fail.pony
@@ -1,0 +1,12 @@
+primitive Fail
+  """
+  'This should never happen' error encountered. Bail out of our running
+  program. Print where the error happened and exit.
+  """
+  fun apply(loc: SourceLoc = __loc) =>
+    @fprintf[I32](
+      @pony_os_stderr[Pointer[U8]](),
+      "This should never happen: failure in %s at line %s\n".cstring(),
+      loc.file().cstring(),
+      loc.line().string().cstring())
+    @exit[None](U8(1))

--- a/lib/sendence/mort/unreachable.pony
+++ b/lib/sendence/mort/unreachable.pony
@@ -1,0 +1,12 @@
+primitive Unreachable
+  """
+  `Fail` with a more explicit message. To be used with code that should fail
+  if it reaches an "unreachable" point.
+  """
+  fun apply(loc: SourceLoc = __loc) =>
+    @fprintf[I32](
+      @pony_os_stderr[Pointer[U8]](),
+      "The unreachable was reached in %s at line %s\n".cstring(),
+      loc.file().cstring(),
+      loc.line().string().cstring())
+    @exit[None](U8(1))


### PR DESCRIPTION
We currently have wallaroo/fail. This creates a corresponding class in
sendence/mort that can we can refactor to using. I'm not doing that now
so that we don't create a mess prior to open sourcing, but with this
change, we can open an issue to make the change.

Also adds an `Unreachable` that will also exit but will be more obvious
in code that it's unreachable. This way we no longer need code like:

```pony
// unreachable
Fail()
```

instead we can replace it with the more concise

```pony
Unreachable()
```