### PR TITLE
Fix bug in output printer in Python celsius README

### DIFF
--- a/examples/python/celsius/README.md
+++ b/examples/python/celsius/README.md
@@ -70,7 +70,7 @@ import struct
 with open('celsius.out', 'rb') as f:
     while True:
         try:
-            print struct.unpack('>Id', f.read(12))
+            print struct.unpack('>If', f.read(12))
         except:
             break
 ```


### PR DESCRIPTION
The program for displaying the output in the Python celsius example
now unpacks the payload bytes as a float. Previously it had been
unpacked as an integer, which is wrong.

Fixes #1249

[skip-ci]