### PR TITLE
Change `make clean` to not clean docker

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -671,7 +671,7 @@ clean-docker: ## cleanup docker images and containers
 	$(if $(strip $(dangling)),$(QUIET)docker $(docker_host_arg) rmi $(dangling),)
 
 # rule to clean everything
-clean: clean-$(ROOT_TARGET_SUFFIX) clean-docker ## Clean all projects (pony & monhub) and cleanup docker images
+clean: clean-$(ROOT_TARGET_SUFFIX) ## Clean all projects (pony & monhub) and cleanup docker images
 	$(QUIET)rm -f lib/wallaroo/wallaroo lib/wallaroo/wallaroo.o
 	$(QUIET)rm -f sent.txt received.txt
 	$(QUIET)echo 'Done cleaning.'


### PR DESCRIPTION
Prior to this commit `make clean` would also run `clean-docker`
to clean up dangling docker containers/images. This could be
surprising to non-suspecting users so this commit changes
`make clean` to no longer run `clean-docker`. Folks who want
can still run `make clean-docker` to clean up dangling docker
resources.