### PR TITLE
Add --depth and -b flags to 'git clone' command

### DIFF
--- a/book/getting-started/linux-setup.md
+++ b/book/getting-started/linux-setup.md
@@ -208,9 +208,8 @@ cd ~/wallaroo-tutorial
 This will be our base directory in what follows. If you haven't already cloned the Wallaroo repo, do so now (this will create a subdirectory called `wallaroo`):
 
 ```bash
-git clone https://github.com/WallarooLabs/wallaroo
+git clone --depth 1 -b release-0.1.2 https://github.com/WallarooLabs/wallaroo
 cd wallaroo
-git checkout release-0.1.2
 ```
 
 ## Installing Machida

--- a/book/getting-started/macos-setup.md
+++ b/book/getting-started/macos-setup.md
@@ -117,9 +117,8 @@ This will be our base directory in what follows. If you haven't already
 cloned the Wallaroo repo, do so now:
 
 ```bash
-git clone https://github.com/WallarooLabs/wallaroo
+git clone --depth 1 -b release-0.1.2 https://github.com/WallarooLabs/wallaroo
 cd wallaroo
-git checkout release-0.1.2
 ```
 
 This will create a subdirectory called `wallaroo`.


### PR DESCRIPTION
Fixes #1517

@SeanTAllen I removed the redundant `git checkout` from
both the Linux and MacOS "Getting Started" chapters.
As release-meister, your release process automation may
need altering if your script(s) are searching for commands such
as `git checkout`.

[skip ci]