### PR TITLE
Fix bug in Python word count partitioning logic

### DIFF
--- a/examples/python/word_count/word_count.py
+++ b/examples/python/word_count/word_count.py
@@ -89,7 +89,7 @@ class WordTotalsBuilder(object):
 
 class WordPartitionFunction(object):
     def partition(self, data):
-        if data[0] >= 'a' or data[0] <= 'z':
+        if data[0] >= 'a' and data[0] <= 'z':
           return data[0]
         else:
           return "!"


### PR DESCRIPTION
When I wrote, I did "or" rather than "and" which is going to result in
nothing going to the "!" bucket.