### PR TITLE
Alphabet_partitioned fix reader code snippet

### DIFF
--- a/examples/python/alphabet_partitioned/README.md
+++ b/examples/python/alphabet_partitioned/README.md
@@ -115,11 +115,11 @@ You can read the output with the following code:
 ```python
 import struct
 
-
+num_bytes = 4 + 1 + 8
 with open('alphabet.out', 'rb') as f:
     while True:
         try:
-            print struct.unpack('>LsL', f.read(9))
+            print struct.unpack('>IsQ', f.read(num_bytes))
         except:
             break
 ```


### PR DESCRIPTION
The alphabet_partitioned reader code snippet in README.md got out of sync with the code in alphabet_partitioned.py.

Fixes #1381

[skip ci]
