### PR TITLE
Fix memory leak observed in #1612

### DIFF
--- a/lib/wallaroo/core/topology/runner.pony
+++ b/lib/wallaroo/core/topology/runner.pony
@@ -667,7 +667,6 @@ class StateRunner[S: State ref] is (Runner & ReplayableRunner &
     _event_log = event_log
     _id = None
     _auth = auth
-    _wb.reserve(8)
 
   fun ref set_step_id(id: U128) =>
     _id = id
@@ -737,7 +736,6 @@ class StateRunner[S: State ref] is (Runner & ReplayableRunner &
         ifdef "resilience" then
           sc.write_log_entry(_wb)
           let payload = _wb.done()
-          _wb.reserve(8)
           match _id
           | let buffer_id: U128 =>
             _event_log.queue_log_entry(buffer_id, i_msg_uid, frac_ids,
@@ -755,7 +753,6 @@ class StateRunner[S: State ref] is (Runner & ReplayableRunner &
           | let buffer_id: U128 =>
             _state.write_log_entry(_wb, _auth)
             let payload = _wb.done()
-            _wb.reserve(8)
             _event_log.queue_log_entry(buffer_id, i_msg_uid, frac_ids,
               U64.max_value(), producer.current_sequence_id(), consume payload)
           end


### PR DESCRIPTION
See #1612 for the initial bug report.  The calls to `reserve` were added to combat file corruption, see https://github.com/WallarooLabs/wallaroo/issues/1612#issuecomment-333893592.  

I'm not sure that the files are not also corrupted by this PR.  Do not merge until we can confirm.
