### PR TITLE
Update d3 dependency for Metrics UI and Market Spread Reports UI

### DIFF
--- a/monitoring_hub/apps/market_spread_reports_ui/package.json
+++ b/monitoring_hub/apps/market_spread_reports_ui/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "accounting": "^0.4.1",
     "babel-jest": "^5.3.0",
-    "d3": "jtfmumm/d3",
+    "d3": "wallaroolabs/d3",
     "express": "^4.13.3",
     "flux": "^2.1.1",
     "history": "^1.12.6",

--- a/monitoring_hub/apps/metrics_reporter_ui/package.json
+++ b/monitoring_hub/apps/metrics_reporter_ui/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "accounting": "^0.4.1",
     "babel-jest": "^5.3.0",
-    "d3": "jtfmumm/d3",
+    "d3": "wallaroolabs/d3",
     "express": "^4.13.3",
     "flux": "^2.1.1",
     "history": "^1.12.6",


### PR DESCRIPTION
Both the Metrics UI and Market Spread Reports UI depended on a fork
of d3 hosted by jtfmumm. This has been moved to the WallarooLabs
github account and the relevant pacakge.json files have been updated.
This fork is needed due to the addition of handling Immutable.js lists
in several function calls.

This was opened to verify CI passes, review is not needed. Merging if CI passes.