### PR TITLE
Replace use of Metrics UI from Sendence to WallarooLabs DockerHub

### DIFF
--- a/book/getting-started/linux-setup.md
+++ b/book/getting-started/linux-setup.md
@@ -192,7 +192,7 @@ All of the Docker commands throughout the rest of this manual assume that you ha
 ## Install the Metrics UI
 
 ```bash
-sudo docker pull sendence/wallaroo-metrics-ui:0.1
+sudo docker pull wallaroolabs/wallaroo-metrics-ui:0.1
 ```
 
 ## Set up Environment for the Wallaroo Tutorial

--- a/book/getting-started/macos-setup.md
+++ b/book/getting-started/macos-setup.md
@@ -100,7 +100,7 @@ Installing Docker will result in it running on your machine. After you reboot yo
 ## Install the Metrics UI
 
 ```bash
-docker pull sendence/wallaroo-metrics-ui:0.1
+docker pull wallaroolabs/wallaroo-metrics-ui:0.1
 ```
 
 ## Set up Environment for the Wallaroo Tutorial

--- a/book/getting-started/run-a-wallaroo-application.md
+++ b/book/getting-started/run-a-wallaroo-application.md
@@ -23,7 +23,7 @@ To start the Metrics UI run:
 
 ```bash
 docker run -d --name mui -p 0.0.0.0:4000:4000 -p 0.0.0.0:5001:5001 \
-  sendence/wallaroo-metrics-ui:0.1
+  wallaroolabs/wallaroo-metrics-ui:0.1
 ```
 
 You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000).

--- a/book/getting-started/windows-setup.md
+++ b/book/getting-started/windows-setup.md
@@ -11,7 +11,7 @@ You'll need Docker for Windows to run the Wallaroo metrics UI. There are [instru
 ## Install the Metrics UI
 
 ```bash
-docker pull sendence/wallaroo-metrics-ui:0.1
+docker pull wallaroolabs/wallaroo-metrics-ui:0.1
 ```
 
 ## Install Bash on Ubuntu on Windows

--- a/book/metrics/metrics-ui.md
+++ b/book/metrics/metrics-ui.md
@@ -21,14 +21,14 @@ NOTE: You might need to run with sudo depending on how you set up Docker.
 Once you have Docker setup, you can grab the Metrics UI image by running:
 
 ```
-docker pull sendence/wallaroo-metrics-ui:0.1
+docker pull wallaroolabs/wallaroo-metrics-ui:0.1
 ```
 
 To start the Metrics UI you will run:
 
 ```bash
 docker run -d --name mui -p 0.0.0.0:4000:4000 -p 0.0.0.0:5001:5001 \
-  sendence/wallaroo-metrics-ui:0.1
+  wallaroolabs/wallaroo-metrics-ui:0.1
 ```
 
 If you are running locally, open [http://localhost:4000](http://localhost:4000)


### PR DESCRIPTION
This replaces all references to the Sendence DockerHub repo in relation
to the Metrics UI in favor of WallarooLabs repo. This is done in order
to remove all references to Sendence from the Wallaroo repo.

Closes #1531

Related to #1276

**Test:**

Go through "Run a Application" and verify that you can pull the Metrics UI image and that it works as expected with the given example.

[skip ci]