### PR TITLE
Add "--no-write" to usage of Giles sender in examples

### DIFF
--- a/examples/cpp/alphabet-cpp/README.md
+++ b/examples/cpp/alphabet-cpp/README.md
@@ -56,5 +56,5 @@ In a separate shell each:
     ```bash
      ../../../../giles/sender/sender --host 127.0.0.1:7010 --file votes.msg \
        --batch-size 50 --interval 10_000_000 --binary --msg-size 9 --repeat \
-       --ponythreads=1 --messages 1000000
+       --ponythreads=1 --messages 1000000 --no-write
     ```

--- a/examples/cpp/counter-app/README.md
+++ b/examples/cpp/counter-app/README.md
@@ -73,5 +73,5 @@ In a separate shell each:
     ```bash
      ../../../../giles/sender/sender --host 127.0.0.1:7010 --file data_gen/numbers.msg \
        --batch-size 50 --interval 10_000_000 --binary --msg-size 44 --repeat \
-       --ponythreads=1 --messages 1000000
+       --ponythreads=1 --messages 1000000 --no-write
     ```

--- a/examples/python/alphabet/README.md
+++ b/examples/python/alphabet/README.md
@@ -72,7 +72,7 @@ Send messages:
 ```bash
 ../../../giles/sender/sender --host 127.0.0.1:7010 --file votes.msg \
   --batch-size 50 --interval 10_000_000 --messages 1000000 --binary \
-  --msg-size 9 --repeat --ponythreads=1
+  --msg-size 9 --repeat --ponythreads=1 --no-write
 ```
 ## Reading the Output
 

--- a/examples/python/alphabet_partitioned/README.md
+++ b/examples/python/alphabet_partitioned/README.md
@@ -89,7 +89,7 @@ Send messages:
 ```bash
 ../../../giles/sender/sender --host 127.0.0.1:7010 \
   --file votes.msg --batch-size 50 --interval 10_000_000 \
-  --messages 1000000 --binary --msg-size 9 --repeat --ponythreads=1
+  --messages 1000000 --binary --msg-size 9 --repeat --ponythreads=1 --no-write
 ```
 
 ## Shutdown

--- a/examples/python/celsius/README.md
+++ b/examples/python/celsius/README.md
@@ -60,7 +60,7 @@ Send messages:
 ../../../giles/sender/sender --host 127.0.0.1:7010 \
   --file celsius.msg --batch-size 50 --interval 10_000_000 \
   --messages 1000000 --repeat \
-  --ponythreads=1 --binary --msg-size 8
+  --ponythreads=1 --binary --msg-size 8 --no-write
 ```
 
 ## Reading the Output

--- a/examples/python/reverse/README.md
+++ b/examples/python/reverse/README.md
@@ -65,7 +65,7 @@ Send some messages:
 ```bash
 ../../../giles/sender/sender --host 127.0.0.1:7010 --file words.txt \
   --batch-size 5 --interval 100_000_000 --messages 150 --repeat \
-  --ponythreads=1
+  --ponythreads=1 --no-write
 ```
 
 ## Reading the Output

--- a/examples/python/word_count/README.md
+++ b/examples/python/word_count/README.md
@@ -63,7 +63,7 @@ In a third shell, send some messages:
 ```bash
 ../../../giles/sender/sender --host 127.0.0.1:7010 --file count_this.txt \
   --batch-size 5 --interval 100_000_000 --messages 10000000 \
-  --ponythreads=1 --repeat
+  --ponythreads=1 --repeat --no-write
 ```
 
 ## Reading the Output


### PR DESCRIPTION
It's not needed, we don't use the files. Which means we are creating
junk files on the user machine and slowing down giles efficiency.

[skip ci]