### PR TITLE
Update example READMEs with correct options.

### DIFF
--- a/examples/pony/alphabet/README.md
+++ b/examples/pony/alphabet/README.md
@@ -56,7 +56,8 @@ docker start mui
 
 ```bash
 ./alphabet --in 127.0.0.1:7010 --out 127.0.0.1:7002 --metrics 127.0.0.1:5001 \
-  --control 127.0.0.1:12500 --data 127.0.0.1:12501 --cluster-initializer
+  --control 127.0.0.1:12500 --data 127.0.0.1:12501 --external 127.0.0.1:5050 \
+  --cluster-initializer
 ```
 
 3. Start a sender
@@ -65,4 +66,10 @@ docker start mui
 ../../../../giles/sender/sender --host 127.0.0.1:7010 \
   --file data_gen/votes.msg \ --batch-size 5 --interval 100_000_000 \
   --messages 150000000 --binary --variable-size --repeat --ponythreads=1 --no-write
+```
+
+4. Shut down cluster once finished processing
+
+```bash
+../../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
 ```

--- a/examples/pony/celsius-kafka/README.md
+++ b/examples/pony/celsius-kafka/README.md
@@ -42,8 +42,8 @@ docker start mui
 ./celsius-kafka --kafka_source_topic test --kafka_source_brokers 127.0.0.1 \
   --kafka_sink_topic test --kafka_sink_brokers 127.0.0.1 \
   --metrics 127.0.0.1:5001  --control 127.0.0.1:12500 --data 127.0.0.1:12501 \
-   --cluster-initializer --kafka_sink_max_message_size 100000 \
-   --kafka_sink_max_produce_buffer_ms 10
+  --kafka_sink_max_message_size 100000 --kafka_sink_max_produce_buffer_ms 10 \
+  --cluster-initializer --external 127.0.0.1:5050
 ```
 
 `kafka_sink_max_message_size` controls maximum size of message sent to kafka in a single produce request. Kafka will return errors if this is bigger than server is configured to accept.
@@ -51,3 +51,9 @@ docker start mui
 `kafka_sink_max_produce_buffer_ms` controls maximum time (in ms) to buffer messages before sending to kafka. Either don't specify it or set it to `0` to disable batching on produce.
 
 3. Send data into kafka using kafkacat or some other mechanism
+
+4. Shut down cluster once finished processing
+
+```bash
+../../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
+```

--- a/examples/pony/celsius/README.md
+++ b/examples/pony/celsius/README.md
@@ -55,7 +55,8 @@ docker start mui
 
 ```bash
 ./celsius --in 127.0.0.1:7010 --out 127.0.0.1:7002 --metrics 127.0.0.1:5001 \
-  --control 127.0.0.1:12500 --data 127.0.0.1:12501
+  --control 127.0.0.1:12500 --data 127.0.0.1:12501 --external 127.0.0.1:5050 \
+  --cluster-initializer
 ```
 
 3. Start a sender
@@ -65,4 +66,10 @@ docker start mui
   --file data_gen/celsius.msg \
   --batch-size 5 --interval 100_000_000 --messages 150 --binary \
   --variable-size --repeat --ponythreads=1 --no-write
+```
+
+4. Shut down cluster once finished processing
+
+```bash
+../../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
 ```

--- a/examples/python-wactor/CRDT/README.md
+++ b/examples/python-wactor/CRDT/README.md
@@ -33,7 +33,8 @@ Run `atkin` with `--application-module CRDT`:
 ```bash
 atkin --application-module CRDT --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
   --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
-  --name worker-name --cluster-initializer --ponythreads=1
+  --external 127.0.0.1:5050 --cluster-initializer --name worker-name \
+  --ponythreads=1
 ```
 
 In a third shell, send some messages:
@@ -59,4 +60,10 @@ accumulator act report: GCounter(15)
 round 4: GCounter(17)
 accumulator act report: GCounter(17)
 round 5: GCounter(33)
+```
+
+## Shutting down cluster once finished processing
+
+```bash
+../../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
 ```

--- a/examples/python-wactor/celsius-broadcastvars/README.md
+++ b/examples/python-wactor/celsius-broadcastvars/README.md
@@ -46,7 +46,8 @@ Run `atkin` with `--application-module celsius`:
 ```bash
 atkin --application-module celsius --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
   --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
-  --name worker-name --cluster-initializer --ponythreads=1
+  --external 127.0.0.1:5050 --cluster-initializer --name worker-name \
+  --ponythreads=1
 ```
 
 In a third shell, send some messages:
@@ -73,4 +74,10 @@ with open('celsius.out', 'rb') as f:
             print struct.unpack('>Lf', f.read(8))
         except:
             break
+```
+
+## Shutting down cluster once finished processing
+
+```bash
+../../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
 ```

--- a/examples/python-wactor/matching-engine/README.md
+++ b/examples/python-wactor/matching-engine/README.md
@@ -49,7 +49,8 @@ Run `atkin` with `--application-module matching-engine`:
 atkin --application-module matching-engine --in 127.0.0.1:7010 \
   --out 127.0.0.1:7002,127.0.0.1:7003,127.0.0.1:7004 \
   --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
-  --name worker-name --cluster-initializer --ponythreads=1
+  --external 127.0.0.1:5050 --cluster-initializer --name worker-name \
+  --ponythreads=1
 ```
 
 In a third shell, send some messages:
@@ -93,3 +94,9 @@ with open('matching-engine-L1.out', 'rb') as f:
 
 "T" stands for Trade, "B" for Bid and "A" for Ask. The first number if price,
 the second is quantity.
+
+## Shutting down cluster once finished processing
+
+```bash
+../../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
+```

--- a/examples/python/alphabet/README.md
+++ b/examples/python/alphabet/README.md
@@ -31,8 +31,8 @@ Run `machida` with `--application-module alphabet`.
 ```bash
 machida --application-module alphabet --in 127.0.0.1:7010 \
   --out 127.0.0.1:7002 --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 \
-  --data 127.0.0.1:6001 --name worker-name  --cluster-initializer \
-  --ponythreads=1
+  --external 127.0.0.1:5050 --cluster-initializer --data 127.0.0.1:6001 \
+  --name worker-name --ponythreads=1
 ```
 
 In a third shell, send some messages
@@ -61,4 +61,11 @@ with open('alphabet.out', 'rb') as f:
             print struct.unpack('>LsL', f.read(9))
         except:
             break
+```
+
+## Shutting down the cluster
+
+To shut down the cluster, you will need to use the `cluster_shutdown` tool.
+```bash
+../../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
 ```

--- a/examples/python/alphabet_partitioned/README.md
+++ b/examples/python/alphabet_partitioned/README.md
@@ -67,3 +67,9 @@ with open('received.txt', 'rb') as f:
         except:
             break
 ```
+
+Remember to shut down the cluster once finished processing
+
+```bash
+../../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:6002
+```

--- a/examples/python/celsius/README.md
+++ b/examples/python/celsius/README.md
@@ -45,7 +45,8 @@ Run `machida` with `--application-module celsius`:
 ```bash
 machida --application-module celsius --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
   --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
-  --name worker-name  --cluster-initializer --ponythreads=1
+  --name worker-name --external 127.0.0.1:5050 --cluster-initializer \
+  --ponythreads=1
 ```
 
 In a third shell, send some messages:
@@ -72,4 +73,10 @@ with open('celsius.out', 'rb') as f:
             print struct.unpack('>If', f.read(12))
         except:
             break
+```
+
+## Shutting down cluster once finished processing
+
+```bash
+../../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
 ```

--- a/examples/python/market_spread/README.md
+++ b/examples/python/market_spread/README.md
@@ -37,8 +37,10 @@ Run `machida` with `--application-module market_spread`:
 
 ```bash
 machida --application-module market_spread \
-  -i 127.0.0.1:7010,127.0.0.1:7011 -o 127.0.0.1:7002 -m 127.0.0.1:5001 \
-  -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n worker-name -t --ponythreads=1
+  --in 127.0.0.1:7010,127.0.0.1:7011 --out 127.0.0.1:7002 \
+  --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
+  --worker-name worker1 --external 127.0.0.1:5050 --cluster-initializer \
+  --ponythreads=1
 ```
 
 Send some market data messages
@@ -57,4 +59,10 @@ and some orders messages
   ../../../../testing/data/market_spread/orders/350-symbols_orders-fixish.msg --batch-size 20 \
   --interval 100_000_000 --messages 1000000 --binary --repeat --ponythreads=1 \
   --msg-size 57 --no-write
+```
+
+shut down cluster once finished processing
+
+```bash
+../../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
 ```

--- a/examples/python/reverse/README.md
+++ b/examples/python/reverse/README.md
@@ -31,7 +31,8 @@ Run `machida` with `--application-module reverse`:
 ```bash
 machida --application-module reverse --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
   --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
-  --name worker-name  --cluster-initializer --ponythreads=1
+  --name worker-name --external 127.0.0.1:5050 --cluster-initializer \
+  --ponythreads=1
 ```
 
 In a third shell, send some messages:
@@ -40,4 +41,9 @@ In a third shell, send some messages:
 ../../../../giles/sender/sender --host 127.0.0.1:7010 --file words.txt \
 --batch-size 5 --interval 100_000_000 --messages 150 --repeat \
 --ponythreads=1
+```
+
+When processing has finished, shut down the cluster:
+```bash
+../../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
 ```

--- a/examples/python/sequence/README.md
+++ b/examples/python/sequence/README.md
@@ -32,7 +32,8 @@ Run `machida` with `--application-module sequence`:
 ```bash
 machida --application-module sequence --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
   --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
-  --name worker-name --cluster-initializer --ponythreads=1
+  --name worker-name --external 127.0.0.1:5050 --cluster-initializer \
+  --ponythreads=1
 ```
 
 In a third shell, send some messages:
@@ -41,4 +42,10 @@ In a third shell, send some messages:
 ../../../../giles/sender/sender --host 127.0.0.1:7010 --batch-size 10 \
   --interval 100_000_000 --ponythreads=1 --binary --msg-size 12 --no-write \
   --u64 --messages 100
+```
+
+Shut down cluster once finished processing:
+
+```bash
+../../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
 ```

--- a/examples/python/sequence_partitioned/README.md
+++ b/examples/python/sequence_partitioned/README.md
@@ -47,8 +47,8 @@ export PYTHONPATH="$PYTHONPATH:.:$HOME/wallaroo-tutorial/wallaroo/machida"
 export PATH="$PATH:$HOME/wallaroo-tutorial/wallaroo/machida/build"
 machida --application-module sequence_partitioned --in 127.0.0.1:7010 \
   --out 127.0.0.1:7002 --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 \
-  --data 127.0.0.1:6001 --worker-count 2 --cluster-initializer \
-  --ponythreads=1
+  --data 127.0.0.1:6001 --external 127.0.0.1:5050 --worker-count 2
+  --cluster-initializer --ponythreads=1
 ```
 
 Worker:
@@ -58,7 +58,7 @@ export PYTHONPATH="$PYTHONPATH:.:$HOME/wallaroo-tutorial/wallaroo/machida"
 export PATH="$PATH:$HOME/wallaroo-tutorial/wallaroo/machida/build"
 machida --application-module sequence_partitioned --in 127.0.0.1:7010 \
   --out 127.0.0.1:7002 --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 \
-  --name worker-2 --ponythreads=1
+  --external 127.0.0.1:5051 --name worker-2 --ponythreads=1
 ```
 
 In a third shell, send some messages:
@@ -67,4 +67,10 @@ In a third shell, send some messages:
 ../../../../giles/sender/sender --host 127.0.0.1:7010 --batch-size 10 \
   --interval 100_000_000 --ponythreads=1 --binary --msg-size 12 --no-write \
   --u64 --messages 100
+```
+
+Shut down cluster once finished processing:
+
+```bash
+../../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
 ```

--- a/examples/python/word_count/README.md
+++ b/examples/python/word_count/README.md
@@ -30,8 +30,8 @@ Run `machida` with `--application-module word_count`:
 ```bash
 machida --application-module word_count --in 127.0.0.1:7010 \
   --out 127.0.0.1:7002 --metrics 127.0.0.1:5001 \
-  --control 127.0.0.1:6000 --data 127.0.0.1:6001 --cluster-initializer \
-  --name worker-name --ponythreads=1
+  --control 127.0.0.1:6000 --data 127.0.0.1:6001 --external 127.0.0.1:5050 \
+  --cluster-initializer --name worker-name --ponythreads=1
 ```
 
 In a third shell, send some messages:
@@ -43,3 +43,9 @@ In a third shell, send some messages:
 ```
 
 And then... watch a streaming output of words and counts appear in the listener window.
+
+Shut down cluster once finished processing:
+
+```bash
+../../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
+```


### PR DESCRIPTION
Some of these READMEs were out of date with regards to command-line options:
- Single worker setups now require `--cluster-initializer`
- Non-initializers cannot have `--data` or `--worker-count` any longer
- Added `--external` and the usage of `cluster_shutdown

This addresses both #1232 and #1250