### PR TITLE
Clarify setup for those who have already done some steps

### DIFF
--- a/book/getting-started/linux-setup.md
+++ b/book/getting-started/linux-setup.md
@@ -198,7 +198,7 @@ sudo docker pull wallaroolabs/wallaroo-metrics-ui:0.1
 
 ## Set up Environment for the Wallaroo Tutorial
 
-Create a directory called `~/wallaroo-tutorial` and navigate there by running
+If you haven't already done so, create a directory called `~/wallaroo-tutorial` and navigate there by running
 
 ```bash
 cd ~/

--- a/book/getting-started/macos-setup.md
+++ b/book/getting-started/macos-setup.md
@@ -105,7 +105,7 @@ docker pull wallaroolabs/wallaroo-metrics-ui:0.1
 
 ## Set up Environment for the Wallaroo Tutorial
 
-Create a directory called `~/wallaroo-tutorial` and navigate there by running
+If you haven't already done so, create a directory called `~/wallaroo-tutorial` and navigate there by running
 
 ```bash
 cd ~/


### PR DESCRIPTION
Add some text to the Linux and Mac setup documentation to make it
clear that the user can skip part of the setup instructions if they
have already done them.

Old: "Create a directory called `~/wallaroo-tutorial` and navigate
there by running"

New: "If you haven't already done so, create a directory called
`~/wallaroo-tutorial` and navigate there by running"

This should prevent confusion by people who, for whatever reason, have
already done these steps.

Fixes #1422

[skip ci]