### PR TITLE
Fix `make arch=amd64` docker related issue

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -220,7 +220,7 @@ ifeq ($(shell uname -s),Linux)
   docker_user_arg := -u `id -u`
   extra_awk_arg := \\
   host_ip_src = $(shell ifconfig `route -n | grep '^0.0.0.0' | awk '{print $$8}'` | egrep -o 'inet addr:[^ ]+' | awk -F: '{print $$2}')
-  system_cpus := $(shell which cset && sudo cset set -l -r | grep '/system' | awk '{print $$2}')
+  system_cpus := $(shell which cset > /dev/null && sudo cset set -l -r | grep '/system' | awk '{print $$2}')
   ifneq (,$(system_cpus))
     docker_cpu_arg := --cpuset-cpus $(system_cpus)
   endif


### PR DESCRIPTION
A recent change in commit d98aeac caused `make arch=amd64` to fail
with `docker: invalid reference format.`.

This commit fixes that issue.
