### PR TITLE
Remove references to running on Windows Bash/WSL

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -17,7 +17,6 @@
 * [Setting up Your Environment](book/getting-started/setup.md)
   * [MacOS Installation](book/getting-started/macos-setup.md)
   * [Ubuntu Installation](book/getting-started/linux-setup.md)
-  * [Windows Installation](book/getting-started/windows-setup.md)
 * [Run a Wallaroo Application](book/getting-started/run-a-wallaroo-application.md)
 * [Conclusion](book/getting-started/conclusion.md)
 
@@ -61,8 +60,6 @@
 
 ### Debugging Python Wallaroo Applications
 * [Debugging](book/python/debugging.md)
-* [Remote Debugging Setup for Windows](book/python/windows-remote-debugging-setup.md)
-   * [Remote Debugging Using Wing IDE](book/python/wing-remote-debugging.md)
 
 ## Appendix
 * [Wallaroo Command-Line Options](book/appendix/wallaroo-command-line-options.md)

--- a/book/getting-started/setup.md
+++ b/book/getting-started/setup.md
@@ -1,8 +1,7 @@
 # Setting Up Your Environment for Wallaroo
 
-It is currently possible to develop Wallaroo applications on MacOS, Linux, or Windows. This guide currently has installation instructions for MacOS, Ubuntu Linux, and Windows 10 Pro via Bash/WSL. It's assumed if you are using a different Linux distribution that you are able to translate the Ubuntu instructions to your distribution of choice. Windows instructions are dependent on the usage of Bash/WSL. Follow the instructions for your operating system:
+It is currently possible to develop Wallaroo applications on MacOS and Linux. This guide currently has installation instructions for MacOS and Ubuntu Linux. It's assumed if you are using a different Linux distribution that you are able to translate the Ubuntu instructions to your distribution of choice. Follow the instructions for your operating system:
 
 - [MacOS setup](macos-setup.md)
 - [Ubunutu setup](linux-setup.md)
-- [Windows setup](windows-setup.md)
 

--- a/book/python/debugging.md
+++ b/book/python/debugging.md
@@ -31,11 +31,6 @@ def application_setup(arg):
 
 The above will insert a breakpoint in the current stack frame and allow you to inspect the `application_setup` function. `pdb` comes with a nice set of features so if you're interested in using it go have a look at the official [documentation](https://docs.python.org/2/library/pdb.html).
 
-For Windows users who would prefer to do remote debugging due to Bash/WSL, continue to our [Setting up Windows for Remote Debugging using Wing IDE](/book/python/wing-on-windows-remote-debugging-setup.md) instructions.
-
-
 ## Other Debugging Options
 
 Debugging using `print` or `pdb` is great because they're available on all platforms. However, we realize you might have your own debugging process. We encourage you to use the tools that best fit your needs and we are available to help get you set up if needed.
-
-We've had a user base reach out to us to help them get set up in using [Wing IDE](https://wingware.com/) to do remote debugging. Wing is available on all platforms and includes its own powerful debugger that allows for interactive debugging via the IDE. Because of the unique nature of developing Wallaroo on Windows (all programs are run in Linux via Bash/WSL) we've included a section for [Setting up Windows for Remote Debugging using Wing IDE](book/python/wing-on-windows-remote-debugging-setup.md) and [Setting up Wing IDE for Remote Debugging a Python Wallaroo Application](book/python/wing-remote-debugging.md).

--- a/intro.md
+++ b/intro.md
@@ -19,7 +19,7 @@ Although not required, you will get the most out of this tutorial if you have pr
 
 ## Supported development environments
 
-It is currently possible to develop Wallaroo applications on MacOS, Linux or Windows. This guide has installation instructions for MacOS, Ubuntu Linux, and Windows 10 Pro via Bash/WSL. It's assumed if you are using a different Linux distribution that you are able to translate the Ubuntu instructions to your distribution of choice.
+It is currently possible to develop Wallaroo applications on MacOS and Linux. This guide has installation instructions for MacOS, and Ubuntu Linux. It's assumed if you are using a different Linux distribution that you are able to translate the Ubuntu instructions to your distribution of choice.
 
 ## What to Expect
 


### PR DESCRIPTION
Due to poor performance in giles sender which we do not currently have time
to investigate, we are removing all mentions of supporting Windows Bash/WSL
in the book. This will be revisited prior to hard launch.

See issue #1332

[skip ci]