### PR TITLE
Make `Makefile` control variables explicit instead of implicit and have `make test` run `make unit-tests` and `make integration-tests`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,9 @@ rules_mk_path := $(ROOT_MAKEFILE_PATH)/rules.mk
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/Makefile
+++ b/Makefile
@@ -7,17 +7,31 @@ ROOT_MAKEFILE := $(lastword $(MAKEFILE_LIST))
 ROOT_MAKEFILE_PATH := $(dir $(ROOT_MAKEFILE))
 rules_mk_path := $(ROOT_MAKEFILE_PATH)/rules.mk
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/book/Makefile
+++ b/book/Makefile
@@ -9,9 +9,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/book/Makefile
+++ b/book/Makefile
@@ -7,20 +7,32 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/cpp_api/Makefile
+++ b/cpp_api/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/cpp_api/Makefile
+++ b/cpp_api/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -43,7 +43,7 @@ CPPAPI_PATH = $(wallaroo_path)/cpp_api/cpp/cppapi
 CPPAPI_BUILD_PATH = $(CPPAPI_PATH)/build
 
 build-cpp_api: cpp_api_clean cpp_api_build
-test-cpp_api: build-cpp_api
+unit-tests-cpp_api: build-cpp_api
 clean-cpp_api: cpp_api_clean
 
 cpp_api_build:

--- a/cpp_api/Makefile
+++ b/cpp_api/Makefile
@@ -44,16 +44,16 @@ CPPAPI_BUILD_PATH = $(CPPAPI_PATH)/build
 
 build-cpp_api: cpp_api_clean cpp_api_build
 test-cpp_api: build-cpp_api
-clean-cpp_api = cpp_api_clean
+clean-cpp_api: cpp_api_clean
 
 cpp_api_build:
-	mkdir -p $(CPPAPI_BUILD_PATH)
-	cd $(CPPAPI_BUILD_PATH) && cmake -DCMAKE_INSTALL_PREFIX=/tmp/cpp_api ..
-	cd $(CPPAPI_BUILD_PATH) && make
-	cd $(CPPAPI_BUILD_PATH) && make install/local
+	$(QUIET)mkdir -p $(CPPAPI_BUILD_PATH)
+	$(QUIET)cd $(CPPAPI_BUILD_PATH) && cmake -DCMAKE_INSTALL_PREFIX=/tmp/cpp_api ..
+	$(QUIET)cd $(CPPAPI_BUILD_PATH) && make
+	$(QUIET)cd $(CPPAPI_BUILD_PATH) && make install/local
 
 cpp_api_clean:
-	rm -rf $(CPPAPI_BUILD_PATH)
+	$(QUIET)rm -rf $(CPPAPI_BUILD_PATH)
 
 cpp_api_test:
 	$(QUIET)echo "cpp_api tests"

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/examples/cpp/Makefile
+++ b/examples/cpp/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/examples/cpp/Makefile
+++ b/examples/cpp/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/examples/cpp/alphabet-cpp/Makefile
+++ b/examples/cpp/alphabet-cpp/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-#TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := false
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := false
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := false
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := false
+
 
 ifeq ($(shell uname -s),Linux)
 	PONY_LINKER = --linker g++

--- a/examples/cpp/alphabet-cpp/Makefile
+++ b/examples/cpp/alphabet-cpp/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -51,7 +51,7 @@ ALPHABET_HPP = $(ALPHABET_PATH)/include
 ALPHABET_PONY_SOURCE = $(ALPHABET_PATH)/alphabet-app
 
 build-examples-cpp-alphabet-cpp-all = build-cpp_api-all alphabet_cpp_clean alphabet_cpp_build
-test-examples-cpp-alphabet-cpp-all = build-examples-cpp-alphabet-cpp-all alphabet_cpp_test
+unit-tests-examples-cpp-alphabet-cpp-all = build-examples-cpp-alphabet-cpp-all alphabet_cpp_test
 clean-examples-cpp-alphabet-cpp-all = clean-cpp_api-all alphabet_cpp_clean
 
 alphabet_cpp_build:

--- a/examples/cpp/alphabet-cpp/Makefile
+++ b/examples/cpp/alphabet-cpp/Makefile
@@ -55,13 +55,13 @@ test-examples-cpp-alphabet-cpp-all = build-examples-cpp-alphabet-cpp-all alphabe
 clean-examples-cpp-alphabet-cpp-all = clean-cpp_api-all alphabet_cpp_clean
 
 alphabet_cpp_build:
-	mkdir -p $(ALPHABET_BUILD)
-	c++ --debug -c -o $(ALPHABET_BUILD)/alphabet.o $(ALPHABET_CPP)/alphabet.cpp -Wall -std=c++11 -I$(ALPHABET_HPP) -I$(WALLAROO_CPP_INCLUDE)
-	ar rs $(ALPHABET_BUILD)/libalphabet.a $(ALPHABET_BUILD)/alphabet.o
-	ponyc $(PONY_LINKER) --debug --export --output=$(ALPHABET_BUILD) --path $(WALLAROO_LIB):$(CPP_PONY_LIB):$(WALLAROO_CPP_LIB):$(ALPHABET_BUILD) $(ALPHABET_PONY_SOURCE)
+	$(QUIET)mkdir -p $(ALPHABET_BUILD)
+	$(QUIET)c++ $(debug_arg) -c -o $(ALPHABET_BUILD)/alphabet.o $(ALPHABET_CPP)/alphabet.cpp -Wall -std=c++11 -I$(ALPHABET_HPP) -I$(WALLAROO_CPP_INCLUDE)
+	$(QUIET)ar rs $(ALPHABET_BUILD)/libalphabet.a $(ALPHABET_BUILD)/alphabet.o
+	$(QUIET)ponyc $(PONY_LINKER) $(debug_arg) --export --output=$(ALPHABET_BUILD) --path $(WALLAROO_LIB):$(CPP_PONY_LIB):$(WALLAROO_CPP_LIB):$(ALPHABET_BUILD) $(ALPHABET_PONY_SOURCE)
 
 alphabet_cpp_clean:
-	rm -rf $(ALPHABET_BUILD)
+	$(QUIET)rm -rf $(ALPHABET_BUILD)
 
 alphabet_cpp_test:
 	$(QUIET)echo "alphabet-cpp tests"

--- a/examples/cpp/counter-app/Makefile
+++ b/examples/cpp/counter-app/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -51,7 +51,7 @@ WALLAROO_CPP_LIB = $(WALLAROO_CPP_INSTALL)/lib/WallarooCppApi
 WALLAROO_CPP_INCLUDE = $(WALLAROO_CPP_INSTALL)/include/
 
 build-examples-cpp-counter-app-all = build-cpp_api-all counter_app_clean counter_app_build
-test-examples-cpp-counter-app-all = build-examples-cpp-counter-app-all counter_app_test
+unit-tests-examples-cpp-counter-app-all = build-examples-cpp-counter-app-all counter_app_test
 clean-examples-cpp-counter-app-all = clean-cpp_api-all counter_app_clean
 
 counter_app_build:

--- a/examples/cpp/counter-app/Makefile
+++ b/examples/cpp/counter-app/Makefile
@@ -55,13 +55,13 @@ test-examples-cpp-counter-app-all = build-examples-cpp-counter-app-all counter_a
 clean-examples-cpp-counter-app-all = clean-cpp_api-all counter_app_clean
 
 counter_app_build:
-	mkdir -p $(COUNTER_BUILD)
-	c++ --debug -c -o $(COUNTER_BUILD)/Counter.o $(COUNTER_CPP)/Counter.cpp -Wall -std=c++11 -I$(COUNTER_HPP) -I$(WALLAROO_CPP_INCLUDE)
-	ar rs $(COUNTER_BUILD)/libcounter.a $(COUNTER_BUILD)/Counter.o
-	ponyc $(PONY_LINKER) --debug --export --output=$(COUNTER_BUILD) --path $(WALLAROO_LIB):$(CPP_PONY_LIB):$(WALLAROO_CPP_LIB):$(COUNTER_BUILD) $(COUNTER_PONY_SOURCE)
+	$(QUIET)mkdir -p $(COUNTER_BUILD)
+	$(QUIET)c++ $(debug_arg) -c -o $(COUNTER_BUILD)/Counter.o $(COUNTER_CPP)/Counter.cpp -Wall -std=c++11 -I$(COUNTER_HPP) -I$(WALLAROO_CPP_INCLUDE)
+	$(QUIET)ar rs $(COUNTER_BUILD)/libcounter.a $(COUNTER_BUILD)/Counter.o
+	$(QUIET)ponyc $(PONY_LINKER) $(debug_arg) --export --output=$(COUNTER_BUILD) --path $(WALLAROO_LIB):$(CPP_PONY_LIB):$(WALLAROO_CPP_LIB):$(COUNTER_BUILD) $(COUNTER_PONY_SOURCE)
 
 counter_app_clean:
-	rm -rf $(COUNTER_BUILD)
+	$(QUIET)rm -rf $(COUNTER_BUILD)
 
 counter_app_test:
 	$(QUIET)echo "counter-app tests"

--- a/examples/cpp/counter-app/Makefile
+++ b/examples/cpp/counter-app/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-#TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := false
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := false
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := false
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := false
+
 
 ifeq ($(shell uname -s),Linux)
 	PONY_LINKER = --linker g++

--- a/examples/pony/Makefile
+++ b/examples/pony/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/examples/pony/Makefile
+++ b/examples/pony/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/examples/pony/alphabet/Makefile
+++ b/examples/pony/alphabet/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -40,7 +40,7 @@ ALPHABET_PONY_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 # standard rules generation makefile
 include $(rules_mk_path)
 
-test-examples-pony-alphabet: alphabet_pony_test
+integration-tests-examples-pony-alphabet: alphabet_pony_test
 
 alphabet_pony_test:
 	cd $(ALPHABET_PONY_PATH) && \

--- a/examples/pony/alphabet/Makefile
+++ b/examples/pony/alphabet/Makefile
@@ -7,20 +7,32 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
 
 
 ALPHABET_PONY_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/examples/pony/alphabet/data_gen/Makefile
+++ b/examples/pony/alphabet/data_gen/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/examples/pony/alphabet/data_gen/Makefile
+++ b/examples/pony/alphabet/data_gen/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/examples/pony/celsius-kafka/Makefile
+++ b/examples/pony/celsius-kafka/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/examples/pony/celsius-kafka/Makefile
+++ b/examples/pony/celsius-kafka/Makefile
@@ -7,20 +7,32 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
 
 
 CELSIUS_PONY_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/examples/pony/celsius/Makefile
+++ b/examples/pony/celsius/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -40,7 +40,7 @@ CELSIUS_PONY_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 # standard rules generation makefile
 include $(rules_mk_path)
 
-test-examples-pony-celsius: celsius_pony_test
+integration-tests-examples-pony-celsius: celsius_pony_test
 
 celsius_pony_test:
 	cd $(CELSIUS_PONY_PATH) && \

--- a/examples/pony/celsius/Makefile
+++ b/examples/pony/celsius/Makefile
@@ -7,20 +7,32 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
 
 
 CELSIUS_PONY_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/examples/pony/celsius/data_gen/Makefile
+++ b/examples/pony/celsius/data_gen/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/examples/pony/celsius/data_gen/Makefile
+++ b/examples/pony/celsius/data_gen/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/examples/python/Makefile
+++ b/examples/python/Makefile
@@ -7,20 +7,32 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-#TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
 
 
 # standard rules generation makefile

--- a/examples/python/Makefile
+++ b/examples/python/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/examples/python/alphabet/Makefile
+++ b/examples/python/alphabet/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -41,9 +41,9 @@ ALPHABET_PY_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 include $(rules_mk_path)
 
 build-examples-python-alphabet: build-machida
-test-examples-python-alphabet: build-examples-python-alphabet
+integration-tests-examples-python-alphabet: build-examples-python-alphabet
 
-test-examples-python-alphabet: alphabet_py_test
+integration-tests-examples-python-alphabet: alphabet_py_test
 
 alphabet_py_test:
 	cd $(ALPHABET_PY_PATH) && \

--- a/examples/python/alphabet/Makefile
+++ b/examples/python/alphabet/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := false
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := false
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := false
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := false
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := false
+
 
 ALPHABET_PY_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/examples/python/alphabet_partitioned/Makefile
+++ b/examples/python/alphabet_partitioned/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -41,9 +41,9 @@ ALPHABET_PARTITIONED_PY_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 include $(rules_mk_path)
 
 build-examples-python-alphabet_partitioned: build-machida
-test-examples-python-alphabet_partitioned: build-examples-python-alphabet_partitioned
+integration-tests-examples-python-alphabet_partitioned: build-examples-python-alphabet_partitioned
 
-test-examples-python-alphabet_partitioned: alphabet_partitioned_py_test
+integration-tests-examples-python-alphabet_partitioned: alphabet_partitioned_py_test
 
 alphabet_partitioned_py_test:
 	cd $(ALPHABET_PARTITIONED_PY_PATH) && \

--- a/examples/python/alphabet_partitioned/Makefile
+++ b/examples/python/alphabet_partitioned/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := false
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := false
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := false
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := false
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := false
+
 
 ALPHABET_PARTITIONED_PY_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/examples/python/celsius-kafka/Makefile
+++ b/examples/python/celsius-kafka/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := false
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := false
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := false
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := false
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := false
+
 
 CELSIUS_KAFKA_PY_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/examples/python/celsius-kafka/Makefile
+++ b/examples/python/celsius-kafka/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/examples/python/celsius/Makefile
+++ b/examples/python/celsius/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := false
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := false
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := false
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := false
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := false
+
 
 CELSIUS_PY_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/examples/python/celsius/Makefile
+++ b/examples/python/celsius/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -42,9 +42,9 @@ include $(rules_mk_path)
 
 
 build-examples-python-celsius: build-machida
-test-examples-python-celsius: build-examples-python-celsius
+integration-tests-examples-python-celsius: build-examples-python-celsius
 
-test-examples-python-celsius: celsius_py_test
+integration-tests-examples-python-celsius: celsius_py_test
 
 celsius_py_test:
 	cd $(CELSIUS_PY_PATH) && \

--- a/examples/python/market_spread/Makefile
+++ b/examples/python/market_spread/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := false
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := false
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := false
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := false
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := false
+
 
 MARKET_SPREAD_PY_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/examples/python/market_spread/Makefile
+++ b/examples/python/market_spread/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -41,9 +41,9 @@ MARKET_SPREAD_PY_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 include $(rules_mk_path)
 
 build-examples-python-market_spread: build-machida
-test-examples-python-market_spread: build-examples-python-market_spread
+integration-tests-examples-python-market_spread: build-examples-python-market_spread
 
-test-examples-python-market_spread: market_spread_py_test
+integration-tests-examples-python-market_spread: market_spread_py_test
 
 market_spread_py_test:
 	cd $(MARKET_SPREAD_PY_PATH) && \

--- a/examples/python/reverse/Makefile
+++ b/examples/python/reverse/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-#TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := false
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := false
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := false
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := false
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := false
+
 
 REVERSE_PY_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/examples/python/reverse/Makefile
+++ b/examples/python/reverse/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -41,9 +41,9 @@ REVERSE_PY_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 include $(rules_mk_path)
 
 build-examples-python-reverse: build-machida
-test-examples-python-reverse: build-examples-python-reverse
+integration-tests-examples-python-reverse: build-examples-python-reverse
 
-test-examples-python-reverse: reverse_py_test
+integration-tests-examples-python-reverse: reverse_py_test
 
 reverse_py_test:
 	cd $(REVERSE_PY_PATH) && \

--- a/examples/python/word_count/Makefile
+++ b/examples/python/word_count/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := false
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := false
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := false
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := false
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := false
+
 
 WORD_COUNT_PY_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/examples/python/word_count/Makefile
+++ b/examples/python/word_count/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -41,8 +41,8 @@ WORD_COUNT_PY_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 include $(rules_mk_path)
 
 build-examples-python-word_count: build-machida
-test-examples-python-word_count: build-examples-python-word_count
-test-examples-python-word_count: word_count_py_test
+integration-tests-examples-python-word_count: build-examples-python-word_count
+integration-tests-examples-python-word_count: word_count_py_test
 clean-examples-python-alphabet: word_count_py_clean
 
 word_count_py_test:

--- a/giles/Makefile
+++ b/giles/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/giles/Makefile
+++ b/giles/Makefile
@@ -7,17 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/giles/receiver/Makefile
+++ b/giles/receiver/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/giles/receiver/Makefile
+++ b/giles/receiver/Makefile
@@ -7,17 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/giles/sender/Makefile
+++ b/giles/sender/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/giles/sender/Makefile
+++ b/giles/sender/Makefile
@@ -7,17 +7,32 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
 
 
 # standard rules generation makefile

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -7,17 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/lib/wallaroo/Makefile
+++ b/lib/wallaroo/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 LIB_WALLAROO_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/lib/wallaroo/Makefile
+++ b/lib/wallaroo/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -40,7 +40,7 @@ LIB_WALLAROO_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 # standard rules generation makefile
 include $(rules_mk_path)
 
-test-lib-wallaroo: lib_wallaroo_test
+unit-tests-lib-wallaroo: lib_wallaroo_test
 
 lib_wallaroo_test:
 	cd $(abspath $(LIB_WALLAROO_PATH:%/=%)) && ./$(notdir $(abspath $(LIB_WALLAROO_PATH:%/=%))) --sequential

--- a/lib/wallaroo_labs/Makefile
+++ b/lib/wallaroo_labs/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -40,7 +40,7 @@ LIB_WALLAROO_LABS_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 # standard rules generation makefile
 include $(rules_mk_path)
 
-test-lib-wallaroo_labs: lib_wallaroo_labs_test
+unit-tests-lib-wallaroo_labs: lib_wallaroo_labs_test
 
 lib_wallaroo_labs_test:
 	cd $(abspath $(LIB_WALLAROO_LABS_PATH:%/=%)) && ./$(notdir $(abspath $(LIB_WALLAROO_LABS_PATH:%/=%))) --sequential

--- a/lib/wallaroo_labs/Makefile
+++ b/lib/wallaroo_labs/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 LIB_WALLAROO_LABS_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/machida/Makefile
+++ b/machida/Makefile
@@ -57,7 +57,9 @@ test-machida: build-machida
 clean-machida: machida_clean
 
 machida_clean:
-	rm -rf $(MACHIDA_BUILD)
+	$(QUIET)rm -rf $(MACHIDA_BUILD)
+	$(QUIET)rm -f $(MACHIDA_PATH)/machida.d
+	$(QUIET)rm -rf $(MACHIDA_PATH)/.deps
 
 machida_build: $(MACHIDA_BUILD)/machida
 
@@ -66,17 +68,17 @@ $(MACHIDA_BUILD)/machida: $(MACHIDA_BUILD)/libpython-wallaroo.a
 	$(eval original_PONYCFLAGS := $(PONYCFLAGS))
 	$(eval PONYCFLAGS := $(original_PONYCFLAGS) -D resilience -D spike -D spiketrace --output=$(MACHIDA_BUILD) --path=$(MACHIDA_BUILD))
 	$(call PONYC,$(abspath $(MACHIDA_PATH:%/=%)))
-	mv $(abspath $(MACHIDA_BUILD:%/=%))/machida $(abspath $(MACHIDA_BUILD:%/=%))/machida_resilience
+	$(QUIET)mv $(abspath $(MACHIDA_BUILD:%/=%))/machida $(abspath $(MACHIDA_BUILD:%/=%))/machida_resilience
 	$(eval PONYCFLAGS := $(original_PONYCFLAGS) --output=$(MACHIDA_BUILD) --path=$(MACHIDA_BUILD))
 	$(call PONYC,$(abspath $(MACHIDA_PATH:%/=%)))
 	$(eval PONYCFLAGS := $(original_PONYCFLAGS))
 
 $(MACHIDA_BUILD)/libpython-wallaroo.a: $(MACHIDA_BUILD)/python-wallaroo.o
-	ar rvs $(MACHIDA_BUILD)/libpython-wallaroo.a $(MACHIDA_BUILD)/python-wallaroo.o
+	$(QUIET)ar rvs $(MACHIDA_BUILD)/libpython-wallaroo.a $(MACHIDA_BUILD)/python-wallaroo.o
 
 $(MACHIDA_BUILD)/python-wallaroo.o: $(MACHIDA_CPP)/python-wallaroo.c
-	mkdir -p $(MACHIDA_BUILD)
-	cc -g -o $(MACHIDA_BUILD)/python-wallaroo.o -c $(MACHIDA_CPP)/python-wallaroo.c
+	$(QUIET)mkdir -p $(MACHIDA_BUILD)
+	$(QUIET)cc -g -o $(MACHIDA_BUILD)/python-wallaroo.o -c $(MACHIDA_CPP)/python-wallaroo.c
 
 # end of prevent rules from being evaluated/included multiple times
 endif

--- a/machida/Makefile
+++ b/machida/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := false
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := false
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := false
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := false
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := false
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/machida/Makefile
+++ b/machida/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -53,7 +53,7 @@ WALLAROO_LIB =  $(wallaroo_path)/lib
 # with our own custom rules. This allows the top level commands like
 # "make test" to work.
 build-machida: machida_build
-test-machida: build-machida
+unit-tests-machida: build-machida
 clean-machida: machida_clean
 
 machida_clean:

--- a/monitoring_hub/Makefile
+++ b/monitoring_hub/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/monitoring_hub/Makefile
+++ b/monitoring_hub/Makefile
@@ -7,17 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := false
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/monitoring_hub/apps/Makefile
+++ b/monitoring_hub/apps/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/monitoring_hub/apps/Makefile
+++ b/monitoring_hub/apps/Makefile
@@ -7,17 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := false
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/monitoring_hub/apps/market_spread_reports/Makefile
+++ b/monitoring_hub/apps/market_spread_reports/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/monitoring_hub/apps/market_spread_reports/Makefile
+++ b/monitoring_hub/apps/market_spread_reports/Makefile
@@ -7,17 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/monitoring_hub/apps/market_spread_reports_ui/Makefile
+++ b/monitoring_hub/apps/market_spread_reports_ui/Makefile
@@ -12,7 +12,7 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/monitoring_hub/apps/market_spread_reports_ui/Makefile
+++ b/monitoring_hub/apps/market_spread_reports_ui/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/monitoring_hub/apps/market_spread_reports_ui/Makefile
+++ b/monitoring_hub/apps/market_spread_reports_ui/Makefile
@@ -7,17 +7,32 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
 
 
 # standard rules generation makefile

--- a/monitoring_hub/apps/metrics_reporter/Makefile
+++ b/monitoring_hub/apps/metrics_reporter/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/monitoring_hub/apps/metrics_reporter/Makefile
+++ b/monitoring_hub/apps/metrics_reporter/Makefile
@@ -7,17 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/monitoring_hub/apps/metrics_reporter_ui/Makefile
+++ b/monitoring_hub/apps/metrics_reporter_ui/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/monitoring_hub/apps/metrics_reporter_ui/Makefile
+++ b/monitoring_hub/apps/metrics_reporter_ui/Makefile
@@ -7,17 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/monitoring_hub/apps/monitoring_hub_utils/Makefile
+++ b/monitoring_hub/apps/monitoring_hub_utils/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/monitoring_hub/apps/monitoring_hub_utils/Makefile
+++ b/monitoring_hub/apps/monitoring_hub_utils/Makefile
@@ -7,17 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/rules.mk
+++ b/rules.mk
@@ -380,8 +380,8 @@ endef
 # rule to generate targets for building actual pony executable including dependencies to relevant *.pony files so incremental builds work properly
 define ponyc-goal
 # include dependencies for already compiled executables
--include $(1:%/=%)/$(notdir $(abspath $(1:%/=%))).d
-$(1:%/=%)/$(notdir $(abspath $(1:%/=%))):
+-include $(abspath $(1:%/=%))/$(notdir $(abspath $(1:%/=%))).d
+$(abspath $(1:%/=%))/$(notdir $(abspath $(1:%/=%))):
 	$$(call PONYC,$(abspath $(1:%/=%)))
 endef
 
@@ -393,7 +393,7 @@ build-pony-all: build-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
 build-docker-pony-all: build-docker-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
 push-docker-pony-all: push-docker-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
 build-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))-all += build-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
-build-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))): $(1:%/=%)/$(notdir $(abspath $(1:%/=%)))
+build-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))): $(abspath $(1:%/=%))/$(notdir $(abspath $(1:%/=%)))
 .PHONY: build-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))) build-docker-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))) push-docker-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))) build-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))-all
 endef
 
@@ -426,15 +426,15 @@ endef
 
 # rule to generate targets for building actual monhub executable including dependencies to relevant files so incremental builds work properly
 define monhub-goal
-$(1:%/=%)/../../_build/dev/lib/$(notdir $(abspath $(1:%/=%)))/ebin/$(notdir $(abspath $(1:%/=%))).app: $(shell find $(wildcard $(abspath $1)/config) $(wildcard $(abspath $1)/lib) $(wildcard $(abspath $1)/mix.exs) $(wildcard $(abspath $1)/priv) $(wildcard $(abspath $1)/web) $(wildcard $(abspath $1)/package.json) -type f)
+$(abspath $(1:%/=%))/../../_build/dev/lib/$(notdir $(abspath $(1:%/=%)))/ebin/$(notdir $(abspath $(1:%/=%))).app: $(shell find $(wildcard $(abspath $1)/config) $(wildcard $(abspath $1)/lib) $(wildcard $(abspath $1)/mix.exs) $(wildcard $(abspath $1)/priv) $(wildcard $(abspath $1)/web) $(wildcard $(abspath $1)/package.json) -type f)
 	$$(call MONHUBC,$(abspath $(1:%/=%)))
 endef
 
 # rule to generate targets for building actual monhub executable including dependencies to relevant files so incremental builds work properly
 define monhub-release-goal
-$(1:%/=%)/rel/$(notdir $(abspath $(1:%/=%)))/bin/$(notdir $(abspath $(1:%/=%))): $(shell find $(wildcard $(abspath $1)/config) $(wildcard $(abspath $1)/lib) $(wildcard $(abspath $1)/mix.exs) $(wildcard $(abspath $1)/priv) $(wildcard $(abspath $1)/web) $(wildcard $(abspath $1)/package.json) -type f)
+$(abspath $(1:%/=%))/rel/$(notdir $(abspath $(1:%/=%)))/bin/$(notdir $(abspath $(1:%/=%))): $(shell find $(wildcard $(abspath $1)/config) $(wildcard $(abspath $1)/lib) $(wildcard $(abspath $1)/mix.exs) $(wildcard $(abspath $1)/priv) $(wildcard $(abspath $1)/web) $(wildcard $(abspath $1)/package.json) -type f)
 	$$(call MONHUBR,$(abspath $(1:%/=%)))
-release-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))): monhub-arch-check $(1:%/=%)/rel/$(notdir $(abspath $(1:%/=%)))/bin/$(notdir $(abspath $(1:%/=%)))
+release-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))): monhub-arch-check $(abspath $(1:%/=%))/rel/$(notdir $(abspath $(1:%/=%)))/bin/$(notdir $(abspath $(1:%/=%)))
 release-monhub-all: release-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
 .PHONY: release-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
 endef
@@ -447,7 +447,7 @@ build-monhub-all: build-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))
 build-docker-monhub-all: build-docker-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
 push-docker-monhub-all: push-docker-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
 build-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))-all += build-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
-build-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))): $(1:%/=%)/../../_build/dev/lib/$(notdir $(abspath $(1:%/=%)))/ebin/$(notdir $(abspath $(1:%/=%))).app
+build-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))): $(abspath $(1:%/=%))/../../_build/dev/lib/$(notdir $(abspath $(1:%/=%)))/ebin/$(notdir $(abspath $(1:%/=%))).app
 .PHONY: build-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))) build-docker-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))) push-docker-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))) build-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))-all
 endef
 

--- a/rules.mk
+++ b/rules.mk
@@ -58,6 +58,8 @@ CUSTOM_PATH = $(integration_bin_path):$(machida_bin_path)
 # initialize default for some normal targets and variables
 build-wallarooroot-all :=
 test-wallarooroot-all :=
+unit-tests-wallarooroot-all :=
+integration-tests-wallarooroot-all :=
 clean-wallarooroot-all :=
 build-docker-wallarooroot-all :=
 push-docker-wallarooroot-all :=
@@ -399,11 +401,15 @@ endef
 define pony-test-goal
 test-pony-all: test-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
 test-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))-all += test-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
-test-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))): build-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
-ifneq ($($(ABS_PREV_MAKEFILE)_TEST_COMMAND),false)
+test-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))): unit-tests-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))) integration-tests-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
+unit-tests-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))-all += unit-tests-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
+unit-tests-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))): build-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
+ifneq ($($(ABS_PREV_MAKEFILE)_UNIT_TEST_COMMAND),false)
 	cd $(abspath $(1:%/=%)) && ./$(notdir $(abspath $(1:%/=%)))
 endif
-.PHONY: test-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))) test-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))-all
+integration-tests-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))-all += integration-tests-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
+integration-tests-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))): build-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
+.PHONY: test-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))) test-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))-all unit-tests-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))) integration-tests-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
 endef
 
 # rule to generate targets for clean-* for devs to use
@@ -449,11 +455,15 @@ endef
 define monhub-test-goal
 test-monhub-all: test-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
 test-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))-all += test-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
-test-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))): build-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
-ifneq ($($(ABS_PREV_MAKEFILE)_TEST_COMMAND),false)
+test-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))): unit-tests-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))) integration-tests-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
+unit-tests-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))-all += unit-tests-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
+unit-tests-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))): build-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
+integration-tests-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))-all += integration-tests-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
+integration-tests-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))): build-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
+ifneq ($($(ABS_PREV_MAKEFILE)_UNIT_TEST_COMMAND),false)
 	cd $(abspath $(1:%/=%)) && mix test
 endif
-.PHONY: test-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))) test-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))-all
+.PHONY: test-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))) test-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))-all unit-tests-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))) integration-tests-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
 endef
 
 # rule to generate targets for clean-* for devs to use
@@ -492,15 +502,19 @@ $(eval MY_TARGET_SUFFIX := $(if $(filter $(abs_wallaroo_dir),$(abspath $1)),wall
 
 $(eval build-$(MY_TARGET_SUFFIX:%-all=%):)
 $(eval test-$(MY_TARGET_SUFFIX:%-all=%):)
+$(eval unit-tests-$(MY_TARGET_SUFFIX:%-all=%):)
+$(eval integration-tests-$(MY_TARGET_SUFFIX:%-all=%):)
 $(eval clean-$(MY_TARGET_SUFFIX:%-all=%):)
 $(eval build-$(MY_TARGET_SUFFIX): build-$(MY_TARGET_SUFFIX:%-all=%) $(build-$(MY_TARGET_SUFFIX)))
 $(eval test-$(MY_TARGET_SUFFIX): test-$(MY_TARGET_SUFFIX:%-all=%) $(test-$(MY_TARGET_SUFFIX)))
+$(eval unit-tests-$(MY_TARGET_SUFFIX): unit-tests-$(MY_TARGET_SUFFIX:%-all=%) $(unit-tests-$(MY_TARGET_SUFFIX)))
+$(eval integration-tests-$(MY_TARGET_SUFFIX): integration-tests-$(MY_TARGET_SUFFIX:%-all=%) $(integration-tests-$(MY_TARGET_SUFFIX)))
 $(eval clean-$(MY_TARGET_SUFFIX): clean-$(MY_TARGET_SUFFIX:%-all=%) $(clean-$(MY_TARGET_SUFFIX)))
 
 $(eval build-docker-$(MY_TARGET_SUFFIX): $(build-docker-$(MY_TARGET_SUFFIX)))
 $(eval push-docker-$(MY_TARGET_SUFFIX): $(push-docker-$(MY_TARGET_SUFFIX)))
 
-.PHONY: build-$(MY_TARGET_SUFFIX) test-$(MY_TARGET_SUFFIX) clean-$(MY_TARGET_SUFFIX) build-docker-$(MY_TARGET_SUFFIX) push-docker-$(MY_TARGET_SUFFIX)
+.PHONY: build-$(MY_TARGET_SUFFIX) test-$(MY_TARGET_SUFFIX) unit-tests-$(MY_TARGET_SUFFIX) integration-tests-$(MY_TARGET_SUFFIX) clean-$(MY_TARGET_SUFFIX) build-docker-$(MY_TARGET_SUFFIX) push-docker-$(MY_TARGET_SUFFIX)
 endef
 
 # rule to generate targets for *-all for devs to use
@@ -509,6 +523,8 @@ $(eval MAKEDIRS := $(sort $(dir $(wildcard $(1:%/=%)/*/Makefile))))
 $(eval MY_TARGET_SUFFIX := $(if $(filter $(abs_wallaroo_dir),$(abspath $1)),wallarooroot-all,$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))-all))
 $(foreach mdir,$(MAKEDIRS),$(eval build-$(MY_TARGET_SUFFIX) += build-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $(mdir))))-all))
 $(foreach mdir,$(MAKEDIRS),$(eval test-$(MY_TARGET_SUFFIX) += test-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $(mdir))))-all))
+$(foreach mdir,$(MAKEDIRS),$(eval unit-tests-$(MY_TARGET_SUFFIX) += unit-tests-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $(mdir))))-all))
+$(foreach mdir,$(MAKEDIRS),$(eval integration-tests-$(MY_TARGET_SUFFIX) += integration-tests-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $(mdir))))-all))
 $(foreach mdir,$(MAKEDIRS),$(eval clean-$(MY_TARGET_SUFFIX) += clean-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $(mdir))))-all))
 $(foreach mdir,$(MAKEDIRS),$(eval build-docker-$(MY_TARGET_SUFFIX) += build-docker-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $(mdir))))-all))
 $(foreach mdir,$(MAKEDIRS),$(eval push-docker-$(MY_TARGET_SUFFIX) += push-docker-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $(mdir))))-all))
@@ -522,7 +538,9 @@ ROOT_TARGET_SUFFIX := $(if $(filter $(abs_wallaroo_dir),$(abspath $(ROOT_PATH)))
 # default targets
 .DEFAULT_GOAL := build
 build: build-$(ROOT_TARGET_SUFFIX) ## Build all projects (pony & monhub) (DEFAULT)
-test: test-$(ROOT_TARGET_SUFFIX) ## Test all projects (pony & monhub)
+test: unit-tests integration-tests ## Test all projects (pony & monhub)
+unit-tests: unit-tests-$(ROOT_TARGET_SUFFIX) ## Test all projects (pony & monhub)
+integration-tests: integration-tests-$(ROOT_TARGET_SUFFIX) ## Test all projects (pony & monhub)
 build-pony: build-pony-all ## Build all pony projects
 test-pony: test-pony-all ## Test all pony projects
 clean-pony: clean-pony-all ## Clean all pony projects
@@ -677,7 +695,7 @@ help: ## this help message
 endif # RULES_MK
 
 # check control variables for valid values
-$(evel $(call check-values,$(ABS_PREV_MAKEFILE)_TEST_COMMAND,false true))
+$(evel $(call check-values,$(ABS_PREV_MAKEFILE)_UNIT_TEST_COMMAND,false true))
 $(evel $(call check-values,$(ABS_PREV_MAKEFILE)_PONY_TARGET,false true))
 $(evel $(call check-values,$(ABS_PREV_MAKEFILE)_PONYC_TARGET,false true))
 $(evel $(call check-values,$(ABS_PREV_MAKEFILE)_DOCKER_TARGET,false true))

--- a/rules.mk
+++ b/rules.mk
@@ -205,7 +205,7 @@ $(eval \
     $$(call host_ip_src)))
 
 ifeq ($(debug),true)
-  debug_arg := -d
+  debug_arg := --debug
 endif
 
 # validation of variable

--- a/testing/Makefile
+++ b/testing/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/Makefile
+++ b/testing/Makefile
@@ -7,17 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/correctness/Makefile
+++ b/testing/correctness/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/correctness/Makefile
+++ b/testing/correctness/Makefile
@@ -7,17 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/correctness/apps/Makefile
+++ b/testing/correctness/apps/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/correctness/apps/Makefile
+++ b/testing/correctness/apps/Makefile
@@ -7,17 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/correctness/apps/multi_sink/Makefile
+++ b/testing/correctness/apps/multi_sink/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/correctness/apps/multi_sink/Makefile
+++ b/testing/correctness/apps/multi_sink/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/correctness/apps/ping_pong/Makefile
+++ b/testing/correctness/apps/ping_pong/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/correctness/apps/ping_pong/Makefile
+++ b/testing/correctness/apps/ping_pong/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/correctness/apps/sequence_window/Makefile
+++ b/testing/correctness/apps/sequence_window/Makefile
@@ -45,8 +45,8 @@ build-testing-correctness-apps-sequence_window: build-testing-correctness-apps-s
 
 # This will build three different binaries of sequence_window, but respect PONYCFLAGS passed
 # to Make
--include $(subst $(abs_wallaroo_dir)/,,$(SEQUENCE_WINDOW_PATH:%/=%))/$(notdir $(abspath $(SEQUENCE_WINDOW_PATH:%/=%))).d
-$(subst $(abs_wallaroo_dir)/,,$(SEQUENCE_WINDOW_PATH:%/=%))/$(notdir $(abspath $(SEQUENCE_WINDOW_PATH:%/=%))):
+-include $(abspath $(SEQUENCE_WINDOW_PATH:%/=%))/$(notdir $(abspath $(SEQUENCE_WINDOW_PATH:%/=%))).d
+$(abspath $(SEQUENCE_WINDOW_PATH:%/=%))/$(notdir $(abspath $(SEQUENCE_WINDOW_PATH:%/=%))):
 	$(eval original_PONYCFLAGS := $(PONYCFLAGS))
 	$(eval PONYCFLAGS := $(original_PONYCFLAGS) -D resilience -D spike -D spiketrace -D validate)
 	$(call PONYC,$(abspath $(SEQUENCE_WINDOW_PATH:%/=%)))

--- a/testing/correctness/apps/sequence_window/Makefile
+++ b/testing/correctness/apps/sequence_window/Makefile
@@ -7,23 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate of PONYC command
-PONYC_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := false
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 SEQUENCE_WINDOW_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/testing/correctness/apps/sequence_window/Makefile
+++ b/testing/correctness/apps/sequence_window/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -57,9 +57,9 @@ $(subst $(abs_wallaroo_dir)/,,$(SEQUENCE_WINDOW_PATH:%/=%))/$(notdir $(abspath $
 	$(eval PONYCFLAGS := $(original_PONYCFLAGS))
 	$(call PONYC,$(abspath $(SEQUENCE_WINDOW_PATH:%/=%)))
 
-test-testing-correctness-apps-sequence_window: build-testing-correctness-apps-sequence_window
+integration-tests-testing-correctness-apps-sequence_window: build-testing-correctness-apps-sequence_window
 
-test-testing-correctness-apps-sequence_window: sequence_window_test
+integration-tests-testing-correctness-apps-sequence_window: sequence_window_test
 
 sequence_window_test:
 	cd $(SEQUENCE_WINDOW_PATH) && \

--- a/testing/correctness/apps/sequence_window/ring/Makefile
+++ b/testing/correctness/apps/sequence_window/ring/Makefile
@@ -7,18 +7,32 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
 
 
 # standard rules generation makefile

--- a/testing/correctness/apps/sequence_window/ring/Makefile
+++ b/testing/correctness/apps/sequence_window/ring/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/correctness/apps/sequence_window/validator/Makefile
+++ b/testing/correctness/apps/sequence_window/validator/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 VALIDATOR_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 VALIDATOR_EXAMPLES := $(VALIDATOR_PATH)/examples

--- a/testing/correctness/apps/sequence_window/validator/Makefile
+++ b/testing/correctness/apps/sequence_window/validator/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -42,7 +42,7 @@ VALIDATOR_EXAMPLES := $(VALIDATOR_PATH)/examples
 include $(rules_mk_path)
 
 
-test-testing-correctness-apps-sequence_window-validator: validator_test
+integration-tests-testing-correctness-apps-sequence_window-validator: validator_test
 clean-testing-correctness-apps-sequence_window-validator: validator_clean
 
 validator_clean:

--- a/testing/correctness/apps/sequence_window/window_codecs/Makefile
+++ b/testing/correctness/apps/sequence_window/window_codecs/Makefile
@@ -7,18 +7,32 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
 
 
 # standard rules generation makefile

--- a/testing/correctness/apps/sequence_window/window_codecs/Makefile
+++ b/testing/correctness/apps/sequence_window/window_codecs/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/correctness/apps/sequence_window_python/Makefile
+++ b/testing/correctness/apps/sequence_window_python/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-#TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := false
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := false
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := false
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := false
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := false
+
 
 SEQUENCE_WINDOW_PYTHON_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/testing/correctness/apps/sequence_window_python/Makefile
+++ b/testing/correctness/apps/sequence_window_python/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -44,8 +44,8 @@ include $(rules_mk_path)
 
 build-testing-correctness-apps-sequence_window_python: build-machida
 build-testing-correctness-apps-sequence_window_python: build-testing-correctness-apps-sequence_window-validator
-test-testing-correctness-apps-sequence_window_python: build-testing-correctness-apps-sequence_window_python
-test-testing-correctness-apps-sequence_window_python: sequence_window_python_test
+integration-tests-testing-correctness-apps-sequence_window_python: build-testing-correctness-apps-sequence_window_python
+integration-tests-testing-correctness-apps-sequence_window_python: sequence_window_python_test
 
 sequence_window_python_test:
 	cd $(SEQUENCE_WINDOW_PYTHON_PATH) && \

--- a/testing/correctness/apps/sequence_window_simple_state/Makefile
+++ b/testing/correctness/apps/sequence_window_simple_state/Makefile
@@ -7,20 +7,32 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate of PONYC command
-PONYC_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := false
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
 
 
 SEQUENCE_WINDOW_SIMPLE_STATE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/testing/correctness/apps/sequence_window_simple_state/Makefile
+++ b/testing/correctness/apps/sequence_window_simple_state/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -59,9 +59,9 @@ $(subst $(abs_wallaroo_dir)/,,$(SEQUENCE_WINDOW_SIMPLE_STATE_PATH:%/=%))/$(notdi
 	$(call PONYC,$(abspath $(SEQUENCE_WINDOW_SIMPLE_STATE_PATH:%/=%)))
 
 
-test-testing-correctness-apps-sequence_window_simple_state: build-testing-correctness-apps-sequence_window_simple_state
+integration-tests-testing-correctness-apps-sequence_window_simple_state: build-testing-correctness-apps-sequence_window_simple_state
 
-test-testing-correctness-apps-sequence_window_simple_state: sequence_window_simple_state_test
+integration-tests-testing-correctness-apps-sequence_window_simple_state: sequence_window_simple_state_test
 
 sequence_window_simple_state_test:
 	cd $(SEQUENCE_WINDOW_SIMPLE_STATE_PATH) && \

--- a/testing/correctness/apps/sequence_window_simple_state/Makefile
+++ b/testing/correctness/apps/sequence_window_simple_state/Makefile
@@ -46,8 +46,8 @@ build-testing-correctness-apps-sequence_window_simple_state: build-testing-corre
 
 # This will build three different binaries of sequence_window, but respect PONYCFLAGS passed
 # to Make
--include $(subst $(abs_wallaroo_dir)/,,$(SEQUENCE_WINDOW_SIMPLE_STATE_PATH:%/=%))/$(notdir $(abspath $(SEQUENCE_WINDOW_SIMPLE_STATE_PATH:%/=%))).d
-$(subst $(abs_wallaroo_dir)/,,$(SEQUENCE_WINDOW_SIMPLE_STATE_PATH:%/=%))/$(notdir $(abspath $(SEQUENCE_WINDOW_SIMPLE_STATE_PATH:%/=%))):
+-include $(abspath $(SEQUENCE_WINDOW_SIMPLE_STATE_PATH:%/=%))/$(notdir $(abspath $(SEQUENCE_WINDOW_SIMPLE_STATE_PATH:%/=%))).d
+$(abspath $(SEQUENCE_WINDOW_SIMPLE_STATE_PATH:%/=%))/$(notdir $(abspath $(SEQUENCE_WINDOW_SIMPLE_STATE_PATH:%/=%))):
 	$(eval original_PONYCFLAGS := $(PONYCFLAGS))
 	$(eval PONYCFLAGS := $(original_PONYCFLAGS) -D resilience -D spike -D spiketrace -D validate)
 	$(call PONYC,$(abspath $(SEQUENCE_WINDOW_SIMPLE_STATE_PATH:%/=%)))

--- a/testing/correctness/apps/sequence_window_simple_state/ring/Makefile
+++ b/testing/correctness/apps/sequence_window_simple_state/ring/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/correctness/apps/sequence_window_simple_state/ring/Makefile
+++ b/testing/correctness/apps/sequence_window_simple_state/ring/Makefile
@@ -7,17 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/correctness/apps/sequence_window_simple_state/window_codecs/Makefile
+++ b/testing/correctness/apps/sequence_window_simple_state/window_codecs/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/correctness/apps/sequence_window_simple_state/window_codecs/Makefile
+++ b/testing/correctness/apps/sequence_window_simple_state/window_codecs/Makefile
@@ -7,17 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/correctness/apps/weighted_test/Makefile
+++ b/testing/correctness/apps/weighted_test/Makefile
@@ -7,20 +7,32 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
 
 
 # standard rules generation makefile

--- a/testing/correctness/apps/weighted_test/Makefile
+++ b/testing/correctness/apps/weighted_test/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/correctness/tests/Makefile
+++ b/testing/correctness/tests/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -41,8 +41,8 @@ CUSTOM_PATH += :$(SEQUENCE_WINDOW_PATH):$(VALIDATOR_PATH):$(EXTERNAL_SENDER_PATH
 build-testing-correctness-tests: build-testing-correctness-apps-sequence_window
 build-testing-correctness-tests: build-testing-tools-external_sender
 build-testing-correctness-tests: build-machida
-test-testing-correctness-tests: build-testing-correctness-tests
-test-testing-correctness-tests: correctness_tests
+integration-tests-testing-correctness-tests: build-testing-correctness-tests
+integration-tests-testing-correctness-tests: correctness_tests
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/correctness/tests/Makefile
+++ b/testing/correctness/tests/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-#TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := false
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := false
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := false
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := false
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := false
+
 
 CORRECTNESS_TESTS_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 CUSTOM_PATH += :$(SEQUENCE_WINDOW_PATH):$(VALIDATOR_PATH):$(EXTERNAL_SENDER_PATH)

--- a/testing/correctness/topology_layouts/Makefile
+++ b/testing/correctness/topology_layouts/Makefile
@@ -7,20 +7,32 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-# TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
 
 
 # standard rules generation makefile

--- a/testing/correctness/topology_layouts/Makefile
+++ b/testing/correctness/topology_layouts/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/correctness/topology_layouts/apps/Makefile
+++ b/testing/correctness/topology_layouts/apps/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-# TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/correctness/topology_layouts/apps/Makefile
+++ b/testing/correctness/topology_layouts/apps/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/correctness/topology_layouts/apps/single_stream/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/Makefile
@@ -7,20 +7,32 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-# TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
 
 
 # standard rules generation makefile

--- a/testing/correctness/topology_layouts/apps/single_stream/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/correctness/topology_layouts/apps/single_stream/filtering_stateless/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/filtering_stateless/Makefile
@@ -7,20 +7,32 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-# TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
 
 
 # standard rules generation makefile

--- a/testing/correctness/topology_layouts/apps/single_stream/filtering_stateless/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/filtering_stateless/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/correctness/topology_layouts/apps/single_stream/filtering_stateless/filtered_stateful_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/filtering_stateless/filtered_stateful_app/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -40,7 +40,7 @@ SINGLE_STREAM_FILTERING_STATELESS_FILTERED_STATEFUL_APP_PATH := $(dir $(abspath 
 # standard rules generation makefile
 include $(rules_mk_path)
 
-test-testing-correctness-topology_layouts-apps-single_stream-filtering_stateless-filtered_stateful_app: single_worker_filtering_stateless_filtered_stateful_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-filtering_stateless-filtered_stateful_app: single_worker_filtering_stateless_filtered_stateful_app_test
 
 single_worker_filtering_stateless_filtered_stateful_app_test:
 	cd $(SINGLE_STREAM_FILTERING_STATELESS_FILTERED_STATEFUL_APP_PATH) && \
@@ -57,7 +57,7 @@ single_worker_filtering_stateless_filtered_stateful_app_test:
 # This should never happen: failure in lib/wallaroo/initialization/local_topology.pony at line 1236
 # See Issue: 947
 
-# test-testing-correctness-topology_layouts-apps-single_stream-filtering_stateless-filtered_stateful_app: two_worker_single_worker_filtering_stateless_filtered_stateful_app_test
+# integration-tests-testing-correctness-topology_layouts-apps-single_stream-filtering_stateless-filtered_stateful_app: two_worker_single_worker_filtering_stateless_filtered_stateful_app_test
 
 two_worker_single_worker_filtering_stateless_filtered_stateful_app_test:
 	cd $(SINGLE_STREAM_FILTERING_STATELESS_FILTERED_STATEFUL_APP_PATH) && \
@@ -70,7 +70,7 @@ two_worker_single_worker_filtering_stateless_filtered_stateful_app_test:
 	--command './filtered_stateful_app' \
 	--sink-expect 50
 
-# test-testing-correctness-topology_layouts-apps-single_stream-filtering_stateless-filtered_stateful_app: three_worker_single_worker_filtering_stateless_filtered_stateful_app_test
+# integration-tests-testing-correctness-topology_layouts-apps-single_stream-filtering_stateless-filtered_stateful_app: three_worker_single_worker_filtering_stateless_filtered_stateful_app_test
 
 three_worker_single_worker_filtering_stateless_filtered_stateful_app_test:
 	cd $(SINGLE_STREAM_FILTERING_STATELESS_FILTERED_STATEFUL_APP_PATH) && \

--- a/testing/correctness/topology_layouts/apps/single_stream/filtering_stateless/filtered_stateful_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/filtering_stateless/filtered_stateful_app/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-# RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 SINGLE_STREAM_FILTERING_STATELESS_FILTERED_STATEFUL_APP_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/testing/correctness/topology_layouts/apps/single_stream/filtering_stateless/filtered_stateless_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/filtering_stateless/filtered_stateless_app/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -41,7 +41,7 @@ SINGLE_STREAM_FILTERING_STATELESS_FILTERERED_STATELESS_APP_PATH := $(dir $(abspa
 include $(rules_mk_path)
 
 
-test-testing-correctness-topology_layouts-apps-single_stream-filtering_stateless-filtered_stateless_app: single_worker_filtering_stateless_filtered_stateless_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-filtering_stateless-filtered_stateless_app: single_worker_filtering_stateless_filtered_stateless_app_test
 
 single_worker_filtering_stateless_filtered_stateless_app_test:
 	cd $(SINGLE_STREAM_FILTERING_STATELESS_FILTERERED_STATELESS_APP_PATH) && \
@@ -53,7 +53,7 @@ single_worker_filtering_stateless_filtered_stateless_app_test:
 	--command './filtered_stateless_app' \
 	--sink-expect 50
 
-test-testing-correctness-topology_layouts-apps-single_stream-filtering_stateless-filtered_stateless_app: two_worker_single_worker_filtering_stateless_filtered_stateless_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-filtering_stateless-filtered_stateless_app: two_worker_single_worker_filtering_stateless_filtered_stateless_app_test
 
 two_worker_single_worker_filtering_stateless_filtered_stateless_app_test:
 	rm -f /tmp/filtered_stateless_app*
@@ -67,7 +67,7 @@ two_worker_single_worker_filtering_stateless_filtered_stateless_app_test:
 	--command './filtered_stateless_app' \
 	--sink-expect 50
 
-test-testing-correctness-topology_layouts-apps-single_stream-filtering_stateless-filtered_stateless_app: three_worker_single_worker_filtering_stateless_filtered_stateless_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-filtering_stateless-filtered_stateless_app: three_worker_single_worker_filtering_stateless_filtered_stateless_app_test
 
 three_worker_single_worker_filtering_stateless_filtered_stateless_app_test:
 	rm -f /tmp/filtered_stateless_app*

--- a/testing/correctness/topology_layouts/apps/single_stream/filtering_stateless/filtered_stateless_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/filtering_stateless/filtered_stateless_app/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-# RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 SINGLE_STREAM_FILTERING_STATELESS_FILTERERED_STATELESS_APP_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/testing/correctness/topology_layouts/apps/single_stream/filtering_stateless/stateful_filtered_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/filtering_stateless/stateful_filtered_app/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -40,7 +40,7 @@ SINGLE_STREAM_FILTERING_STATELESS_STATEFUL_FILTERED_APP_PATH := $(dir $(abspath 
 # standard rules generation makefile
 include $(rules_mk_path)
 
-test-testing-correctness-topology_layouts-apps-single_stream-filtering_stateless-stateful_filtered_app: single_worker_filtering_stateless_stateful_filtered_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-filtering_stateless-stateful_filtered_app: single_worker_filtering_stateless_stateful_filtered_app_test
 
 single_worker_filtering_stateless_stateful_filtered_app_test:
 	cd $(SINGLE_STREAM_FILTERING_STATELESS_STATEFUL_FILTERED_APP_PATH) && \
@@ -57,7 +57,7 @@ single_worker_filtering_stateless_stateful_filtered_app_test:
 # This should never happen: failure in lib/wallaroo/initialization/local_topology.pony at line 1236
 # See Issue: 947
 
-# test-testing-correctness-topology_layouts-apps-single_stream-filtering_stateless-stateful_filtered_app: two_worker_single_worker_filtering_stateless_stateful_filtered_app_test
+# integration-tests-testing-correctness-topology_layouts-apps-single_stream-filtering_stateless-stateful_filtered_app: two_worker_single_worker_filtering_stateless_stateful_filtered_app_test
 
 two_worker_single_worker_filtering_stateless_stateful_filtered_app_test:
 	cd $(SINGLE_STREAM_FILTERING_STATELESS_STATEFUL_FILTERED_APP_PATH) && \
@@ -70,7 +70,7 @@ two_worker_single_worker_filtering_stateless_stateful_filtered_app_test:
 	--command './stateful_filtered_app' \
 	--sink-expect 50
 
-# test-testing-correctness-topology_layouts-apps-single_stream-filtering_stateless-stateful_filtered_app: three_worker_single_worker_filtering_stateless_stateful_filtered_app_test
+# integration-tests-testing-correctness-topology_layouts-apps-single_stream-filtering_stateless-stateful_filtered_app: three_worker_single_worker_filtering_stateless_stateful_filtered_app_test
 
 three_worker_single_worker_filtering_stateless_stateful_filtered_app_test:
 	cd $(SINGLE_STREAM_FILTERING_STATELESS_STATEFUL_FILTERED_APP_PATH) && \

--- a/testing/correctness/topology_layouts/apps/single_stream/filtering_stateless/stateful_filtered_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/filtering_stateless/stateful_filtered_app/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-# RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 SINGLE_STREAM_FILTERING_STATELESS_STATEFUL_FILTERED_APP_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/testing/correctness/topology_layouts/apps/single_stream/filtering_stateless/stateless_filtered_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/filtering_stateless/stateless_filtered_app/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-# RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 SINGLE_STREAM_FILTERING_STATELESS_STATELESS_FILTERED_APP_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/testing/correctness/topology_layouts/apps/single_stream/filtering_stateless/stateless_filtered_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/filtering_stateless/stateless_filtered_app/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -41,7 +41,7 @@ SINGLE_STREAM_FILTERING_STATELESS_STATELESS_FILTERED_APP_PATH := $(dir $(abspath
 include $(rules_mk_path)
 
 
-test-testing-correctness-topology_layouts-apps-single_stream-filtering_stateless-stateless_filtered_app: single_stream_filtering_stateless_stateless_filter_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-filtering_stateless-stateless_filtered_app: single_stream_filtering_stateless_stateless_filter_app_test
 
 single_stream_filtering_stateless_stateless_filter_app_test:
 	cd $(SINGLE_STREAM_FILTERING_STATELESS_STATELESS_FILTERED_APP_PATH) && \
@@ -53,7 +53,7 @@ single_stream_filtering_stateless_stateless_filter_app_test:
 	--command './stateless_filtered_app' \
 	--sink-expect 100
 
-test-testing-correctness-topology_layouts-apps-single_stream-filtering_stateless-stateless_filtered_app: two_worker_single_stream_filtering_stateless_stateless_filter_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-filtering_stateless-stateless_filtered_app: two_worker_single_stream_filtering_stateless_stateless_filter_app_test
 
 two_worker_single_stream_filtering_stateless_stateless_filter_app_test:
 	cd $(SINGLE_STREAM_FILTERING_STATELESS_STATELESS_FILTERED_APP_PATH) && \
@@ -66,7 +66,7 @@ two_worker_single_stream_filtering_stateless_stateless_filter_app_test:
 	--command './stateless_filtered_app' \
 	--sink-expect 100
 
-test-testing-correctness-topology_layouts-apps-single_stream-filtering_stateless-stateless_filtered_app: three_worker_single_stream_filtering_stateless_stateless_filter_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-filtering_stateless-stateless_filtered_app: three_worker_single_stream_filtering_stateless_stateless_filter_app_test
 
 three_worker_single_stream_filtering_stateless_stateless_filter_app_test:
 	cd $(SINGLE_STREAM_FILTERING_STATELESS_STATELESS_FILTERED_APP_PATH) && \

--- a/testing/correctness/topology_layouts/apps/single_stream/partitioned/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/partitioned/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-# TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/correctness/topology_layouts/apps/single_stream/partitioned/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/partitioned/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/correctness/topology_layouts/apps/single_stream/partitioned/state_partition_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/partitioned/state_partition_app/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -41,9 +41,9 @@ SINGLE_STREAM_PARTITIONED_STATE_PARTITION_APP_PATH := $(dir $(abspath $(lastword
 # standard rules generation makefile
 include $(rules_mk_path)
 
-test-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_app: build-testing-correctness-topology_layouts-apps-validator
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_app: build-testing-correctness-topology_layouts-apps-validator
 
-test-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_app: single_stream_partitioned_state_partition_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_app: single_stream_partitioned_state_partition_app_test
 
 single_stream_partitioned_state_partition_app_test:
 	cd $(SINGLE_STREAM_PARTITIONED_STATE_PARTITION_APP_PATH) && \
@@ -55,7 +55,7 @@ single_stream_partitioned_state_partition_app_test:
 	--command './state_partition_app' \
 	--sink-expect 100
 
-test-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_app: two_worker_single_stream_partitioned_state_partition_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_app: two_worker_single_stream_partitioned_state_partition_app_test
 
 two_worker_single_stream_partitioned_state_partition_app_test:
 	cd $(SINGLE_STREAM_PARTITIONED_STATE_PARTITION_APP_PATH) && \
@@ -68,7 +68,7 @@ two_worker_single_stream_partitioned_state_partition_app_test:
 	--command './state_partition_app' \
 	--sink-expect 100
 
-test-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_app: three_worker_single_stream_partitioned_state_partition_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_app: three_worker_single_stream_partitioned_state_partition_app_test
 
 three_worker_single_stream_partitioned_state_partition_app_test:
 	cd $(SINGLE_STREAM_PARTITIONED_STATE_PARTITION_APP_PATH) && \

--- a/testing/correctness/topology_layouts/apps/single_stream/partitioned/state_partition_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/partitioned/state_partition_app/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-# RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 TOPOLOGY_LAYOUT_VALIDATOR_PATH = $(wallaroo_path)/testing/correctness/topology_layouts/apps/validator
 SINGLE_STREAM_PARTITIONED_STATE_PARTITION_APP_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/testing/correctness/topology_layouts/apps/single_stream/partitioned/state_partition_state_partition_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/partitioned/state_partition_state_partition_app/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-# RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 TOPOLOGY_LAYOUT_VALIDATOR_PATH = $(wallaroo_path)/testing/correctness/topology_layouts/apps/validator
 SINGLE_STREAM_PARTITIONED_STATE_PARTITION_STATE_PARTITION_APP_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/testing/correctness/topology_layouts/apps/single_stream/partitioned/state_partition_state_partition_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/partitioned/state_partition_state_partition_app/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -41,9 +41,9 @@ SINGLE_STREAM_PARTITIONED_STATE_PARTITION_STATE_PARTITION_APP_PATH := $(dir $(ab
 # standard rules generation makefile
 include $(rules_mk_path)
 
-test-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_state_partition_app: build-testing-correctness-topology_layouts-apps-validator
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_state_partition_app: build-testing-correctness-topology_layouts-apps-validator
 
-test-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_state_partition_app: single_stream_partitioned_state_partition_state_partition_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_state_partition_app: single_stream_partitioned_state_partition_state_partition_app_test
 
 single_stream_partitioned_state_partition_state_partition_app_test:
 	cd $(SINGLE_STREAM_PARTITIONED_STATE_PARTITION_STATE_PARTITION_APP_PATH) && \
@@ -60,7 +60,7 @@ single_stream_partitioned_state_partition_state_partition_app_test:
 # This should never happen: failure in lib/wallaroo/initialization/local_topology.pony at line 1236
 # See Issue: 947
 
-#test-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_state_partition_app: two_worker_single_stream_partitioned_state_partition_state_partition_app_test
+#integration-tests-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_state_partition_app: two_worker_single_stream_partitioned_state_partition_state_partition_app_test
 
 two_worker_single_stream_partitioned_state_partition_state_partition_app_test:
 	cd $(SINGLE_STREAM_PARTITIONED_STATE_PARTITION_STATE_PARTITION_APP_PATH) && \
@@ -73,7 +73,7 @@ two_worker_single_stream_partitioned_state_partition_state_partition_app_test:
 	--command './state_partition_state_partition_app' \
 	--sink-expect 100
 
-#test-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_state_partition_app: three_worker_single_stream_partitioned_state_partition_state_partition_app_test
+#integration-tests-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_state_partition_app: three_worker_single_stream_partitioned_state_partition_state_partition_app_test
 
 three_worker_single_stream_partitioned_state_partition_state_partition_app_test:
 	cd $(SINGLE_STREAM_PARTITIONED_STATE_PARTITION_STATE_PARTITION_APP_PATH) && \

--- a/testing/correctness/topology_layouts/apps/single_stream/partitioned/state_partition_stateful_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/partitioned/state_partition_stateful_app/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -41,9 +41,9 @@ SINGLE_STREAM_PARTITIONED_STATE_PARTITION_STATEFUL_APP_PATH := $(dir $(abspath $
 # standard rules generation makefile
 include $(rules_mk_path)
 
-test-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_stateful_app: build-testing-correctness-topology_layouts-apps-validator
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_stateful_app: build-testing-correctness-topology_layouts-apps-validator
 
-test-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_stateful_app: single_stream_partitioned_state_partition_stateful_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_stateful_app: single_stream_partitioned_state_partition_stateful_app_test
 
 single_stream_partitioned_state_partition_stateful_app_test:
 	cd $(SINGLE_STREAM_PARTITIONED_STATE_PARTITION_STATEFUL_APP_PATH) && \
@@ -60,7 +60,7 @@ single_stream_partitioned_state_partition_stateful_app_test:
 # This should never happen: failure in lib/wallaroo/initialization/local_topology.pony at line 1236
 # See Issue: 947
 
-#test-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_stateful_app: two_worker_single_stream_partitioned_state_partition_stateful_app_test
+#integration-tests-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_stateful_app: two_worker_single_stream_partitioned_state_partition_stateful_app_test
 
 two_worker_single_stream_partitioned_state_partition_stateful_app_test:
 	cd $(SINGLE_STREAM_PARTITIONED_STATE_PARTITION_STATEFUL_APP_PATH) && \
@@ -73,7 +73,7 @@ two_worker_single_stream_partitioned_state_partition_stateful_app_test:
 	--command './state_partition_stateful_app' \
 	--sink-expect 100
 
-#test-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_stateful_app: three_worker_single_stream_partitioned_state_partition_stateful_app_test
+#integration-tests-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_stateful_app: three_worker_single_stream_partitioned_state_partition_stateful_app_test
 
 three_worker_single_stream_partitioned_state_partition_stateful_app_test:
 	cd $(SINGLE_STREAM_PARTITIONED_STATE_PARTITION_STATEFUL_APP_PATH) && \

--- a/testing/correctness/topology_layouts/apps/single_stream/partitioned/state_partition_stateful_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/partitioned/state_partition_stateful_app/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-# RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 TOPOLOGY_LAYOUT_VALIDATOR_PATH = $(wallaroo_path)/testing/correctness/topology_layouts/apps/validator
 SINGLE_STREAM_PARTITIONED_STATE_PARTITION_STATEFUL_APP_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/testing/correctness/topology_layouts/apps/single_stream/partitioned/state_partition_stateless_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/partitioned/state_partition_stateless_app/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -41,9 +41,9 @@ SINGLE_STREAM_PARTITIONED_STATE_PARTITION_STATELESS_APP_PATH := $(dir $(abspath 
 # standard rules generation makefile
 include $(rules_mk_path)
 
-test-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_stateless_app: build-testing-correctness-topology_layouts-apps-validator
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_stateless_app: build-testing-correctness-topology_layouts-apps-validator
 
-test-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_stateless_app: single_stream_partitioned_state_partition_stateless_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_stateless_app: single_stream_partitioned_state_partition_stateless_app_test
 
 single_stream_partitioned_state_partition_stateless_app_test:
 	cd $(SINGLE_STREAM_PARTITIONED_STATE_PARTITION_STATELESS_APP_PATH) && \
@@ -60,7 +60,7 @@ single_stream_partitioned_state_partition_stateless_app_test:
 # This should never happen: failure in lib/wallaroo/initialization/local_topology.pony at line 1236
 # See Issue: 947
 
-#test-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_stateless_app: two_worker_single_stream_partitioned_state_partition_stateless_app_test
+#integration-tests-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_stateless_app: two_worker_single_stream_partitioned_state_partition_stateless_app_test
 
 two_worker_single_stream_partitioned_state_partition_stateless_app_test:
 	cd $(SINGLE_STREAM_PARTITIONED_STATE_PARTITION_STATELESS_APP_PATH) && \
@@ -73,7 +73,7 @@ two_worker_single_stream_partitioned_state_partition_stateless_app_test:
 	--command './state_partition_stateless_app' \
 	--sink-expect 100
 
-#test-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_stateless_app: three_worker_single_stream_partitioned_state_partition_stateless_app_test
+#integration-tests-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_stateless_app: three_worker_single_stream_partitioned_state_partition_stateless_app_test
 
 three_worker_single_stream_partitioned_state_partition_stateless_app_test:
 	cd $(SINGLE_STREAM_PARTITIONED_STATE_PARTITION_STATELESS_APP_PATH) && \

--- a/testing/correctness/topology_layouts/apps/single_stream/partitioned/state_partition_stateless_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/partitioned/state_partition_stateless_app/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-# RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 TOPOLOGY_LAYOUT_VALIDATOR_PATH = $(wallaroo_path)/testing/correctness/topology_layouts/apps/validator
 SINGLE_STREAM_PARTITIONED_STATE_PARTITION_STATELESS_APP_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/testing/correctness/topology_layouts/apps/single_stream/stateful_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/stateful_app/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-# RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 SINGLE_STREAM_STATEFUL_APP_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/testing/correctness/topology_layouts/apps/single_stream/stateful_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/stateful_app/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -40,7 +40,7 @@ SINGLE_STREAM_STATEFUL_APP_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST)))
 # standard rules generation makefile
 include $(rules_mk_path)
 
-test-testing-correctness-topology_layouts-apps-single_stream-stateful_app: single_stream_stateful_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-stateful_app: single_stream_stateful_app_test
 
 single_stream_stateful_app_test:
 	cd $(SINGLE_STREAM_STATEFUL_APP_PATH) && \
@@ -51,7 +51,7 @@ single_stream_stateful_app_test:
 	--command './stateful_app' \
 	--sink-expect 100
 
-test-testing-correctness-topology_layouts-apps-single_stream-stateful_app: two_worker_single_stream_stateful_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-stateful_app: two_worker_single_stream_stateful_app_test
 
 two_worker_single_stream_stateful_app_test:
 	cd $(SINGLE_STREAM_STATEFUL_APP_PATH) && \
@@ -63,7 +63,7 @@ two_worker_single_stream_stateful_app_test:
 	--command './stateful_app' \
 	--sink-expect 100
 
-test-testing-correctness-topology_layouts-apps-single_stream-stateful_app: three_worker_single_stream_stateful_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-stateful_app: three_worker_single_stream_stateful_app_test
 
 three_worker_single_stream_stateful_app_test:
 	cd $(SINGLE_STREAM_STATEFUL_APP_PATH) && \

--- a/testing/correctness/topology_layouts/apps/single_stream/stateful_stateless_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/stateful_stateless_app/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-# RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 SINGLE_STREAM_STATEFUL_STATELESS_APP_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/testing/correctness/topology_layouts/apps/single_stream/stateful_stateless_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/stateful_stateless_app/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -40,7 +40,7 @@ SINGLE_STREAM_STATEFUL_STATELESS_APP_PATH := $(dir $(abspath $(lastword $(MAKEFI
 # standard rules generation makefile
 include $(rules_mk_path)
 
-test-testing-correctness-topology_layouts-apps-single_stream-stateful_stateless_app: single_stream_stateful_stateless_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-stateful_stateless_app: single_stream_stateful_stateless_app_test
 
 single_stream_stateful_stateless_app_test:
 	cd $(SINGLE_STREAM_STATEFUL_STATELESS_APP_PATH) && \

--- a/testing/correctness/topology_layouts/apps/single_stream/stateful_stateless_stateful_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/stateful_stateless_stateful_app/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -40,7 +40,7 @@ SINGLE_STREAM_STATEFUL_STATELESS_STATEFUL_APP_PATH := $(dir $(abspath $(lastword
 # standard rules generation makefile
 include $(rules_mk_path)
 
-test-testing-correctness-topology_layouts-apps-single_stream-stateful_stateless_stateful_app: single_stream_stateful_stateless_stateful_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-stateful_stateless_stateful_app: single_stream_stateful_stateless_stateful_app_test
 
 single_stream_stateful_stateless_stateful_app_test:
 	cd $(SINGLE_STREAM_STATEFUL_STATELESS_STATEFUL_APP_PATH) && \
@@ -56,7 +56,7 @@ single_stream_stateful_stateless_stateful_app_test:
 # This should never happen: failure in lib/wallaroo/initialization/local_topology.pony at line 1236
 # See Issue: 947
 
-#test-testing-correctness-topology_layouts-apps-single_stream-stateful_stateless_stateful_app: two_worker_single_stream_stateful_stateless_stateful_app_test
+#integration-tests-testing-correctness-topology_layouts-apps-single_stream-stateful_stateless_stateful_app: two_worker_single_stream_stateful_stateless_stateful_app_test
 
 two_worker_single_stream_stateful_stateless_stateful_app_test:
 	cd $(SINGLE_STREAM_STATEFUL_STATELESS_STATEFUL_APP_PATH) && \
@@ -68,7 +68,7 @@ two_worker_single_stream_stateful_stateless_stateful_app_test:
 	--command './stateful_stateless_stateful_app' \
 	--sink-expect 100
 
-#test-testing-correctness-topology_layouts-apps-single_stream-stateful_stateless_stateful_app: three_worker_single_stream_stateful_stateless_stateful_app_test
+#integration-tests-testing-correctness-topology_layouts-apps-single_stream-stateful_stateless_stateful_app: three_worker_single_stream_stateful_stateless_stateful_app_test
 
 three_worker_single_stream_stateful_stateless_stateful_app_test:
 	cd $(SINGLE_STREAM_STATEFUL_STATELESS_STATEFUL_APP_PATH) && \

--- a/testing/correctness/topology_layouts/apps/single_stream/stateful_stateless_stateful_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/stateful_stateless_stateful_app/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-# RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 SINGLE_STREAM_STATEFUL_STATELESS_STATEFUL_APP_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/testing/correctness/topology_layouts/apps/single_stream/stateless_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/stateless_app/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -41,7 +41,7 @@ SINGLE_STREAM_STATELESS_APP_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))
 include $(rules_mk_path)
 
 
-test-testing-correctness-topology_layouts-apps-single_stream-stateless_app: single_stream_stateless_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-stateless_app: single_stream_stateless_app_test
 
 single_stream_stateless_app_test:
 	cd $(SINGLE_STREAM_STATELESS_APP_PATH) && \
@@ -52,7 +52,7 @@ single_stream_stateless_app_test:
 	--command './stateless_app' \
 	--sink-expect 100
 
-test-testing-correctness-topology_layouts-apps-single_stream-stateless_app: two_worker_single_stream_stateless_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-stateless_app: two_worker_single_stream_stateless_app_test
 
 two_worker_single_stream_stateless_app_test:
 	cd $(SINGLE_STREAM_STATELESS_APP_PATH) && \
@@ -64,7 +64,7 @@ two_worker_single_stream_stateless_app_test:
 	--command './stateless_app' \
 	--sink-expect 100
 
-test-testing-correctness-topology_layouts-apps-single_stream-stateless_app: three_worker_single_stream_stateless_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-stateless_app: three_worker_single_stream_stateless_app_test
 
 three_worker_single_stream_stateless_app_test:
 	cd $(SINGLE_STREAM_STATELESS_APP_PATH) && \

--- a/testing/correctness/topology_layouts/apps/single_stream/stateless_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/stateless_app/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-# RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 SINGLE_STREAM_STATELESS_APP_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/testing/correctness/topology_layouts/apps/single_stream/stateless_stateful_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/stateless_stateful_app/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -41,7 +41,7 @@ SINGLE_STREAM_STATELESS_STATEFUL_APP_PATH := $(dir $(abspath $(lastword $(MAKEFI
 include $(rules_mk_path)
 
 
-test-testing-correctness-topology_layouts-apps-single_stream-stateless_stateful_app: single_stream_stateless_stateful_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-stateless_stateful_app: single_stream_stateless_stateful_app_test
 
 single_stream_stateless_stateful_app_test:
 	cd $(SINGLE_STREAM_STATELESS_STATEFUL_APP_PATH) && \
@@ -52,7 +52,7 @@ single_stream_stateless_stateful_app_test:
 	--command './stateless_stateful_app' \
 	--sink-expect 100
 
-test-testing-correctness-topology_layouts-apps-single_stream-stateless_stateful_app: two_worker_single_stream_stateless_stateful_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-stateless_stateful_app: two_worker_single_stream_stateless_stateful_app_test
 
 two_worker_single_stream_stateless_stateful_app_test:
 	cd $(SINGLE_STREAM_STATELESS_STATEFUL_APP_PATH) && \
@@ -64,7 +64,7 @@ two_worker_single_stream_stateless_stateful_app_test:
 	--command './stateless_stateful_app' \
 	--sink-expect 100
 
-test-testing-correctness-topology_layouts-apps-single_stream-stateless_stateful_app: three_worker_single_stream_stateless_stateful_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-stateless_stateful_app: three_worker_single_stream_stateless_stateful_app_test
 
 three_worker_single_stream_stateless_stateful_app_test:
 	cd $(SINGLE_STREAM_STATELESS_STATEFUL_APP_PATH) && \

--- a/testing/correctness/topology_layouts/apps/single_stream/stateless_stateful_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/stateless_stateful_app/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-# RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 SINGLE_STREAM_STATELESS_STATEFUL_APP_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/testing/correctness/topology_layouts/apps/single_stream/stateless_stateful_stateless_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/stateless_stateful_stateless_app/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-# RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 SINGLE_STREAM_STATELESS_STATEFUL_STATELESS_APP_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/testing/correctness/topology_layouts/apps/single_stream/stateless_stateful_stateless_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/stateless_stateful_stateless_app/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -40,7 +40,7 @@ SINGLE_STREAM_STATELESS_STATEFUL_STATELESS_APP_PATH := $(dir $(abspath $(lastwor
 # standard rules generation makefile
 include $(rules_mk_path)
 
-test-testing-correctness-topology_layouts-apps-single_stream-stateless_stateful_stateless_app: single_stream_stateless_stateful_stateless_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-stateless_stateful_stateless_app: single_stream_stateless_stateful_stateless_app_test
 
 single_stream_stateless_stateful_stateless_app_test:
 	cd $(SINGLE_STREAM_STATELESS_STATEFUL_STATELESS_APP_PATH) && \

--- a/testing/correctness/topology_layouts/apps/validator/Makefile
+++ b/testing/correctness/topology_layouts/apps/validator/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/correctness/topology_layouts/apps/validator/Makefile
+++ b/testing/correctness/topology_layouts/apps/validator/Makefile
@@ -7,20 +7,32 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-# PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
 
 
 # standard rules generation makefile

--- a/testing/performance/Makefile
+++ b/testing/performance/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/performance/Makefile
+++ b/testing/performance/Makefile
@@ -7,17 +7,32 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
 
 
 # standard rules generation makefile

--- a/testing/performance/apps/Makefile
+++ b/testing/performance/apps/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/performance/apps/Makefile
+++ b/testing/performance/apps/Makefile
@@ -7,17 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/performance/apps/market-spread-cpp/Makefile
+++ b/testing/performance/apps/market-spread-cpp/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -52,7 +52,7 @@ WALLAROO_CPP_INCLUDE = $(WALLAROO_CPP_INSTALL)/include/
 
 
 build-testing-performance-apps-market-spread-cpp-all = build-cpp_api-all marketspread_cpp_clean marketspread_cpp_build
-test-testing-performance-apps-market-spread-cpp-all = build-testing-performance-apps-market-spread-cpp-all marketspread_cpp_test
+unit-tests-testing-performance-apps-market-spread-cpp-all = build-testing-performance-apps-market-spread-cpp-all marketspread_cpp_test
 clean-testing-performance-apps-market-spread-cpp-all = clean-cpp_api-all marketspread_cpp_clean
 
 marketspread_cpp_build:

--- a/testing/performance/apps/market-spread-cpp/Makefile
+++ b/testing/performance/apps/market-spread-cpp/Makefile
@@ -56,13 +56,13 @@ test-testing-performance-apps-market-spread-cpp-all = build-testing-performance-
 clean-testing-performance-apps-market-spread-cpp-all = clean-cpp_api-all marketspread_cpp_clean
 
 marketspread_cpp_build:
-	mkdir -p $(MSCPP_BUILD)
-	c++ --debug -c -o $(MSCPP_BUILD)/market-spread-cpp.o $(MSCPP_CPP)/market-spread-cpp.cpp -Wall -std=c++11 -I$(MSCPP_HPP) -I$(WALLAROO_CPP_INCLUDE)
-	ar rs $(MSCPP_BUILD)/libmarket-spread-cpp.a $(MSCPP_BUILD)/market-spread-cpp.o
-	ponyc $(PONY_LINKER) --debug --export --output=$(MSCPP_BUILD) --path $(WALLAROO_LIB):$(CPP_PONY_LIB):$(WALLAROO_CPP_LIB):$(MSCPP_BUILD) $(MSCPP_PONY_SOURCE)
+	$(QUIET)mkdir -p $(MSCPP_BUILD)
+	$(QUIET)c++ $(debug_arg) -c -o $(MSCPP_BUILD)/market-spread-cpp.o $(MSCPP_CPP)/market-spread-cpp.cpp -Wall -std=c++11 -I$(MSCPP_HPP) -I$(WALLAROO_CPP_INCLUDE)
+	$(QUIET)ar rs $(MSCPP_BUILD)/libmarket-spread-cpp.a $(MSCPP_BUILD)/market-spread-cpp.o
+	$(QUIET)ponyc $(PONY_LINKER) $(debug_arg) --export --output=$(MSCPP_BUILD) --path $(WALLAROO_LIB):$(CPP_PONY_LIB):$(WALLAROO_CPP_LIB):$(MSCPP_BUILD) $(MSCPP_PONY_SOURCE)
 
 marketspread_cpp_clean:
-	rm -rf $(MSCPP_BUILD)
+	$(QUIET)rm -rf $(MSCPP_BUILD)
 
 marketspread_cpp_test:
 	$(QUIET)echo "market-spread-cpp tests"

--- a/testing/performance/apps/market-spread-cpp/Makefile
+++ b/testing/performance/apps/market-spread-cpp/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-#TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := false
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := false
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := false
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := false
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := false
+
 
 ifeq ($(shell uname -s),Linux)
 	PONY_LINKER = --linker g++

--- a/testing/performance/apps/market-spread-encode/Makefile
+++ b/testing/performance/apps/market-spread-encode/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/performance/apps/market-spread-encode/Makefile
+++ b/testing/performance/apps/market-spread-encode/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/performance/apps/market-spread/Makefile
+++ b/testing/performance/apps/market-spread/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/performance/apps/market-spread/Makefile
+++ b/testing/performance/apps/market-spread/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/performance/apps/one-stream-market/Makefile
+++ b/testing/performance/apps/one-stream-market/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/performance/apps/one-stream-market/Makefile
+++ b/testing/performance/apps/one-stream-market/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/performance/apps/word_count/Makefile
+++ b/testing/performance/apps/word_count/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/performance/apps/word_count/Makefile
+++ b/testing/performance/apps/word_count/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/tools/Makefile
+++ b/testing/tools/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/tools/Makefile
+++ b/testing/tools/Makefile
@@ -7,17 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/tools/dagon/Makefile
+++ b/testing/tools/dagon/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/tools/dagon/Makefile
+++ b/testing/tools/dagon/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/tools/dagon/dagon-child/Makefile
+++ b/testing/tools/dagon/dagon-child/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/tools/dagon/dagon-child/Makefile
+++ b/testing/tools/dagon/dagon-child/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/tools/dagon/dagon-notifier/Makefile
+++ b/testing/tools/dagon/dagon-notifier/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/tools/dagon/dagon-notifier/Makefile
+++ b/testing/tools/dagon/dagon-notifier/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/tools/external_sender/Makefile
+++ b/testing/tools/external_sender/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/tools/external_sender/Makefile
+++ b/testing/tools/external_sender/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 EXTERNAL_SENDER_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 

--- a/testing/tools/fallor/Makefile
+++ b/testing/tools/fallor/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/tools/fallor/Makefile
+++ b/testing/tools/fallor/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/tools/fix_generator/Makefile
+++ b/testing/tools/fix_generator/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/tools/fix_generator/Makefile
+++ b/testing/tools/fix_generator/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/tools/fix_generator/initial_nbbo_generator/Makefile
+++ b/testing/tools/fix_generator/initial_nbbo_generator/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/tools/fix_generator/initial_nbbo_generator/Makefile
+++ b/testing/tools/fix_generator/initial_nbbo_generator/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/tools/fix_generator/nbbo_generator/Makefile
+++ b/testing/tools/fix_generator/nbbo_generator/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/tools/fix_generator/nbbo_generator/Makefile
+++ b/testing/tools/fix_generator/nbbo_generator/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/tools/fix_generator/orders_generator/Makefile
+++ b/testing/tools/fix_generator/orders_generator/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/tools/fix_generator/orders_generator/Makefile
+++ b/testing/tools/fix_generator/orders_generator/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/tools/fixish_converter/Makefile
+++ b/testing/tools/fixish_converter/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/tools/fixish_converter/Makefile
+++ b/testing/tools/fixish_converter/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/tools/merrick/Makefile
+++ b/testing/tools/merrick/Makefile
@@ -7,20 +7,32 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
 
 
 # standard rules generation makefile

--- a/testing/tools/merrick/Makefile
+++ b/testing/tools/merrick/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/tools/robson/Makefile
+++ b/testing/tools/robson/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/tools/robson/Makefile
+++ b/testing/tools/robson/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/tools/wesley/Makefile
+++ b/testing/tools/wesley/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := false
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/tools/wesley/Makefile
+++ b/testing/tools/wesley/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/tools/wesley/double-test/Makefile
+++ b/testing/tools/wesley/double-test/Makefile
@@ -7,20 +7,32 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
 
 
 # standard rules generation makefile

--- a/testing/tools/wesley/double-test/Makefile
+++ b/testing/tools/wesley/double-test/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/tools/wesley/identity-test/Makefile
+++ b/testing/tools/wesley/identity-test/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/tools/wesley/identity-test/Makefile
+++ b/testing/tools/wesley/identity-test/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/tools/wesley/market-spread-test/Makefile
+++ b/testing/tools/wesley/market-spread-test/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/tools/wesley/market-spread-test/Makefile
+++ b/testing/tools/wesley/market-spread-test/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/testing/tools/wesley/word-length-count-test/Makefile
+++ b/testing/tools/wesley/word-length-count-test/Makefile
@@ -7,20 +7,32 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
 
 
 # standard rules generation makefile

--- a/testing/tools/wesley/word-length-count-test/Makefile
+++ b/testing/tools/wesley/word-length-count-test/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/tools/wesley/wordcount-test/Makefile
+++ b/testing/tools/wesley/wordcount-test/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/testing/tools/wesley/wordcount-test/Makefile
+++ b/testing/tools/wesley/wordcount-test/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -7,17 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-#EXS_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/utils/cluster_shutdown/Makefile
+++ b/utils/cluster_shutdown/Makefile
@@ -10,9 +10,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
-# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.

--- a/utils/cluster_shutdown/Makefile
+++ b/utils/cluster_shutdown/Makefile
@@ -7,20 +7,33 @@ endif
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-# uncomment to disable generate test related targets in this directory
-TEST_TARGET := false
 
-# uncomment to disable generate pony related targets (build/test/clean) for pony sources in this directory
-#PONY_TARGET := false
+# The following are control variables that determine what logic from `rules.mk` is enabled
 
-# uncomment to disable generate exs related targets (build/test/clean) for elixir sources in this directory
-EXS_TARGET := false
+# `true`/`false` to enable/disable the actual test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_TEST_COMMAND := false
 
-# uncomment to disable generate docker related targets (build/push) for Dockerfile in this directory
-#DOCKER_TARGET := false
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
-# uncomment to disable generate recursing into Makefiles of subdirectories
-#RECURSE_SUBMAKEFILES := false
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
 
 # standard rules generation makefile
 include $(rules_mk_path)


### PR DESCRIPTION
This PR has changes for two issues (in separate logical commits) but both are related to how the makefiles work and I figured it would be easier to test them both at the same time for anyone reviewing/validating that I didn't break anything by mistake. I can split into two different PR's if that is desired.

---------

Prior to this a bad setting or an error in one Makefile
could lead to other rules defined in other Makefiles not working
at all. This commit changes the control variables used by `rules.mk`
to be explicit (must be either `true` or `false`) and to be unique
for every makefile so they're not shared between makefiles anymore.

resolves #1587

-------------

Prior to this we only had a `make test` target (and related
for all subdirectories) targets. This commit adds the
`make unit-tests` and `make integration-tests` targets as required
to split up running of unit tests from integration tests.

Additinally this renames the related control variable to be
`UNIT_TEST_COMMAND`.

This also re-categorizes any custom test targets to be
dependencies of either `make unit-tests` or `make integration-tests`
as appropriate.

resolves #1130

----------

This PR also includes some minor consistency fixes for some of the custom overridden targets we have where we now properly respect the `VERBOSE=true` and `debug=true` and other minor details.