### PR TITLE
Updates dependency versions in MonHub README

### DIFF
--- a/monitoring_hub/README.md
+++ b/monitoring_hub/README.md
@@ -3,8 +3,8 @@ An umbrella application containing shared utils and different UI components
 
 ## Shared Dependency Installation Guide
 ### Depends on:
-	1. Erlang 18.0 >
-	2. Elixir 1.2.0
+	1. Erlang 18.x
+	2. Elixir 1.2.x
 	3. Node 4.2.2
 		- Node-Sass
 		- Browserify


### PR DESCRIPTION
Previously, we incorrectly stated that Erlang 18 or greater could be used to
build the MonHub. The MonHub needs to be built with Erlang 18 to avoid deprecation
warnings and it incompatible with Erlang 20.

This is also a test to verify the changelog hook works as expected.

[skip ci]