### PR TITLE
Remove dangling bundle.json file

### DIFF
--- a/testing/correctness/apps/bundle.json
+++ b/testing/correctness/apps/bundle.json
@@ -1,7 +1,0 @@
-{
-  "deps": [
-    { "type": "local",
-      "local-path": "../../../lib/"
-    }
-  ]
-}


### PR DESCRIPTION
This PR removes an orphaned bundle.json file from `testing/correctness/apps/`

If CI passes, this should be good to merge.