### PR TITLE
Send all unacked messages when resuming normal sending at OutgoingBoundary

### DIFF
--- a/lib/wallaroo/core/boundary/boundary.pony
+++ b/lib/wallaroo/core/boundary/boundary.pony
@@ -975,6 +975,7 @@ class BoundaryNotify is WallarooOutgoingNetworkActorNotify
           @printf[I32]("Received StartNormalDataSendingMsg at Boundary\n"
             .cstring())
         end
+        conn.receive_connect_ack(sn.last_id_seen)
         conn.start_normal_sending()
       | let aw: AckWatermarkMsg =>
         ifdef "trace" then

--- a/lib/wallaroo/core/messages/channel_messages.pony
+++ b/lib/wallaroo/core/messages/channel_messages.pony
@@ -152,8 +152,10 @@ primitive ChannelMsgEncoder
   =>
     _encode(AckDataConnectMsg(last_id_seen), auth)?
 
-  fun start_normal_data_sending(auth: AmbientAuth): Array[ByteSeq] val ? =>
-    _encode(StartNormalDataSendingMsg, auth)?
+  fun start_normal_data_sending(last_id_seen: SeqId, auth: AmbientAuth):
+    Array[ByteSeq] val ?
+  =>
+    _encode(StartNormalDataSendingMsg(last_id_seen), auth)?
 
   fun replay_complete(sender_name: String, boundary_id: U128,
     auth: AmbientAuth): Array[ByteSeq] val ?
@@ -334,7 +336,11 @@ class val AckDataConnectMsg is ChannelMsg
   new val create(last_id_seen': SeqId) =>
     last_id_seen = last_id_seen'
 
-primitive StartNormalDataSendingMsg is ChannelMsg
+class val StartNormalDataSendingMsg is ChannelMsg
+  let last_id_seen: SeqId
+
+  new val create(last_id_seen': SeqId) =>
+    last_id_seen = last_id_seen'
 
 class val RequestBoundaryCountMsg is ChannelMsg
   let sender_name: String

--- a/lib/wallaroo/ent/data_receiver/data_receiver.pony
+++ b/lib/wallaroo/ent/data_receiver/data_receiver.pony
@@ -91,7 +91,8 @@ actor DataReceiver is Producer
 
   fun _inform_boundary_to_send_normal_messages() =>
     try
-      let start_msg = ChannelMsgEncoder.start_normal_data_sending(_auth)?
+      let start_msg = ChannelMsgEncoder.start_normal_data_sending(
+        _last_id_seen, _auth)?
       _write_on_conn(start_msg)
     else
       Fail()
@@ -284,7 +285,6 @@ class _DataReceiverAcceptingMessagesPhase is _DataReceiverProcessingPhase
     _data_receiver = dr
 
   fun data_connect() =>
-    _data_receiver._ack_data_connect()
     _data_receiver._inform_boundary_to_send_normal_messages()
 
 trait _TimerInit


### PR DESCRIPTION
Formerly, when resuming normal sending, we were assuming that
we had already sent all unacked messages from our queue.
However, it's possible that more messages enter the queue between
the time a connection is acked and we are told to resume normal
sending. Now as part of resuming normal sending, we send everything
past the last_seen_id from our queue to make sure we don't drop
messages.

Closes #1764