### PR TITLE
Run receiver with --no-write in "run an application"

### DIFF
--- a/book/getting-started/run-a-wallaroo-application.md
+++ b/book/getting-started/run-a-wallaroo-application.md
@@ -52,7 +52,7 @@ We'll use Giles Receiver to listen for data from our Wallaroo application.
 
 ```bash
 cd ~/wallaroo-tutorial/wallaroo/giles/receiver
-./receiver -l 127.0.0.1:5555 --ponythreads=1
+./receiver -l 127.0.0.1:5555 --no-write --ponythreads=1
 ```
 
 You should see the `Listening for data` that indicates that Giles receiver is running.


### PR DESCRIPTION
Its a performance drag. On my machine writing to disk is very slow and
creates a choppy experience. My OSX machine is ugh, but what are you
going to do.

Closes #1428

[skip ci]