### PR TITLE
Fix bug when chaining multiple state partitions after a stateless partition on the source

### DIFF
--- a/testing/correctness/topology_layouts/apps/single_stream/parallel_stateless_state_partition_state_partition/.gitignore
+++ b/testing/correctness/topology_layouts/apps/single_stream/parallel_stateless_state_partition_state_partition/.gitignore
@@ -1,0 +1,1 @@
+parallel_stateless_state_partition_state_partition_app

--- a/testing/correctness/topology_layouts/apps/single_stream/parallel_stateless_state_partition_state_partition/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/parallel_stateless_state_partition_state_partition/Makefile
@@ -1,0 +1,83 @@
+# include root makefile
+ifndef ROOT_MAKEFILE_MK
+include ../../../../../../Makefile
+endif
+
+# prevent rules from being evaluated/included multiple times
+ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
+$(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
+
+
+# The following are control variables that determine what logic from `rules.mk` is enabled
+
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
+
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
+
+SINGLE_STREAM_PARALLEL_STATELESS_STATE_PARTITION_PARALLEL_STATELESS_APP_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+# standard rules generation makefile
+include $(rules_mk_path)
+
+
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-parallel_stateless_state_partition_parallel_stateless_app: single_stream_parallel_stateless_state_partition_parallel_stateless_app_test
+
+single_stream_parallel_stateless_state_partition_parallel_stateless_app_test:
+	cd $(SINGLE_STREAM_PARALLEL_STATELESS_STATE_PARTITION_PARALLEL_STATELESS_APP_PATH) && \
+	integration_test \
+	--sequence-sender '(0,100]' \
+	--validation-cmd 'python validate.py --n 100 --output' \
+	--output 'received.txt' \
+	--log-level error \
+	--command './parallel_stateless_state_partition_parallel_stateless_app' \
+	--sink-expect 100
+
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-parallel_stateless_state_partition_parallel_stateless_app: two_worker_single_stream_parallel_stateless_state_partition_parallel_stateless_app_test
+
+two_worker_single_stream_parallel_stateless_state_partition_parallel_stateless_app_test:
+	cd $(SINGLE_STREAM_PARALLEL_STATELESS_STATE_PARTITION_PARALLEL_STATELESS_APP_PATH) && \
+	integration_test \
+	--sequence-sender '(0,100]' \
+	--workers 2 \
+	--validation-cmd 'python validate.py --n 100 --output' \
+	--output 'received.txt' \
+	--log-level error \
+	--command './parallel_stateless_state_partition_parallel_stateless_app' \
+	--sink-expect 100
+
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-parallel_stateless_state_partition_parallel_stateless_app: three_worker_single_stream_parallel_stateless_state_partition_parallel_stateless_app_test
+
+three_worker_single_stream_parallel_stateless_state_partition_parallel_stateless_app_test:
+	cd $(SINGLE_STREAM_PARALLEL_STATELESS_STATE_PARTITION_PARALLEL_STATELESS_APP_PATH) && \
+	integration_test \
+	--sequence-sender '(0,100]' \
+	--workers 3 \
+	--validation-cmd 'python validate.py --n 100 --output' \
+	--output 'received.txt' \
+	--log-level error \
+	--command './parallel_stateless_state_partition_parallel_stateless_app' \
+	--sink-expect 100
+
+# end of prevent rules from being evaluated/included multiple times
+endif

--- a/testing/correctness/topology_layouts/apps/single_stream/parallel_stateless_state_partition_state_partition/bundle.json
+++ b/testing/correctness/topology_layouts/apps/single_stream/parallel_stateless_state_partition_state_partition/bundle.json
@@ -1,0 +1,10 @@
+{
+  "deps": [
+    { "type": "local",
+      "local-path": "../../../../../../lib"
+    },
+    { "type": "local",
+      "local-path": "../../lib"
+    }
+  ]
+}

--- a/testing/correctness/topology_layouts/apps/single_stream/parallel_stateless_state_partition_state_partition/parallel_stateless_state_partition_state_partition_app.pony
+++ b/testing/correctness/topology_layouts/apps/single_stream/parallel_stateless_state_partition_state_partition/parallel_stateless_state_partition_state_partition_app.pony
@@ -1,0 +1,68 @@
+/*
+
+Copyright 2017 The Wallaroo Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing
+ permissions and limitations under the License.
+
+*/
+
+"""
+Topology Layout Integration Test
+
+This is a test application to verify that the following topology layout compiles and runs for 1-3 workers. The included Makefile will run an integration test with a given input and an expected output to verify results. Those tests are run as part of CI.
+
+Single Stream to Single Sink
+Single Pipeline
+Parallel Stateless Computation
+State Partition (there will be three partitions)
+Parallel Stateless Computation
+"""
+
+use "generic_app_components"
+use "wallaroo"
+use "wallaroo/core/sink/tcp_sink"
+use "wallaroo/core/source"
+use "wallaroo/core/source/tcp_source"
+use "wallaroo/core/topology"
+
+actor Main
+  new create(env: Env) =>
+    try
+      // This is basically the same as applying mod 2 before a double
+      // computation
+      let mod6partition = Partition[U64, U64](
+        Mod6PartitionFunction, recover [0; 2; 4] end)
+
+      let application = recover val
+        Application("single_stream-parallel_stateless_state_partition_state_partition_app")
+          .new_pipeline[U64, U64]("U64 Double CountAndMax CountAndMax",
+            TCPSourceConfig[U64].from_options(U64Decoder,
+              TCPSourceConfigCLIParser(env.args)?(0)?))
+            .to_parallel[U64]({(): Double => Double})
+            .to_state_partition[U64, U64, CountMax, CountAndMax](
+              UpdateCountAndMax, CountAndMaxBuilder,
+              "count-and-max",
+              mod6partition where multi_worker = true)
+            .to_state_partition[U64, U64, CountMax, CountAndMax](
+              UpdateCountAndMaxFromCountMax, CountAndMaxBuilder,
+              "count-and-max",
+              mod6partition where multi_worker = true)
+            .to_sink(TCPSinkConfig[CountMax].from_options(
+              FramedCountMaxEncoder,
+              TCPSinkConfigCLIParser(env.args)?(0)?))?
+      end
+      Startup(env, application,
+        "single_stream-parallel_stateless_state_partition_state_partition_app")
+    else
+      @printf[I32]("Couldn't build topology\n".cstring())
+    end

--- a/testing/correctness/topology_layouts/apps/single_stream/parallel_stateless_state_partition_state_partition/validate.py
+++ b/testing/correctness/topology_layouts/apps/single_stream/parallel_stateless_state_partition_state_partition/validate.py
@@ -1,0 +1,69 @@
+# Copyright 2017 The Wallaroo Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+
+import argparse
+from struct import calcsize, unpack
+
+
+fmt = '>IQQ'
+def decode(bs):
+    return unpack(fmt, bs)[1:3]
+
+
+parser = argparse.ArgumentParser('Parallel Stateless -> State Partition -> '
+                                 'State Partition validator')
+parser.add_argument('--output', type=argparse.FileType('rb'),
+                    help="The output file of the application.")
+parser.add_argument('--n', type=int,
+                    help="The final number in the sequence from 1 to n.")
+args = parser.parse_args()
+
+
+chunk_size = calcsize(fmt)
+received = []
+while True:
+    chunk = args.output.read(chunk_size)
+    if not chunk:
+        break
+    received.append(decode(chunk))
+
+# Split on partition (mod 3)
+processed = [[], [], []]
+for c,m in received:
+    processed[m % 3].append((c,m))
+# Sort on max
+processed2 = [sorted(p, key=lambda x: x[1]) for p in processed]
+# Pick last one from each
+processed3 = [p[-1] for p in processed2]
+
+# We'll just repeat the compuation to derive the correct results:
+maxes = [0, 0, 0]
+counts = [0, 0, 0]
+for v in range(1, args.n+1):
+    v2 = v * 2  # double
+    i = (v2 % 6)/2  # partition mod 6, then map (0,2,4) to (0,1,2)
+    maxes[i] = v2   # set max for partition to max/2
+    counts[i] += 1  # set count for partition
+
+expected = [(counts[i], maxes[i]) for i in range(0,3)]
+
+
+try:
+    assert(expected == processed3)
+    assert(args.n == len(received))
+except Exception as e:
+    print 'expected final output to be:\n', expected
+    print 'but received:\n', received
+    raise e


### PR DESCRIPTION
Prior to this change, we were not taking account
of having coalesced a series of computations after
a parallel stateless computation when deciding how
to handle future state partitions.  This meant that
when you chained Parallel Stateless -> State Partition ->
State Partition, the second State Partition was not
spun up correctly.

This also adds an automated layout test.

Closes #1718.