### PR TITLE
Add stateless partition shrink recalculation

### DIFF
--- a/lib/wallaroo/core/initialization/application_distributor.pony
+++ b/lib/wallaroo/core/initialization/application_distributor.pony
@@ -19,8 +19,6 @@ Copyright 2017 The Wallaroo Authors.
 use "collections"
 use "files"
 use "net"
-use "wallaroo_labs/dag"
-use "wallaroo_labs/messages"
 use "wallaroo"
 use "wallaroo/core/common"
 use "wallaroo/ent/recovery"
@@ -29,6 +27,9 @@ use "wallaroo/core/messages"
 use "wallaroo/core/metrics"
 use "wallaroo/core/source/tcp_source"
 use "wallaroo/core/topology"
+use "wallaroo_labs/dag"
+use "wallaroo_labs/messages"
+use "wallaroo_labs/thread_count"
 
 actor ApplicationDistributor is Distributor
   let _auth: AmbientAuth
@@ -648,7 +649,7 @@ actor ApplicationDistributor is Distributor
                 // containing the blueprint for creating the stateless
                 // partition router.
                 let next_id = next_runner_builder.id()
-                let pony_thread_count = @ponyint_sched_cores[I32]().usize()
+                let pony_thread_count = ThreadCount()
                 let psd = StatelessPartition.pre_stateless_data(
                   pipeline.name(), next_id, all_workers, pony_thread_count)?
 

--- a/lib/wallaroo/core/initialization/local_topology.pony
+++ b/lib/wallaroo/core/initialization/local_topology.pony
@@ -1093,7 +1093,8 @@ actor LocalTopologyInitializer is LayoutInitializer
                   let stateless_partition_router =
                     LocalStatelessPartitionRouter(next_node.id, _worker_name,
                       pre_stateless_data.partition_id_to_step_id,
-                      consume partition_routes)
+                      consume partition_routes,
+                      pre_stateless_data.steps_per_worker)
 
                   built_routers(next_node.id) = stateless_partition_router
                   stateless_partition_routers(next_node.id) =

--- a/lib/wallaroo/core/topology/_test_router_equality.pony
+++ b/lib/wallaroo/core/topology/_test_router_equality.pony
@@ -307,7 +307,7 @@ primitive _RecoveryReplayerGenerator
 primitive _StatelessPartitionGenerator
   fun apply(): StatelessPartitionRouter =>
     LocalStatelessPartitionRouter(0, "", recover Map[U64, U128] end,
-      recover Map[U64, (Step | ProxyRouter)] end)
+      recover Map[U64, (Step | ProxyRouter)] end, 1)
 
 actor _Cluster is Cluster
   be notify_cluster_of_new_stateful_step[K: (Hashable val & Equatable[K] val)](

--- a/lib/wallaroo/core/topology/stateless_partition.pony
+++ b/lib/wallaroo/core/topology/stateless_partition.pony
@@ -1,0 +1,58 @@
+use "collections"
+use "wallaroo/core/common"
+
+
+primitive StatelessPartition
+  fun pre_stateless_data(pipeline_name: String, partition_id: StepId,
+    workers: Array[String] val, threads_per_worker: USize): PreStatelessData ?
+  =>
+    let step_id_gen = StepIdGenerator
+
+    // First we calculate the size of the partition and determine
+    // where the steps in the partition go in the cluster. We are
+    // populating three maps. Two of them, partition_id_to_worker
+    // and partition_id_to_step_id, will be used to create a
+    // StatelessPartitionRouter during local topology
+    // initialization. The third, worker_to_step_id, will be used
+    // here to determine which step ids we will put in which
+    // local graphs.
+    let ws = Array[String]
+    for w in workers.values() do ws.push(w) end
+    let sorted_workers = Sort[Array[String], String](ws)
+    let worker_count = workers.size()
+    let partition_count = worker_count * threads_per_worker
+    let partition_id_to_worker_trn =
+      recover trn Map[U64, String] end
+    let partition_id_to_step_id_trn =
+      recover trn Map[U64, U128] end
+    let worker_to_step_id_trn =
+      recover trn Map[String, Array[U128] trn] end
+    for w in sorted_workers.values() do
+      worker_to_step_id_trn(w) = recover Array[U128] end
+    end
+    for id in Range[U64](0, partition_count.u64()) do
+      let step_id = step_id_gen()
+      partition_id_to_step_id_trn(id) = step_id
+      let w = sorted_workers(id.usize() % worker_count)?
+      partition_id_to_worker_trn(id) = w
+      worker_to_step_id_trn(w)?.push(step_id)
+    end
+    let partition_id_to_worker: Map[U64, String] val =
+      consume partition_id_to_worker_trn
+    let partition_id_to_step_id: Map[U64, U128] val =
+      consume partition_id_to_step_id_trn
+    let worker_to_step_id_collector =
+      recover trn Map[String, Array[U128] val] end
+    for (k, v) in worker_to_step_id_trn.pairs() do
+      match worker_to_step_id_trn(k) = recover Array[U128] end
+      | let arr: Array[U128] trn =>
+        worker_to_step_id_collector(k) = consume arr
+      end
+    end
+    let worker_to_step_id: Map[String, Array[U128] val] val =
+      consume worker_to_step_id_collector
+
+    PreStatelessData(pipeline_name, partition_id,
+      partition_id_to_worker,
+      partition_id_to_step_id, worker_to_step_id,
+      threads_per_worker)

--- a/lib/wallaroo/core/topology/step_initializer.pony
+++ b/lib/wallaroo/core/topology/step_initializer.pony
@@ -266,17 +266,20 @@ class val PreStatelessData
   let partition_id_to_worker: Map[U64, String] val
   let partition_id_to_step_id: Map[U64, U128] val
   let worker_to_step_id: Map[String, Array[U128] val] val
+  let steps_per_worker: USize
 
   new val create(pipeline_name': String, step_id': U128,
     partition_id_to_worker': Map[U64, String] val,
     partition_id_to_step_id': Map[U64, U128] val,
-    worker_to_step_id': Map[String, Array[U128] val] val)
+    worker_to_step_id': Map[String, Array[U128] val] val,
+    steps_per_worker': USize)
   =>
     _pipeline_name = pipeline_name'
     _id = step_id'
     partition_id_to_worker = partition_id_to_worker'
     partition_id_to_step_id = partition_id_to_step_id'
     worker_to_step_id = worker_to_step_id'
+    steps_per_worker = steps_per_worker'
 
   fun name(): String => "PreStatelessData"
   fun state_name(): String => ""

--- a/lib/wallaroo_labs/thread_count/thread_count.pony
+++ b/lib/wallaroo_labs/thread_count/thread_count.pony
@@ -1,0 +1,3 @@
+primitive ThreadCount
+  fun apply(): USize =>
+    @ponyint_sched_cores[I32]().usize()


### PR DESCRIPTION
When we shrink the cluster size, we need to call a method
on StatelessPartitionRouter to get a new router with routes
to the leaving workers removed. This commit adds that method
and breaks out the logic for initially setting up a stateless
partition.

Closes #1621.