### PR TITLE
Add celsius-kafka to examples/python/README.md

### DIFF
--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -10,6 +10,7 @@ To get set up for running examples, if you haven't already, refer to [Building a
 
 - [reverse](reverse/): a string reversing stream application.
 - [celsius](celsius/): a Celsius-to-Fahrenheit stream application.
+- [celsius-kafka](celsius-kafka/): A Celsius-to-Fahrenheit stream application using a Kafka source and a Kafka sink (instead of a TCP source and a TCP sink).
 
 ### Simple Stateful Applications
 


### PR DESCRIPTION

- add link and description to celsius-kafka in python/README

closes #1393