### PR TITLE
Move "installation" instructions for Giles

### DIFF
--- a/book/getting-started/linux-setup.md
+++ b/book/getting-started/linux-setup.md
@@ -192,6 +192,25 @@ cd ~/wallaroo-tutorial/wallaroo/machida
 make
 ```
 
+## Install Giles Sender
+
+Giles Sender is used to supply data to Wallaroo applications over TCP.
+
+```bash
+cd ~/wallaroo-tutorial/wallaroo/giles/sender
+make
+```
+
+## Install Giles Receiver
+
+Giles Receiver receives data from Wallaroo over TCP.
+
+
+```bash
+cd ~/wallaroo-tutorial/wallaroo/giles/receiver
+make
+```
+
 ## Conclusion
 
 Awesome! All set. Time to try running your first application.

--- a/book/getting-started/macos-setup.md
+++ b/book/getting-started/macos-setup.md
@@ -81,15 +81,6 @@ sudo make install
 brew install python
 ```
 
-## Installing Machida
-
-Machida is the program that runs Wallaroo Python applications. Change to the `machida` directory:
-
-```bash
-cd ~/wallaroo-tutorial/wallaroo/machida
-make
-```
-
 ## Install Docker
 
 You'll need Docker to run the Wallaroo metrics UI. There are [instructions](https://docs.docker.com/docker-for-mac/) for getting Docker up and running on MacOS on the [Docker website](https://docs.docker.com/docker-for-mac/). Installing Docker will result in it running on your machine. After you reboot your machine, that will no longer be the case. In the future, you'll need to have Docker running in order to use a variety of commands in this book. We suggest that you [set up Docker to boot automatically](https://docs.docker.com/docker-for-mac/#general).
@@ -122,6 +113,33 @@ git checkout 0.0.1-rc15
 Note: You need to login to GitHub for credentials
 
 This will create a subdirectory called `wallaroo`.
+
+## Installing Machida
+
+Machida is the program that runs Wallaroo Python applications. Change to the `machida` directory:
+
+```bash
+cd ~/wallaroo-tutorial/wallaroo/machida
+make
+```
+
+## Install Giles Sender
+
+Giles Sender is used to supply data to Wallaroo applications over TCP.
+
+```bash
+cd ~/wallaroo-tutorial/wallaroo/giles/sender
+make
+```
+
+## Install Giles Receiver
+
+Giles Receiver receives data from Wallaroo over TCP.
+
+```bash
+cd ~/wallaroo-tutorial/wallaroo/giles/receiver
+make
+```
 
 ## Conclusion
 

--- a/book/getting-started/run-a-application.md
+++ b/book/getting-started/run-a-application.md
@@ -46,18 +46,10 @@ docker start mui
 
 ## Terminal 2, Run Giles Receiver
 
-We need to set up a data receiver where we can send the output stream from our application. Change to the Giles receiver directory compile it:
+We'll use Giles Receiver to listen for data from our Wallaroo application.
 
 ```bash
 cd ~/wallaroo-tutorial/wallaroo/giles/receiver
-make
-```
-
-This will create a binary called `receiver`.
-
-You will now be able to start the `receiver` with the following command:
-
-```bash
 ./receiver -l 127.0.0.1:5555 --ponythreads=1
 ```
 
@@ -93,20 +85,12 @@ cd ~/wallaroo-tutorial/wallaroo/examples/python/celsius/data_gen
 
 This will create a `celsius.msg` file in your current working directory.
 
-### Sending Data
-
-Giles Sender is used to mimic the behavior of an incoming data source. It can be built like this:
-
-```bash
-cd ~/wallaroo-tutorial/wallaroo/giles/sender
-make
-```
-
-This will create a binary called `sender`
+### Sending Data with Giles Sender
 
 You will now be able to start the `sender` with the following command:
 
 ```bash
+cd ~/wallaroo-tutorial/wallaroo/giles/sender
 ./sender -h 127.0.0.1:7000 -m 10000 -y -s 300 \
   -f ~/wallaroo-tutorial/wallaroo/examples/pony/celsius/data_gen/celsius.msg \
   -r -w -g 8 --ponythreads=1


### PR DESCRIPTION
Per issue #1287, Andy feels this is a better placement. The MacOS
instructions were in a different order than the Linux ones. This
different order would result in the existing Machida install
instructions to not work. As part of this PR, I reworked to order of the
MacOS instructions to match the Linux ones which should allow everything
to correct work as all required directories will be in place before
building machida and giles.

[skip ci]

Closes #1287