### PR TITLE
Update Docker Wallaroo Setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ COPY rules.mk /wallaroo-src/
 COPY SUMMARY.md /wallaroo-src/
 COPY SUPPORT.md /wallaroo-src/
 COPY utils /wallaroo-src/utils/
-COPY docker/docker-setup.sh /wallaroo-src/
+COPY docker/environment-setup.sh /wallaroo-src/
 
 RUN mkdir /metrics_ui-src && \
     cp -r /wallaroo-src/monitoring_hub/apps/metrics_reporter_ui/rel/metrics_reporter_ui /metrics_ui-src
@@ -76,7 +76,7 @@ RUN make clean && \
     cp giles/receiver/receiver /wallaroo-bin/receiver && \
     cp machida/build/machida /wallaroo-bin/machida && \
     cp utils/cluster_shutdown/cluster_shutdown /wallaroo-bin/cluster_shutdown && \
-    cp docker-setup.sh /wallaroo-bin && \
+    cp environment-setup.sh /wallaroo-bin && \
     make clean
 
 
@@ -87,4 +87,4 @@ ENV PYTHONPATH /src/wallaroo/machida:$PYTHONPATH
 
 WORKDIR /src
 
-ENTRYPOINT ["docker-setup.sh"]
+ENTRYPOINT ["environment-setup.sh"]

--- a/docker/environment-setup.sh
+++ b/docker/environment-setup.sh
@@ -1,13 +1,14 @@
 #!/bin/sh
 
-cd /src/wallaroo
-if [ ! -f Dockerfile ]; then
+WALLAROO_DIR="/src/wallaroo"
+cd $WALLAROO_DIR
+if [ ! "$(ls -A $WALLAROO_DIR)" ]; then
   echo "====== Copying Wallaroo Source Code to Working Directory (/src/wallaroo) ======"
   cp -r /wallaroo-src/* /src/wallaroo
 fi
 if [ -d /src/python-virtualenv ]; then
   cd /src/python-virtualenv
-  if [ ! -f pip-selfcheck.json ]; then
+  if [ ! -f bin/activate ]; then
     echo "====== Setting up Persistent Python Virtual Environment ======"
     virtualenv .
     echo "====== Done Setting up Persistent Python Virtual Environment ======"
@@ -18,5 +19,5 @@ if [ -d /src/python-virtualenv ]; then
   . bin/activate
 fi
 cd /src
-exec bash
-
+(cat ~/.bashrc; echo "PS1=\"$PS1\"") > /.prompt
+exec bash --rcfile /.prompt


### PR DESCRIPTION
Renames docker-setup.sh to environment-setup.sh since it sets up the Wallaroo
and virtualenv environments for users within Docker. Updates how we determine
to copy wallaroo source content to the /src/wallaroo folder, will now only do
so if the /src/wallaroo directory is empty. Updates how we determine setting
up virtualenv, if the bin/activate script is not present we will create a new
virtualenv.

[skip-ci]