### PR TITLE
Supply proper `--pony` flags in all example text

### DIFF
--- a/book/getting-started/run-a-wallaroo-application.md
+++ b/book/getting-started/run-a-wallaroo-application.md
@@ -52,7 +52,7 @@ We'll use Giles Receiver to listen for data from our Wallaroo application.
 
 ```bash
 cd ~/wallaroo-tutorial/wallaroo/giles/receiver
-./receiver -l 127.0.0.1:5555 --no-write --ponythreads=1
+./receiver -l 127.0.0.1:5555 --no-write --ponythreads=1 --ponynoblock 
 ```
 
 You should see the `Listening for data` that indicates that Giles receiver is running.
@@ -72,7 +72,7 @@ cd ~/wallaroo-tutorial/wallaroo/machida
 ./build/machida --application-module celsius --in 127.0.0.1:7000 \
   --out 127.0.0.1:5555 --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 \
   --data 127.0.0.1:6001 --name worker-name --external 127.0.0.1:5050 \
-  --cluster-initializer --ponythreads=1
+  --cluster-initializer --ponythreads=1 --ponynoblock 
 ```
 
 This tells the "Celsius to Fahrenheit" application that it should listen on port `7000` for incoming data, write outgoing data to port `5555`, and send metrics data to port `5001`.
@@ -88,8 +88,8 @@ You will now be able to start the `sender` with the following command:
 ```bash
 cd ~/wallaroo-tutorial/wallaroo/giles/sender
 ./sender --host 127.0.0.1:7000 --messages 25000000 --binary --batch-size 300 \
-  --repeat --no-write --msg-size 8 --ponythreads=1 --file \
-  ~/wallaroo-tutorial/wallaroo/examples/python/celsius/celsius.msg
+  --repeat --no-write --msg-size 8 --ponythreads=1 --ponynoblock \
+  --file ~/wallaroo-tutorial/wallaroo/examples/python/celsius/celsius.msg
 ```
 
 If the sender is working correctly, you should see `Connected` printed to the screen. If you see that, you can be assured that we are now sending data into our example application.

--- a/book/wallaroo-tools/giles-receiver.md
+++ b/book/wallaroo-tools/giles-receiver.md
@@ -37,7 +37,7 @@ make
 ### Listen for Wallaroo output and save to `received.txt`
 
 ```bash
-receiver --listen 127.0.0.1:5555
+receiver --listen 127.0.0.1:5555 --ponythreads=1 --ponynoblock 
 ```
 
 ### Listen for Wallaroo output, but don't save anything (e.g. "A Very Fast Sink Receiver")
@@ -45,7 +45,7 @@ receiver --listen 127.0.0.1:5555
 If you just want your application to run as fast as possible without spending any resources on _saving output data_, use
 
 ```bash
-receiver --listen 127.0.0.1:5555 --no-write
+receiver --listen 127.0.0.1:5555 --no-write --ponythreads=1 --ponynoblock 
 ```
 
 ## Pony Runtime Options

--- a/book/wallaroo-tools/giles-sender.md
+++ b/book/wallaroo-tools/giles-sender.md
@@ -130,14 +130,15 @@ To concatenate the files, in order, use
 
 ```bash
 sender --host 127.0.0.1:7000 --file=file1,file2 --messages=100 --batch-size=1 \
-  --interval=10_000_000 --no-write
+  --interval=10_000_000 --no-write --ponythreads=1 --ponynoblock 
 ```
 
 To send the contents of the first file twice, then the contents of the second file once, use
 
 ```bash
 sender --host 127.0.0.1:7000 --file=file1,file1,file2 --messages=100 \
-  --batch-size=1 --interval=10_000_000 --no-write
+  --batch-size=1 --interval=10_000_000 --no-write \
+  --ponythreads=1 --ponynoblock 
 ```
 
 Multiple input files are also supported for binary input, but they must all be either fixed length or variable length.
@@ -150,7 +151,7 @@ To send the sequence `'1', '2', '3', ..., '100'`
 Use
 
 ```bash
-sender --host 127.0.0.1:7000 --messages 100
+sender --host 127.0.0.1:7000 --messages 100 --ponythreads=1 --ponynoblock 
 ```
 
 ### Send a sequence of numbers, encoded as big-endian U64
@@ -160,7 +161,8 @@ To send the sequence `1,2,3,...,100`
 Use
 
 ```bash
-sender --host 127.0.0.1:7000 --messages 100 --u64
+sender --host 127.0.0.1:7000 --messages 100 --u64 \
+  --ponythreads=1 --ponynoblock 
 ```
 
 To send the sequence `101,102,...,200`
@@ -168,7 +170,8 @@ To send the sequence `101,102,...,200`
 Use
 
 ```bash
-sender --host 127.0.0.1:7000 --messages 100 --u64 --start-from 100
+sender --host 127.0.0.1:7000 --messages 100 --u64 --start-from 100 \
+  --ponythreads=1 --ponynoblock 
 ```
 
 ## Preparing Data Files for Giles Sender

--- a/examples/cpp/alphabet-cpp/README.md
+++ b/examples/cpp/alphabet-cpp/README.md
@@ -50,11 +50,12 @@ In a separate shell each:
     ```bash
     ./build/alphabet-app --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
       --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
-      --worker-name worker-name --cluster-initializer --ponythreads=1
+      --worker-name worker-name --cluster-initializer --ponythreads=1 \
+      --ponynoblock
     ```
 3. Start sending data
     ```bash
      ../../../../giles/sender/sender --host 127.0.0.1:7010 --file votes.msg \
        --batch-size 50 --interval 10_000_000 --binary --msg-size 9 --repeat \
-       --ponythreads=1 --messages 1000000 --no-write
+       --ponythreads=1 --ponynoblock --messages 1000000 --no-write
     ```

--- a/examples/cpp/counter-app/README.md
+++ b/examples/cpp/counter-app/README.md
@@ -67,11 +67,12 @@ In a separate shell each:
     ```bash
     ./build/counter-app --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
       --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
-      --worker-name worker-name --cluster-initializer --ponythreads=1
+      --worker-name worker-name --cluster-initializer --ponythreads=1 \
+      --ponynoblock
     ```
 3. Start sending data
     ```bash
      ../../../../giles/sender/sender --host 127.0.0.1:7010 --file data_gen/numbers.msg \
        --batch-size 50 --interval 10_000_000 --binary --msg-size 44 --repeat \
-       --ponythreads=1 --messages 1000000 --no-write
+       --ponythreads=1 --ponynoblock --messages 1000000 --no-write
     ```

--- a/examples/pony/alphabet/README.md
+++ b/examples/pony/alphabet/README.md
@@ -43,7 +43,8 @@ docker start mui
 1. Start a listener
 
 ```bash
-../../../../giles/receiver/receiver --listen 127.0.0.1:7002 --no-write
+../../../../giles/receiver/receiver --listen 127.0.0.1:7002 --no-write \
+  --ponythreads=1 --ponynoblock
 ```
 
 2. Start the application
@@ -51,7 +52,7 @@ docker start mui
 ```bash
 ./alphabet --in 127.0.0.1:7010 --out 127.0.0.1:7002 --metrics 127.0.0.1:5001 \
   --control 127.0.0.1:12500 --data 127.0.0.1:12501 --external 127.0.0.1:5050 \
-  --cluster-initializer
+  --cluster-initializer --ponynoblock --ponythreads=1
 ```
 
 3. Start a sender
@@ -59,7 +60,8 @@ docker start mui
 ```bash
 ../../../../giles/sender/sender --host 127.0.0.1:7010 \
   --file data_gen/votes.msg \ --batch-size 5 --interval 100_000_000 \
-  --messages 150000000 --binary --variable-size --repeat --ponythreads=1 --no-write
+  --messages 150000000 --binary --variable-size --repeat --ponythreads=1 \
+  --ponynoblock --no-write
 ```
 
 4. Shut down cluster once finished processing

--- a/examples/pony/celsius-kafka/README.md
+++ b/examples/pony/celsius-kafka/README.md
@@ -43,7 +43,8 @@ docker start mui
   --kafka_sink_topic test --kafka_sink_brokers 127.0.0.1 \
   --metrics 127.0.0.1:5001  --control 127.0.0.1:12500 --data 127.0.0.1:12501 \
   --kafka_sink_max_message_size 100000 --kafka_sink_max_produce_buffer_ms 10 \
-  --cluster-initializer --external 127.0.0.1:5050
+  --cluster-initializer --external 127.0.0.1:5050 --ponythreads=1 \
+  --ponynoblock
 ```
 
 `kafka_sink_max_message_size` controls maximum size of message sent to kafka in a single produce request. Kafka will return errors if this is bigger than server is configured to accept.

--- a/examples/pony/celsius/README.md
+++ b/examples/pony/celsius/README.md
@@ -42,7 +42,8 @@ docker start mui
 1. Start a listener
 
 ```bash
-../../../../giles/receiver/receiver --listen 127.0.0.1:7002 --no-write
+../../../../giles/receiver/receiver --listen 127.0.0.1:7002 --no-write \
+  --ponynoblock --ponythreads=1
 ```
 
 2. Start the application
@@ -50,7 +51,7 @@ docker start mui
 ```bash
 ./celsius --in 127.0.0.1:7010 --out 127.0.0.1:7002 --metrics 127.0.0.1:5001 \
   --control 127.0.0.1:12500 --data 127.0.0.1:12501 --external 127.0.0.1:5050 \
-  --cluster-initializer
+  --cluster-initializer --ponynoblock --ponythreads=1
 ```
 
 3. Start a sender
@@ -59,7 +60,7 @@ docker start mui
 ../../../../giles/sender/sender --host 127.0.0.1:7010 \
   --file data_gen/celsius.msg \
   --batch-size 5 --interval 100_000_000 --messages 150 --binary \
-  --variable-size --repeat --ponythreads=1 --no-write
+  --variable-size --repeat --ponythreads=1 --ponynoblock --no-write
 ```
 
 4. Shut down cluster once finished processing

--- a/examples/python/alphabet/README.md
+++ b/examples/python/alphabet/README.md
@@ -62,7 +62,7 @@ Run `machida` with `--application-module alphabet`:
 machida --application-module alphabet --in 127.0.0.1:7010 \
   --out 127.0.0.1:7002 --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 \
   --external 127.0.0.1:5050 --cluster-initializer --data 127.0.0.1:6001 \
-  --name worker-name --ponythreads=1
+  --name worker-name --ponythreads=1 --ponynoblock
 ```
 
 ### Shell 3
@@ -72,7 +72,7 @@ Send messages:
 ```bash
 ../../../giles/sender/sender --host 127.0.0.1:7010 --file votes.msg \
   --batch-size 50 --interval 10_000_000 --messages 1000000 --binary \
-  --msg-size 9 --repeat --ponythreads=1 --no-write
+  --msg-size 9 --repeat --ponythreads=1 --ponynoblock --no-write
 ```
 ## Reading the Output
 

--- a/examples/python/alphabet_partitioned/README.md
+++ b/examples/python/alphabet_partitioned/README.md
@@ -62,7 +62,7 @@ Run `machida` with `--application-module alphabet_partitioned` as an initializer
 machida --application-module alphabet_partitioned --in 127.0.0.1:7010 \
   --out 127.0.0.1:7002 --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 \
   --data 127.0.0.1:6001 --worker-count 2 --cluster-initializer \
-  --external 127.0.0.1:6002 --ponythreads=1
+  --external 127.0.0.1:6002 --ponythreads=1 --ponynoblock
 ```
 
 ### Shell 3
@@ -79,7 +79,7 @@ Run `machida` with `--application-module alphabet_partitioned` as a worker:
 ```bash
 machida --application-module alphabet_partitioned --in 127.0.0.1:7010 \
   --out 127.0.0.1:7002 --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 \
-  --name worker-2 --external 127.0.0.1:6010 --ponythreads=1
+  --name worker-2 --external 127.0.0.1:6010 --ponythreads=1 --ponynoblock
 ```
 
 ### Shell 4
@@ -89,7 +89,8 @@ Send messages:
 ```bash
 ../../../giles/sender/sender --host 127.0.0.1:7010 \
   --file votes.msg --batch-size 50 --interval 10_000_000 \
-  --messages 1000000 --binary --msg-size 9 --repeat --ponythreads=1 --no-write
+  --messages 1000000 --binary --msg-size 9 --repeat --ponythreads=1 \
+  --ponynoblock --no-write
 ```
 
 ## Shutdown

--- a/examples/python/celsius-kafka/README.md
+++ b/examples/python/celsius-kafka/README.md
@@ -101,7 +101,8 @@ machida --application-module celsius \
   --kafka_sink_topic test-out --kafka_sink_brokers 127.0.0.1:9092 \
   --kafka_sink_max_message_size 100000 --kafka_sink_max_produce_buffer_ms 10 \
   --metrics 127.0.0.1:5001 --control 127.0.0.1:12500 --data 127.0.0.1:12501 \
-  --external 127.0.0.1:5050 --cluster-initializer --ponythreads=1
+  --external 127.0.0.1:5050 --cluster-initializer --ponythreads=1 \
+  --ponynoblock 
 ```
 
 `kafka_sink_max_message_size` controls maximum size of message sent to kafka in a single produce request. Kafka will return errors if this is bigger than server is configured to accept.

--- a/examples/python/celsius/README.md
+++ b/examples/python/celsius/README.md
@@ -49,7 +49,7 @@ Run `machida` with `--application-module celsius`:
 machida --application-module celsius --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
   --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
   --name worker-name --external 127.0.0.1:5050 --cluster-initializer \
-  --ponythreads=1
+  --ponythreads=1 --ponynoblock
 ```
 
 ### Shell 3
@@ -59,8 +59,8 @@ Send messages:
 ```bash
 ../../../giles/sender/sender --host 127.0.0.1:7010 \
   --file celsius.msg --batch-size 50 --interval 10_000_000 \
-  --messages 1000000 --repeat \
-  --ponythreads=1 --binary --msg-size 8 --no-write
+  --messages 1000000 --repeat --binary --msg-size 8 --no-write \
+  --ponythreads=1 --ponynoblock 
 ```
 
 ## Reading the Output

--- a/examples/python/market_spread/README.md
+++ b/examples/python/market_spread/README.md
@@ -87,7 +87,7 @@ machida --application-module market_spread \
   --in 127.0.0.1:7010,127.0.0.1:7011 --out 127.0.0.1:7002 \
   --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
   --worker-name worker1 --external 127.0.0.1:5050 --cluster-initializer \
-  --ponythreads=1
+  --ponythreads=1 --ponynoblock 
 ```
 
 ### Shell 3
@@ -98,7 +98,7 @@ First prime the market data state with these initial messages, sent in via Giles
 ../../../giles/sender/sender --host 127.0.0.1:7011 --file \
   ../../../testing/data/market_spread/nbbo/350-symbols_initial-nbbo-fixish.msg \
   --batch-size 20 --interval 100_000_000 --messages 350 --binary \
-  --ponythreads=1 --msg-size 46 --no-write
+  --ponythreads=1 --ponynoblock --msg-size 46 --no-write
 ```
 
 ### Shell 4
@@ -109,7 +109,7 @@ To send market messages, run this command:
 ../../../giles/sender/sender --host 127.0.0.1:7011 --file \
   ../../../testing/data/market_spread/nbbo/350-symbols_nbbo-fixish.msg \
   --batch-size 20 --interval 100_000_000 --messages 1000000 --binary \
-  --repeat --ponythreads=1 --msg-size 46 --no-write
+  --repeat --ponythreads=1 --ponynoblock --msg-size 46 --no-write
 ```
 
 Once you've started sending Market messages, go to the next section to start sending order messages.
@@ -122,7 +122,7 @@ To send order messages, run this command:
 ../../../giles/sender/sender --host 127.0.0.1:7010 --file \
   ../../../testing/data/market_spread/orders/350-symbols_orders-fixish.msg \
   --batch-size 20 --interval 100_000_000 --messages 1000000 --binary \
-  --repeat --ponythreads=1 --msg-size 57 --no-write
+  --repeat --ponythreads=1 --ponynoblock --msg-size 57 --no-write
 ```
 
 ## Shutdown

--- a/examples/python/reverse/README.md
+++ b/examples/python/reverse/README.md
@@ -55,7 +55,7 @@ Run `machida` with `--application-module reverse`:
 machida --application-module reverse --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
   --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
   --name worker-name --external 127.0.0.1:5050 --cluster-initializer \
-  --ponythreads=1
+  --ponythreads=1 --ponynoblock 
 ```
 
 ### Shell 3
@@ -65,7 +65,7 @@ Send some messages:
 ```bash
 ../../../giles/sender/sender --host 127.0.0.1:7010 --file words.txt \
   --batch-size 5 --interval 100_000_000 --messages 150 --repeat \
-  --ponythreads=1 --no-write
+  --ponythreads=1 --ponynoblock --no-write
 ```
 
 ## Reading the Output

--- a/examples/python/word_count/README.md
+++ b/examples/python/word_count/README.md
@@ -53,7 +53,7 @@ Run `machida` with `--application-module word_count`:
 machida --application-module word_count --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
   --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
   --name worker-name --external 127.0.0.1:5050 --cluster-initializer \
-  --ponythreads=1
+  --ponythreads=1 --ponynoblock 
 ```
 
 ### Shell 3
@@ -63,7 +63,7 @@ In a third shell, send some messages:
 ```bash
 ../../../giles/sender/sender --host 127.0.0.1:7010 --file count_this.txt \
   --batch-size 5 --interval 100_000_000 --messages 10000000 \
-  --ponythreads=1 --repeat --no-write
+  --ponythreads=1 --ponynoblock --repeat --no-write
 ```
 
 ## Reading the Output


### PR DESCRIPTION
We get really bad performance when we don't use `--ponynoblock`. Many
examples were missing that flag. This commit also adds missing
`--ponythreads=1` to applications that were missing.

[skip ci]