### PR TITLE
Fix command to generate data in Run A Application

### DIFF
--- a/book/getting-started/run-a-wallaroo-application.md
+++ b/book/getting-started/run-a-wallaroo-application.md
@@ -80,7 +80,7 @@ A data generator is bundled with the application. Use these commands to generate
 
 ```bash
 cd ~/wallaroo-tutorial/wallaroo/examples/python/celsius/data_gen
-./data_gen 10000
+./data_gen.py 10000
 ```
 
 This will create a `celsius.msg` file in your current working directory.


### PR DESCRIPTION
Prior to this commit generating the data in Run A Application didn't
work correctly.

resolves #1330

[skip ci]