### PR TITLE
Add Env as argument to source/sink builders

### DIFF
--- a/lib/wallaroo/core/initialization/local_topology.pony
+++ b/lib/wallaroo/core/initialization/local_topology.pony
@@ -974,8 +974,8 @@ actor LocalTopologyInitializer is LayoutInitializer
                 // egress_builder finds it from _outgoing_boundaries
                 let sink =
                   try
-                    egress_builder(_worker_name,
-                      consume sink_reporter, _auth, _outgoing_boundaries)?
+                    egress_builder(_worker_name, consume sink_reporter, _env,
+                      _auth, _outgoing_boundaries)?
                   else
                     @printf[I32]("Failed to build sink from egress_builder\n"
                       .cstring())
@@ -1415,7 +1415,7 @@ actor LocalTopologyInitializer is LayoutInitializer
               // Create a sink or OutgoingBoundary. If the latter,
               // egress_builder finds it from _outgoing_boundaries
               let sink = egress_builder(_worker_name,
-                consume sink_reporter, _auth, _outgoing_boundaries)?
+                consume sink_reporter, _env, _auth, _outgoing_boundaries)?
 
               match sink
               | let d: DisposableActor =>
@@ -1630,7 +1630,7 @@ actor LocalTopologyInitializer is LayoutInitializer
         "topology was initialized!\n").cstring())
     else
       for builder in sl_builders.values() do
-        let sl = builder()
+        let sl = builder(_env)
         _router_registry.register_source_listener(sl)
       end
     end

--- a/lib/wallaroo/core/sink/kafka_sink/kafka_sink.pony
+++ b/lib/wallaroo/core/sink/kafka_sink/kafka_sink.pony
@@ -46,6 +46,7 @@ actor KafkaSink is (Consumer & KafkaClientManager & KafkaProducer)
 
   var _kc: (KafkaClient tag | None) = None
   let _conf: KafkaConfig val
+  let _env: Env
   let _auth: TCPConnectionAuth
 
   // Producer (Resilience)
@@ -67,11 +68,12 @@ actor KafkaSink is (Consumer & KafkaClientManager & KafkaProducer)
 
   new create(encoder_wrapper: KafkaEncoderWrapper,
     metrics_reporter: MetricsReporter iso, conf: KafkaConfig val,
-    auth: TCPConnectionAuth)
+    env: Env, auth: TCPConnectionAuth)
   =>
     _encoder = encoder_wrapper
     _metrics_reporter = consume metrics_reporter
     _conf = conf
+    _env = env
     _auth = auth
 
     _topic = try

--- a/lib/wallaroo/core/sink/kafka_sink/kafka_sink_config.pony
+++ b/lib/wallaroo/core/sink/kafka_sink/kafka_sink_config.pony
@@ -204,7 +204,7 @@ class val KafkaSinkBuilder
     _conf = conf
     _auth = auth
 
-  fun apply(reporter: MetricsReporter iso): Sink =>
+  fun apply(reporter: MetricsReporter iso, env: Env): Sink =>
     @printf[I32]("Creating Kafka Sink\n".cstring())
 
-    KafkaSink(_encoder_wrapper, consume reporter, _conf, _auth)
+    KafkaSink(_encoder_wrapper, consume reporter, _conf, env, _auth)

--- a/lib/wallaroo/core/sink/sink.pony
+++ b/lib/wallaroo/core/sink/sink.pony
@@ -27,4 +27,4 @@ interface val SinkConfig[Out: Any val]
   fun apply(): SinkBuilder
 
 interface val SinkBuilder
-  fun apply(reporter: MetricsReporter iso): Sink
+  fun apply(reporter: MetricsReporter iso, env: Env): Sink

--- a/lib/wallaroo/core/sink/tcp_sink/tcp_sink.pony
+++ b/lib/wallaroo/core/sink/tcp_sink/tcp_sink.pony
@@ -77,6 +77,7 @@ actor TCPSink is Consumer
   - Optional in sink deduplication (this woud involve storing what we sent and
     was acknowleged.)
   """
+  let _env: Env
   // Steplike
   let _encoder: TCPEncoderWrapper
   let _wb: Writer = Writer
@@ -125,7 +126,7 @@ actor TCPSink is Consumer
 
   let _terminus_route: TerminusRoute = TerminusRoute
 
-  new create(encoder_wrapper: TCPEncoderWrapper,
+  new create(env: Env, encoder_wrapper: TCPEncoderWrapper,
     metrics_reporter: MetricsReporter iso, host: String, service: String,
     initial_msgs: Array[Array[ByteSeq] val] val,
     from: String = "", init_size: USize = 64, max_size: USize = 16384,
@@ -135,6 +136,7 @@ actor TCPSink is Consumer
     Connect via IPv4 or IPv6. If `from` is a non-empty string, the connection
     will be made from the specified interface.
     """
+    _env = env
     _encoder = encoder_wrapper
     _metrics_reporter = consume metrics_reporter
     _read_buf = recover Array[U8].>undefined(init_size) end

--- a/lib/wallaroo/core/sink/tcp_sink/tcp_sink_builder.pony
+++ b/lib/wallaroo/core/sink/tcp_sink/tcp_sink_builder.pony
@@ -104,9 +104,9 @@ class val TCPSinkBuilder
     _service = service
     _initial_msgs = initial_msgs
 
-  fun apply(reporter: MetricsReporter iso): Sink =>
+  fun apply(reporter: MetricsReporter iso, env: Env): Sink =>
     @printf[I32](("Connecting to sink at " + _host + ":" + _service + "\n")
       .cstring())
 
-    TCPSink(_encoder_wrapper, consume reporter, _host, _service,
+    TCPSink(env, _encoder_wrapper, consume reporter, _host, _service,
       _initial_msgs)

--- a/lib/wallaroo/core/source/kafka_source/kafka_source_listener_notify.pony
+++ b/lib/wallaroo/core/source/kafka_source/kafka_source_listener_notify.pony
@@ -35,9 +35,9 @@ class KafkaSourceListenerNotify[In: Any val]
     _target_router = target_router
     _auth = auth
 
-  fun ref build_source(): KafkaSourceNotify[In] iso^ ? =>
+  fun ref build_source(env: Env): KafkaSourceNotify[In] iso^ ? =>
     try
-      _source_builder(_event_log, _auth, _target_router) as
+      _source_builder(_event_log, _auth, _target_router, env) as
         KafkaSourceNotify[In] iso^
     else
       @printf[I32](

--- a/lib/wallaroo/core/source/kafka_source/kafka_source_notify.pony
+++ b/lib/wallaroo/core/source/kafka_source/kafka_source_notify.pony
@@ -28,17 +28,19 @@ use "wallaroo/core/source"
 use "wallaroo/core/topology"
 
 primitive KafkaSourceNotifyBuilder[In: Any val]
-  fun apply(pipeline_name: String, auth: AmbientAuth,
+  fun apply(pipeline_name: String, env: Env, auth: AmbientAuth,
     handler: SourceHandler[In] val,
     runner_builder: RunnerBuilder, router: Router,
     metrics_reporter: MetricsReporter iso, event_log: EventLog,
     target_router: Router, pre_state_target_id: (U128 | None) = None):
     SourceNotify iso^
   =>
-    KafkaSourceNotify[In](pipeline_name, auth, handler, runner_builder, router,
-      consume metrics_reporter, event_log, target_router, pre_state_target_id)
+    KafkaSourceNotify[In](pipeline_name, env, auth, handler, runner_builder,
+      router, consume metrics_reporter, event_log, target_router,
+      pre_state_target_id)
 
 class KafkaSourceNotify[In: Any val]
+  let _env: Env
   let _msg_id_gen: MsgIdGenerator = MsgIdGenerator
   let _pipeline_name: String
   let _source_name: String
@@ -48,7 +50,7 @@ class KafkaSourceNotify[In: Any val]
   let _omni_router: OmniRouter = EmptyOmniRouter
   let _metrics_reporter: MetricsReporter
 
-  new iso create(pipeline_name: String, auth: AmbientAuth,
+  new iso create(pipeline_name: String, env: Env, auth: AmbientAuth,
     handler: SourceHandler[In] val,
     runner_builder: RunnerBuilder, router: Router,
     metrics_reporter: MetricsReporter iso, event_log: EventLog,
@@ -56,6 +58,7 @@ class KafkaSourceNotify[In: Any val]
   =>
     _pipeline_name = pipeline_name
     _source_name = pipeline_name + " source"
+    _env = env
     _handler = handler
     _runner = runner_builder(event_log, auth, None,
       target_router, pre_state_target_id)

--- a/lib/wallaroo/core/source/source.pony
+++ b/lib/wallaroo/core/source/source.pony
@@ -27,8 +27,8 @@ use "wallaroo/core/topology"
 
 trait val SourceBuilder
   fun name(): String
-  fun apply(event_log: EventLog, auth: AmbientAuth, target_router: Router):
-    SourceNotify iso^
+  fun apply(event_log: EventLog, auth: AmbientAuth, target_router: Router,
+    env: Env): SourceNotify iso^
   fun val update_router(router: Router): SourceBuilder
 
 class val BasicSourceBuilder[In: Any val, SH: SourceHandler[In] val] is SourceBuilder
@@ -65,11 +65,12 @@ class val BasicSourceBuilder[In: Any val, SH: SourceHandler[In] val] is SourceBu
 
   fun name(): String => _name
 
-  fun apply(event_log: EventLog, auth: AmbientAuth, target_router: Router):
-    SourceNotify iso^
+  fun apply(event_log: EventLog, auth: AmbientAuth, target_router: Router,
+    env: Env): SourceNotify iso^
   =>
-    _source_notify_builder(_name, auth, _handler, _runner_builder, _router,
-      _metrics_reporter.clone(), event_log, target_router, _pre_state_target_id)
+    _source_notify_builder(_name, env, auth, _handler, _runner_builder,
+      _router, _metrics_reporter.clone(), event_log, target_router,
+      _pre_state_target_id)
 
   fun val update_router(router: Router): SourceBuilder =>
     BasicSourceBuilder[In, SH](_app_name, _worker_name, _name, _runner_builder,

--- a/lib/wallaroo/core/source/source_listener.pony
+++ b/lib/wallaroo/core/source/source_listener.pony
@@ -30,7 +30,7 @@ use "wallaroo/core/source/tcp_source"
 use "wallaroo/core/topology"
 
 interface val SourceListenerBuilder
-  fun apply(): SourceListener
+  fun apply(env: Env): SourceListener
 
 interface val SourceListenerBuilderBuilder
   fun apply(source_builder: SourceBuilder, router: Router,

--- a/lib/wallaroo/core/source/source_notify.pony
+++ b/lib/wallaroo/core/source/source_notify.pony
@@ -42,7 +42,7 @@ interface SourceNotify
   fun ref update_boundaries(obs: box->Map[String, OutgoingBoundary])
 
 interface val SourceNotifyBuilder[In: Any val, SH: SourceHandler[In] val]
-  fun apply(pipeline_name: String, auth: AmbientAuth,
+  fun apply(pipeline_name: String, env: Env, auth: AmbientAuth,
     handler: SH,
     runner_builder: RunnerBuilder, router: Router,
     metrics_reporter: MetricsReporter iso, event_log: EventLog,

--- a/lib/wallaroo/core/source/tcp_source/framed_source_notify.pony
+++ b/lib/wallaroo/core/source/tcp_source/framed_source_notify.pony
@@ -32,18 +32,19 @@ use "wallaroo/core/topology"
 
 
 primitive TCPFramedSourceNotifyBuilder[In: Any val]
-  fun apply(pipeline_name: String, auth: AmbientAuth,
+  fun apply(pipeline_name: String, env: Env, auth: AmbientAuth,
     handler: FramedSourceHandler[In] val,
     runner_builder: RunnerBuilder, router: Router,
     metrics_reporter: MetricsReporter iso, event_log: EventLog,
     target_router: Router, pre_state_target_id: (U128 | None) = None):
     SourceNotify iso^
   =>
-    TCPFramedSourceNotify[In](pipeline_name, auth, handler, runner_builder,
-      router, consume metrics_reporter, event_log, target_router,
-      pre_state_target_id)
+    TCPFramedSourceNotify[In](pipeline_name, env, auth, handler,
+      runner_builder, router, consume metrics_reporter, event_log,
+      target_router, pre_state_target_id)
 
 class TCPFramedSourceNotify[In: Any val] is TCPSourceNotify
+  let _env: Env
   let _msg_id_gen: MsgIdGenerator = MsgIdGenerator
   var _header: Bool = true
   let _pipeline_name: String
@@ -55,7 +56,7 @@ class TCPFramedSourceNotify[In: Any val] is TCPSourceNotify
   let _metrics_reporter: MetricsReporter
   let _header_size: USize
 
-  new iso create(pipeline_name: String, auth: AmbientAuth,
+  new iso create(pipeline_name: String, env: Env, auth: AmbientAuth,
     handler: FramedSourceHandler[In] val,
     runner_builder: RunnerBuilder, router: Router,
     metrics_reporter: MetricsReporter iso, event_log: EventLog,
@@ -63,6 +64,7 @@ class TCPFramedSourceNotify[In: Any val] is TCPSourceNotify
   =>
     _pipeline_name = pipeline_name
     _source_name = pipeline_name + " source"
+    _env = env
     _handler = handler
     _runner = runner_builder(event_log, auth, None,
       target_router, pre_state_target_id)

--- a/lib/wallaroo/core/source/tcp_source/tcp_source_listener.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source_listener.pony
@@ -46,6 +46,7 @@ actor TCPSourceListener is SourceListener
   # TCPSourceListener
   """
 
+  let _env: Env
   let _router: Router
   let _router_registry: RouterRegistry
   let _route_builder: RouteBuilder
@@ -66,7 +67,7 @@ actor TCPSourceListener is SourceListener
   let _auth: AmbientAuth
   let _target_router: Router
 
-  new create(source_builder: SourceBuilder, router: Router,
+  new create(env: Env, source_builder: SourceBuilder, router: Router,
     router_registry: RouterRegistry, route_builder: RouteBuilder,
     outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val,
     event_log: EventLog, auth: AmbientAuth,
@@ -81,6 +82,7 @@ actor TCPSourceListener is SourceListener
     """
     Listens for both IPv4 and IPv6 connections.
     """
+    _env = env
     _router = router
     _router_registry = router_registry
     _route_builder = route_builder
@@ -213,7 +215,7 @@ actor TCPSourceListener is SourceListener
 
   fun ref _notify_connected(): TCPSourceNotify iso^ ? =>
     try
-      _source_builder(_event_log, _auth, _target_router)
+      _source_builder(_event_log, _auth, _target_router, _env)
         as TCPSourceNotify iso^
     else
       @printf[I32](

--- a/lib/wallaroo/core/source/tcp_source/tcp_source_listener_builder.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source_listener_builder.pony
@@ -68,8 +68,8 @@ class val TCPSourceListenerBuilder
     _service = service
     _metrics_reporter = consume metrics_reporter
 
-  fun apply(): SourceListener =>
-    TCPSourceListener(_source_builder, _router, _router_registry,
+  fun apply(env: Env): SourceListener =>
+    TCPSourceListener(env, _source_builder, _router, _router_registry,
       _route_builder, _outgoing_boundary_builders,
       _event_log, _auth, _layout_initializer, _metrics_reporter.clone(),
       _default_target, _default_in_route_builder, _target_router, _host,

--- a/lib/wallaroo/core/topology/step_initializer.pony
+++ b/lib/wallaroo/core/topology/step_initializer.pony
@@ -203,7 +203,7 @@ class val EgressBuilder
     _proxy_addr
 
   fun apply(worker_name: String, reporter: MetricsReporter ref,
-    auth: AmbientAuth,
+    env: Env, auth: AmbientAuth,
     proxies: Map[String, OutgoingBoundary] val =
       recover Map[String, OutgoingBoundary] end): Consumer ?
   =>
@@ -218,7 +218,7 @@ class val EgressBuilder
     | None =>
       match _sink_builder
       | let sb: SinkBuilder =>
-        sb(reporter.clone())
+        sb(reporter.clone(), env)
       else
         EmptySink
       end


### PR DESCRIPTION
Particular source and sink implementations (like our
Kafka implementations) might need access to `OutStream`
for logging purposes. We cannot hold a reference to this
in our builders since then they cannot be serialized to
send across workers during initialization. This threads
Env through the builder apply methods so that we can
provide the reference when we are actually building on
a particular worker.

Closes #1241