### PR TITLE
Update in-line code examples in `book/python` to match latest API

### DIFF
--- a/book/python/writing-your-own-application.md
+++ b/book/python/writing-your-own-application.md
@@ -89,11 +89,11 @@ An application is constructed of pipelines which, in turn, are constructed from 
 
 ```python
 ab = wallaroo.ApplicationBuilder("Reverse Word")
-ab.new_pipeline("reverse", Decoder(),
-    wallaroo.TCPSourceConfig("localhost", "7002"))
+ab.new_pipeline("reverse",
+                wallaroo.TCPSourceConfig("localhost", "7002", Decoder()))
 ```
 
-Since each pipeline must have a source, it must also have a source decoder. So `new_pipeline` takes a name and a `Decoder` instance as its arguments.
+Each pipeline must have a source, and each source must have a decoder, so `new_pipeline` takes a name and a `TCPSourceConfig` instance as its arguments.
 
 Next, we add the computation step:
 
@@ -101,10 +101,10 @@ Next, we add the computation step:
 ab.to(Reverse)
 ```
 
-And finally, we add the sink along with an encoder:
+And finally, we add the sink, using a `TCPSinkConfig`:
 
 ```python
-ab.to_sink(Encoder(), wallaroo.TCPSinkConfig("localhost", "7010"))
+ab.to_sink(wallaroo.TCPSinkConfig("localhost", "7010", Encoder()))
 ```
 
 ### The `application_setup` Entry Point
@@ -117,11 +117,10 @@ def application_setup(args):
     out_host, out_port = wallaroo.tcp_parse_output_addrs(args)[0]
 
     ab = wallaroo.ApplicationBuilder("Reverse Word")
-    ab.new_pipeline("reverse", Decoder(),
-                    wallaroo.TCPSourceConfig(in_host, in_port))
+    ab.new_pipeline("reverse",
+                    wallaroo.TCPSourceConfig(in_host, in_port, Decoder()))
     ab.to(Reverse)
-    ab.to_sink(Encoder(),
-               wallaroo.TCPSinkConfig(out_host, out_port))
+    ab.to_sink(wallaroo.TCPSinkConfig(out_host, out_port, Encoder()))
     return ab.build()
 ```
 

--- a/book/python/writing-your-own-partitioned-stateful-application.md
+++ b/book/python/writing-your-own-partitioned-stateful-application.md
@@ -89,12 +89,11 @@ def application_setup(args):
 
     letter_partitions = list(string.ascii_lowercase)
     ab = wallaroo.ApplicationBuilder("alphabet")
-    ab.new_pipeline("alphabet", Decoder(),
-                    wallaroo.TCPSourceConfig(in_host, in_port))
+    ab.new_pipeline("alphabet",
+                    wallaroo.TCPSourceConfig(in_host, in_port, Decoder()))
     ab.to_state_partition(AddVotes(), LetterStateBuilder(), "letter state",
                           LetterPartitionFunction(), letter_partitions)
-    ab.to_sink(Encoder(),
-               wallaroo.TCPSinkConfig(out_host, out_port))
+    ab.to_sink(wallaroo.TCPSinkConfig(out_host, out_port, Encoder()))
     return ab.build()
 ```
 

--- a/book/python/writing-your-own-stateful-application.md
+++ b/book/python/writing-your-own-stateful-application.md
@@ -118,11 +118,10 @@ def application_setup(args):
     out_host, out_port = wallaroo.tcp_parse_output_addrs(args)[0]
 
     ab = wallaroo.ApplicationBuilder("alphabet")
-    ab.new_pipeline("alphabet", Decoder(),
-                    wallaroo.TCPSourceConfig(in_host, in_port))
+    ab.new_pipeline("alphabet",
+                    wallaroo.TCPSourceConfig(in_host, in_port, Decoder()))
     ab.to_stateful(AddVotes(), LetterStateBuilder(), "letter state")
-    ab.to_sink(Encoder(),
-               wallaroo.TCPSinkConfig(out_host, out_port))
+    ab.to_sink(wallaroo.TCPSinkConfig(out_host, out_port, Encoder()))
     return ab.build()
 ```
 

--- a/machida/wallaroo.py
+++ b/machida/wallaroo.py
@@ -106,16 +106,6 @@ class ApplicationBuilder(object):
 
 
 class TCPSourceConfig(object):
-    def __init__(self, host, port, encoder):
-        self._host = host
-        self._port = port
-        self._encoder = encoder
-
-    def to_tuple(self):
-        return ("tcp", self._host, self._port, self._encoder)
-
-
-class TCPSinkConfig(object):
     def __init__(self, host, port, decoder):
         self._host = host
         self._port = port
@@ -123,6 +113,16 @@ class TCPSinkConfig(object):
 
     def to_tuple(self):
         return ("tcp", self._host, self._port, self._decoder)
+
+
+class TCPSinkConfig(object):
+    def __init__(self, host, port, encoder):
+        self._host = host
+        self._port = port
+        self._encoder = encoder
+
+    def to_tuple(self):
+        return ("tcp", self._host, self._port, self._encoder)
 
 
 class KafkaSourceConfig(object):


### PR DESCRIPTION
The usage of `new_pipeline`, `to_sink`, `TCPSourceConfig` and `TCPSinkConfig` in the in-line code sections in the python section of the book is outdated, and doesn't work with our current release version.

This PR:
- updates the usage to match our current API
- corrects a naming error in the `wallaroo.py` API (this is opaque to users)

## Testing:
In addition to the CI tests, testing of the documentation changes should be done manually, by copying the code from the in-line code examples in the documentation and running it.

closes #1690 