### PR TITLE
Add check for MacOS version, for python headers

### DIFF
--- a/machida/cpp/python-wallaroo.c
+++ b/machida/cpp/python-wallaroo.c
@@ -17,7 +17,11 @@ Copyright 2017 The Wallaroo Authors.
 */
 
 #ifdef __APPLE__
-    #include <Python/Python.h>
+    #if MAC_OS_X_VERSION_MAX_ALLOWED < 101300
+        #include <Python/Python.h>
+    #else
+        #include <Python2.7/Python.h>
+    #endif
 #else
     #include <python2.7/Python.h>
 #endif


### PR DESCRIPTION
In MacOS >= 10.13, the Python C headers have moved. This check addresses the
issue by using the MAC_OS_X_VERSION_MAX_ALLOWED build flag.