### PR TITLE
Suggest strongly to avoid using MacPorts for Wallaroo

### DIFF
--- a/book/getting-started/macos-setup.md
+++ b/book/getting-started/macos-setup.md
@@ -14,7 +14,7 @@ xcode-select --install
 
 You can then click “Install” to download and install Xcode Command Line Tools.
 
-## Installing a package manager, Homebrew
+## Installing a Package Manager, Homebrew
 
 Homebrew is used for easy installation of certain packages needed by Pony.
 
@@ -93,7 +93,9 @@ brew install python
 
 ## Install Docker
 
-You'll need Docker to run the Wallaroo metrics UI. There are [instructions](https://docs.docker.com/docker-for-mac/) for getting Docker up and running on MacOS on the [Docker website](https://docs.docker.com/docker-for-mac/). Installing Docker will result in it running on your machine. After you reboot your machine, that will no longer be the case. In the future, you'll need to have Docker running in order to use a variety of commands in this book. We suggest that you [set up Docker to boot automatically](https://docs.docker.com/docker-for-mac/#general).
+You'll need Docker to run the Wallaroo metrics UI. There are [instructions](https://docs.docker.com/docker-for-mac/) for getting Docker up and running on MacOS on the [Docker website](https://docs.docker.com/docker-for-mac/).  We recommend the 'Standard' version of the 'Docker for Mac' package.
+
+Installing Docker will result in it running on your machine. After you reboot your machine, that will no longer be the case. In the future, you'll need to have Docker running in order to use a variety of commands in this book. We suggest that you [set up Docker to boot automatically](https://docs.docker.com/docker-for-mac/#general).
 
 ## Install the Metrics UI
 


### PR DESCRIPTION
Small suggested change to Getting Started section for macOS that MacPorts should not be used.  Part of #1258's review for 0.1.0 release.

While I'm at it, I'm going to make a few other small clarifications to the `macos-setup.md` document and squash them together with the MacPorts warning.

[skip ci]
