### PR TITLE
Create ProxyRouters to all required steps during initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Wallaroo will be documented in this file.
 
 ### Fixed
 
+- Create ProxyRouters to all required steps during initialization
+
 ### Added
 
 ### Changed

--- a/lib/wallaroo/core/initialization/local_topology.pony
+++ b/lib/wallaroo/core/initialization/local_topology.pony
@@ -1232,6 +1232,21 @@ actor LocalTopologyInitializer is LayoutInitializer
           end
         end
 
+        //////////////
+        // Create ProxyRouters to all non-state steps in the
+        // topology that we haven't yet created routers to
+        for (tid, target) in t.step_map().pairs() do
+          if not built_routers.contains(tid) then
+            match target
+            | let pa: ProxyAddress val =>
+              if pa.worker != _worker_name then
+                built_routers(tid) = ProxyRouter(pa.worker,
+                  _outgoing_boundaries(pa.worker)?, pa, _auth)
+              end
+            end
+          end
+        end
+
         /////
         // Register pre state target routes on corresponding state steps
         for psd in t.pre_state_data().values() do

--- a/testing/correctness/topology_layouts/apps/single_stream/partitioned/state_partition_state_partition_app/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/partitioned/state_partition_state_partition_app/Makefile
@@ -55,12 +55,7 @@ single_stream_partitioned_state_partition_state_partition_app_test:
 	--command './state_partition_state_partition_app' \
 	--sink-expect 100
 
-# Multi-worker tests currently fail:
-# Error initializing local topology
-# This should never happen: failure in lib/wallaroo/initialization/local_topology.pony at line 1236
-# See Issue: 947
-
-#integration-tests-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_state_partition_app: two_worker_single_stream_partitioned_state_partition_state_partition_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_state_partition_app: two_worker_single_stream_partitioned_state_partition_state_partition_app_test
 
 two_worker_single_stream_partitioned_state_partition_state_partition_app_test:
 	cd $(SINGLE_STREAM_PARTITIONED_STATE_PARTITION_STATE_PARTITION_APP_PATH) && \
@@ -73,7 +68,7 @@ two_worker_single_stream_partitioned_state_partition_state_partition_app_test:
 	--command './state_partition_state_partition_app' \
 	--sink-expect 100
 
-#integration-tests-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_state_partition_app: three_worker_single_stream_partitioned_state_partition_state_partition_app_test
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-partitioned-state_partition_state_partition_app: three_worker_single_stream_partitioned_state_partition_state_partition_app_test
 
 three_worker_single_stream_partitioned_state_partition_state_partition_app_test:
 	cd $(SINGLE_STREAM_PARTITIONED_STATE_PARTITION_STATE_PARTITION_APP_PATH) && \


### PR DESCRIPTION
During local topology initialization, we were not formerly creating
ProxyRouters to all potential target steps for state computation
outputs destined for other workers. This fixes that and in the
process fixes a bug around chaining state partitions in multiworker
setups.  The relevant layout topology test has also been enabled.

Closes #1668