### PR TITLE
Add Docker Install Docs

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -13,11 +13,15 @@
 * [Clustered Wallaroo](book/core-concepts/clustering.md)
 
 ## Developing with Wallaroo
-
-* [Setting up Your Environment](book/getting-started/setup.md)
-  * [MacOS Installation](book/getting-started/macos-setup.md)
-  * [Ubuntu Installation](book/getting-started/linux-setup.md)
-* [Run a Wallaroo Application](book/getting-started/run-a-wallaroo-application.md)
+* [Choosing an Installation Option](book/getting-started/choosing-an-installation-option.md)
+* Installing with Docker
+  * [Setting Up Your Environment](book/getting-started/docker-setup.md)
+  * [Run a Wallaroo Application in Docker](book/getting-started/run-a-wallaroo-application-docker.md)
+* Installing From Source
+  * [Setting up Your Environment](book/getting-started/setup.md)
+    * [MacOS Installation](book/getting-started/macos-setup.md)
+    * [Ubuntu Installation](book/getting-started/linux-setup.md)
+  * [Run a Wallaroo Application](book/getting-started/run-a-wallaroo-application.md)
 * [Conclusion](book/getting-started/conclusion.md)
 
 <!--
@@ -69,6 +73,7 @@
 * [Monitoring Metrics with the Monitoring Hub](book/metrics/metrics-ui.md)
 * [Decoding Giles Receiver Output](book/appendix/decoding-giles-receiver-output.md)
 * [Wallaroo and Long-Running Data Processing and Other Workflows](book/appendix/wallaroo-and-long-running-data-processing-and-other-workflows.md)
+* [Tips for using Wallaroo in Docker](book/appendix/wallaroo-in-docker-tips.md)
 
 ## Legal
 * [Terms and Conditions](book/legal/terms.md)

--- a/book/appendix/wallaroo-in-docker-tips.md
+++ b/book/appendix/wallaroo-in-docker-tips.md
@@ -1,0 +1,15 @@
+# Tips for using Wallaroo in Docker
+
+In this section, we will cover some tips that can help faciliate the development process for users of the Wallaroo Docker image.
+
+## Editing Wallaroo files within the Wallaroo Docker container
+
+When we start the Wallaroo Docker image with the `-v /tmp/wallaroo-docker/wallaroo-src:/src/wallaroo` option, as described in the [Run a Wallaroo Application in Docker](/book/getting-started/run-a-wallaroo-application-docker.md) section, we will be creating a new directory locally at `/tmp/wallaroo-docker/wallaroo-src` if it does not exist, which will be populated with the Wallaroo source code when we start the container for the first time. It is to be noted that the Wallaroo Docker image will only copy the source code to an empty directory on the host so it is advised that you use an empty directory the first time you run the `docker run` command. The source code will persist on your machine until you decide to remove it.
+
+Now, you can modify any of the Python example applications, located under `/tmp/wallaroo-docker/wallaroo-src/examples/python`, using the editor of your choice on your machine.
+
+## Installing Python modules in Virtualenv
+
+When we start the Wallaroo Docker image with the `-v /tmp/wallaroo-docker/python-virtualenv:/src/python-virtualenv` option, as described in the [Run a Wallaroo Application in Docker](/book/getting-started/run-a-wallaroo-application-docker.md) section, we will be creating a new directory locally at `/tmp/wallaroo-docker/python-virtualenv` if it does not exist, which will create a persistent Python `virtualenv` directory on your machine.
+
+Now, anytime you enter the Wallaroo Docker image with the `bash docker exec -it wally environment-setup.sh` command, you will automatically be in the Wallaroo `virtualenv` and can install modules using `pip install` or `easy_install`. These modules will persist even if you exit the container and re enter as long as you start with the same mount options for the `virtualenv` directory. It is to be noted that any modules that are installed via `apt-get` will not persist beyond the lifecycle of the container.

--- a/book/getting-started/choosing-an-installation-option.md
+++ b/book/getting-started/choosing-an-installation-option.md
@@ -1,0 +1,11 @@
+# Choosing an Installation Option for Wallaroo
+
+We currently provide two different ways for a user to install Wallaroo: [Installing with Docker](/book/getting-started/docker-setup.md) and installing from source on [OSX](/book/getting-started/macos-setup.md) or [Linux](/book/getting-started/linux-setup.md). If you are unsure about which solution is right for you, we wanted to provide a breakdown of each approach.
+
+## Installing with Docker
+
+Installing with Docker provides the benefit of needing to install only one system dependency: Docker itself. We decided to provide this option due to the isolated environment provided by Docker containers and the quick start time. You won't need to install the system dependencies needed by Wallaroo to test it out, a huge benefit we assumed many first time users might be interested in. Once Docker is set up, the user will only need to run a `docker pull` and they will have Wallaroo and all of its support tools available to them within the Wallaroo Docker image. The Docker environment has limited customizability due to the nature of a containers lifecycle but we have provided options to persist both code changes and Python modules for users. We recommend this process for users looking to get started quickly and who do not rely on a heavily customized environment for development.
+
+## Installing from Source
+
+Installing from source will allow our users to take full advantage of the development environment that they are used to. There is a bit of additional set up time due to the complexities of setting up a distributed data processing framework, but we believe that is outweighed by the user being able to use the tooling that they're most familiar with. We recommend this process for users who would prefer to use their development environment and do not mind the additional set up necessary for Wallaroo to be running on their machine. If you are on MacOS Sierra or High Sierra, we recommend installing via Docker due to a kernel panic caused by a few Wallaroo applications. The cause behind the kernel panics is currently under investigation.

--- a/book/getting-started/docker-setup.md
+++ b/book/getting-started/docker-setup.md
@@ -1,0 +1,43 @@
+# Setting Up Your Environment for Wallaroo in Docker
+
+To get you up and running quickly with Wallaroo, we have provided a Docker image which includes Wallaroo and related tools needed to run and modify a few example applications. We should warn that this Docker image was created with the intent of getting users started quickly with Wallaroo and is not intended to be a fully customizable development environment or suitable for production. MacOS Sierra and High Sierra users are recommended to install via Docker to avoid a kernel panic caused by a few Wallaroo applications, this is currently under investigation.
+
+## Installing Docker
+
+### MacOS
+
+There are [instructions](https://docs.docker.com/docker-for-mac/) for getting Docker up and running on MacOS on the [Docker website](https://docs.docker.com/docker-for-mac/).  We recommend the 'Standard' version of the 'Docker for Mac' package.
+
+Installing Docker will result in it running on your machine. After you reboot your machine, that will no longer be the case. In the future, you'll need to have Docker running in order to use a variety of commands in this book. We suggest that you [set up Docker to boot automatically](https://docs.docker.com/docker-for-mac/#general).
+
+### Linux Ubuntu
+
+There are [instructions](https://docs.docker.com/engine/installation/linux/ubuntu/) for getting Docker up and running on Ubuntu on the [Docker website](https://docs.docker.com/engine/installation/linux/ubuntu/).
+
+Installing Docker will result in it running on your machine. After you reboot your machine, that will no longer be the case. In the future, you'll need to have Docker running in order to use a variety of commands in this book. We suggest that you [set up Docker to boot automatically](https://docs.docker.com/engine/installation/linux/linux-postinstall/#configure-docker-to-start-on-boot).
+
+All of the Docker commands throughout the rest of this manual assume that you have permission to run Docker commands as a non-root user. Follow the [Manage Docker as a non-root user](https://docs.docker.com/engine/installation/linux/linux-postinstall/#manage-docker-as-a-non-root-user) instructions to set that up. If you don't want to allow a non-root user to run Docker commands, you'll need to run `sudo docker` anywhere you see `docker` for a command.
+
+## Get the official Wallaroo image from [Bintray](https://bintray.com/wallaroo-labs/wallaroolabs/first-install%3Awallaroo):
+
+```bash
+docker pull wallaroo-labs-docker-wallaroolabs.bintray.io/dev/wallaroo:7b1f3550
+```
+
+## What's Included in the Wallaroo Docker image
+
+- **Machida**: runs Wallaroo Python applications.
+
+- **Giles Sender**: supplies data to Wallaroo applications over TCP.
+
+- **Giles Receiver**: receives data from Wallaroo over TCP.
+
+- **Cluster Shutdown tool**: notifies the cluster to shut down cleanly.
+
+- **Metrics UI**: receives and displays metrics for running Wallaroo applications.
+
+- **Wallaroo Source Code**: full Wallaroo source code is provided, including Python example applications.
+
+## Conclusion
+
+Awesome! All set. Time to try running your first Wallaroo application in Docker.

--- a/book/getting-started/macos-setup.md
+++ b/book/getting-started/macos-setup.md
@@ -1,6 +1,6 @@
 # Setting Up Your MacOS Environment for Wallaroo
 
-These instructions have been tested on OSX El Capitan and MacOS Sierra.
+These instructions have been tested on OSX El Capitan and MacOS Sierra. If you are on Sierra or High Sierra, we recommend installing via [Docker](/book/getting-started/docker-setup.md) due to a Kernel panic caused by a few of the Wallaroo applications, this is currently under investigation.
 
 There are a few applications/tools which are required to be installed before you can proceed with the setup of the Wallaroo environment.
 

--- a/book/getting-started/run-a-wallaroo-application-docker.md
+++ b/book/getting-started/run-a-wallaroo-application-docker.md
@@ -1,0 +1,205 @@
+# Run a Wallaroo Application in Docker
+
+In this section, we're going to run an example Wallaroo application in Docker. By the time you are finished, you'll have validated that your Docker environment is set up and working correctly. If you haven't already completed the Docker setup [instructions](book/getting-started/docker-setup.md), please do so before continuing.
+
+There's a couple Wallaroo support applications that you'll be interacting with for the first time:
+
+- Our Metrics UI that allows you to monitor the performance and health of your applications.
+- Giles receiver is designed to capture TCP output from Wallaroo applications.
+- Giles sender is used to send test data into Wallaroo applications over TCP.
+- Machida, our program for running Wallaroo Python applications.
+
+You're going to set up our "Celsius to Fahrenheit" example application. Giles sender will be used to pump data into the application. Giles receiver will receive the output and our Metrics UI will be running so you can observe the overall performance.
+
+The Metrics UI process will be run in the background. The other three processes (receiver, sender, and Wallaroo) will run in the foreground. We recommend that you run each process in a separate terminal.
+
+NOTE: If you haven't set up Docker to run without root, you will need to use `sudo` with your Docker commands.
+
+Let's get started!
+
+## Terminal 1, Start the Wallaroo Docker container
+
+```bash
+docker run --rm -it --privileged -p 4000:4000 \
+-v /tmp/wallaroo-docker/wallaroo-src:/src/wallaroo \
+-v /tmp/wallaroo-docker/python-virtualenv:/src/python-virtualenv \
+--name wally \
+wallaroo-labs-docker-wallaroolabs.bintray.io/dev/wallaroo:7b1f3550
+```
+
+### Breaking down the Docker command
+
+- `docker run`: The Docker command to start a new container.
+
+- `--rm`: Automatically clean up the container and remove the file system on exit.
+
+- `-it`: Allows us to work with interactive processes by allocating a tty for the container.
+
+- `--privileged`: Gives the container access to the hosts' devices. This allows certain system calls to be used by Wallaroo, specifically `mbind` and `set_mempolicy`. This setting is optional, but by excluding it there will be a performance degradation in Wallaroo's processing capabilities.
+
+- `-p 4000:4000`: Maps the default port for HTTP requests for the Metrics UI from the container to the host. This makes it possible to call up the Metrics UI from a browser on the host.
+
+- `-v /tmp/wallaroo-docker/wallaroo-src:/src/wallaroo`: Mounts a host directory as a data volume within the container. The first time you run this, you must use an empty directory in order for the Docker image to copy the Wallaroo source code to your host. This allows you to open and modify the Wallaroo source code with the editor of your choice on your host. The Wallaroo source code will persist on your machine after the container is stopped or deleted. This setting is optional, but without it you would need to use an editor within the container to view or modify the Wallaroo source code.
+
+- `-v /tmp/wallaroo-docker/python-virtualenv:/src/python-virtualenv`: Mounts a host directory as a data volume within the container. The first time this is run for the provided directory, this command will setup a persistent Python virtual environment using [virtualenv](https://virtualenv.pypa.io/en/stable/) for the container on your host. Thus, if you need to install any python modules using `pip` or `easy_install` they will persist after the container is stopped or deleted. This setting is optional, but without it, you will not have a persistent `virtualenv` for the container.
+
+- `--name wally`: The name for the container. This setting is optional but makes it easier to reference the container in later commands.
+
+## Terminal 2, Start the Metrics UI
+
+Enter the Wallaroo Docker container:
+
+```bash
+docker exec -it wally environment-setup.sh
+```
+
+This command will start a new Bash shell within the container, which will run the `environment-setup.sh` script to ensure our persistent Python `virtualenv` is set up.
+
+To start the Metrics UI run:
+
+```bash
+metrics_reporter_ui start
+```
+
+You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000).
+
+If you need to restart the UI, run:
+
+```bash
+metrics_reporter_ui restart
+```
+
+When it's time to stop the UI, run:
+
+```bash
+metrics_reporter_ui stop
+```
+
+If you need to start the UI after stopping it, run:
+
+```bash
+metrics_reporter_ui start
+```
+
+## Terminal 3, Run Giles Receiver
+
+Enter the Wallaroo Docker container:
+
+```bash
+docker exec -it wally environment-setup.sh
+```
+
+We'll use Giles Receiver to listen for data from our Wallaroo application.
+
+```bash
+receiver --listen 127.0.0.1:5555 --no-write --ponythreads=1 --ponynoblock
+```
+
+You should see the line `Listening for data` that indicates that Giles receiver is running.
+
+## Terminal 4, Run the "Celsius to Fahrenheit" Application
+
+Enter the Wallaroo Docker container:
+
+```bash
+docker exec -it wally environment-setup.sh
+```
+
+First, we'll need to get to the python Celsius example directory with the following command:
+
+```bash
+cd /src/wallaroo/examples/python/celsius
+```
+
+Now that we are in the proper directory, and the Metrics UI and a data receiver are up and running, we can run the application itself by executing the following command:
+
+```bash
+machida --application-module celsius --in 127.0.0.1:7000 \
+  --out 127.0.0.1:5555 --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 \
+  --data 127.0.0.1:6001 --name worker-name --external 127.0.0.1:5050 \
+  --cluster-initializer --ponythreads=1 --ponynoblock
+```
+
+This tells the "Celsius to Fahrenheit" application that it should listen on port `7000` for incoming data, write outgoing data to port `5555`, and send metrics data to port `5001`.
+
+## Terminal 5, Sending Data
+
+Enter the Wallaroo Docker container:
+
+```bash
+docker exec -it wally environment-setup.sh
+```
+
+We will be sending in 25,000,000 messages using a pre-generated data file. The data file will be repeatedly sent via Giles Sender until we reach 25,000,000 messages.
+
+You will now be able to start the `sender` with the following command:
+
+```bash
+sender --host 127.0.0.1:7000 --messages 25000000 --binary --batch-size 300 \
+  --repeat --no-write --msg-size 8 --ponythreads=1 --ponynoblock \
+  --file /src/wallaroo/examples/python/celsius/celsius.msg
+```
+
+If the sender is working correctly, you should see `Connected` printed to the screen. If you see that, you can be assured that we are now sending data into our example application.
+
+## Check Out Some Metrics
+
+### First Look
+
+Once the sender has successfully connected, if you [visit the Metrics UI](http://localhost:4000) the landing page should show you that the "Celsius to Fahrenheit" application has successfully connected.
+
+![Landing Page](/book/metrics/images/landing-page.png)
+
+If your landing page resembles the one above, the "Celsius to Fahrenheit" application has successfully connected to the Metrics UI.
+
+Now, let's have a look at some metrics. By clicking on the "Celsius to Fahrenheit" link, you'll be taken to the "Application Dashboard" page. On this page you should see metric stats for the following:
+
+- a single pipeline: `Celsius Conversion`
+- a single worker: `Initializer`
+- three computations: `Add32`, `Decode Time in TCP Source`, `Multiply by 1.8`
+
+![Application Dashboard Page](/book/metrics/images/application-dashboard-page.png)
+
+You'll see the metric stats update as data continues to be processed in our application.
+
+You can then click into one of the elements within a category, to get to a detailed metrics page for that element. If we were to click into the `Add32` computation, we'll be taken to this page:
+
+![Computation Detailed Metrics page](/book/metrics/images/computation-detailed-metrics-page.png)
+
+Feel free to click around and get a feel for how the Metrics UI is setup and how it is used to monitor a running Wallaroo application. If you'd like a deeper dive into the Metrics UI, have a look at our [Monitoring Metrics with the Monitoring Hub](/book/metrics/metrics-ui.md) section.
+
+## Shutdown
+
+### Terminal 6, Cluster Shutdown
+
+Enter the Wallaroo Docker container:
+
+```bash
+docker exec -it wally environment-setup.sh
+```
+
+You can shut down the cluster with this command once processing has finished:
+
+```bash
+cluster_shutdown 127.0.0.1:5050
+```
+
+You can shut down Giles Sender and Giles Receiver by pressing Ctrl-c from their respective shells.
+
+You can shut down the Metrics UI with the following command:
+
+```bash
+metrics_reporter_ui stop
+```
+
+### Wallaroo Container
+
+To shut down the Wallaroo container, use the `docker stop` command in a shell on your host:
+
+```bash
+docker stop wally
+```
+
+This command will also terminate any active sessions you may have left open to the docker container.
+
+For tips on editing existing Wallaroo example code or installing Python modules within Docker, have a look at our [Tips for using Wallaroo in Docker](/book/appendix/wallaroo-in-docker-tips.md) section.

--- a/examples/python/alphabet/README.md
+++ b/examples/python/alphabet/README.md
@@ -34,7 +34,9 @@ The `Decoder`'s `decode(...)` method creates a `Votes` object with the letter be
 
 ## Running Alphabet
 
-In order to run the application you will need Machida, Giles Sender, and the Cluster Shutdown tool. To build them, please see the [Linux](/book/getting-started/linux-setup.md) or [Mac OS](/book/getting-started/macos-setup.md) setup instructions.
+In order to run the application you will need Machida, Giles Sender, and the Cluster Shutdown tool. To build them, please see the [Linux](/book/getting-started/linux-setup.md) or [Mac OS](/book/getting-started/macos-setup.md) setup instructions. Alternatively, they could be run in Docker, please see the [Docker](/book/getting-started/docker-setup.md) setup instructions and our [Run an Application in Docker](/book/getting-started/run-a-wallaroo-application-docker.md) guide if you haven't already done so.
+
+Note: If running in Docker, the relative paths are not necessary for binaries as they are all bound to the PATH within the container. You will not need to set the `PATH` variable and `PYTHONPATH` already includes the current working directory.
 
 You will need three separate shells to run this application. Open each shell and go to the `examples/python/alphabet` directory.
 

--- a/examples/python/alphabet_partitioned/README.md
+++ b/examples/python/alphabet_partitioned/README.md
@@ -34,7 +34,9 @@ The `Decoder`'s `decode(...)` method creates a `Votes` object with the letter be
 
 ## Running Alphabet Partitioned
 
-In order to run the application you will need Machida, Giles Sender, Giles Receiver, and the Cluster Shutdown tool. To build them, please see the [Linux](/book/getting-started/linux-setup.md) or [Mac OS](/book/getting-started/macos-setup.md) setup instructions.
+In order to run the application you will need Machida, Giles Sender, and the Cluster Shutdown tool. To build them, please see the [Linux](/book/getting-started/linux-setup.md) or [Mac OS](/book/getting-started/macos-setup.md) setup instructions. Alternatively, they could be run in Docker, please see the [Docker](/book/getting-started/docker-setup.md) setup instructions and our [Run an Application in Docker](/book/getting-started/run-a-wallaroo-application-docker.md) guide if you haven't already done so.
+
+Note: If running in Docker, the relative paths are not necessary for binaries as they are all bound to the PATH within the container. You will not need to set the `PATH` variable and `PYTHONPATH` already includes the current working directory.
 
 You will need four separate shells to run this application. Open each shell and go to the `examples/python/alphabet_partitioned` directory.
 

--- a/examples/python/celsius-kafka/README.md
+++ b/examples/python/celsius-kafka/README.md
@@ -21,7 +21,9 @@ The `Decoder`'s `decode(...)` method creates a float from the value represented 
 
 ## Running Celsius Kafka
 
-In order to run the application you will need Machida and the Cluster Shutdown tool. To build them, please see the [Linux](/book/getting-started/linux-setup.md) or [Mac OS](/book/getting-started/macos-setup.md) setup instructions.
+In order to run the application you will need Machida and the Cluster Shutdown tool. To build them, please see the [Linux](/book/getting-started/linux-setup.md) or [Mac OS](/book/getting-started/macos-setup.md) setup instructions. Alternatively, they could be run in Docker, please see the [Docker](/book/getting-started/docker-setup.md) setup instructions and our [Run an Application in Docker](/book/getting-started/run-a-wallaroo-application-docker.md) guide if you haven't already done so.
+
+Note: If running in Docker, the relative paths are not necessary for binaries as they are all bound to the PATH within the container. You will not need to set the `PATH` variable and `PYTHONPATH` already includes the current working directory. The kafkfa cluster and kafkacat should be run from your host and not within the Docker container.
 
 You will also need access to a Kafka cluster. This example assumes that there is a Kafka broker listening on port `9092` on `127.0.0.1`.
 
@@ -61,6 +63,8 @@ docker exec -it local_kafka_1_1 /kafka/bin/kafka-topics.sh --zookeeper \
   zookeeper:2181 --create --partitions 4 --topic test-out --replication-factor \
   1 # to create a test-out topic; change arguments as desired
 ```
+
+Note: The `./cluster up 1` command outputs `Host IP used for Kafka Brokers is <YOUR_HOST_IP>`. You will need to use this IP address for the `kafka_source_brokers` and `kafka_sink_brokers` arguments when starting `machida` within Docker in order to communicate with the cluster running on your host machine.
 
 #### Set up a listener to monitor the Kafka topic to which you would the application to publish results. We usually use `kafkacat`.
 
@@ -102,7 +106,7 @@ machida --application-module celsius \
   --kafka_sink_max_message_size 100000 --kafka_sink_max_produce_buffer_ms 10 \
   --metrics 127.0.0.1:5001 --control 127.0.0.1:12500 --data 127.0.0.1:12501 \
   --external 127.0.0.1:5050 --cluster-initializer --ponythreads=1 \
-  --ponynoblock 
+  --ponynoblock
 ```
 
 `kafka_sink_max_message_size` controls maximum size of message sent to kafka in a single produce request. Kafka will return errors if this is bigger than server is configured to accept.

--- a/examples/python/celsius/README.md
+++ b/examples/python/celsius/README.md
@@ -22,7 +22,9 @@ The `Decoder`'s `decode(...)` method creates a float from the value represented 
 
 ## Running Celsius
 
-In order to run the application you will need Machida, Giles Sender, and the Cluster Shutdown tool. To build them, please see the [Linux](/book/getting-started/linux-setup.md) or [Mac OS](/book/getting-started/macos-setup.md) setup instructions.
+In order to run the application you will need Machida, Giles Sender, and the Cluster Shutdown tool. To build them, please see the [Linux](/book/getting-started/linux-setup.md) or [Mac OS](/book/getting-started/macos-setup.md) setup instructions. Alternatively, they could be run in Docker, please see the [Docker](/book/getting-started/docker-setup.md) setup instructions and our [Run an Application in Docker](/book/getting-started/run-a-wallaroo-application-docker.md) guide if you haven't already done so.
+
+Note: If running in Docker, the relative paths are not necessary for binaries as they are all bound to the PATH within the container. You will not need to set the `PATH` variable and `PYTHONPATH` already includes the current working directory.
 
 You will need three separate shells to run this application. Open each shell and go to the `examples/python/celsius` directory.
 
@@ -60,7 +62,7 @@ Send messages:
 ../../../giles/sender/sender --host 127.0.0.1:7010 \
   --file celsius.msg --batch-size 50 --interval 10_000_000 \
   --messages 1000000 --repeat --binary --msg-size 8 --no-write \
-  --ponythreads=1 --ponynoblock 
+  --ponythreads=1 --ponynoblock
 ```
 
 ## Reading the Output

--- a/examples/python/market_spread/README.md
+++ b/examples/python/market_spread/README.md
@@ -59,7 +59,9 @@ The Order messages are handled by the `OrderDecoder`'s `decode(...)` method, whi
 
 ## Running Market Spread
 
-In order to run the application you will need Machida, Giles Sender, and the Cluster Shutdown tool. To build them, please see the [Linux](/book/getting-started/linux-setup.md) or [Mac OS](/book/getting-started/macos-setup.md) setup instructions.
+In order to run the application you will need Machida, Giles Sender, and the Cluster Shutdown tool. To build them, please see the [Linux](/book/getting-started/linux-setup.md) or [Mac OS](/book/getting-started/macos-setup.md) setup instructions. Alternatively, they could be run in Docker, please see the [Docker](/book/getting-started/docker-setup.md) setup instructions and our [Run an Application in Docker](/book/getting-started/run-a-wallaroo-application-docker.md) guide if you haven't already done so.
+
+Note: If running in Docker, the relative paths are not necessary for binaries as they are all bound to the PATH within the container. You will not need to set the `PATH` variable and `PYTHONPATH` already includes the current working directory.
 
 You will need five separate shells to run this application. Open each shell and go to the `examples/python/market_spread` directory.
 

--- a/examples/python/reverse/README.md
+++ b/examples/python/reverse/README.md
@@ -28,7 +28,9 @@ The `Decoders`'s `decode(...)` method creates a string from the value represente
 
 ## Running Reverse
 
-In order to run the application you will need Machida, Giles Sender, and the Cluster Shutdown tool. To build them, please see the [Linux](/book/getting-started/linux-setup.md) or [Mac OS](/book/getting-started/macos-setup.md) setup instructions.
+In order to run the application you will need Machida, Giles Sender, and the Cluster Shutdown tool. To build them, please see the [Linux](/book/getting-started/linux-setup.md) or [Mac OS](/book/getting-started/macos-setup.md) setup instructions. Alternatively, they could be run in Docker, please see the [Docker](/book/getting-started/docker-setup.md) setup instructions and our [Run an Application in Docker](/book/getting-started/run-a-wallaroo-application-docker.md) guide if you haven't already done so.
+
+Note: If running in Docker, the relative paths are not necessary for binaries as they are all bound to the PATH within the container. You will not need to set the `PATH` variable and `PYTHONPATH` already includes the current working directory.
 
 You will need three separate shells to run this application. Open each shell and go to the `examples/python/reverse` directory.
 
@@ -55,7 +57,7 @@ Run `machida` with `--application-module reverse`:
 machida --application-module reverse --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
   --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
   --name worker-name --external 127.0.0.1:5050 --cluster-initializer \
-  --ponythreads=1 --ponynoblock 
+  --ponythreads=1 --ponynoblock
 ```
 
 ### Shell 3

--- a/examples/python/word_count/README.md
+++ b/examples/python/word_count/README.md
@@ -26,7 +26,9 @@ The `Decoder`'s `decode(...)` method turns the input message into a string. That
 
 ## Running Word Count
 
-In order to run the application you will need Machida, Giles Sender, and the Cluster Shutdown tool. To build them, please see the [Linux](/book/getting-started/linux-setup.md) or [Mac OS](/book/getting-started/macos-setup.md) setup instructions.
+In order to run the application you will need Machida, Giles Sender, and the Cluster Shutdown tool. To build them, please see the [Linux](/book/getting-started/linux-setup.md) or [Mac OS](/book/getting-started/macos-setup.md) setup instructions. Alternatively, they could be run in Docker, please see the [Docker](/book/getting-started/docker-setup.md) setup instructions and our [Run an Application in Docker](/book/getting-started/run-a-wallaroo-application-docker.md) guide if you haven't already done so.
+
+Note: If running in Docker, the relative paths are not necessary for binaries as they are all bound to the PATH within the container. You will not need to set the `PATH` variable and `PYTHONPATH` already includes the current working directory.
 
 You will need three separate shells to run this application. Open each shell and go to the `examples/python/word_count` directory.
 
@@ -53,7 +55,7 @@ Run `machida` with `--application-module word_count`:
 machida --application-module word_count --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
   --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
   --name worker-name --external 127.0.0.1:5050 --cluster-initializer \
-  --ponythreads=1 --ponynoblock 
+  --ponythreads=1 --ponynoblock
 ```
 
 ### Shell 3


### PR DESCRIPTION
**Add Docker Install Docs**

- Adds Docker Setup Instructions and "Run A Application in Docker". 
- Adds these new docs under "First Install" within "Getting Started". 
- Moves existing documentation under "Installing From Source" within "Getting Started". 
- Updates Python example README's with `Note` comment for running in Docker.

**Files to Review:**
- [Docker Setup](https://github.com/WallarooLabs/wallaroo/blob/add-docker-install-docs/book/getting-started/docker-setup.md)
- [Run A Application in Docker](https://github.com/WallarooLabs/wallaroo/blob/add-docker-install-docs/book/getting-started/run-a-wallaroo-application-docker.md)
- All README's in the [examples/python](https://github.com/WallarooLabs/wallaroo/tree/add-docker-install-docs/examples/python) directory.
- [Tips for running Wallarooin Docker](https://github.com/WallarooLabs/wallaroo/blob/add-docker-install-docs/book/appendix/wallaroo-in-docker-tips.md)
- [Choosing an Installation Option for Wallaroo](https://github.com/WallarooLabs/wallaroo/blob/add-docker-install-docs/book/getting-started/choosing-an-installation-option.md)


Closes: #1681 #1682 #1683