### PR TITLE
Uses long arguments for all Wallaroo Labs commands

### DIFF
--- a/book/getting-started/run-a-wallaroo-application.md
+++ b/book/getting-started/run-a-wallaroo-application.md
@@ -52,7 +52,7 @@ We'll use Giles Receiver to listen for data from our Wallaroo application.
 
 ```bash
 cd ~/wallaroo-tutorial/wallaroo/giles/receiver
-./receiver -l 127.0.0.1:5555 --no-write --ponythreads=1 --ponynoblock
+./receiver --listen 127.0.0.1:5555 --no-write --ponythreads=1 --ponynoblock
 ```
 
 You should see the `Listening for data` that indicates that Giles receiver is running.

--- a/book/wallaroo-tools/giles-receiver.md
+++ b/book/wallaroo-tools/giles-receiver.md
@@ -4,9 +4,9 @@
 
 Giles components act as external testers for Wallaroo. Giles Receiver is used to mimic the behavior of an external sink for outgoing data from Wallaroo. Giles Receiver has the option to run in one of two ways:
 
-- With no other commandline options given, it will write incoming binary data to file, preceded by a timestamp of when the message was received. For example, `./giles/receiver -l 127.0.0.1:5555` will write any data received on port 5555.
+- With no other commandline options given, it will write incoming binary data to file, preceded by a timestamp of when the message was received. For example, `./giles/receiver --listen 127.0.0.1:5555` will write any data received on port 5555.
 
-- With the `--no-write/-w` flag given as a commandline argument, it will drop all incoming binary data and not write to file. For example, `./giles/receiver -l 127.0.0.1:5555 -w` will receive and drop any data received on port 5555.
+- With the `--no-write/-w` flag given as a commandline argument, it will drop all incoming binary data and not write to file. For example, `./giles/receiver --listen 127.0.0.1:5555 --no-write` will receive and drop any data received on port 5555.
 
 ### Building `giles/receiver`
 
@@ -37,7 +37,7 @@ make
 ### Listen for Wallaroo output and save to `received.txt`
 
 ```bash
-receiver --listen 127.0.0.1:5555 --ponythreads=1 --ponynoblock 
+receiver --listen 127.0.0.1:5555 --ponythreads=1 --ponynoblock
 ```
 
 ### Listen for Wallaroo output, but don't save anything (e.g. "A Very Fast Sink Receiver")
@@ -45,7 +45,7 @@ receiver --listen 127.0.0.1:5555 --ponythreads=1 --ponynoblock
 If you just want your application to run as fast as possible without spending any resources on _saving output data_, use
 
 ```bash
-receiver --listen 127.0.0.1:5555 --no-write --ponythreads=1 --ponynoblock 
+receiver --listen 127.0.0.1:5555 --no-write --ponythreads=1 --ponynoblock
 ```
 
 ## Pony Runtime Options

--- a/book/wallaroo-tools/giles-sender.md
+++ b/book/wallaroo-tools/giles-sender.md
@@ -4,10 +4,10 @@
 
 Giles components act as external testers for Wallaroo. Giles Sender is used to mimic the behavior of an incoming data source. Giles Sender sends data to Wallaroo in one of four ways:
 
-- With no other commandline options given, it will send string representations of integers, starting with `1` and increasing by `1` with each new message. For example, `./giles/sender -h 127.0.0.1:8081 -m 100` will send messages containing string representations of the numbers `1` through `100`.
-- With a file name given as the `--file/-f` argument it will send each line of the given file as a message. For example, `./giles/sender -h 127.0.0.1:8081 -m 100 -f war-and-peace.txt` will send messages containing each of the first 100 lines of the file `war-and-peace.txt`.
-- With a file name given as the `--file/-f` argument and binary format specified with `--binary/-y` and every message is 24 bytes, specified with `--msg-size/-g`, it will send every 24 bytes of the given file as a message. For example, `./giles/sender -h 127.0.0.1:8081 -m 100 -f binary-data-file.txt -y -g 24` will send every 24 bytes until it has sent 100 messages
-- With a file name given as the `--file/-f` argument and binary format specified with `--binary/-y` and variable message lengths specified with `--variable-size/-z`, it will read 4 bytes to get the message size, send that message and repeat. For example, `./giles/sender  127.0.0.1:8081 -m 100 -f binary-data-file.txt -y -z` will initially read a 4 byte header, send that message and repeat until it has sent 100 messages.
+- With no other commandline options given, it will send string representations of integers, starting with `1` and increasing by `1` with each new message. For example, `./giles/sender --host 127.0.0.1:8081 --messages 100` will send messages containing string representations of the numbers `1` through `100`.
+- With a file name given as the `--file/-f` argument it will send each line of the given file as a message. For example, `./giles/sender --host 127.0.0.1:8081 --messages 100 --file war-and-peace.txt` will send messages containing each of the first 100 lines of the file `war-and-peace.txt`.
+- With a file name given as the `--file/-f` argument and binary format specified with `--binary/-y` and every message is 24 bytes, specified with `--msg-size/-g`, it will send every 24 bytes of the given file as a message. For example, `./giles/sender --host 127.0.0.1:8081 --messages 100 --file binary-data-file.txt --binary --msg-size 24` will send every 24 bytes until it has sent 100 messages
+- With a file name given as the `--file/-f` argument and binary format specified with `--binary/-y` and variable message lengths specified with `--variable-size/-z`, it will read 4 bytes to get the message size, send that message and repeat. For example, `./giles/sender --host 127.0.0.1:8081 --messages 100 --file binary-data-file.txt --binary --variable-size` will initially read a 4 byte header, send that message and repeat until it has sent 100 messages.
 
 ### Building `giles/sender`
 
@@ -130,7 +130,7 @@ To concatenate the files, in order, use
 
 ```bash
 sender --host 127.0.0.1:7000 --file=file1,file2 --messages=100 --batch-size=1 \
-  --interval=10_000_000 --no-write --ponythreads=1 --ponynoblock 
+  --interval=10_000_000 --no-write --ponythreads=1 --ponynoblock
 ```
 
 To send the contents of the first file twice, then the contents of the second file once, use
@@ -138,7 +138,7 @@ To send the contents of the first file twice, then the contents of the second fi
 ```bash
 sender --host 127.0.0.1:7000 --file=file1,file1,file2 --messages=100 \
   --batch-size=1 --interval=10_000_000 --no-write \
-  --ponythreads=1 --ponynoblock 
+  --ponythreads=1 --ponynoblock
 ```
 
 Multiple input files are also supported for binary input, but they must all be either fixed length or variable length.
@@ -151,7 +151,7 @@ To send the sequence `'1', '2', '3', ..., '100'`
 Use
 
 ```bash
-sender --host 127.0.0.1:7000 --messages 100 --ponythreads=1 --ponynoblock 
+sender --host 127.0.0.1:7000 --messages 100 --ponythreads=1 --ponynoblock
 ```
 
 ### Send a sequence of numbers, encoded as big-endian U64
@@ -162,7 +162,7 @@ Use
 
 ```bash
 sender --host 127.0.0.1:7000 --messages 100 --u64 \
-  --ponythreads=1 --ponynoblock 
+  --ponythreads=1 --ponynoblock
 ```
 
 To send the sequence `101,102,...,200`
@@ -171,7 +171,7 @@ Use
 
 ```bash
 sender --host 127.0.0.1:7000 --messages 100 --u64 --start-from 100 \
-  --ponythreads=1 --ponynoblock 
+  --ponythreads=1 --ponynoblock
 ```
 
 ## Preparing Data Files for Giles Sender


### PR DESCRIPTION
This changes all of the commands that run WallarooLabs programs to use
long arguments. Using long arguments instead of short arguments will
make it easier for users to understand what the commands are doing.

Fixes #1629

[skip ci]