### PR TITLE
Remove print statements from Python market spread

### DIFF
--- a/examples/python/market_spread/market_spread.py
+++ b/examples/python/market_spread/market_spread.py
@@ -108,7 +108,6 @@ class CheckOrder(object):
 
     def compute(self, data, state):
         if state.should_reject_trades:
-            print "rejecting"
             ts = int(time.time() * 100000)
             return (OrderResult(data, state.last_bid,
                                 state.last_offer, ts),
@@ -235,6 +234,4 @@ class UpdateMarketData(object):
         state.last_offer = data.offer
         state.should_reject_trades = should_reject_trades
 
-        if should_reject_trades:
-            print "Should reject trades"
         return (None, True)


### PR DESCRIPTION
Prior to this commit the Python version of market spread printed
messages to the console when orders were rejected, and if trades on a
certain symbol should be rejected. This could result in lots of
messages being printed, which could in turn cause performance problems
and make it difficult to see important messages coming from Wallaroo.

The `print` statements have been removed from the application.

Closes #1380