### PR TITLE
Small grammar/spelling fixes in documentation

### DIFF
--- a/examples/python/alphabet/README.md
+++ b/examples/python/alphabet/README.md
@@ -45,7 +45,7 @@ This will generate 1000 messages.
 
 ## Running Alphabet
 
-In order to run the application you will need Machida, Giles Sender, Giles Reciever and the Cluster Shutdown tool. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
+In order to run the application you will need Machida, Giles Sender, Giles Receiver, and the Cluster Shutdown tool. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
 
 You will need three separate shells to run this application. Open each shell and go to the `examples/python/alphabet` directory.
 

--- a/examples/python/alphabet_partitioned/README.md
+++ b/examples/python/alphabet_partitioned/README.md
@@ -45,7 +45,7 @@ This will generate 1000 messages.
 
 ## Running Alphabet Partitioned
 
-In order to run the application you will need Machida, Giles Sender, Giles Receiver and the Cluster Shutdown tool. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
+In order to run the application you will need Machida, Giles Sender, Giles Receiver, and the Cluster Shutdown tool. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
 
 You will need four separate shells to run this application. Open each shell and go to the `examples/python/alphabet_partitioned` directory.
 

--- a/examples/python/celsius/README.md
+++ b/examples/python/celsius/README.md
@@ -33,7 +33,7 @@ This will generate a million messages.
 
 ## Running Celsius
 
-In order to run the application you will need Machida, Giles Sender, Giles Reciever and the Cluster Shutdown tool. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
+In order to run the application you will need Machida, Giles Sender, Giles Receiver, and the Cluster Shutdown tool. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
 
 You will need three separate shells to run this application. Open each shell and go to the `examples/python/celsius` directory.
 

--- a/examples/python/market_spread/README.md
+++ b/examples/python/market_spread/README.md
@@ -59,7 +59,7 @@ The Order messages are handled by the `OrderDecoder`'s `decode(...)` method, whi
 
 ## Running Market Spread
 
-In order to run the application you will need Machida, Giles Sender, Giles Reciever and the Cluster Shutdown tool. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
+In order to run the application you will need Machida, Giles Sender, Giles Receiver, and the Cluster Shutdown tool. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
 
 You will need three separate shells to run this application. Open each shell and go to the `examples/python/market_spread` directory.
 

--- a/examples/python/reverse/README.md
+++ b/examples/python/reverse/README.md
@@ -28,7 +28,7 @@ The `Decoders`'s `decode(...)` method creates a string from the value represente
 
 ## Running Reverse
 
-In order to run the application you will need Machida, Giles Sender, Giles Reciever and the Cluster Shutdown tool. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
+In order to run the application you will need Machida, Giles Sender, Giles Receiver, and the Cluster Shutdown tool. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
 
 You will need three separate shells to run this application. Open each shell and go to the `examples/python/reverse` directory.
 

--- a/examples/python/word_count/README.md
+++ b/examples/python/word_count/README.md
@@ -26,7 +26,7 @@ The `Decoder`'s `decode(...)` method turns the input message into a string. That
 
 ## Running Word Count
 
-In order to run the application you will need Machida, Giles Sender and the Cluster Shutdown tool. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
+In order to run the application you will need Machida, Giles Sender, and the Cluster Shutdown tool. To build them, please see the [Linux](/book/linux-setup.md) or [Mac OS](/book/macos-setup.md) setup instructions.
 
 You will need three separate shells to run this application. Open each shell and go to the `examples/python/word_count` directory.
 


### PR DESCRIPTION
- Receiver was spelled wrong
- Wallaroo Labs loves the Oxford comma

[skip ci]