### PR TITLE
Add instructions to compile cluster shutdown tool in setup

### DIFF
--- a/book/getting-started/linux-setup.md
+++ b/book/getting-started/linux-setup.md
@@ -235,6 +235,15 @@ cd ~/wallaroo-tutorial/wallaroo/giles/receiver
 make
 ```
 
+## Install Cluster Shutdown tool
+
+The Cluster Shutdown tool is used to tell the cluster to shut down cleanly.
+
+```bash
+cd ~/wallaroo-tutorial/wallaroo/utils/cluster_shutdown
+make
+```
+
 ## Conclusion
 
 Awesome! All set. Time to try running your first application.

--- a/book/getting-started/macos-setup.md
+++ b/book/getting-started/macos-setup.md
@@ -147,6 +147,15 @@ cd ~/wallaroo-tutorial/wallaroo/giles/receiver
 make
 ```
 
+## Install Cluster Shutdown tool
+
+The Cluster Shutdown tool is used to tell the cluster to shut down cleanly.
+
+```bash
+cd ~/wallaroo-tutorial/wallaroo/utils/cluster_shutdown
+make
+```
+
 ## Conclusion
 
 Awesome! All set. Time to try running your first application.

--- a/examples/python/alphabet/README.md
+++ b/examples/python/alphabet/README.md
@@ -45,7 +45,7 @@ This will generate 1000 messages.
 
 ## Running Alphabet
 
-In order to run the application you will need Machida, Giles Sender, and Giles Reciever. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
+In order to run the application you will need Machida, Giles Sender, Giles Reciever and the Cluster Shutdown tool. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
 
 You will need three separate shells to run this application. Open each shell and go to the `examples/python/alphabet` directory.
 
@@ -101,9 +101,10 @@ with open('alphabet.out', 'rb') as f:
             break
 ```
 
-## Shutting down the cluster
+## Shutting Down The Cluster
 
-To shut down the cluster, you will need to use the `cluster_shutdown` tool.
+You can shut down the cluster with this command once processing has finished:
+
 ```bash
 ../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
 ```

--- a/examples/python/alphabet_partitioned/README.md
+++ b/examples/python/alphabet_partitioned/README.md
@@ -45,7 +45,7 @@ This will generate 1000 messages.
 
 ## Running Alphabet Partitioned
 
-In order to run the application you will need Machida, Giles Sender, and Giles Reciever. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
+In order to run the application you will need Machida, Giles Sender, Giles Reciever and the Cluster Shutdown tool. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
 
 You will need four separate shells to run this application. Open each shell and go to the `examples/python/alphabet_partitioned` directory.
 
@@ -124,8 +124,10 @@ with open('alphabet.out', 'rb') as f:
             break
 ```
 
-Remember to shut down the cluster once finished processing
+## Shutting Down The Cluster
+
+You can shut down the cluster with this command once processing has finished:
 
 ```bash
-../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:6002
+../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
 ```

--- a/examples/python/celsius-kafka/README.md
+++ b/examples/python/celsius-kafka/README.md
@@ -21,7 +21,7 @@ The `Decoder`'s `decode(...)` method creates a float from the value represented 
 
 ## Running Celsius Kafka
 
-In order to run the application you will need Machida. To build it, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
+In order to run the application you will need Machida and the Cluster Shutdown tool. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
 
 You will also need access to a Kafka cluster. This example assumes that there is a Kafka broker listening on port `9092` on `127.0.0.1`.
 
@@ -58,3 +58,11 @@ Run `machida` with `--application-module celsius`:
 ### Shell 3
 
 Send data into Kafka. Again, we use `kafakcat`.
+
+## Shutting Down The Cluster
+
+You can shut down the cluster with this command when you're ready:
+
+```bash
+../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
+```

--- a/examples/python/celsius/README.md
+++ b/examples/python/celsius/README.md
@@ -33,7 +33,7 @@ This will generate a million messages.
 
 ## Running Celsius
 
-In order to run the application you will need Machida, Giles Sender, and Giles Receiver. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
+In order to run the application you will need Machida, Giles Sender, Giles Reciever and the Cluster Shutdown tool. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
 
 You will need three separate shells to run this application. Open each shell and go to the `examples/python/celsius` directory.
 

--- a/examples/python/market_spread/README.md
+++ b/examples/python/market_spread/README.md
@@ -59,7 +59,7 @@ The Order messages are handled by the `OrderDecoder`'s `decode(...)` method, whi
 
 ## Running Market Spread
 
-In order to run the application you will need Machida, Giles Sender, and Giles Receiver. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
+In order to run the application you will need Machida, Giles Sender, Giles Reciever and the Cluster Shutdown tool. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
 
 You will need three separate shells to run this application. Open each shell and go to the `examples/python/market_spread` directory.
 

--- a/examples/python/reverse/README.md
+++ b/examples/python/reverse/README.md
@@ -28,7 +28,7 @@ The `Decoders`'s `decode(...)` method creates a string from the value represente
 
 ## Running Reverse
 
-In order to run the application you will need Machida, Giles Sender, and Giles Receiver. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
+In order to run the application you will need Machida, Giles Sender, Giles Reciever and the Cluster Shutdown tool. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
 
 You will need three separate shells to run this application. Open each shell and go to the `examples/python/reverse` directory.
 
@@ -72,7 +72,9 @@ Send some messages:
 
 The output will be printed to the console in the first shell. Each line should be the reverse of a word found in the `words.txt` file.
 
-## Shutting down cluster once finished processing
+## Shutting Down The Cluster
+
+You can shut down the cluster with this command once processing has finished:
 
 ```bash
 ../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050

--- a/examples/python/word_count/README.md
+++ b/examples/python/word_count/README.md
@@ -26,7 +26,7 @@ The `Decoder`'s `decode(...)` method turns the input message into a string. That
 
 ## Running Word Count
 
-In order to run the application you will need Machida and Giles Sender. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
+In order to run the application you will need Machida, Giles Sender and the Cluster Shutdown tool. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
 
 You will need three separate shells to run this application. Open each shell and go to the `examples/python/word_count` directory.
 


### PR DESCRIPTION
* Add instructions to compile cluster shutdown tool in linux setup
* Add instructions to compile cluster shutdown tool in macos setup
* Update all python example readme's for cluster shutdown tool dependency

Prior to this commit we didn't instruct people to compile the cluster
shutdown tool but did tell them to use the tool as part of the example
readme's to stop clusters.

resolves #1328

[skip ci]