### PR TITLE
Fix incremental building when not using default Pony build target

### DIFF
--- a/atkin/Makefile
+++ b/atkin/Makefile
@@ -45,6 +45,7 @@ atkin_clean:
 
 atkin_build: $(ATKIN_BUILD)/atkin
 
+-include $(ATKIN_PATH)/atkin.d
 $(ATKIN_BUILD)/atkin: $(ATKIN_BUILD)/libpython-wactor.a
 	$(eval original_PONYCFLAGS := $(PONYCFLAGS))
 	$(eval PONYCFLAGS := $(original_PONYCFLAGS) --output=$(ATKIN_BUILD) --path=$(ATKIN_BUILD))

--- a/machida/Makefile
+++ b/machida/Makefile
@@ -48,6 +48,7 @@ machida_clean:
 
 machida_build: $(MACHIDA_BUILD)/machida
 
+-include $(MACHIDA_PATH)/machida.d
 $(MACHIDA_BUILD)/machida: $(MACHIDA_BUILD)/libpython-wallaroo.a
 	$(eval original_PONYCFLAGS := $(PONYCFLAGS))
 	$(eval PONYCFLAGS := $(original_PONYCFLAGS) -D resilience -D spike -D spiketrace --output=$(MACHIDA_BUILD) --path=$(MACHIDA_BUILD))

--- a/testing/correctness/apps/sequence_window/Makefile
+++ b/testing/correctness/apps/sequence_window/Makefile
@@ -35,6 +35,7 @@ build-testing-correctness-apps-sequence_window: build-testing-correctness-apps-s
 
 # This will build three different binaries of sequence_window, but respect PONYCFLAGS passed
 # to Make
+-include $(subst $(abs_buffy_dir)/,,$(SEQUENCE_WINDOW_PATH:%/=%))/$(notdir $(abspath $(SEQUENCE_WINDOW_PATH:%/=%))).d
 $(subst $(abs_buffy_dir)/,,$(SEQUENCE_WINDOW_PATH:%/=%))/$(notdir $(abspath $(SEQUENCE_WINDOW_PATH:%/=%))):
 	$(eval original_PONYCFLAGS := $(PONYCFLAGS))
 	$(eval PONYCFLAGS := $(original_PONYCFLAGS) -D resilience -D spike -D spiketrace -D validate)

--- a/testing/correctness/apps/sequence_window_simple_state/Makefile
+++ b/testing/correctness/apps/sequence_window_simple_state/Makefile
@@ -34,6 +34,7 @@ build-testing-correctness-apps-sequence_window_simple_state: build-testing-corre
 
 # This will build three different binaries of sequence_window, but respect PONYCFLAGS passed
 # to Make
+-include $(subst $(abs_buffy_dir)/,,$(SEQUENCE_WINDOW_SIMPLE_STATE_PATH:%/=%))/$(notdir $(abspath $(SEQUENCE_WINDOW_SIMPLE_STATE_PATH:%/=%))).d
 $(subst $(abs_buffy_dir)/,,$(SEQUENCE_WINDOW_SIMPLE_STATE_PATH:%/=%))/$(notdir $(abspath $(SEQUENCE_WINDOW_SIMPLE_STATE_PATH:%/=%))):
 	$(eval original_PONYCFLAGS := $(PONYCFLAGS))
 	$(eval PONYCFLAGS := $(original_PONYCFLAGS) -D resilience -D spike -D spiketrace -D validate)


### PR DESCRIPTION
Issue was that when we disabled the default pony build target to create a custom one, we didn't tell the custom make target to use the dependency file.