### PR TITLE
Move HubProtocol to MonHub

### DIFF
--- a/monitoring_hub/apps/metrics_reporter_ui/config/dev.exs
+++ b/monitoring_hub/apps/metrics_reporter_ui/config/dev.exs
@@ -8,7 +8,9 @@ use Mix.Config
 # with brunch.io to recompile .js and .css sources.
 config :metrics_reporter_ui, MetricsReporterUI.Endpoint,
   http: [port: System.get_env("PHX_HTTP_PORT") || 4000],
-  tcp: [port: System.get_env("PHX_TCP_PORT") || 5001],
+  tcp: [port: System.get_env("PHX_TCP_PORT") || 5001,
+        tcp_server: MonitoringHubUtils.TCPServer,
+        protocol_options: [serializer: MonitoringHubUtils.Serializers.HubProtocol]],
   debug_errors: true,
   code_reloader: true,
   check_origin: false,

--- a/monitoring_hub/apps/metrics_reporter_ui/config/prod.exs
+++ b/monitoring_hub/apps/metrics_reporter_ui/config/prod.exs
@@ -13,7 +13,9 @@ use Mix.Config
 # which you typically run after static files are built.
 config :metrics_reporter_ui, MetricsReporterUI.Endpoint,
   http: [port: 4000],
-  tcp: [port: 5001],
+  tcp: [port: 5001,
+        tcp_server: MonitoringHubUtils.TCPServer,
+        protocol_options: [serializer: MonitoringHubUtils.Serializers.HubProtocol]],
   check_origin: false,
   # url: [host: "example.com", port: 80],
   cache_static_manifest: "priv/static/manifest.json",

--- a/monitoring_hub/apps/metrics_reporter_ui/mix.exs
+++ b/monitoring_hub/apps/metrics_reporter_ui/mix.exs
@@ -39,7 +39,7 @@ defmodule MetricsReporterUI.Mixfile do
      {:gettext, "~> 0.9"},
      {:cowboy, "~> 1.0"},
      {:exrm, "~> 1.0.8"},
-     {:phoenix_tcp, git: "https://github.com/WallarooLabs/phoenix_tcp.git", branch: "add-hub-protocol"},
+     {:phoenix_tcp, git: "https://github.com/WallarooLabs/phoenix_tcp.git", branch: "master"},
      {:monitoring_hub_utils, in_umbrella: true},
      {:metrics_reporter, in_umbrella: true}]
   end

--- a/monitoring_hub/apps/metrics_reporter_ui/web/channels/metrics_socket.ex
+++ b/monitoring_hub/apps/metrics_reporter_ui/web/channels/metrics_socket.ex
@@ -20,7 +20,9 @@ defmodule MetricsReporterUI.MetricsSocket do
   transport :websocket, Phoenix.Transports.WebSocket
   transport :longpoll, Phoenix.Transports.LongPoll
   transport :tcp, PhoenixTCP.Transports.TCP,
-    timeout: :infinity
+    timeout: :infinity,
+    serializer: MonitoringHubUtils.Serializers.TCPSerializer,
+    tcp_server: MonitoringHubUtils.TCPServer
 
   # Socket params are passed from the client and can
   # be used to verify and authenticate a user. After

--- a/monitoring_hub/apps/monitoring_hub_utils/lib/monitoring_hub_utils/serializers.ex
+++ b/monitoring_hub/apps/monitoring_hub_utils/lib/monitoring_hub_utils/serializers.ex
@@ -1,0 +1,2 @@
+defmodule MonitoringHubUtils.Serializers do
+end

--- a/monitoring_hub/apps/monitoring_hub_utils/lib/monitoring_hub_utils/serializers/hub_protocol.ex
+++ b/monitoring_hub/apps/monitoring_hub_utils/lib/monitoring_hub_utils/serializers/hub_protocol.ex
@@ -1,0 +1,370 @@
+defmodule MonitoringHubUtils.Serializers.HubProtocol do
+
+  # due to not sending data back to Wallaroo, encoding defaults to 1
+  def encode(_value) do
+    << 1 >>
+  end
+
+  def encode_to_iodata!(_value) do
+    << 1 >>
+  end
+
+  def decode(data) do
+    error_msg = decode_error_msg
+    case decode!(data) do
+      ^error_msg ->
+        {:error, decode_error_msg}
+      decoded_msg ->
+        {:ok, decoded_msg}
+    end
+  end
+
+  def decode!(<< 1 :: size(8) >> = _iodata) do
+    %{
+      "path" => "/socket/tcp",
+      "params" => nil
+    }
+  end
+
+  def decode!(<< 2 :: size(8), topic_size :: size(32),
+    topic :: binary-size(topic_size) >> = _iodata)
+  do
+    %{
+      "event" => "phx_join",
+      "topic" => topic,
+      "ref" => nil,
+      "payload" => %{}
+    }
+  end
+
+  def decode!(<< 2 :: size(8), topic_size :: size(32),
+    topic :: binary-size(topic_size), worker_name_size :: size(32),
+    worker_name :: binary-size(worker_name_size) >> = _iodata)
+  do
+    %{
+      "event" => "phx_join",
+      "topic" => topic,
+      "ref" => nil,
+      "payload" => %{
+        "worker_name" => worker_name
+      }
+    }
+  end
+
+  def decode!(<< 3 :: size(8), event_size :: size(32),
+    event :: binary-size(event_size), topic_size :: size(32),
+    topic :: binary-size(topic_size), payload_size :: size(32),
+    payload :: binary>> = _iodata)
+  do
+    %{
+      "event" => event,
+      "topic" => topic,
+      "ref" => nil,
+      "payload" => payload_decode(payload)
+    }
+  end
+
+  def decode!(_unknown_data) do
+    decode_error_msg
+  end
+
+  # 4-header : 1-side-U8 : 4-client_id-U32 : 6-order_id-String :
+  # 4-symbol-String : 8-order_qty-F64 : 8-price-F64 : 8-bid-F64 :
+  # 8-offer-F64 : 8-timestamp-U64
+
+  defp payload_decode(<< _header :: size(32), side :: unsigned-integer-size(8),
+    client_id :: unsigned-integer-size(32), order_id :: bitstring-size(48),
+    symbol :: bitstring-size(32), order_qty :: float-size(64),
+    price :: float-size(64), bid :: float-size(64), offer :: float-size(64),
+    timestamp :: unsigned-integer-size(64) >>)
+  do
+
+    side_string = if side == 1, do: "BUY", else: "SELL"
+    %{
+      "side" => side_string,
+      "client_id" => client_id,
+      "order_id" => order_id,
+      "symbol" => symbol,
+      "order_qty" => order_qty,
+      "price" => price,
+      "bid" => bid,
+      "offer" => offer,
+      "timestamp" => round(timestamp / 1000000000)
+    }
+  end
+
+  # (4)-[header]-U32 :
+  # (4)-[name-size]-U32 : (name-size)-[name]-String :
+  # (4)-[category-size]-U32 : (category-size)-[category]-String :
+  # (4)-[worker-name-size]-U32 : (worker-name-size)-[worker-name]-String :
+  # (4)-[pipeline-name-size]-U32 : (pipeline-name-size)-[pipeline-name]-String :
+  # (2)-[id]-U16
+  # [65 8-byte latency values as U64s] :
+  # (8)-period-U64 : 8-period_ends_at_timestamp-U64
+
+  defp payload_decode(<< _header :: size(32), name_size :: size(32),
+    name :: binary-size(name_size), category_size :: size(32),
+    "computation", worker_name_size :: size(32),
+    worker_name :: binary-size(worker_name_size),
+    pipeline_name_size :: size(32), pipeline_name :: binary-size(pipeline_name_size),
+    id :: size(16),
+    bin_0 :: unsigned-integer-size(64),
+    bin_1 :: unsigned-integer-size(64), bin_2 :: unsigned-integer-size(64),
+    bin_3 :: unsigned-integer-size(64), bin_4 :: unsigned-integer-size(64),
+    bin_5 :: unsigned-integer-size(64), bin_6 :: unsigned-integer-size(64),
+    bin_7 :: unsigned-integer-size(64), bin_8 :: unsigned-integer-size(64),
+    bin_9 :: unsigned-integer-size(64), bin_10 :: unsigned-integer-size(64),
+    bin_11 :: unsigned-integer-size(64), bin_12 :: unsigned-integer-size(64),
+    bin_13 :: unsigned-integer-size(64), bin_14 :: unsigned-integer-size(64),
+    bin_15 :: unsigned-integer-size(64), bin_16 :: unsigned-integer-size(64),
+    bin_17 :: unsigned-integer-size(64), bin_18 :: unsigned-integer-size(64),
+    bin_19 :: unsigned-integer-size(64), bin_20 :: unsigned-integer-size(64),
+    bin_21 :: unsigned-integer-size(64), bin_22 :: unsigned-integer-size(64),
+    bin_23 :: unsigned-integer-size(64), bin_24 :: unsigned-integer-size(64),
+    bin_25 :: unsigned-integer-size(64), bin_26 :: unsigned-integer-size(64),
+    bin_27 :: unsigned-integer-size(64), bin_28 :: unsigned-integer-size(64),
+    bin_29 :: unsigned-integer-size(64), bin_30 :: unsigned-integer-size(64),
+    bin_31 :: unsigned-integer-size(64), bin_32 :: unsigned-integer-size(64),
+    bin_33 :: unsigned-integer-size(64), bin_34 :: unsigned-integer-size(64),
+    bin_35 :: unsigned-integer-size(64), bin_36 :: unsigned-integer-size(64),
+    bin_37 :: unsigned-integer-size(64), bin_38 :: unsigned-integer-size(64),
+    bin_39 :: unsigned-integer-size(64), bin_40 :: unsigned-integer-size(64),
+    bin_41 :: unsigned-integer-size(64), bin_42 :: unsigned-integer-size(64),
+    bin_43 :: unsigned-integer-size(64), bin_44 :: unsigned-integer-size(64),
+    bin_45 :: unsigned-integer-size(64), bin_46 :: unsigned-integer-size(64),
+    bin_47 :: unsigned-integer-size(64), bin_48 :: unsigned-integer-size(64),
+    bin_49 :: unsigned-integer-size(64), bin_50 :: unsigned-integer-size(64),
+    bin_51 :: unsigned-integer-size(64), bin_52 :: unsigned-integer-size(64),
+    bin_53 :: unsigned-integer-size(64), bin_54 :: unsigned-integer-size(64),
+    bin_55 :: unsigned-integer-size(64), bin_56 :: unsigned-integer-size(64),
+    bin_57 :: unsigned-integer-size(64), bin_58 :: unsigned-integer-size(64),
+    bin_59 :: unsigned-integer-size(64), bin_60 :: unsigned-integer-size(64),
+    bin_61 :: unsigned-integer-size(64), bin_62 :: unsigned-integer-size(64),
+    bin_63 :: unsigned-integer-size(64), bin_64 :: unsigned-integer-size(64),
+    min_val :: unsigned-integer-size(64), max_val :: unsigned-integer-size(64),
+    period :: unsigned-integer-size(64), timestamp :: unsigned-integer-size(64),
+    >>)
+  do
+    %{
+      "name" => pipeline_name <> "@" <> worker_name <> ":" <> name,
+      "category" => "computation",
+      "worker" => worker_name,
+      "pipeline" => pipeline_name,
+      "id" => to_string(id),
+      "latency_list" => [bin_0, bin_1, bin_2, bin_3, bin_4, bin_5, bin_6,
+        bin_7, bin_8, bin_9, bin_10, bin_11, bin_12, bin_13, bin_14, bin_15,
+        bin_16, bin_17, bin_18, bin_19, bin_20, bin_21, bin_22, bin_23, bin_24,
+        bin_25, bin_26, bin_27, bin_28, bin_29, bin_30, bin_31, bin_32, bin_33,
+        bin_34, bin_35, bin_36, bin_37, bin_38, bin_39, bin_40, bin_41, bin_42,
+        bin_43, bin_44, bin_45, bin_46, bin_47, bin_48, bin_49, bin_50, bin_51,
+        bin_52, bin_53, bin_54, bin_55, bin_56, bin_57, bin_58, bin_59, bin_60,
+        bin_61, bin_62, bin_63, bin_64],
+      "min" => min_val,
+      "max" => max_val,
+      "period" => period,
+      "period" => round(period / 1000000000),
+      "timestamp" => round(timestamp / 1000000000)
+    }
+  end
+
+  defp payload_decode(<< _header :: size(32), name_size :: size(32),
+    name :: binary-size(name_size), category_size :: size(32),
+    "start-to-end", worker_name_size :: size(32),
+    worker_name :: binary-size(worker_name_size),
+    pipeline_name_size :: size(32), pipeline_name :: binary-size(pipeline_name_size),
+    id :: size(16),
+    bin_0 :: unsigned-integer-size(64),
+    bin_1 :: unsigned-integer-size(64), bin_2 :: unsigned-integer-size(64),
+    bin_3 :: unsigned-integer-size(64), bin_4 :: unsigned-integer-size(64),
+    bin_5 :: unsigned-integer-size(64), bin_6 :: unsigned-integer-size(64),
+    bin_7 :: unsigned-integer-size(64), bin_8 :: unsigned-integer-size(64),
+    bin_9 :: unsigned-integer-size(64), bin_10 :: unsigned-integer-size(64),
+    bin_11 :: unsigned-integer-size(64), bin_12 :: unsigned-integer-size(64),
+    bin_13 :: unsigned-integer-size(64), bin_14 :: unsigned-integer-size(64),
+    bin_15 :: unsigned-integer-size(64), bin_16 :: unsigned-integer-size(64),
+    bin_17 :: unsigned-integer-size(64), bin_18 :: unsigned-integer-size(64),
+    bin_19 :: unsigned-integer-size(64), bin_20 :: unsigned-integer-size(64),
+    bin_21 :: unsigned-integer-size(64), bin_22 :: unsigned-integer-size(64),
+    bin_23 :: unsigned-integer-size(64), bin_24 :: unsigned-integer-size(64),
+    bin_25 :: unsigned-integer-size(64), bin_26 :: unsigned-integer-size(64),
+    bin_27 :: unsigned-integer-size(64), bin_28 :: unsigned-integer-size(64),
+    bin_29 :: unsigned-integer-size(64), bin_30 :: unsigned-integer-size(64),
+    bin_31 :: unsigned-integer-size(64), bin_32 :: unsigned-integer-size(64),
+    bin_33 :: unsigned-integer-size(64), bin_34 :: unsigned-integer-size(64),
+    bin_35 :: unsigned-integer-size(64), bin_36 :: unsigned-integer-size(64),
+    bin_37 :: unsigned-integer-size(64), bin_38 :: unsigned-integer-size(64),
+    bin_39 :: unsigned-integer-size(64), bin_40 :: unsigned-integer-size(64),
+    bin_41 :: unsigned-integer-size(64), bin_42 :: unsigned-integer-size(64),
+    bin_43 :: unsigned-integer-size(64), bin_44 :: unsigned-integer-size(64),
+    bin_45 :: unsigned-integer-size(64), bin_46 :: unsigned-integer-size(64),
+    bin_47 :: unsigned-integer-size(64), bin_48 :: unsigned-integer-size(64),
+    bin_49 :: unsigned-integer-size(64), bin_50 :: unsigned-integer-size(64),
+    bin_51 :: unsigned-integer-size(64), bin_52 :: unsigned-integer-size(64),
+    bin_53 :: unsigned-integer-size(64), bin_54 :: unsigned-integer-size(64),
+    bin_55 :: unsigned-integer-size(64), bin_56 :: unsigned-integer-size(64),
+    bin_57 :: unsigned-integer-size(64), bin_58 :: unsigned-integer-size(64),
+    bin_59 :: unsigned-integer-size(64), bin_60 :: unsigned-integer-size(64),
+    bin_61 :: unsigned-integer-size(64), bin_62 :: unsigned-integer-size(64),
+    bin_63 :: unsigned-integer-size(64), bin_64 :: unsigned-integer-size(64),
+    min_val :: unsigned-integer-size(64), max_val :: unsigned-integer-size(64),
+    period :: unsigned-integer-size(64), timestamp :: unsigned-integer-size(64),
+    >>)
+  do
+    %{
+      "name" => pipeline_name <> "@" <> worker_name,
+      "category" => "start-to-end",
+      "worker" => worker_name,
+      "pipeline" => pipeline_name,
+      "id" => to_string(id),
+      "latency_list" => [bin_0, bin_1, bin_2, bin_3, bin_4, bin_5, bin_6,
+        bin_7, bin_8, bin_9, bin_10, bin_11, bin_12, bin_13, bin_14, bin_15,
+        bin_16, bin_17, bin_18, bin_19, bin_20, bin_21, bin_22, bin_23, bin_24,
+        bin_25, bin_26, bin_27, bin_28, bin_29, bin_30, bin_31, bin_32, bin_33,
+        bin_34, bin_35, bin_36, bin_37, bin_38, bin_39, bin_40, bin_41, bin_42,
+        bin_43, bin_44, bin_45, bin_46, bin_47, bin_48, bin_49, bin_50, bin_51,
+        bin_52, bin_53, bin_54, bin_55, bin_56, bin_57, bin_58, bin_59, bin_60,
+        bin_61, bin_62, bin_63, bin_64],
+      "min" => min_val,
+      "max" => max_val,
+      "period" => period,
+      "period" => round(period / 1000000000),
+      "timestamp" => round(timestamp / 1000000000)
+    }
+  end
+
+  defp payload_decode(<< _header :: size(32), name_size :: size(32),
+    name :: binary-size(name_size), category_size :: size(32),
+    "node-ingress-egress", worker_name_size :: size(32),
+    worker_name :: binary-size(worker_name_size),
+    pipeline_name_size :: size(32), pipeline_name :: binary-size(pipeline_name_size),
+    id :: size(16),
+    bin_0 :: unsigned-integer-size(64),
+    bin_1 :: unsigned-integer-size(64), bin_2 :: unsigned-integer-size(64),
+    bin_3 :: unsigned-integer-size(64), bin_4 :: unsigned-integer-size(64),
+    bin_5 :: unsigned-integer-size(64), bin_6 :: unsigned-integer-size(64),
+    bin_7 :: unsigned-integer-size(64), bin_8 :: unsigned-integer-size(64),
+    bin_9 :: unsigned-integer-size(64), bin_10 :: unsigned-integer-size(64),
+    bin_11 :: unsigned-integer-size(64), bin_12 :: unsigned-integer-size(64),
+    bin_13 :: unsigned-integer-size(64), bin_14 :: unsigned-integer-size(64),
+    bin_15 :: unsigned-integer-size(64), bin_16 :: unsigned-integer-size(64),
+    bin_17 :: unsigned-integer-size(64), bin_18 :: unsigned-integer-size(64),
+    bin_19 :: unsigned-integer-size(64), bin_20 :: unsigned-integer-size(64),
+    bin_21 :: unsigned-integer-size(64), bin_22 :: unsigned-integer-size(64),
+    bin_23 :: unsigned-integer-size(64), bin_24 :: unsigned-integer-size(64),
+    bin_25 :: unsigned-integer-size(64), bin_26 :: unsigned-integer-size(64),
+    bin_27 :: unsigned-integer-size(64), bin_28 :: unsigned-integer-size(64),
+    bin_29 :: unsigned-integer-size(64), bin_30 :: unsigned-integer-size(64),
+    bin_31 :: unsigned-integer-size(64), bin_32 :: unsigned-integer-size(64),
+    bin_33 :: unsigned-integer-size(64), bin_34 :: unsigned-integer-size(64),
+    bin_35 :: unsigned-integer-size(64), bin_36 :: unsigned-integer-size(64),
+    bin_37 :: unsigned-integer-size(64), bin_38 :: unsigned-integer-size(64),
+    bin_39 :: unsigned-integer-size(64), bin_40 :: unsigned-integer-size(64),
+    bin_41 :: unsigned-integer-size(64), bin_42 :: unsigned-integer-size(64),
+    bin_43 :: unsigned-integer-size(64), bin_44 :: unsigned-integer-size(64),
+    bin_45 :: unsigned-integer-size(64), bin_46 :: unsigned-integer-size(64),
+    bin_47 :: unsigned-integer-size(64), bin_48 :: unsigned-integer-size(64),
+    bin_49 :: unsigned-integer-size(64), bin_50 :: unsigned-integer-size(64),
+    bin_51 :: unsigned-integer-size(64), bin_52 :: unsigned-integer-size(64),
+    bin_53 :: unsigned-integer-size(64), bin_54 :: unsigned-integer-size(64),
+    bin_55 :: unsigned-integer-size(64), bin_56 :: unsigned-integer-size(64),
+    bin_57 :: unsigned-integer-size(64), bin_58 :: unsigned-integer-size(64),
+    bin_59 :: unsigned-integer-size(64), bin_60 :: unsigned-integer-size(64),
+    bin_61 :: unsigned-integer-size(64), bin_62 :: unsigned-integer-size(64),
+    bin_63 :: unsigned-integer-size(64), bin_64 :: unsigned-integer-size(64),
+    min_val :: unsigned-integer-size(64), max_val :: unsigned-integer-size(64),
+    period :: unsigned-integer-size(64), timestamp :: unsigned-integer-size(64),
+    >>)
+  do
+    %{
+      "name" => pipeline_name <> "*" <> worker_name,
+      "category" => "node-ingress-egress",
+      "worker" => worker_name,
+      "pipeline" => pipeline_name,
+      "id" => to_string(id),
+      "latency_list" => [bin_0, bin_1, bin_2, bin_3, bin_4, bin_5, bin_6,
+        bin_7, bin_8, bin_9, bin_10, bin_11, bin_12, bin_13, bin_14, bin_15,
+        bin_16, bin_17, bin_18, bin_19, bin_20, bin_21, bin_22, bin_23, bin_24,
+        bin_25, bin_26, bin_27, bin_28, bin_29, bin_30, bin_31, bin_32, bin_33,
+        bin_34, bin_35, bin_36, bin_37, bin_38, bin_39, bin_40, bin_41, bin_42,
+        bin_43, bin_44, bin_45, bin_46, bin_47, bin_48, bin_49, bin_50, bin_51,
+        bin_52, bin_53, bin_54, bin_55, bin_56, bin_57, bin_58, bin_59, bin_60,
+        bin_61, bin_62, bin_63, bin_64],
+      "min" => min_val,
+      "max" => max_val,
+      "period" => period,
+      "period" => round(period / 1000000000),
+      "timestamp" => round(timestamp / 1000000000)
+    }
+  end
+
+  defp payload_decode(<< _header :: size(32), name_size :: size(32),
+    name :: binary-size(name_size), category_size :: size(32),
+    category :: binary-size(category_size), worker_name_size :: size(32),
+    worker_name :: binary-size(worker_name_size),
+    pipeline_name_size :: size(32), pipeline_name :: binary-size(pipeline_name_size),
+    id :: size(16),
+    bin_0 :: unsigned-integer-size(64),
+    bin_1 :: unsigned-integer-size(64), bin_2 :: unsigned-integer-size(64),
+    bin_3 :: unsigned-integer-size(64), bin_4 :: unsigned-integer-size(64),
+    bin_5 :: unsigned-integer-size(64), bin_6 :: unsigned-integer-size(64),
+    bin_7 :: unsigned-integer-size(64), bin_8 :: unsigned-integer-size(64),
+    bin_9 :: unsigned-integer-size(64), bin_10 :: unsigned-integer-size(64),
+    bin_11 :: unsigned-integer-size(64), bin_12 :: unsigned-integer-size(64),
+    bin_13 :: unsigned-integer-size(64), bin_14 :: unsigned-integer-size(64),
+    bin_15 :: unsigned-integer-size(64), bin_16 :: unsigned-integer-size(64),
+    bin_17 :: unsigned-integer-size(64), bin_18 :: unsigned-integer-size(64),
+    bin_19 :: unsigned-integer-size(64), bin_20 :: unsigned-integer-size(64),
+    bin_21 :: unsigned-integer-size(64), bin_22 :: unsigned-integer-size(64),
+    bin_23 :: unsigned-integer-size(64), bin_24 :: unsigned-integer-size(64),
+    bin_25 :: unsigned-integer-size(64), bin_26 :: unsigned-integer-size(64),
+    bin_27 :: unsigned-integer-size(64), bin_28 :: unsigned-integer-size(64),
+    bin_29 :: unsigned-integer-size(64), bin_30 :: unsigned-integer-size(64),
+    bin_31 :: unsigned-integer-size(64), bin_32 :: unsigned-integer-size(64),
+    bin_33 :: unsigned-integer-size(64), bin_34 :: unsigned-integer-size(64),
+    bin_35 :: unsigned-integer-size(64), bin_36 :: unsigned-integer-size(64),
+    bin_37 :: unsigned-integer-size(64), bin_38 :: unsigned-integer-size(64),
+    bin_39 :: unsigned-integer-size(64), bin_40 :: unsigned-integer-size(64),
+    bin_41 :: unsigned-integer-size(64), bin_42 :: unsigned-integer-size(64),
+    bin_43 :: unsigned-integer-size(64), bin_44 :: unsigned-integer-size(64),
+    bin_45 :: unsigned-integer-size(64), bin_46 :: unsigned-integer-size(64),
+    bin_47 :: unsigned-integer-size(64), bin_48 :: unsigned-integer-size(64),
+    bin_49 :: unsigned-integer-size(64), bin_50 :: unsigned-integer-size(64),
+    bin_51 :: unsigned-integer-size(64), bin_52 :: unsigned-integer-size(64),
+    bin_53 :: unsigned-integer-size(64), bin_54 :: unsigned-integer-size(64),
+    bin_55 :: unsigned-integer-size(64), bin_56 :: unsigned-integer-size(64),
+    bin_57 :: unsigned-integer-size(64), bin_58 :: unsigned-integer-size(64),
+    bin_59 :: unsigned-integer-size(64), bin_60 :: unsigned-integer-size(64),
+    bin_61 :: unsigned-integer-size(64), bin_62 :: unsigned-integer-size(64),
+    bin_63 :: unsigned-integer-size(64), bin_64 :: unsigned-integer-size(64),
+    min_val :: unsigned-integer-size(64), max_val :: unsigned-integer-size(64),
+    period :: unsigned-integer-size(64), timestamp :: unsigned-integer-size(64),
+    >>)
+  do
+    %{
+      "name" => name,
+      "category" => category,
+      "worker" => worker_name,
+      "pipeline" => pipeline_name,
+      "id" => to_string(id),
+      "latency_list" => [bin_0, bin_1, bin_2, bin_3, bin_4, bin_5, bin_6,
+        bin_7, bin_8, bin_9, bin_10, bin_11, bin_12, bin_13, bin_14, bin_15,
+        bin_16, bin_17, bin_18, bin_19, bin_20, bin_21, bin_22, bin_23, bin_24,
+        bin_25, bin_26, bin_27, bin_28, bin_29, bin_30, bin_31, bin_32, bin_33,
+        bin_34, bin_35, bin_36, bin_37, bin_38, bin_39, bin_40, bin_41, bin_42,
+        bin_43, bin_44, bin_45, bin_46, bin_47, bin_48, bin_49, bin_50, bin_51,
+        bin_52, bin_53, bin_54, bin_55, bin_56, bin_57, bin_58, bin_59, bin_60,
+        bin_61, bin_62, bin_63, bin_64],
+      "min" => min_val,
+      "max" => max_val,
+      "period" => period,
+      "period" => round(period / 1000000000),
+      "timestamp" => round(timestamp / 1000000000)
+    }
+  end
+
+  defp decode_error_msg do
+    "Unable to decode message using #{__MODULE__}"
+  end
+
+
+end

--- a/monitoring_hub/apps/monitoring_hub_utils/lib/monitoring_hub_utils/serializers/tcp_serializer.ex
+++ b/monitoring_hub/apps/monitoring_hub_utils/lib/monitoring_hub_utils/serializers/tcp_serializer.ex
@@ -1,0 +1,43 @@
+defmodule MonitoringHubUtils.Serializers.TCPSerializer do
+	@behaviour Phoenix.Transports.Serializer
+
+	alias Phoenix.Socket.Reply
+	alias Phoenix.Socket.Message
+	alias Phoenix.Socket.Broadcast
+	alias MonitoringHubUtils.Serializers.HubProtocol
+
+	@doc """
+	Translates a `Phoenix.Socket.Broadcast` into a `Phoenix.Socket.Message`.
+	"""
+	def fastlane!(%Broadcast{} = msg) do
+		{:socket_push, :binary, HubProtocol.encode_to_iodata!(%Message{
+			topic: msg.topic,
+			event: msg.event,
+			payload: msg.payload
+		})}
+	end
+
+	@doc """
+	Encodes a `Phoenix.Socket.Message` struct to Binary data
+	"""
+	def encode!(%Reply{} = reply) do
+		{:socket_push, :binary, HubProtocol.encode_to_iodata!(%Message{
+			topic: reply.topic,
+			event: "phx_reply",
+			ref: reply.ref,
+			payload: %{status: reply.status, response: reply.payload}
+		})}
+	end
+	def encode!(%Message{} = msg) do
+		{:socket_push, :binary, HubProtocol.encode_to_iodata!(msg)}
+	end
+
+	@doc """
+	Decodes Binary data into `Phoenix.Socket.Message` struct.
+	"""
+	def decode!(message, _opts) do
+		message
+		|> HubProtocol.decode!()
+		|> Phoenix.Socket.Message.from_map!()
+	end
+end

--- a/monitoring_hub/apps/monitoring_hub_utils/lib/monitoring_hub_utils/tcp_server.ex
+++ b/monitoring_hub/apps/monitoring_hub_utils/lib/monitoring_hub_utils/tcp_server.ex
@@ -1,0 +1,127 @@
+defmodule MonitoringHubUtils.TCPServer do
+	use GenServer
+  require Logger
+
+  @behavious :ranch_protocol
+
+  def start_link(ref, tcp_socket, tcp_transport, opts \\ []) do
+    :proc_lib.start_link(__MODULE__, :init, [ref, tcp_socket, tcp_transport, opts])
+  end
+
+  def init(ref, tcp_socket, tcp_transport, opts) do
+    :ok = :proc_lib.init_ack({:ok, self()})
+    :ok = :ranch.accept_ack(ref)
+    :ok = tcp_transport.setopts(tcp_socket, [:binary, active: :once, packet: 4])
+    state = %{
+      tcp_transport: tcp_transport,
+      tcp_socket: tcp_socket,
+      handlers: Keyword.fetch!(opts, :handlers),
+      serializer: opts[:serializer] || Poison,
+    }
+    :gen_server.enter_loop(__MODULE__, [], state)
+  end
+
+  def handle_info({:tcp, tcp_socket, data}, %{handlers: handlers, tcp_transport: tcp_transport, serializer: serializer} = state) do
+    case serializer.decode(data) do
+      {:ok, %{"path" => path, "params" => params}} ->
+        case Map.get(handlers, path) do
+          # handler is the server which handles the tcp messages
+          # currently there is only one server,
+          # module is the transport module
+          # opts = {endpoint, socket, transport}
+          # endpoint being the endpoint defined in the phx app
+          # socket being the socket defined in the phx app
+          # transport being the atom defining the transport
+          {handler, module, opts} ->
+            case module.init(params, opts) do
+              {:ok, {module, {opts, timeout}}} ->
+                state = %{
+                  tcp_transport: tcp_transport,
+                  tcp_socket: tcp_socket,
+                  handler: handler,
+                  transport_module: module,
+                  transport_config: opts,
+                  timeout: timeout
+                }
+                :ok = tcp_transport.setopts(tcp_socket, [active: :once])
+                Logger.info "Connection successful on TCPServer"
+                {:noreply, state, timeout}
+              {:error, error_msg} ->
+                Logger.warn "Error connecting to TCPServer: #{error_msg}"
+                :ok = tcp_transport.setopts(tcp_socket, [active: :once])
+                {:noreply, state}
+            end
+          nil ->
+            Logger.warn "No path matches for '#{path}'' on TCPServer"
+            :ok = tcp_transport.setopts(tcp_socket, [active: :once])
+            {:noreply, state}
+        end
+      {:error, _error} ->
+        Logger.warn "Unable to decode data in #{__MODULE__}'s handle_info() using #{serializer} in TCPServer"
+        :ok = tcp_transport.setopts(tcp_socket, [active: :once])
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:tcp, _tcp_socket, payload},
+    %{transport_module: module, transport_config: config} = state) do
+    handle_reply state, module.tcp_handle(payload, config)
+  end
+
+  def handle_info({:tcp_closed, _tcp_socket},
+    %{transport_module: module, transport_config: config} = state) do
+    module.tcp_close(config)
+    {:stop, :shutdown, state}
+  end
+
+  def handle_info({:tcp_closed, _tcp_socket}, state) do
+    {:stop, :shutdown, state}
+  end
+
+  def handle_info(:timeout, %{transport_module: module, transport_config: config} = state) do
+    module.tcp_close(config)
+    {:stop, :shutdown, state}
+  end
+
+  def handle_info(msg, %{transport_module: module, transport_config: config} = state) do
+    handle_reply state, module.tcp_info(msg, config)
+  end
+
+  def terminate(_reason, %{transport_module: module, transport_config: config}) do
+    module.tcp_close(config)
+  end
+
+  def terminate(_reason, _state) do
+    :ok
+  end
+
+  defp handle_reply(state, {:shutdown, new_config}) do
+    new_state = Map.put(state, :transport_config, new_config)
+    {:stop, :shutdown, new_state}
+  end
+
+  defp handle_reply(%{timeout: timeout, tcp_transport: transport,
+    tcp_socket: socket} = state, {:ok, new_config}) do
+    new_state = Map.put(state, :transport_config, new_config)
+    :ok = transport.setopts(socket, [active: :once])
+    {:noreply, new_state, timeout}
+  end
+
+  defp handle_reply(%{timeout: timeout, tcp_transport: transport, tcp_socket: socket} = state,
+      {:reply, {_encoding, encoded_payload}, new_config}) do
+    :ok = transport.setopts(socket, [active: :once])
+    new_state = Map.put(state, :transport_config, new_config)
+    {:noreply, new_state, timeout}
+  end
+
+  defp connected_json do
+    Poison.encode!(
+      %{"payload" => %{"status" => "ok",
+        "response" => "connected"},
+      "topic" => "",
+      "event" => "",
+      "ref" => nil}
+    )
+  end
+
+end

--- a/monitoring_hub/apps/monitoring_hub_utils/mix.exs
+++ b/monitoring_hub/apps/monitoring_hub_utils/mix.exs
@@ -35,6 +35,7 @@ defmodule MonitoringHubUtils.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:gproc, "~> 0.5.0"}]
+    [{:gproc, "~> 0.5.0"},
+     {:phoenix, "~> 1.1.2"}]
   end
 end

--- a/monitoring_hub/mix.lock
+++ b/monitoring_hub/mix.lock
@@ -16,7 +16,7 @@
   "phoenix_ecto": {:hex, :phoenix_ecto, "2.0.2", "1aff51d1cd21cc39d7891cae2284399cbf4b8e32fb7864e68f5d272d2934e48a", [:mix], [{:poison, "~> 1.3 or ~> 2.0", [hex: :poison, optional: true]}, {:phoenix_html, "~> 2.2", [hex: :phoenix_html, optional: true]}, {:ecto, "~> 1.1.2", [hex: :ecto, optional: false]}]},
   "phoenix_html": {:hex, :phoenix_html, "2.6.0", "b9f7e091eb3d908586d9634596478fb9e577ee033d76f4ff327a745569bdd2d8", [:mix], [{:plug, "~> 0.13 or ~> 1.0", [hex: :plug, optional: false]}]},
   "phoenix_live_reload": {:hex, :phoenix_live_reload, "1.0.5", "829218c4152ba1e9848e2bf8e161fcde6b4ec679a516259442561d21fde68d0b", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}, {:phoenix, "~> 1.0 or ~> 1.2-rc", [hex: :phoenix, optional: false]}]},
-  "phoenix_tcp": {:git, "https://github.com/WallarooLabs/phoenix_tcp.git", "e49b53047f5fcf2fbef8f0d2570dbdccc25a839f", [branch: "add-hub-protocol"]},
+  "phoenix_tcp": {:git, "https://github.com/WallarooLabs/phoenix_tcp.git", "016200fc8946261cb85ea1439e64e1a6b727beeb", [branch: "master"]},
   "plug": {:hex, :plug, "1.1.6", "8927e4028433fcb859e000b9389ee9c37c80eb28378eeeea31b0273350bf668b", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]},
   "poison": {:hex, :poison, "1.5.2", "560bdfb7449e3ddd23a096929fb9fc2122f709bcc758b2d5d5a5c7d0ea848910", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},


### PR DESCRIPTION
This PR is to move the HubProtocol over from `phoenix_tcp` into the MonitoringHub. This is being done in order to make phoenix_tcp open source friendly. `phoenix_tcp` has been updated to default to JSON serialization and to use a server which sends back responses as part of the "open source friendly" work. 

The changes in this PR override the serializer and server in `phoenix_tcp` for usage with Walaroo in order to receive metrics.

**Testing**

Run the following commands to pull and run the Metrics UI:

`docker pull docker.sendence.com:5043/sendence/monitoring_hub-apps-metrics_reporter_ui.amd64:0.1.0-18-gd7a600c`

`docker run -p 4000:4000 -p 5001:5001 -d --name mui-test docker.sendence.com:5043/sendence/monitoring_hub-apps-metrics_reporter_ui.amd64:0.1.0-18-gd7a600c`

Start up any Wallaroo application and verify that the Metrics UI works as you would expect:
   -  [x] application connects
   -  [x] metrics show up on UI

Shut down Metrics UI:

`docker stop mui-test`

**Do not merge once approved, commits need to be rebased!**
