### PR TITLE
Explicity state that cluster_shutdown should be run in a new terminal window

### DIFF
--- a/book/getting-started/run-a-wallaroo-application.md
+++ b/book/getting-started/run-a-wallaroo-application.md
@@ -122,6 +122,8 @@ Feel free to click around and get a feel for how the Metrics UI is setup and how
 
 ## Shutdown
 
+### Terminal 5, Cluster Shutdown
+
 You can shut down the cluster with this command once processing has finished:
 
 ```bash


### PR DESCRIPTION
This removes the potential  error that might be caused by the user accidentally
closing Wallaroo in order to run the cluster shutdown tool.

Fixes #1646

[skip ci]