### PR TITLE
Fix join message sending bug

### DIFF
--- a/lib/wallaroo/ent/network/control_channel_tcp.pony
+++ b/lib/wallaroo/ent/network/control_channel_tcp.pony
@@ -355,6 +355,13 @@ class JoiningControlSenderConnectNotifier is TCPConnectionNotify
     _startup = startup
 
   fun ref connected(conn: TCPConnection ref) =>
+    try
+      let cluster_join_msg =
+        ChannelMsgEncoder.join_cluster(_worker_name, _auth)?
+      conn.writev(cluster_join_msg)
+    else
+      Fail()
+    end
     conn.expect(4)
     _header = true
 

--- a/lib/wallaroo/startup.pony
+++ b/lib/wallaroo/startup.pony
@@ -176,9 +176,6 @@ actor Startup
         let control_conn: TCPConnection =
           TCPConnection(auth, consume control_notifier, j_addr(0)?, j_addr(1)?)
         _disposables.set(control_conn)
-        let cluster_join_msg =
-          ChannelMsgEncoder.join_cluster(_startup_options.worker_name, auth)?
-        control_conn.writev(cluster_join_msg)
         @printf[I32]("Attempting to join cluster...\n".cstring())
         // This only exists to keep joining worker alive while it waits for
         // cluster information.


### PR DESCRIPTION
We were writing the join message on worker join to
the TCPConnection before it was connected and the
data was being lost.  We now wait until we know there's
a connection before writing.

Closes #1657.