### PR TITLE
Fix bug in sink CLIParser

### DIFF
--- a/lib/wallaroo/core/sink/tcp_sink/tcp_sink_builder.pony
+++ b/lib/wallaroo/core/sink/tcp_sink/tcp_sink_builder.pony
@@ -47,7 +47,7 @@ primitive TCPSinkConfigCLIParser
     let opts = recover trn Array[TCPSinkConfigOptions] end
 
     for output in outputs.split(",").values() do
-      let o = outputs.split(":")
+      let o = output.split(":")
       opts.push(TCPSinkConfigOptions(o(0), o(1)))
     end
 


### PR DESCRIPTION
When parsing the outputs argument, we were splitting the
original outputs string every time instead of the
individual output strings.

Closes #1519 