### PR TITLE
Fix bug in submakefile include logic

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -403,8 +403,9 @@ endef
 # rule to generate includes for makefiles in subdirs of first argument
 define make-goal
 $(eval MAKEDIRS := $(sort $(dir $(wildcard $(1:%/=%)/*/Makefile))))
+$(eval MAKEFILES := $(sort $(wildcard $(1:%/=%)/*/Makefile)))
 $(foreach mdir,$(MAKEDIRS),$(eval $(notdir $(mdir:%/=%)) := $(mdir)))
-$(foreach mdir,$(MAKEDIRS),$(eval include $($(notdir $(mdir:%/=%)))Makefile))
+$(eval include $(MAKEFILES))
 endef
 
 # rule to generate targets for building actual pony executable including dependencies to relevant *.pony files so incremental builds work properly


### PR DESCRIPTION
Prior to this submakefile includes had an edge case where they
didn't work correctly if the same name was used in another part
of the directory tree due to how the includes were handled
individually. This commit resolves it so that the includes are
now all handled as a group ensuring correctness and consistency.

resolves #1231