### PR TITLE
Make Machida compile in OS X High Sierra (10.13)

### DIFF
--- a/machida/cpp/python-wallaroo.c
+++ b/machida/cpp/python-wallaroo.c
@@ -17,6 +17,7 @@ Copyright 2017 The Wallaroo Authors.
 */
 
 #ifdef __APPLE__
+    #include <AvailabilityMacros.h>
     #if MAC_OS_X_VERSION_MAX_ALLOWED < 101300
         #include <Python/Python.h>
     #else


### PR DESCRIPTION
There was an issue that caused Machida to not compile in OS X High
Sierra for some users. There was an `#if` that checked the OS version
to determine where the `Python.h` file is located on the machine, but
the value being checked was undefined unless the
`AvailabilityMacros.h` file was included, which it wasn't.

`AvailabilityMacros.h` is now included if Machida is being built on a
Mac.

Fixes #1724