### PR TITLE
Fix for 1334: Updates message count sent in for Run A Application Example

### DIFF
--- a/book/getting-started/run-a-wallaroo-application.md
+++ b/book/getting-started/run-a-wallaroo-application.md
@@ -86,15 +86,17 @@ cd ~/wallaroo-tutorial/wallaroo/examples/python/celsius/data_gen
 ./data_gen.py 10000
 ```
 
-This will create a `celsius.msg` file in your current working directory.
+This will create a `celsius.msg` file in your current working directory with 10,000 messages.
 
 ### Sending Data with Giles Sender
+
+We will be sending in 25,000,000 messages using the data file generated above. The data file will be repeatedly sent via Giles Sender until we reach 25,000,000 messages.
 
 You will now be able to start the `sender` with the following command:
 
 ```bash
 cd ~/wallaroo-tutorial/wallaroo/giles/sender
-./sender --host 127.0.0.1:7000 --messages 10000 --binary --batch-size 300 \
+./sender --host 127.0.0.1:7000 --messages 25000000 --binary --batch-size 300 \
   --repeat --no-write --msg-size 8 --ponythreads=1 --file \
   ~/wallaroo-tutorial/wallaroo/examples/python/celsius/data_gen/celsius.msg
 ```


### PR DESCRIPTION
Both the amount generated and sent it to the Celsius example needed
to be updated in order to get continous metrics updates in the UI.
This was done in order for the user to be able to navigate the UI and
be able to spend some time looking at it without everything coming to a halt.

Depends on #1355 and #1356 before this can be merged

Closes #1334

[skip ci]