### PR TITLE
Remove stale text about env variables from Python READMEs

### DIFF
--- a/examples/python/reverse/README.md
+++ b/examples/python/reverse/README.md
@@ -19,8 +19,6 @@ In a shell, set up a listener:
 nc -l 127.0.0.1 7002
 ```
 
-In another shell, export the current directory and `wallaroo.py` directories to `PYTHONPATH`:
-
 In another shell, set up your environment variables if you haven't already done so. Assuming you installed Machida according to the tutorial instructions you would do:
 
 ```bash

--- a/examples/python/word_count/README.md
+++ b/examples/python/word_count/README.md
@@ -18,8 +18,6 @@ In a shell, set up a listener:
 nc -l 127.0.0.1 7002
 ```
 
-In another shell, export the current directory and `wallaroo.py` directories to `PYTHONPATH`:
-
 In another shell, set up your environment variables if you haven't already done so. Assuming you installed Machida according to the tutorial instructions you would do:
 
 ```bash


### PR DESCRIPTION
The READMEs for `examples/python/wordcount` and
`examples/python/reverse` contained an extraneous sentence about
setting the environment variables, followed by another few sentences
that gave more information about setting those variables. It looks as
though the first sentence was supposed to be replaced by the following
sentences. This change removes the first sentence.

Closes #1244 

[skip ci]