### PR TITLE
Make sure KafkaSink/KafkaSource dispose properly on shutdown request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ branches:
     - master
     - release
     - /^release-(\d).(\d).(\d)-rc(\d)+$/
+    - /^release-(\d).(\d).(\d)$/
 
 dist: trusty
 sudo: required

--- a/examples/pony/celsius-kafka/bundle.json
+++ b/examples/pony/celsius-kafka/bundle.json
@@ -5,7 +5,7 @@
       },
       { "type": "github",
         "repo": "WallarooLabs/pony-kafka",
-        "tag": "0.1"
+        "tag": "0.1.1"
       }
   ]
 }

--- a/examples/python/celsius-kafka/README.md
+++ b/examples/python/celsius-kafka/README.md
@@ -144,8 +144,6 @@ To shut down the cluster, you will need to use the `cluster_shutdown` tool.
 ../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
 ```
 
-Note: This might not fully shut down the cluster in which case you'll need to use `ctrl-c` to shut it down.
-
 You can shut down the kafkacat producer by pressing Ctrl-d from its shell.
 
 You can shut down the kafkacat consumer by pressing Ctrl-c from its shell.

--- a/lib/wallaroo/Makefile
+++ b/lib/wallaroo/Makefile
@@ -7,6 +7,9 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 
@@ -19,8 +22,15 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 # uncomment to disable generate recursing into Makefiles of subdirectories
 #RECURSE_SUBMAKEFILES := false
 
+LIB_WALLAROO_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
 # standard rules generation makefile
 include $(rules_mk_path)
+
+test-lib-wallaroo: lib_wallaroo_test
+
+lib_wallaroo_test:
+	cd $(abspath $(LIB_WALLAROO_PATH:%/=%)) && ./$(notdir $(abspath $(LIB_WALLAROO_PATH:%/=%))) --sequential
 
 # end of prevent rules from being evaluated/included multiple times
 endif

--- a/lib/wallaroo/core/sink/kafka_sink/kafka_sink.pony
+++ b/lib/wallaroo/core/sink/kafka_sink/kafka_sink.pony
@@ -309,4 +309,7 @@ actor KafkaSink is (Consumer & KafkaClientManager & KafkaProducer)
     Fail()
 
   be dispose() =>
-    None
+    @printf[I32]("Shutting down KafkaSink\n".cstring())
+    try
+      (_kc as KafkaClient tag).dispose()
+    end

--- a/lib/wallaroo/core/source/kafka_source/kafka_source.pony
+++ b/lib/wallaroo/core/source/kafka_source/kafka_source.pony
@@ -235,6 +235,10 @@ actor KafkaSource[In: Any val] is (Producer & KafkaConsumer)
     _notify.received(this, msg, network_received_timestamp)
 
   be dispose() =>
+    @printf[I32]("Shutting down KafkaSource\n".cstring())
+
     for b in _outgoing_boundaries.values() do
       b.dispose()
     end
+
+    _kc.dispose()

--- a/lib/wallaroo_labs/Makefile
+++ b/lib/wallaroo_labs/Makefile
@@ -7,6 +7,9 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
 # uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
 #PONY_TARGET := false
 
@@ -19,8 +22,15 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 # uncomment to disable generate recursing into Makefiles of subdirectories
 #RECURSE_SUBMAKEFILES := false
 
+LIB_WALLAROO_LABS_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
 # standard rules generation makefile
 include $(rules_mk_path)
+
+test-lib-wallaroo_labs: lib_wallaroo_labs_test
+
+lib_wallaroo_labs_test:
+	cd $(abspath $(LIB_WALLAROO_LABS_PATH:%/=%)) && ./$(notdir $(abspath $(LIB_WALLAROO_LABS_PATH:%/=%))) --sequential
 
 # end of prevent rules from being evaluated/included multiple times
 endif

--- a/machida/bundle.json
+++ b/machida/bundle.json
@@ -5,7 +5,7 @@
       },
       { "type": "github",
         "repo": "WallarooLabs/pony-kafka",
-        "tag": "0.1"
+        "tag": "0.1.1"
       }
   ]
 }


### PR DESCRIPTION
Prior to this, the KafkaSource and KafkaSink didn't properly dispose
of the KafkaClient resulting in programs using KafkaSource and
KafkaSink hanging when shutdown was requested.

Also remove temporarily added note in the python celsius-kafka readme
about having to use ctrl-c after shutdown tool.

Resolves #1442