### PR TITLE
Replace use of sendence repo with wallaroolabs in comment

### DIFF
--- a/lib/wallaroo/core/topology/runner.pony
+++ b/lib/wallaroo/core/topology/runner.pony
@@ -509,7 +509,7 @@ class ComputationRunner[In: Any val, Out: Any val]
           var this_is_finished = true
           var this_last_ts = computation_end
           // this is unused and kept here only for short term posterity until
-          // https://github.com/Sendence/wallaroo/issues/1010 is addressed
+          // https://github.com/WallarooLabs/wallaroo/issues/1010 is addressed
           let this_keep_sending = true
 
           for (frac_id, output) in outputs.pairs() do


### PR DESCRIPTION
A comment in runner.pony references the sendence github repo. This commit
replaces that reference with a reference to the wallaroolabs github repo
instead. This is part of the remove sendence mentions as we move towards
open source.

Closes #1543

Related to #1276

[skip ci]