### PR TITLE
reword to remove "obvious"

### DIFF
--- a/book/appendix/decoding-giles-receiver-output.md
+++ b/book/appendix/decoding-giles-receiver-output.md
@@ -2,7 +2,7 @@
 
 Since Giles-Receiver is designed to be a fast sink receiver, it doesn't decode the data it receives from Wallaroo, but instead saves as frame encoded binary data.
 
-As the obvious next step is for a user to want to consume this data, we also provide [Fallor](https://github.com/WallarooLabs/wallaroo/tree/{{ book.wallaroo_version }}/testing/tools/fallor) to decode this data.
+At some point, you will want to consume this data. [Fallor](https://github.com/WallarooLabs/wallaroo/tree/{{ book.wallaroo_version }}/testing/tools/fallor) allows you decode the frame encoded data to text.
 
 ## Fallor Command-Line Options
 


### PR DESCRIPTION
Rewords a statement in the Giles description so that it doesn't use the work "obvious". Fixes #1573 

I also did a grep, and the other 3 places "obvious" shows up use the negative sense ("this is not obvious"), so not problems there.

Just read the Go Python, Go! post on your blog. Seems like a cool project. Also like that you have it under an Apache license 👍 Figured I'd dip my toe in the water with a documentation PR 😁 