### PR TITLE
Various fixes related to testing install instructions and python examples

### DIFF
--- a/book/getting-started/linux-setup.md
+++ b/book/getting-started/linux-setup.md
@@ -4,6 +4,10 @@ These instructions have been tested for Ubuntu Trusty and Xenial releases.
 
 There are a few applications/tools which are required to be installed before you can proceed with the setup of the Wallaroo environment.
 
+## Memory requirements
+
+In order to compile all of the Wallaroo applications your system will need to have approximately 6GB working memory (this can be RAM or swap). If you don't have enough memory, you are likely to see that the compile process is `Killed` by the OS.
+
 ## Installing git
 
 If you do not already have Git installed, install it:
@@ -140,6 +144,26 @@ git clone https://github.com/ponylang/pony-stable
 cd pony-stable
 git checkout 0054b429a54818d187100ed40f5525ec7931b31b
 make
+sudo make install
+```
+
+## Install Compression Development Libraries
+
+### Xenial Ubuntu:
+
+```bash
+sudo apt-get install -y libsnappy-dev liblz4-dev
+```
+
+### Trusty Ubuntu:
+
+*Note:* some older versions of Ubuntu have an outdated `liblz4` package. For these you will need to install from source like this:
+
+```bash
+cd ~/
+wget -O liblz4-1.7.5.tar.gz https://github.com/lz4/lz4/archive/v1.7.5.tar.gz
+tar zxvf liblz4-1.7.5.tar.gz
+cd lz4-1.7.5
 sudo make install
 ```
 

--- a/book/getting-started/macos-setup.md
+++ b/book/getting-started/macos-setup.md
@@ -75,6 +75,12 @@ make
 sudo make install
 ```
 
+## Install Compression Development Libraries
+
+```bash
+brew install snappy lz4
+```
+
 ## Install Python Development Libraries
 
 ```bash

--- a/book/getting-started/run-a-application.md
+++ b/book/getting-started/run-a-application.md
@@ -74,8 +74,11 @@ export PYTHONPATH="$HOME/wallaroo-tutorial/wallaroo/machida:$HOME/wallaroo-tutor
 Now that we have Machida set up to run the "Celsius to Fahrenheit" application, and the metrics UI and something it can send output to up and running, we can run the application itself by executing the following command:
 
 ```bash
+cd ~/wallaroo-tutorial/wallaroo/machida
 ./build/machida --application-module celsius --in 127.0.0.1:7000 \
-  --out 127.0.0.1:5555 --metrics 127.0.0.1:5001 --ponythreads=1
+  --out 127.0.0.1:5555 --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 \
+  --data 127.0.0.1:6001 --name worker-name --external 127.0.0.1:5050 \
+  --cluster-initializer --ponythreads=1
 ```
 
 This tells the "Celsius to Fahrenheit" application that it should listen on port `7000` for incoming data, write outgoing data to port `5555`, and send metrics data to port `5001`.
@@ -88,7 +91,7 @@ A data generator is bundled with the application. Use these commands to generate
 
 ```bash
 cd ~/wallaroo-tutorial/wallaroo/examples/python/celsius/data_gen
-./data_gen 10000
+./data_gen.py 10000
 ```
 
 This will create a `celsius.msg` file in your current working directory.
@@ -108,7 +111,7 @@ You will now be able to start the `sender` with the following command:
 
 ```bash
 ./sender -h 127.0.0.1:7000 -m 10000 -y -s 300 \
-  -f ~/wallaroo-tutorial/wallaroo/examples/pony/celsius/data_gen/celsius.msg \
+  -f ~/wallaroo-tutorial/wallaroo/examples/python/celsius/data_gen/celsius.msg \
   -r -w -g 8 --ponythreads=1
 ```
 
@@ -139,3 +142,22 @@ You can then click into one of the elements within a category, to get to a detai
 ![Computation Detailed Metrics page](/book/metrics/images/computation-detailed-metrics-page.png)
 
 Feel free to click around and get a feel for how the Metrics UI is setup and how it is used to monitor a running Wallaroo application. If you'd like a deeper dive into the Metrics UI, have a look at our [Monitoring Metrics with the Monitoring Hub](/book/metrics/metrics-ui.md) section.
+
+## Shut down cluster once finished processing:
+
+The Cluster Shutdown tool is used to tell the cluster to shut down cleanly. It can be built like this:
+
+```bash
+cd ~/wallaroo-tutorial/wallaroo/utils/cluster_shutdown
+make
+```
+
+This will create a binary called `cluster_shutdown`
+
+You will now be able to use the `cluster_shutdown` util with the following command:
+
+```bash
+./utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
+```
+
+If the cluster shutdown tool is working correctly, you should see `Shutdown request sent` printed to the screen. If you see that, you can be assured that the cluster has successfully received the request to shut down.

--- a/examples/python/alphabet/README.md
+++ b/examples/python/alphabet/README.md
@@ -38,7 +38,7 @@ machida --application-module alphabet --in 127.0.0.1:7010 \
 In a third shell, send some messages
 
 ```bash
-../../../../giles/sender/sender --host 127.0.0.1:7010 --file votes.msg \
+../../../giles/sender/sender --host 127.0.0.1:7010 --file votes.msg \
   --batch-size 50 --interval 10_000_000 --messages 1000000 --binary \
   --msg-size 9 --repeat --ponythreads=1
 ```
@@ -67,5 +67,5 @@ with open('alphabet.out', 'rb') as f:
 
 To shut down the cluster, you will need to use the `cluster_shutdown` tool.
 ```bash
-../../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
+../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
 ```

--- a/examples/python/alphabet_partitioned/README.md
+++ b/examples/python/alphabet_partitioned/README.md
@@ -16,7 +16,7 @@ docker start mui
 In another shell, run Giles Receiver to listen for messages:
 
 ```bash
-../../../../giles/receiver/receiver --ponythreads=1 --ponynoblock \
+../../../giles/receiver/receiver --ponythreads=1 --ponynoblock \
   --listen 127.0.0.1:7002
 ```
 
@@ -46,7 +46,7 @@ machida --application-module alphabet_partitioned --in 127.0.0.1:7010 \
 In a fourth shell, send some messages
 
 ```bash
-../../../../giles/sender/sender --host 127.0.0.1:7010 \
+../../../giles/sender/sender --host 127.0.0.1:7010 \
   --file votes.msg --batch-size 50 --interval 10_000_000 \
   --messages 1000000 --binary --msg-size 9 --repeat --ponythreads=1
 ```
@@ -71,5 +71,5 @@ with open('received.txt', 'rb') as f:
 Remember to shut down the cluster once finished processing
 
 ```bash
-../../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:6002
+../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:6002
 ```

--- a/examples/python/celsius-kafka/README.md
+++ b/examples/python/celsius-kafka/README.md
@@ -16,6 +16,30 @@ See [Wallaroo Environment Setup Instructions](https://github.com/WallarooLabs/wa
 
 In a separate shell, each:
 
+0. Start kafka and create the `test-in` and `test-out` topics
+
+One way to get kafka running with the topics:
+
+This requires `docker-compose`:
+
+```bash
+sudo curl -L https://github.com/docker/compose/releases/download/1.15.0/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+```
+
+```bash
+cd /tmp
+git clone https://github.com/effata/local-kafka-cluster
+cd local-kafka-cluster
+sudo ./cluster up 1 # change 1 to however many brokers are desired to be started
+sudo docker exec -it local_kafka_1_1 /kafka/bin/kafka-topics.sh --zookeeper \
+  zookeeper:2181 --create --partitions 4 --topic test-in --replication-factor \
+  1 # to create a test-in topic; change arguments as desired
+sudo docker exec -it local_kafka_1_1 /kafka/bin/kafka-topics.sh --zookeeper \
+  zookeeper:2181 --create --partitions 4 --topic test-out --replication-factor \
+  1 # to create a test-in topic; change arguments as desired
+```
+
 1. In a shell, start up the Metrics UI if you don't already have it running:
 
 ```bash
@@ -24,13 +48,23 @@ docker start mui
 
 2. Start the application
 
+In another shell, set up your environment variables if you haven't already done so. Assuming you installed Machida according to the tutorial instructions you would do:
+
 ```bash
-./machida --application-module celsius \
+export PYTHONPATH=".:$PYTHONPATH:$HOME/wallaroo-tutorial/wallaroo/machida"
+export PATH="$PATH:$HOME/wallaroo-tutorial/wallaroo/machida/build"
+```
+
+Run `machida` with `--application-module celsius`:
+
+```bash
+machida --application-module celsius \
   --kafka_source_topic test-in --kafka_source_brokers 127.0.0.1:9092 \
   --kafka_sink_topic test-out --kafka_sink_brokers 127.0.0.1:9092 \
-  --kafka_sink_max_message_size 100000 --kafka_sink_max_produce_buffer_ms 10
+  --kafka_sink_max_message_size 100000 --kafka_sink_max_produce_buffer_ms 10 \
   --metrics 127.0.0.1:5001 --control 127.0.0.1:12500 --data 127.0.0.1:12501 \
-  --cluster-initializer --ponythreads=1
+  --name worker-name --external 127.0.0.1:5050 --cluster-initializer \
+  --ponythreads=1
 ```
 
 `kafka_sink_max_message_size` controls maximum size of message sent to kafka in a single produce request. Kafka will return errors if this is bigger than server is configured to accept.
@@ -38,3 +72,30 @@ docker start mui
 `kafka_sink_max_produce_buffer_ms` controls maximum time (in ms) to buffer messages before sending to kafka. Either don't specify it or set it to `0` to disable batching on produce.
 
 3. Send data into kafka using kafkacat or some other mechanism
+
+```bash
+sudo apt-get install kafkacat
+```
+
+Run the following and then type at least 4 characters on each line and hit enter to send in data (only first 4 characters are used/interpreted as a float; the appliction will throw an error and possibly segfault if less than 4 characters are sent in):
+
+```bash
+kafkacat -P -b 127.0.0.1:9092 -t test-in
+```
+
+Note: You can use `ctrl-d` to exit `kafkacat`
+
+4. Shut down cluster once finished processing
+
+```bash
+../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
+```
+
+5. Stop kafka
+
+If you followed the commands from Step 0 to start kafka you can stop it by:
+
+```bash
+cd /tmp/local-kafka-cluster
+sudo ./cluster down # shut down cluster
+```

--- a/examples/python/celsius/README.md
+++ b/examples/python/celsius/README.md
@@ -52,7 +52,7 @@ machida --application-module celsius --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
 In a third shell, send some messages:
 
 ```bash
-../../../../giles/sender/sender --host 127.0.0.1:7010 
+../../../giles/sender/sender --host 127.0.0.1:7010 \
   --file data_gen/celsius.msg --batch-size 50 --interval 10_000_000 \
   --messages 1000000 --repeat \
   --ponythreads=1 --binary --msg-size 8
@@ -79,5 +79,5 @@ with open('celsius.out', 'rb') as f:
 ## Shutting down cluster once finished processing
 
 ```bash
-../../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
+../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
 ```

--- a/examples/python/celsius/data_gen/data_gen.py
+++ b/examples/python/celsius/data_gen/data_gen.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python2
+
 # Copyright 2017 The Wallaroo Authors.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,9 +13,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 #  implied. See the License for the specific language governing
 #  permissions and limitations under the License.
-
-
-#!/usr/bin/env python2
 
 import random
 import struct

--- a/examples/python/market_spread/README.md
+++ b/examples/python/market_spread/README.md
@@ -46,8 +46,8 @@ machida --application-module market_spread \
 Send some market data messages
 
 ```bash
-../../../../giles/sender/sender --host 127.0.0.1:7011 --file \
-  ../../../../testing/data/market_spread/nbbo/350-symbols_nbbo-fixish.msg --batch-size 20 \
+../../../giles/sender/sender --host 127.0.0.1:7011 --file \
+  ../../../testing/data/market_spread/nbbo/350-symbols_nbbo-fixish.msg --batch-size 20 \
   --interval 100_000_000 --messages 1000000 --binary --repeat --ponythreads=1 \
   --msg-size 46 --no-write
 ```
@@ -55,8 +55,8 @@ Send some market data messages
 and some orders messages
 
 ```bash
-../../../../giles/sender/sender --host 127.0.0.1:7010 --file \
-  ../../../../testing/data/market_spread/orders/350-symbols_orders-fixish.msg --batch-size 20 \
+../../../giles/sender/sender --host 127.0.0.1:7010 --file \
+  ../../../testing/data/market_spread/orders/350-symbols_orders-fixish.msg --batch-size 20 \
   --interval 100_000_000 --messages 1000000 --binary --repeat --ponythreads=1 \
   --msg-size 57 --no-write
 ```
@@ -64,5 +64,5 @@ and some orders messages
 shut down cluster once finished processing
 
 ```bash
-../../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
+../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
 ```

--- a/examples/python/reverse/README.md
+++ b/examples/python/reverse/README.md
@@ -38,12 +38,12 @@ machida --application-module reverse --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
 In a third shell, send some messages:
 
 ```bash
-../../../../giles/sender/sender --host 127.0.0.1:7010 --file words.txt \
+../../../giles/sender/sender --host 127.0.0.1:7010 --file words.txt \
 --batch-size 5 --interval 100_000_000 --messages 150 --repeat \
 --ponythreads=1
 ```
 
 When processing has finished, shut down the cluster:
 ```bash
-../../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
+../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
 ```

--- a/examples/python/word_count/README.md
+++ b/examples/python/word_count/README.md
@@ -37,7 +37,7 @@ machida --application-module word_count --in 127.0.0.1:7010 \
 In a third shell, send some messages:
 
 ```bash
-../../../../giles/sender/sender --host 127.0.0.1:7010 --file count_this.txt \
+../../../giles/sender/sender --host 127.0.0.1:7010 --file count_this.txt \
 --batch-size 5 --interval 100_000_000 --messages 10000000 \
 --ponythreads=1 --repeat
 ```
@@ -47,5 +47,5 @@ And then... watch a streaming output of words and counts appear in the listener 
 Shut down cluster once finished processing:
 
 ```bash
-../../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
+../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
 ```

--- a/utils/cluster_shutdown/Makefile
+++ b/utils/cluster_shutdown/Makefile
@@ -7,8 +7,11 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
+# uncomment to disable genrate of test target
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-PONY_TARGET := false
+#PONY_TARGET := false
 
 # uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
 EXS_TARGET := false

--- a/utils/cluster_shutdown/cluster_shutdown.pony
+++ b/utils/cluster_shutdown/cluster_shutdown.pony
@@ -22,7 +22,7 @@ use "wallaroo_labs/messages"
 actor Main
   new create(env: Env) =>
     try
-      let split = env.args(0).split(":")
+      let split = env.args(1).split(":")
       let host = split(0)
       let service = split(1)
 
@@ -47,6 +47,7 @@ class Notifier is TCPConnectionNotify
   fun ref connected(conn: TCPConnection ref) =>
     conn.writev(ExternalMsgEncoder.clean_shutdown())
     conn.dispose()
+    _env.out.print("Shutdown request sent")
 
   fun ref connect_failed(conn: TCPConnection ref) =>
     _env.err.print("Error: Unable to connect to " + _service + ":" + _host)


### PR DESCRIPTION
* Add note about minimum memory requirements
* Add install instructions for compression libaries
* Fix `run-a-application.md` commands and add `cluster_shutdown` tool
  command
* Fix paths to `sender`, `receiver` and `cluster_shutdown` in READMEs
* Add instructions on running kafka for celsius-kafka application
* Add instructions on running kafkacat for celsius-kafka application
* Fix commands for kafka-celsius application
* Fix data_gen.py `#!` placement
* Fix cluster_shutdown makefile to generate pony build target
* Fix cluster_shutdown tool to use argv(1) instead of argv(0) for
  host:port. Also make it print out a message on successful shutdown
  message send.