### PR TITLE
Use 'make' in build instructions repo-wide

### DIFF
--- a/book/to-org/resilience.md
+++ b/book/to-org/resilience.md
@@ -19,7 +19,7 @@ following compiler argument:
 This means the full command to compile with resilience will be:
 
 ```bash
-stable env ponyc -D resilience
+make PONYCFLAGS="-D resilience"
 ```
 
 When running a resilience-enabled Wallaroo app, you can optionally specify the 

--- a/book/wallaroo-tools/giles-receiver.md
+++ b/book/wallaroo-tools/giles-receiver.md
@@ -20,7 +20,7 @@ Compile the `giles-receiver` binary:
 
 ```bash
 cd wallaroo/giles/receiver
-stable env ponyc
+make
 ```
 
 ## Command Line Arguments

--- a/book/wallaroo-tools/giles-sender.md
+++ b/book/wallaroo-tools/giles-sender.md
@@ -21,7 +21,7 @@ Compile the `giles-sender` binary:
 
 ```bash
 cd wallaroo/giles/sender
-stable env ponyc
+make
 ```
 
 ## Command Line Arguments

--- a/examples/pony/alphabet/README.md
+++ b/examples/pony/alphabet/README.md
@@ -16,21 +16,15 @@ See [Wallaroo Environment Setup Instructions](https://github.com/WallarooLabs/wa
 Build Alphabet with
 
 ```bash
-stable env ponyc
+make
 ```
 
 ## Generating Data
 
-A data generator is bundled with the application. It needs to be built:
+A data generator is bundled with the application. Use it to generate a file with a fixed number of psuedo-random votes:
 
-```bash
+```
 cd data_gen
-stable env ponyc
-```
-
-Then you can generate a file with a fixed number of psuedo-random votes:
-
-```
 ./data_gen --message-count 1000
 ```
 

--- a/examples/pony/alphabet/data_gen/Makefile
+++ b/examples/pony/alphabet/data_gen/Makefile
@@ -1,0 +1,29 @@
+# include root makefile
+ifndef ROOT_MAKEFILE_MK
+include ../../../../Makefile
+endif
+
+# prevent rules from being evaluated/included multiple times
+ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
+$(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
+
+# uncomment to disable generate test related targets in this directory
+TEST_TARGET := false
+
+# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
+#PONY_TARGET := false
+
+# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
+EXS_TARGET := false
+
+# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
+DOCKER_TARGET := false
+
+# uncomment to disable generate recursing into Makefiles of subdirectories
+#RECURSE_SUBMAKEFILES := false
+
+# standard rules generation makefile
+include $(rules_mk_path)
+
+# end of prevent rules from being evaluated/included multiple times
+endif

--- a/examples/pony/celsius-kafka/README.md
+++ b/examples/pony/celsius-kafka/README.md
@@ -15,7 +15,7 @@ See [Wallaroo Environment Setup Instructions](https://github.com/WallarooLabs/wa
 Build Celsius-kafka with
 
 ```bash
-stable env ponyc
+make
 ```
 
 ## Celsius-kafka argument

--- a/examples/pony/celsius/README.md
+++ b/examples/pony/celsius/README.md
@@ -15,21 +15,15 @@ See [Wallaroo Environment Setup Instructions](https://github.com/WallarooLabs/wa
 Build Celsius with
 
 ```bash
-stable env ponyc
+make
 ```
 
 ## Generating Data
 
-A data generator is bundled with the application. It needs to be built:
+A data generator is bundled with the application. Use it to generate a file with a fixed number of psuedo-random votes:
 
-```bash
+```
 cd data_gen
-stable env ponyc
-```
-
-Then you can generate a file with a fixed number of psuedo-random votes:
-
-```
 ./data_gen --message-count 10000
 ```
 

--- a/testing/tools/dagon/README.md
+++ b/testing/tools/dagon/README.md
@@ -7,22 +7,13 @@ You will need [pony-stable](https://github.com/ponylang/pony-stable)
 to build the project. Compile and install it, then run these
 commands.
 
-Build dagon:
+Build `dagon` and `dagon-child`:
 ```
-stable fetch
-stable env ponyc --debug
-```
-
-Build dagon-child:
-```
-cd dagon-child
-stable fetch
-stable env ponyc --debug
-cd ..
+make debug=true
 ```
 
 ## Quickstart
-dagon-pony takes four arguments:
+`dagon` takes four arguments:
 ```
 -t time in seconds to wait for processing to finish after Giles
    Sender is done

--- a/testing/tools/dagon/dagon-notifier/README.md
+++ b/testing/tools/dagon/dagon-notifier/README.md
@@ -7,14 +7,13 @@ You will need [pony-stable](https://github.com/ponylang/pony-stable)
 to build the project. Compile and install it, then run these
 commands.
 
-Build dagon-notifier:
+Build `dagon-notifier`:
 ```
-stable fetch
-stable env ponyc --debug
+make debug=true
 ```
 
 ## Quickstart
-dagon-notifier takes two arguments:
+`dagon-notifier` takes two arguments:
 ```
 -d ip address of running dagon process
 -m a string that converts to an encoded external messge


### PR DESCRIPTION
Change build instructions to use 'make' instread of 'stable'.

Reviewer: please note that I've added a `Makefile` and likely didn't get the test target(s) convention correct.

Fixes #1309.