### PR TITLE
Add missing 'return' keyword in KafkaSourceConfigFactory sanity check

### DIFF
--- a/lib/wallaroo/core/source/kafka_source/kafka_source_config.pony
+++ b/lib/wallaroo/core/source/kafka_source/kafka_source_config.pony
@@ -50,7 +50,7 @@ primitive KafkaSourceConfigFactory
       end
 
     if (kafka_brokers.size() == 0) or (kafka_topic == "") then
-      KafkaSourceConfigError("Error! Either brokers is empty or topics is empty!")
+      return KafkaSourceConfigError("Error! Either brokers is empty or topics is empty!")
     end
 
     recover


### PR DESCRIPTION
I overlooked this small bugfix from a TODO list last month: a sanity check in KafkaSourceConfigFactory omitted a `return` keyword.

Fixes #1582 
