### PR TITLE
Add --no-write to Giles receiver commands in examples

### DIFF
--- a/examples/cpp/alphabet-cpp/README.md
+++ b/examples/cpp/alphabet-cpp/README.md
@@ -44,7 +44,7 @@ In a separate shell each:
 1. Start a listener with Giles Receiver
     ```bash
     ../../../../giles/receiver/receiver --ponythreads=1 --ponynoblock \
-      --ponypinasio -l 127.0.0.1:7002
+      --ponypinasio -l 127.0.0.1:7002 --no-write
     ```
 2. Start the application
     ```bash

--- a/examples/pony/alphabet/README.md
+++ b/examples/pony/alphabet/README.md
@@ -43,7 +43,7 @@ docker start mui
 1. Start a listener
 
 ```bash
-../../../../giles/receiver/receiver --listen 127.0.0.1:7002
+../../../../giles/receiver/receiver --listen 127.0.0.1:7002 --no-write
 ```
 
 2. Start the application

--- a/examples/pony/celsius/README.md
+++ b/examples/pony/celsius/README.md
@@ -42,7 +42,7 @@ docker start mui
 1. Start a listener
 
 ```bash
-../../../../giles/receiver/receiver --listen 127.0.0.1:7002
+../../../../giles/receiver/receiver --listen 127.0.0.1:7002 --no-write
 ```
 
 2. Start the application

--- a/examples/python/alphabet_partitioned/README.md
+++ b/examples/python/alphabet_partitioned/README.md
@@ -44,7 +44,7 @@ Run Giles Receiver to listen for TCP output on `127.0.0.1` port `7002`:
 
 ```bash
 ../../../giles/receiver/receiver --ponythreads=1 --ponynoblock \
-  --listen 127.0.0.1:7002
+  --listen 127.0.0.1:7002 --no-write
 ```
 
 ### Shell 2


### PR DESCRIPTION
We never use the received.txt so there is no point in generating what is
effectively junk on the user machine.

[skip ci]