### PR TITLE
Add Shutdown section to Python example READMEs

### DIFF
--- a/examples/python/alphabet/README.md
+++ b/examples/python/alphabet/README.md
@@ -101,10 +101,12 @@ with open('alphabet.out', 'rb') as f:
             break
 ```
 
-## Shutting Down The Cluster
+## Shutdown
 
-You can shut down the cluster with this command once processing has finished:
+You can shut down the Wallaroo cluster with this command once processing has finished:
 
 ```bash
 ../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
 ```
+
+You can shut down Giles Sender by pressing `Ctrl-c` from its shell.

--- a/examples/python/alphabet_partitioned/README.md
+++ b/examples/python/alphabet_partitioned/README.md
@@ -124,10 +124,12 @@ with open('alphabet.out', 'rb') as f:
             break
 ```
 
-## Shutting Down The Cluster
+## Shutdown
 
 You can shut down the cluster with this command once processing has finished:
 
 ```bash
 ../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
 ```
+
+You can shut down Giles Sender and Giles Receiver by pressing `Ctrl-c` from their respective shells.

--- a/examples/python/celsius/README.md
+++ b/examples/python/celsius/README.md
@@ -90,10 +90,12 @@ with open('celsius.out', 'rb') as f:
             break
 ```
 
-## Shutting Down The Cluster
+## Shutdown
 
 You can shut down the cluster with this command once processing has finished:
 
 ```bash
 ../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
 ```
+
+You can shut down Giles Sender by pressing `Ctrl-c` from its shell.

--- a/examples/python/market_spread/README.md
+++ b/examples/python/market_spread/README.md
@@ -114,10 +114,12 @@ To send order messages, run this command:
   --repeat --ponythreads=1 --msg-size 57 --no-write
 ```
 
-## Shutting Down The Cluster
+## Shutdown
 
-The sender commands will send data forever, so processing never really finishes. When you are ready to shut down the cluster you can run this command:
+The sender commands will send data for a long time, so processing never really finishes. When you are ready to shut down the cluster you can run this command:
 
 ```bash
 ../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
 ```
+
+You can shut down Giles Sender by pressing `Ctrl-c` from its shell.

--- a/examples/python/reverse/README.md
+++ b/examples/python/reverse/README.md
@@ -72,10 +72,12 @@ Send some messages:
 
 The output will be printed to the console in the first shell. Each line should be the reverse of a word found in the `words.txt` file.
 
-## Shutting Down The Cluster
+## Shutdown
 
 You can shut down the cluster with this command once processing has finished:
 
 ```bash
 ../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
 ```
+
+You can shut down Giles Sender by pressing `Ctrl-c` from its shell.

--- a/examples/python/word_count/README.md
+++ b/examples/python/word_count/README.md
@@ -70,10 +70,12 @@ In a third shell, send some messages:
 
 There will be a stream of output messages in the first shell (where you ran `nc`).
 
-## Shutting Down The Cluster
+## Shutdown
 
 You can shut down the cluster with this command once processing has finished:
 
 ```bash
 ../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
 ```
+
+You can shut down Giles Sender by pressing `Ctrl-c` from its shell.


### PR DESCRIPTION
This adds explicit instructions to shut down Giles.

Closes #1323.
[skip ci]