### PR TITLE
Update orchestration to use newer Ubuntu 16.04 AMI

### DIFF
--- a/orchestration/ansible/playbooks/aws.yml
+++ b/orchestration/ansible/playbooks/aws.yml
@@ -90,8 +90,16 @@
     become: yes
   - name: sysctl speed change for raid build
     sysctl:
+      name: dev.raid.speed_limit_max
+      value: 2000000000
+      state: present
+      sysctl_set: yes
+      reload: yes
+    become: yes
+  - name: sysctl speed change for raid build
+    sysctl:
       name: dev.raid.speed_limit_min
-      value: 30720
+      value: 2000000000
       state: present
       sysctl_set: yes
       reload: yes

--- a/orchestration/ansible/playbooks/packet.yml
+++ b/orchestration/ansible/playbooks/packet.yml
@@ -64,8 +64,16 @@
     become: yes
   - name: sysctl speed change for raid build
     sysctl:
+      name: dev.raid.speed_limit_max
+      value: 2000000000
+      state: present
+      sysctl_set: yes
+      reload: yes
+    become: yes
+  - name: sysctl speed change for raid build
+    sysctl:
       name: dev.raid.speed_limit_min
-      value: 30720
+      value: 2000000000
       state: present
       sysctl_set: yes
       reload: yes

--- a/orchestration/ansible/playbooks/roles/atlassian.ixgbevf/tasks/install.yml
+++ b/orchestration/ansible/playbooks/roles/atlassian.ixgbevf/tasks/install.yml
@@ -24,6 +24,10 @@
              dest=/usr/src/
              copy=no
 
+# https://stackoverflow.com/a/44833347/1589726
+- name: Remove UTS_UBUNTU_RELEASE_ABI check in kcompat.h
+  command: sed -i 's/#if UTS_UBUNTU_RELEASE_ABI > 255/#if UTS_UBUNTU_RELEASE_ABI > 99255/' /usr/src/ixgbevf-{{ ixgbevf_version }}/src/kcompat.h
+
 - name: Install dkms.conf
   template: src=dkms.conf
             dest="/usr/src/ixgbevf-{{ ixgbevf_version }}/dkms.conf"

--- a/orchestration/terraform/aws-cluster/variables.tf
+++ b/orchestration/terraform/aws-cluster/variables.tf
@@ -116,16 +116,16 @@ variable "instance_volume_size" {
 variable "instance_amis" {
   description = "AMI for all instances."
   default = {
-    sa-east-1 = "ami-78a93c14"
-    us-west-1 = "ami-b20542d2"
-    us-west-2 = "ami-b9ff39d9"
-    us-east-1 = "ami-ddf13fb0"
-    eu-west-1 = "ami-a4d44ed7"
-    ap-southeast-1 = "ami-fc37e59f"
-    ap-southeast-2 = "ami-a387afc0"
-    eu-central-1 = "ami-26e70c49"
-    ap-northeast-1 = "ami-b7d829d6"
-    ap-south-1 = "ami-7e94fe11"
+    sa-east-1 = "ami-1ca7d970"
+    us-west-1 = "ami-1b17257b"
+    us-west-2 = "ami-19e92861"
+    us-east-1 = "ami-bcdc16c6"
+    eu-west-1 = "ami-1b17257b"
+    ap-southeast-1 = "ami-d9dca7ba"
+    ap-southeast-2 = "ami-02ad4060"
+    eu-central-1 = "ami-e613ac89"
+    ap-northeast-1 = "ami-6959870f"
+    ap-south-1 = "ami-50591a3f"
   }
 }
 


### PR DESCRIPTION
* Update to use never ubuntu 16.04 AMI
* Fix ixgbevf compiling issue for aws kernel now in use by ubuntu AMI
* Change sysctl values related to raid format speed to hopefully speed
  up i3 instance type configuration