### PR TITLE
Add Shutdown instructions for tools in "Run A Wallaroo App" doc

### DIFF
--- a/book/getting-started/run-a-wallaroo-application.md
+++ b/book/getting-started/run-a-wallaroo-application.md
@@ -131,11 +131,19 @@ You can then click into one of the elements within a category, to get to a detai
 
 Feel free to click around and get a feel for how the Metrics UI is setup and how it is used to monitor a running Wallaroo application. If you'd like a deeper dive into the Metrics UI, have a look at our [Monitoring Metrics with the Monitoring Hub](/book/metrics/metrics-ui.md) section.
 
-## Shutting Down The Cluster
+## Shutdown
 
 You can shut down the cluster with this command once processing has finished:
 
 ```bash
 cd ~/wallaroo-tutorial/wallaroo/utils/cluster_shutdown
 ./cluster_shutdown 127.0.0.1:5050
+```
+
+You can shut down Giles Sender and Giles Receiver by pressing Ctrl-c from their respective shells.
+
+You can shut down the Metrics UI with the following command:
+
+```bash
+docker stop mui
 ```


### PR DESCRIPTION
Adds shutdown instructions for Giles Sender, Giles Receiver, and the
Metrics UI so that they aren't lingering once a user has completed the
"Run a Wallaroo Application" section in the book.

Closes #1408 and #1421

[skip ci]