### PR TITLE
Improve Python example READMEs

### DIFF
--- a/examples/python/alphabet/README.md
+++ b/examples/python/alphabet/README.md
@@ -45,7 +45,7 @@ This will generate 1000 messages.
 
 ## Running Alphabet
 
-In order to run the application you will need Machida, Giles Sender, and Giles Reciever.
+In order to run the application you will need Machida, Giles Sender, and Giles Reciever. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
 
 You will need three separate shells to run this application. Open each shell and go to the `examples/python/alphabet` directory.
 

--- a/examples/python/alphabet_partitioned/README.md
+++ b/examples/python/alphabet_partitioned/README.md
@@ -45,7 +45,7 @@ This will generate 1000 messages.
 
 ## Running Alphabet Partitioned
 
-In order to run the application you will need Machida, Giles Sender, and Giles Reciever.
+In order to run the application you will need Machida, Giles Sender, and Giles Reciever. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
 
 You will need four separate shells to run this application. Open each shell and go to the `examples/python/alphabet_partitioned` directory.
 

--- a/examples/python/celsius-kafka/README.md
+++ b/examples/python/celsius-kafka/README.md
@@ -21,7 +21,7 @@ The `Decoder`'s `decode(...)` method creates a float from the value represented 
 
 ## Running Celsius Kafka
 
-In order to run the application you will need Machida.
+In order to run the application you will need Machida. To build it, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
 
 You will also need access to a Kafka cluster. This example assumes that there is a Kafka broker listening on port `9092` on `127.0.0.1`.
 

--- a/examples/python/celsius/README.md
+++ b/examples/python/celsius/README.md
@@ -33,7 +33,7 @@ This will generate a million messages.
 
 ## Running Celsius
 
-In order to run the application you will need Machida, Giles Sender, and Giles Receiver.
+In order to run the application you will need Machida, Giles Sender, and Giles Receiver. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
 
 You will need three separate shells to run this application. Open each shell and go to the `examples/python/celsius` directory.
 

--- a/examples/python/market_spread/README.md
+++ b/examples/python/market_spread/README.md
@@ -59,7 +59,7 @@ The Order messages are handled by the `OrderDecoder`'s `decode(...)` method, whi
 
 ## Running Market Spread
 
-In order to run the application you will need Machida, Giles Sender, and Giles Receiver.
+In order to run the application you will need Machida, Giles Sender, and Giles Receiver. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
 
 You will need three separate shells to run this application. Open each shell and go to the `examples/python/market_spread` directory.
 

--- a/examples/python/reverse/README.md
+++ b/examples/python/reverse/README.md
@@ -28,7 +28,7 @@ The `Decoders`'s `decode(...)` method creates a string from the value represente
 
 ## Running Reverse
 
-In order to run the application you will need Machida, Giles Sender, and Giles Receiver.
+In order to run the application you will need Machida, Giles Sender, and Giles Receiver. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
 
 You will need three separate shells to run this application. Open each shell and go to the `examples/python/reverse` directory.
 

--- a/examples/python/word_count/README.md
+++ b/examples/python/word_count/README.md
@@ -26,7 +26,7 @@ The `Decoder`'s `decode(...)` method turns the input message into a string. That
 
 ## Running Word Count
 
-In order to run the application you will need Machida and Giles Sender.
+In order to run the application you will need Machida and Giles Sender. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
 
 You will need three separate shells to run this application. Open each shell and go to the `examples/python/word_count` directory.
 


### PR DESCRIPTION
This represents what I think our Python example READMEs should look
like.

There's a section that describes the application, including the input
and output formats. This gives the reader an idea of what the program
does and how it does it.

The run section specifies how many shells the user will need to run
the example, and clearly describes what should be done in each
shell. There is information about what directory commands should be
run from.

I think it is reasonable to assume that some people will encounter the
Wallaroo repo before reading the book, and one of the first things
they will do is look at the examples. These changes make the examples
more of a useful (if not ideal) starting point for learning about
Wallaroo.

[skip ci]