### PR TITLE
Updates docs for Metrics UI release 0.1

### DIFF
--- a/book/getting-started/linux-setup.md
+++ b/book/getting-started/linux-setup.md
@@ -146,7 +146,7 @@ sudo make install
 ## Install Compression Development Libraries
 
 Wallaroo's Kakfa support requires a `libsnappy` and `liblz` to be installed.
- 
+
 ### Xenial Ubuntu:
 
 ```bash
@@ -182,7 +182,7 @@ All of the Docker commands throughout the rest of this manual assume that you ha
 ## Install the Metrics UI
 
 ```bash
-sudo docker pull sendence/wallaroo-metrics-ui:pre-0.0.1
+sudo docker pull sendence/wallaroo-metrics-ui:0.1
 ```
 
 ## Set up Environment for the Wallaroo Tutorial

--- a/book/getting-started/macos-setup.md
+++ b/book/getting-started/macos-setup.md
@@ -96,7 +96,7 @@ You'll need Docker to run the Wallaroo metrics UI. There are [instructions](http
 ## Install the Metrics UI
 
 ```bash
-docker pull sendence/wallaroo-metrics-ui:pre-0.0.1
+docker pull sendence/wallaroo-metrics-ui:0.1
 ```
 
 ## Set up Environment for the Wallaroo Tutorial

--- a/book/getting-started/run-a-application.md
+++ b/book/getting-started/run-a-application.md
@@ -21,7 +21,7 @@ To start the Metrics UI run:
 
 ```bash
 docker run -d --name mui -p 0.0.0.0:4000:4000 -p 0.0.0.0:5001:5001 \
-  sendence/wallaroo-metrics-ui:pre-0.0.1
+  sendence/wallaroo-metrics-ui:0.1
 ```
 
 You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000).

--- a/book/getting-started/windows-setup.md
+++ b/book/getting-started/windows-setup.md
@@ -11,7 +11,7 @@ You'll need Docker for Windows to run the Wallaroo metrics UI. There are [instru
 ## Install the Metrics UI
 
 ```bash
-docker pull sendence/wallaroo-metrics-ui:pre-0.0.1
+docker pull sendence/wallaroo-metrics-ui:0.1
 ```
 
 ## Install Bash on Ubuntu on Windows

--- a/book/metrics/metrics-ui.md
+++ b/book/metrics/metrics-ui.md
@@ -19,14 +19,14 @@ You should already have Docker installed if you have followed the `Setup` instru
 Once you have Docker setup, you can grab the Metrics UI image by running:
 
 ```
-docker pull sendence/wallaroo-metrics-ui:pre-0.0.1
+docker pull sendence/wallaroo-metrics-ui:0.1
 ```
 
 To start the Metrics UI you will run:
 
 ```bash
 docker run -d --name mui -p 0.0.0.0:4000:4000 -p 0.0.0.0:5001:5001 \
-  sendence/wallaroo-metrics-ui:pre-0.0.1
+  sendence/wallaroo-metrics-ui:0.1
 ```
 
 If you are running locally, open [http://localhost:4000](http://localhost:4000)


### PR DESCRIPTION
Updates docs to point to docker image `sendence/wallaroo-metrics-ui:0.1`
which is compatible with source ingestion metrics.

**To Test:**

Verify that you can pull the docker image and run the UI with an example app. UI should display source and outbound throughput for pipelines. Look at Metrics UI doc for reference.