### PR TITLE
Add note about maybe needing sudo with docker

### DIFF
--- a/book/getting-started/run-a-wallaroo-application.md
+++ b/book/getting-started/run-a-wallaroo-application.md
@@ -17,6 +17,8 @@ Let's get started!
 
 ## Terminal 1, Start the Metrics UI
 
+NOTE: You might need to run with sudo depending on how you set up Docker.
+
 To start the Metrics UI run:
 
 ```bash

--- a/book/metrics/metrics-ui.md
+++ b/book/metrics/metrics-ui.md
@@ -16,6 +16,8 @@ You should already have Docker installed if you have followed the `Setup` instru
 
 #### Running the Metrics UI
 
+NOTE: You might need to run with sudo depending on how you set up Docker.
+
 Once you have Docker setup, you can grab the Metrics UI image by running:
 
 ```

--- a/examples/python/celsius-kafka/README.md
+++ b/examples/python/celsius-kafka/README.md
@@ -45,7 +45,9 @@ sudo chmod +x /usr/local/bin/docker-compose
 OSX: Docker compose is already included as part of Docker for Mac.
 
 
-Clone local-kafka-cluster project and run it (add `sudo` to the commands, including `./cluster up 1`, if docker is not allowed to be run by your user):
+NOTE: You might need to run with sudo depending on how you set up Docker.
+
+Clone local-kafka-cluster project and run it:
 
 ```bash
 cd /tmp
@@ -128,7 +130,9 @@ To shut down the cluster, you will need to use the `cluster_shutdown` tool.
 
 ### Stop kafka
 
-If you followed the commands earlier to start kafka you can stop it by running (add `sudo` if docker is not allowed to be run by your user):
+NOTE: You might need to run with sudo depending on how you set up Docker.
+
+If you followed the commands earlier to start kafka you can stop it by running:
 
 ```bash
 cd /tmp/local-kafka-cluster


### PR DESCRIPTION
This note is needed because depending on how `docker` is set up on linux,
the user may or may not need to use `sudo` to run it.

resolves #1367

[skip ci]