### PR TITLE
Shutdown cluster cleanly when SIGTERM or SIGINT is received

### DIFF
--- a/machida/main.pony
+++ b/machida/main.pony
@@ -33,7 +33,7 @@ actor Main
     Machida.start_python()
 
     try
-      SignalHandler(ShutdownHandler, Sig.int())
+      SignalHandler(MachidaShutdownHandler, Sig.int())
 
       var module_name: String = ""
 

--- a/machida/signal_handling.pony
+++ b/machida/signal_handling.pony
@@ -20,7 +20,7 @@ use "signals"
 
 use @Py_Exit[None]()
 
-class iso ShutdownHandler is SignalNotify
+class iso MachidaShutdownHandler is SignalNotify
   fun ref apply(count: U32): Bool =>
     @Py_Exit()
     false

--- a/testing/correctness/tests/log_rotation/log_rotation.py
+++ b/testing/correctness/tests/log_rotation/log_rotation.py
@@ -14,8 +14,7 @@
 
 
 # import requisite components for integration test
-from integration import (clean_up_resilience_path,
-                         ex_validate,
+from integration import (ex_validate,
                          get_port_values,
                          Metrics,
                          Reader,
@@ -195,7 +194,6 @@ def _test_log_rotation_external_trigger_no_recovery(command):
     finally:
         for r in runners:
             r.stop()
-        clean_up_resilience_path(res_dir)
 
 
 def test_log_rotation_external_trigger_recovery_pony():
@@ -286,8 +284,9 @@ def _test_log_rotation_external_trigger_recovery(command):
         if log_rotated_checker.error:
             raise log_rotated_checker.error
 
-        # stop worker
-        runners[-1].stop()
+        # stop worker in a non-graceful fashion so that recovery files
+        # aren't removed
+        runners[-1].kill()
 
         ## restart worker
         runners.append(runners[-1].respawn())
@@ -374,7 +373,6 @@ def _test_log_rotation_external_trigger_recovery(command):
     finally:
         for r in runners:
             r.stop()
-        clean_up_resilience_path(res_dir)
 
 
 def test_log_rotation_file_size_trigger_no_recovery_pony():
@@ -513,7 +511,6 @@ def _test_log_rotation_file_size_trigger_no_recovery(command):
     finally:
         for r in runners:
             r.stop()
-        clean_up_resilience_path(res_dir)
 
 
 def test_log_rotation_file_size_trigger_recovery_pony():
@@ -594,8 +591,9 @@ def _test_log_rotation_file_size_trigger_recovery(command):
         if log_rotated_checker.error:
             raise log_rotated_checker.error
 
-        # stop worker
-        runners[-1].stop()
+        # stop the worker in a non-graceful fashion so it doesn't remove
+        # recovery files
+        runners[-1].kill()
 
         ## restart worker
         runners.append(runners[-1].respawn())
@@ -680,4 +678,3 @@ def _test_log_rotation_file_size_trigger_recovery(command):
     finally:
         for r in runners:
             r.stop()
-        clean_up_resilience_path(res_dir)

--- a/testing/correctness/tests/recovery/recovery.py
+++ b/testing/correctness/tests/recovery/recovery.py
@@ -14,8 +14,7 @@
 
 
 # import requisite components for integration test
-from integration import (clean_up_resilience_path,
-                         ex_validate,
+from integration import (ex_validate,
                          get_port_values,
                          Metrics,
                          Reader,
@@ -97,8 +96,8 @@ def _test_recovery(command):
         sender.start()
         time.sleep(0.2)
 
-        # stop worker
-        runners[-1].stop()
+        # simulate worker crash by doing a non-graceful shutdown
+        runners[-1].kill()
 
         ## restart worker
         runners.append(runners[-1].respawn())
@@ -164,4 +163,3 @@ def _test_recovery(command):
     finally:
         for r in runners:
             r.stop()
-        clean_up_resilience_path(res_dir)

--- a/testing/correctness/tests/restart_without_resilience/restart_without_resilience.py
+++ b/testing/correctness/tests/restart_without_resilience/restart_without_resilience.py
@@ -14,8 +14,7 @@
 
 
 # import requisite components for integration test
-from integration import (clean_up_resilience_path,
-                         ex_validate,
+from integration import (ex_validate,
                          get_port_values,
                          Metrics,
                          Reader,
@@ -97,8 +96,9 @@ def _test_restart(command):
         sender.start()
         time.sleep(0.2)
 
-        # stop worker
-        runners[-1].stop()
+        # stop worker in a non-graceful fashion so that recovery files
+        # aren't removed
+        runners[-1].kill()
 
         ## restart worker
         runners.append(runners[-1].respawn())
@@ -147,4 +147,3 @@ def _test_restart(command):
     finally:
         for r in runners:
             r.stop()
-        clean_up_resilience_path(res_dir)

--- a/testing/tools/integration/__init__.py
+++ b/testing/tools/integration/__init__.py
@@ -64,8 +64,7 @@ Alternatively, for a CLI style integration tester, you may use the
 """
 
 
-from integration import (clean_up_resilience_path,
-                         ex_validate,
+from integration import (ex_validate,
                          files_generator,
                          get_port_values,
                          is_address_available,

--- a/testing/tools/integration/integration.py
+++ b/testing/tools/integration/integration.py
@@ -632,6 +632,12 @@ class Runner(threading.Thread):
         except:
             pass
 
+    def kill(self):
+        try:
+            self.p.kill()
+        except:
+            pass
+
     def get_output(self):
         self.stdout_file.seek(0)
         self.stderr_file.seek(0)
@@ -744,12 +750,6 @@ def setup_resilience_path(res_dir):
     # if any files are in this directory, remove them
     for f in os.listdir(res_dir):
         os.remove(os.path.join(res_dir, f))
-
-
-def clean_up_resilience_path(res_dir):
-    for f in os.listdir(res_dir):
-        os.remove(os.path.join(res_dir, f))
-    os.rmdir(res_dir)
 
 
 def is_address_available(host, port):
@@ -1143,5 +1143,4 @@ def pipeline_test(generator, expected, command, workers=1, sources=1,
         # clean up any remaining runner processes
         for r in runners:
             r.stop()
-        clean_up_resilience_path(resilience_dir)
     return [(r.name, r.get_output()) for r in runners]


### PR DESCRIPTION
Previously, if a developer working with Wallaroo sent a SIGINT via
ctrl-c in the terminal, Wallaroo would exit but wouldn't gracefully
shutdown. This could lead to errors on the next application startup as
recovery files weren't dispose of properly.

With this commit, sending SIGTERM or SIGINT will shut down Wallaroo
gracefully in the same fashion that the external "shutdown cluster"
command work.

Once we have "shrink to fit" in place, the plan would be to have SIGTERM
and SIGINT remove that individual worker from the cluster rathter than
shut the entire cluster down. Once we have shrink to fit in place, we
might change our mind and go in a different direction and leave this
functionality as is.

Closes #1701