### PR TITLE
Alphabet fix reader code snippet

### DIFF
--- a/examples/python/alphabet/README.md
+++ b/examples/python/alphabet/README.md
@@ -92,11 +92,11 @@ You can read the output with the following code:
 ```python
 import struct
 
-
+num_bytes = 4 + 1 + 8
 with open('alphabet.out', 'rb') as f:
     while True:
         try:
-            print struct.unpack('>LsL', f.read(9))
+            print struct.unpack('>IsQ', f.read(num_bytes))
         except:
             break
 ```


### PR DESCRIPTION
The alphabet reader code snippet in `README.md` got out of sync with the code in `alphabet.py`.  

Fixes #1342

[skip ci]
