### PR TITLE
Drop metrics messages when not connected

### DIFF
--- a/lib/wallaroo/core/metrics/reconnecting_metrics_sink.pony
+++ b/lib/wallaroo/core/metrics/reconnecting_metrics_sink.pony
@@ -163,16 +163,6 @@ actor ReconnectingMetricsSink
       from.cstring())
     _notify_connecting()
 
-  be write(data: ByteSeq) =>
-    """
-    Write a single sequence of bytes.
-    """
-    if not _closed then
-      _in_sent = true
-      write_final(_notify.sent(this, data))
-      _in_sent = false
-    end
-
   be queue(data: ByteSeq) =>
     """
     Queue a single sequence of bytes on linux.
@@ -208,7 +198,7 @@ actor ReconnectingMetricsSink
     Write a sequence of sequences of bytes.
     """
 
-    if not _closed then
+    if not _closed and _connected then
       _in_sent = true
 
       ifdef windows then


### PR DESCRIPTION
Prior to this change, we infinitely queued metrics messages if we
weren't connected to a metrics receiving source. This would cause large
amounts of never ending memory growth. Our previous strategy was to shed
load, at some point that got accidentally changed to "queue if you've
never connected" and "shed load if at some point connected but not now".

This change causes metrics messages to always be shed if not connected.