### PR TITLE
Add link to support opens when people go to open an issue

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,27 @@
+# Getting help with Wallaroo
+
+Looking for help with Wallaroo? Awesome. We are here to help. Before you open an issue against this repo, we ask you read the following to better direct you to the proper forum.
+
+## Should I open an issue?
+
+We ask you to refrain from opening GitHub issues for non-actionable items. We use GitHub issues to track bugs. If you are not sure how to code a particular problem, how to decipher an error message, wondering about a benchmark, or anything of that sort, please use the [mailing list][mailing list] or [IRC][IRC].
+
+## How to get help
+
+You have a couple of different options on how you can get help from the Wallaroo community. If you are looking for an answer "right now," we suggest you give our IRC channel a try. It's `#wallaroo` on Freenode. If you ask a question, be sure to hang around until you get an answer. If you don't get one, or IRC isn't your thing, we have a friendly mailing list you can try. Whatever your question is, it isn't dumb, and we won't get annoyed.
+
+* [Mailing list][mailing list].
+* [IRC][IRC].
+* [Commercial support][commercial support]
+
+Think you've found a bug? It's entirely possible. We do extensive testing of Wallaroo, but bugs do happen. Your best bet is to write to the mailing list with your issue and verify that you are experiencing an issue; once a more knowledgeable member of the community confirms you are experiencing a bug, open an issue.
+
+* [Open an issue][issues]
+
+The Wallaroo community, while small, is helpful and inviting. We think you'll find interacting with us to be an enjoyable experience. You can get a lot more community-related resources in the [community section][website community section] of this site.
+
+[mailing list]: https://groups.io/g/wallaroo
+[IRC]: https://webchat.oftc.net/?channels=wallaroo
+[commercial support]: mailto:hello@wallaroolabs.com
+[issues]: https://github.com/WallarooLabs/wallaroo/issues
+[website community section]: http://www.wallaroolabs.com/community


### PR DESCRIPTION
SUPPORT.md is a "magic" GitHub file. By including this file in the repo,
a link to "support" will appear when a user goes to open an issue. With
this addition, we will have

- SUPPORT.md
- CONTRIBUTING.md
- CODE_OF_CONDUCT.md

which will result in:

Before you open an issue please review the support, contributing, and
conduct guidelines for this repository.

Being displayed on the new issues page.

[skip ci]