### PR TITLE
Don't report a cluster as ready to work until node connection protocol has completed

### DIFF
--- a/lib/wallaroo/core/initialization/layout_initializer.pony
+++ b/lib/wallaroo/core/initialization/layout_initializer.pony
@@ -18,12 +18,19 @@ Copyright 2017 The Wallaroo Authors.
 
 use "collections"
 use "wallaroo/core/boundary"
+use "wallaroo/core/common"
 use "wallaroo/ent/data_receiver"
 use "wallaroo/core/messages"
 
 trait tag LayoutInitializer
   be initialize(cluster_initializer: (ClusterInitializer | None) = None,
     recovering: Bool)
+
+  be report_created(initializable: Initializable)
+
+  be report_initialized(initializable: Initializable)
+
+  be report_ready_to_work(initializable: Initializable)
 
   be receive_immigrant_step(msg: StepMigrationMsg)
 

--- a/lib/wallaroo/core/initialization/local_topology.pony
+++ b/lib/wallaroo/core/initialization/local_topology.pony
@@ -234,6 +234,7 @@ actor LocalTopologyInitializer is LayoutInitializer
   var _initialized: SetIs[Initializable] = _initialized.create()
   var _ready_to_work: SetIs[Initializable] = _ready_to_work.create()
   let _initializables: SetIs[Initializable] = _initializables.create()
+  var _initialization_lifecycle_complete: Bool = false
 
   // Partition router blueprints
   var _partition_router_blueprints:
@@ -1620,7 +1621,9 @@ actor LocalTopologyInitializer is LayoutInitializer
   be report_ready_to_work(initializable: Initializable) =>
     if not _ready_to_work.contains(initializable) then
       _ready_to_work.set(initializable)
-      if _ready_to_work.size() == _initializables.size() then
+      if (not _initialization_lifecycle_complete) and
+        (_ready_to_work.size() == _initializables.size())
+      then
         _complete_initialization_lifecycle()
       end
     else
@@ -1629,7 +1632,7 @@ actor LocalTopologyInitializer is LayoutInitializer
       Fail()
     end
 
-  fun _complete_initialization_lifecycle() =>
+  fun ref _complete_initialization_lifecycle() =>
     if _recovering then
       match _topology
       | let t: LocalTopology =>
@@ -1647,6 +1650,7 @@ actor LocalTopologyInitializer is LayoutInitializer
       // processed first
       _router_registry.inform_cluster_of_join()
     end
+    _initialization_lifecycle_complete = true
 
   be report_event_log_ready_to_work() =>
     // This should only get called after all initializables have reported


### PR DESCRIPTION
Previous to this commit, we were reporting ready to work at
a boundary as soon as the TCP connection was established.
Since we are not actually ready to work until all boundary
connect protocol messages have been received, this changes that.

Closes #1763 