### PR TITLE
Make WordCount in Python word count inherit from object

### DIFF
--- a/examples/python/word_count/word_count.py
+++ b/examples/python/word_count/word_count.py
@@ -53,7 +53,7 @@ class Split(object):
         return words
 
 
-class CountWord():
+class CountWord(object):
     def name(self):
         return "Count Word"
 


### PR DESCRIPTION
The `WordCount` class now inherits from the `object` class. This was
not causing any problems, but it was inconsistent with the way the
rest of the classes are created, and it violates the best practice
which says to always use new-style classes.

This issue was pointed out in a comment to https://vimeo.com/234753585

Fixes #1623