### PR TITLE
Set high watermarks on recovery

### DIFF
--- a/lib/wallaroo/core/ackable.pony
+++ b/lib/wallaroo/core/ackable.pony
@@ -16,6 +16,9 @@ trait tag Ackable
   =>
     None
 
+  be initialize_seq_id_on_recovery(seq_id: SeqId) =>
+    None
+
   be log_flushed(low_watermark: SeqId) =>
     """
     We will be called back here once the eventlogs have been flushed for a

--- a/lib/wallaroo/ent/w_actor/w_actor_wrapper.pony
+++ b/lib/wallaroo/ent/w_actor/w_actor_wrapper.pony
@@ -189,6 +189,9 @@ actor WActorWithState is WActorWrapper
       Fail()
     end
 
+  be initialize_seq_id_on_recovery(seq_id: SeqId) =>
+    None
+
   be log_flushed(low_watermark: SeqId) =>
     None
 

--- a/lib/wallaroo/topology/step_seq_id_generator.pony
+++ b/lib/wallaroo/topology/step_seq_id_generator.pony
@@ -17,7 +17,10 @@ class ref StepSeqIdGenerator
   """
   var _generate_new: Bool = true
   // 0 is reserved for "not seen yet"
-  var _seq_id: SeqId = 0
+  var _seq_id: SeqId
+
+  new create(initial_seq_id: SeqId = 0) =>
+    _seq_id = initial_seq_id
 
   fun ref latest_for_run(): SeqId =>
     """

--- a/lib/wallaroo/topology/steps.pony
+++ b/lib/wallaroo/topology/steps.pony
@@ -32,7 +32,7 @@ actor Step is (Producer & Consumer)
   // list of envelopes
   let _deduplication_list: DeduplicationList = _deduplication_list.create()
   let _event_log: EventLog
-  let _seq_id_generator: StepSeqIdGenerator = StepSeqIdGenerator
+  var _seq_id_generator: StepSeqIdGenerator = StepSeqIdGenerator
 
   let _routes: MapIs[Consumer, Route] = _routes.create()
   var _upstreams: SetIs[Producer] = _upstreams.create()
@@ -40,6 +40,7 @@ actor Step is (Producer & Consumer)
   // Lifecycle
   var _initializer: (LocalTopologyInitializer | None) = None
   var _initialized: Bool = false
+  var _seq_id_initialized_on_recovery: Bool = false
   var _ready_to_work_routes: SetIs[RouteLogic] = _ready_to_work_routes.create()
   let _recovery_replayer: RecoveryReplayer
 
@@ -351,6 +352,13 @@ actor Step is (Producer & Consumer)
         runner!".cstring())
       end
     end
+
+  be initialize_seq_id_on_recovery(seq_id: SeqId) =>
+    ifdef debug then
+      Invariant(_seq_id_initialized_on_recovery == false)
+    end
+    _seq_id_generator = StepSeqIdGenerator(seq_id)
+    _seq_id_initialized_on_recovery = true
 
   be clear_deduplication_list() =>
     _deduplication_list.clear()


### PR DESCRIPTION
Previously all steps reset their local step
id generators to 0 on recovery. We need
those to reflect the highest seq ids known
to downstream steps. This fixes that.

Closes #1225