### PR TITLE
Move travis CI script commands to a bash script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,10 +55,4 @@ install:
   - bash travis/install.sh
 
 script:
-  - make test debug=true
-  # Make sure to run `make clean` between separate test runs to clear any conflicting dependencies
-  - make clean
-  # Run the correctness tests that require a resilience build
-  - make integration-tests-testing-correctness-tests-all resilience=on debug=true
-  # Release Wallaroo docker image
-  - bash travis/docker_release.sh
+  - bash travis/script.sh

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+set -o errexit
+set -o nounset
+
+make test debug=true
+# Make sure to run `make clean` between separate test runs to clear any conflicting dependencies
+make clean
+# Run the correctness tests that require a resilience build
+make integration-tests-testing-correctness-tests-all resilience=on debug=true
+# Release Wallaroo docker image (if needed)
+bash travis/docker_release.sh


### PR DESCRIPTION
Easier to manage. Better error reporting. Can exit out of commands
earlier.