### PR TITLE
Make sure celsuis-kafka doesn't throw errors on invalid input

### DIFF
--- a/examples/python/celsius-kafka/celsius.py
+++ b/examples/python/celsius-kafka/celsius.py
@@ -43,8 +43,9 @@ def application_setup(args):
 
 class Decoder(object):
     def decode(self, bs):
-        return struct.unpack('>f', bs)[0]
-
+        if len(bs) < 4:
+          return 0.0
+        return struct.unpack('>f', bs[:4])[0]
 
 class Multiply(object):
     def name(self):


### PR DESCRIPTION
Prior to this commit the celsius-kafka python application would
throw errors on invalid input (i.e. message is more than or less
than 4 bytes).

This commit fixes the celsius kafka errors/segfaults on invalid
input. The return of `0.0` when the input length is less than
4 bytes should likely be replaced with the appropriate logic
for `skip this message`.

resolves #1439