### PR TITLE
Update book-python-write-your-own-stateful code

### DIFF
--- a/book/python/writing-your-own-stateful-application.md
+++ b/book/python/writing-your-own-stateful-application.md
@@ -88,7 +88,7 @@ The encoder is going to receive a `Votes` instance and encode into a string with
 class Encoder(object):
     def encode(self, data):
         # data is a Votes
-        return struct.pack(">LsQ", 5, data.letter, data.votes)
+        return struct.pack(">IsQ", 9, data.letter, data.votes)
 ```
 
 ### Decoder
@@ -101,10 +101,10 @@ class Decoder(object):
         return 4
 
     def payload_length(self, bs):
-        return struct.unpack(">L", bs)[0]
+        return struct.unpack(">I", bs)[0]
 
     def decode(self, bs):
-        (letter, vote_count) = struct.unpack(">sL", bs)
+        (letter, vote_count) = struct.unpack(">sI", bs)
         return Votes(letter, vote_count)
 ```
 


### PR DESCRIPTION
Code in writing-your-own-stateful-application.md is updated to match
code in examples/python/alphabet/alphabet.py

[skip ci]

closes #1417