### PR TITLE
Add spike and sink-await to integration tests

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -123,7 +123,7 @@ ponyc_tag ?= wallaroolabs-$(strip $(latest_ponyc_tag))-release## tag for ponyc d
 ponyc_runner ?= wallaroolabs/ponyc## ponyc docker image to use
 debug ?= false## Use ponyc debug option (-d)
 debug_arg :=# Final argument string for debug option
-spike ?= false ## use ponycflags -D spike
+spike ?= false## Enable compile-time network fault injection
 spike_arg :=# Final argument string for spike option
 docker_host ?= $(DOCKER_HOST)## docker host to build/run containers on
 ifeq ($(docker_host),)

--- a/rules.mk
+++ b/rules.mk
@@ -123,6 +123,8 @@ ponyc_tag ?= wallaroolabs-$(strip $(latest_ponyc_tag))-release## tag for ponyc d
 ponyc_runner ?= wallaroolabs/ponyc## ponyc docker image to use
 debug ?= false## Use ponyc debug option (-d)
 debug_arg :=# Final argument string for debug option
+spike ?= false ## use ponycflags -D spike
+spike_arg :=# Final argument string for spike option
 docker_host ?= $(DOCKER_HOST)## docker host to build/run containers on
 ifeq ($(docker_host),)
   docker_host := unix:///var/run/docker.sock
@@ -203,6 +205,10 @@ ifeq ($(debug),true)
   debug_arg := --debug
 endif
 
+ifeq ($(spike), true)
+	spike_arg := -D spike
+endif
+
 # validation of variable
 ifdef arch
   $(eval $(call check-values,arch,amd64 native))
@@ -248,11 +254,11 @@ define PONYC
   $(QUIET)cd $(1) && $(ponyc_docker_args) $(PONYSTABLE) fetch \
     $(if $(filter $(ponyc_docker_args),docker),$(quote))
   $(QUIET)cd $(1) && $(ponyc_docker_args) $(PONYSTABLE) env $(PONYCC) $(ponyc_arch_args) \
-    $(debug_arg) $(autoscale_arg) $(clustering_arg) $(resilience_arg) \
+    $(debug_arg) $(spike_arg) $(autoscale_arg) $(clustering_arg) $(resilience_arg) \
     $(PONYCFLAGS) $(target_cpu_arg) . $(if $(filter $(ponyc_docker_args),docker),$(quote))
   $(QUIET)cd $(1) && echo "$@: $(abspath $(1))/bundle.json" | tr '\n' ' ' > $(notdir $(abspath $(1:%/=%))).d
   $(QUIET)cd $(1) && $(ponyc_docker_args) $(PONYSTABLE) env $(PONYCC) $(ponyc_arch_args) \
-    $(debug_arg) $(autoscale_arg) $(clustering_arg) $(resilience_arg) \
+    $(debug_arg) $(spike_arg) $(autoscale_arg) $(clustering_arg) $(resilience_arg) \
     $(PONYCFLAGS) $(target_cpu_arg) . --pass import --files $(if $(filter \
     $(ponyc_docker_args),docker),$(quote)) 2>/dev/null | grep -o "$(abs_wallaroo_dir).*.pony" \
     | awk 'BEGIN { a="" } {a=a$$1":\n"; printf "%s ",$$1} END {print "\n"a}' \

--- a/testing/correctness/apps/sequence_window_simple_state/Makefile
+++ b/testing/correctness/apps/sequence_window_simple_state/Makefile
@@ -50,15 +50,18 @@ integration-tests-testing-correctness-apps-sequence_window_simple_state: sequenc
 
 sequence_window_simple_state_test:
 	cd $(SEQUENCE_WINDOW_SIMPLE_STATE_PATH) && \
-	integration_test --sequence-sender '(0,1000]' \
+	integration_test --sequence-sender '(0,10000]' \
 	  --log-level error \
 		--command './sequence_window_simple_state' \
-		--validation-cmd 'validator -e 1000 -a -i' \
+		--validation-cmd 'validator -e 10000 -a -i' \
 		--output 'received.txt' \
 		--giles-mode \
 		--workers 2 \
 		--batch-size 10 \
-		--sink-expect 1000
+		--sink-await '[9994,9996,9998,10000]' \
+		--sink-await '[9993,9995,9997,9999]' \
+		--spike 0 0.1 200 1
+
 
 clean-testing-correctness-apps-sequence_window_simple_state: sequence_window_simple_state_clean
 

--- a/testing/tools/integration/__init__.py
+++ b/testing/tools/integration/__init__.py
@@ -27,8 +27,8 @@ It has:
     - files_generator: a file source supporting both newlines and framed modes
     - sequence_generator: a framed source encoded U64 sequence generator
         (binary)
-    - iter_generator: a generic framed source encoded generator that operates on
-        iterators. It takes an optional `to_string` lambda for converting
+    - iter_generator: a generic framed source encoded generator that operates
+        on iterators. It takes an optional `to_string` lambda for converting
         iterator items to strings.
     - files_generator: a generic
     - Runner: Runs a single Wallaroo worker with command line parameters.

--- a/testing/tools/integration/integration.py
+++ b/testing/tools/integration/integration.py
@@ -193,13 +193,13 @@ class TCPReceiver(StoppableThread):
                 (clientsocket, address) = self.sock.accept()
                 cl = SingleSocketReceiver(clientsocket, self.data, self.mode,
                                           self.header_fmt,
-                                          name = '{}-{}'.format(
+                                          name='{}-{}'.format(
                                               self.__base_name__,
                                               len(self.clients)))
                 logging.info("{}:{} accepting connection from ({}, {}) on "
                              "port {}."
                              .format(self.__base_name__, self.name, self.host,
-                              self.port, address[1]))
+                                     self.port, address[1]))
                 self.clients.append(cl)
                 cl.start()
         except Exception as err:
@@ -389,6 +389,7 @@ class SinkAwaitValue(StoppableThread):
         self.sink.stop()
         super(SinkAwaitValue, self).stop()
 
+
 class Sender(StoppableThread):
     """
     Send length framed data to a destination (host, port).
@@ -544,7 +545,7 @@ def newline_file_generator(filepath, header_fmt='>I'):
     Generate length-encoded strings from a newline-delimited file.
     """
     with open(filepath, 'rb') as f:
-        f.seek(0,2)
+        f.seek(0, 2)
         fin = f.tell()
         f.seek(0)
         while f.tell() < fin:
@@ -676,8 +677,10 @@ class RunnerReadyChecker(StoppableThread):
                         self.stop()
                         break
                 if time.time() - started > self.timeout:
-                    outputs = [(r.name, r.get_output()[0]) for r in self.runners]
-                    outputs = '\n===\n'.join(('\n---\n'.join(t) for t in outputs))
+                    outputs = [(r.name, r.get_output()[0]) for r in
+                               self.runners]
+                    outputs = '\n===\n'.join(('\n---\n'.join(t) for t in
+                                              outputs))
                     self.error = TimeoutError(
                         'Application did not report as ready after {} '
                         'seconds. It had the following outputs:\n===\n{}'
@@ -788,7 +791,7 @@ def get_port_values(host, sources):
     while len(free_ports) < 3:
         if is_address_available(host, port):
             free_ports.append(port)
-        port +=1
+        port += 1
     return source_ports, free_ports[0], free_ports[1], free_ports[2]
 
 
@@ -801,6 +804,8 @@ BASE_COMMAND = r'''{command} \
     --name {{name}} \
     {{initializer_block}} \
     {{join_block}} \
+    {{spike_block}} \
+    {{alt_block}} \
     --ponythreads=1 \
     --ponypinasio \
     --ponynoblock'''
@@ -811,44 +816,67 @@ INITIALIZER_CMD = r'''{worker_count} \
 JOIN_CMD = r'''--join {host}:{control_port} \
     {worker_count}'''
 WORKER_COUNT_CMD = r'''--worker-count {worker_count}'''
+SPIKE_CMD = r'''--spike-drop \
+    {prob} \
+    {margin} \
+    {seed}'''
+SPIKE_SEED = r'''--spike-seed {seed}'''
+SPIKE_PROB = r'''--spike-prob {prob}'''
+SPIKE_MARGIN = r'''--spike-margin {margin}'''
 
 
 def start_runners(runners, command, host, inputs, outputs, metrics_port,
                   control_port, external_port, data_port, res_dir, workers,
-                  alt_block=None, alt_func=None):
-    cmd_stub = BASE_COMMAND.format(command = command,
-                                   host = host,
-                                   inputs = inputs,
-                                   outputs = outputs,
-                                   metrics_port = metrics_port,
-                                   control_port = control_port,
-                                   res_dir = res_dir)
+                  alt_block=None, alt_func=lambda x: False, spikes={}):
+    cmd_stub = BASE_COMMAND.format(command=command,
+                                   host=host,
+                                   inputs=inputs,
+                                   outputs=outputs,
+                                   metrics_port=metrics_port,
+                                   control_port=control_port,
+                                   res_dir=res_dir)
 
     # for each worker, assign `name` and `cluster-initializer` values
     if workers < 1:
         raise PipelineTestError("workers must be 1 or more")
     x = 0
+    if x in spikes:
+        logging.info("Enabling spike for initializer")
+        sc = spikes[x]
+        spike_block = SPIKE_CMD.format(
+            prob=SPIKE_PROB.format(prob=sc.probability),
+            margin=SPIKE_MARGIN.format(margin=sc.margin),
+            seed=SPIKE_SEED.format(seed=sc.seed) if sc.seed else '')
+    else:
+        spike_block = ''
     cmd = cmd_stub.format(
-        name = 'initializer',
-        initializer_block = INITIALIZER_CMD.format(
-            worker_count = WORKER_COUNT_CMD.format(worker_count = workers),
-            data_port = data_port,
-            external_port = external_port,
-            host = host),
-        join_block = '')
-    if alt_func and alt_func(x):
-        cmd = '''{} \
-            {}'''.format(cmd, alt_block)
-    runners.append(Runner(cmd_string = cmd, name = 'initializer'))
+        name='initializer',
+        initializer_block=INITIALIZER_CMD.format(
+            worker_count=WORKER_COUNT_CMD.format(worker_count=workers),
+            data_port=data_port,
+            external_port=external_port,
+            host=host),
+        join_block='',
+        alt_block=alt_block if alt_func(x) else '',
+        spike_block=spike_block)
+    runners.append(Runner(cmd_string=cmd, name='initializer'))
     for x in range(1, workers):
-        cmd = cmd_stub.format(name = 'worker{}'.format(x),
-                              initializer_block = '',
-                              join_block = '')
-        if alt_func and alt_func(x):
-            cmd = '''{} \
-                {}'''.format(cmd, alt_block)
-        runners.append(Runner(cmd_string = cmd,
-                              name = 'worker{}'.format(x)))
+        if x in spikes:
+            logging.info("Enabling spike for worker{}".format(x))
+            sc = spikes[x]
+            spike_block = SPIKE_CMD.format(
+                prob=SPIKE_PROB.format(prob=sc.probability),
+                margin=SPIKE_MARGIN.format(margin=sc.margin),
+                seed=SPIKE_SEED.format(seed=sc.seed) if sc.seed else '')
+        else:
+            spike_block = ''
+        cmd = cmd_stub.format(name='worker{}'.format(x),
+                              initializer_block='',
+                              join_block='',
+                              alt_block=alt_block if alt_func(x) else '',
+                              spike_block=spike_block)
+        runners.append(Runner(cmd_string=cmd,
+                              name='worker{}'.format(x)))
 
     # start the workers, 50ms apart
     for idx, r in enumerate(runners):
@@ -874,14 +902,14 @@ def start_runners(runners, command, host, inputs, outputs, metrics_port,
 
 def add_runner(runners, command, host, inputs, outputs, metrics_port,
                control_port, external_port, data_port, res_dir, workers,
-               alt_block=None, alt_func=None):
-    cmd_stub = BASE_COMMAND.format(command = command,
-                                   host = host,
-                                   inputs = inputs,
-                                   outputs = outputs,
-                                   metrics_port = metrics_port,
-                                   control_port = control_port,
-                                   res_dir = res_dir)
+               alt_block=None, alt_func=lambda x: False, spikes={}):
+    cmd_stub = BASE_COMMAND.format(command=command,
+                                   host=host,
+                                   inputs=inputs,
+                                   outputs=outputs,
+                                   metrics_port=metrics_port,
+                                   control_port=control_port,
+                                   res_dir=res_dir)
 
     # Test that the new worker *can* join
     if len(runners) < 1:
@@ -892,19 +920,26 @@ def add_runner(runners, command, host, inputs, outputs, metrics_port,
                                 "join!")
 
     x = len(runners)
-    cmd = cmd_stub.format(name = 'worker{}'.format(x),
-                          initializer_block = '',
-                          join_block = JOIN_CMD.format(
-                                host = host,
-                                control_port = control_port,
-                                worker_count = (WORKER_COUNT_CMD.format(
-                                    worker_count = workers) if workers else
-                                    '')))
-    if alt_func and alt_func(x):
-        cmd = '''{} \
-            {}'''.format(cmd, alt_block)
-    runner = Runner(cmd_string = cmd,
-                   name = 'worker{}'.format(x))
+    if x in spikes:
+        logging.info("Enabling spike for joining worker{}".format(x))
+        sc = spikes[x]
+        spike_block = SPIKE_CMD.format(
+            prob=SPIKE_PROB.format(sc.probability),
+            margin=SPIKE_MARGIN.format(sc.margin),
+            seed=SPIKE_SEED.format(sc.seed) if sc.seed else '')
+    else:
+        spike_block = ''
+    cmd = cmd_stub.format(name='worker{}'.format(x),
+                          initializer_block='',
+                          join_block=JOIN_CMD.format(
+                                host=host,
+                                control_port=control_port,
+                                worker_count=(WORKER_COUNT_CMD.format(
+                                    worker_count=workers) if workers else '')),
+                          alt_block=alt_block if alt_func(x) else '',
+                          spike_block=spike_block)
+    runner = Runner(cmd_string=cmd,
+                    name='worker{}'.format(x))
     runners.append(runner)
 
     # start the new worker
@@ -928,14 +963,17 @@ def add_runner(runners, command, host, inputs, outputs, metrics_port,
                 "\n---\n%s" % (x+1, len(runners), r.error))
 
 
-DEFAULT_SINK_EXPECT_TIMEOUT = 30
+DEFAULT_SINK_STOP_TIMEOUT = 30
+
+
 def pipeline_test(generator, expected, command, workers=1, sources=1,
                   mode='framed', sinks=1, decoder=None, pre_processor=None,
-                  batch_size=1, sink_expect=None, sink_expect_timeout=None,
-                  delay=None,
+                  batch_size=1, sink_expect=None, sink_stop_timeout=None,
+                  sink_await=None, delay=None,
                   validate_file=None, giles_mode=False,
                   host='127.0.0.1', listen_attempts=1,
-                  ready_timeout=30, resilience_dir='/tmp/res-dir'):
+                  ready_timeout=30, resilience_dir='/tmp/res-dir',
+                  spikes={}):
     """
     Run a pipeline test without having to instrument everything
     yourself. This only works for 1-source, 1-sink topologies.
@@ -947,8 +985,8 @@ def pipeline_test(generator, expected, command, workers=1, sources=1,
         sequentially, and the index is 0-based against the input addresses.
         the values in this set should be either strings or stringable. If they
         are custom data structures, they should already be encoded as strings.
-    - `expectd`: the expect output set, to be compared against the received output.
-        The data should be directly comparable to the decoded output.
+    - `expectd`: the expect output set, to be compared against the received
+        output. The data should be directly comparable to the decoded output.
     - `command`: the command to run each worker. Make sure to leave out the
         Wallaroo parameters: `--in`, `--out`, `--metrics`, `--data`,
         `--control`, `--external`, `--workers`, `--name`,
@@ -966,33 +1004,39 @@ def pipeline_test(generator, expected, command, workers=1, sources=1,
         Default: None, assume output data is directly comparable.
     - `batch_size`: the batch size to use in the sender. Default: 1
     - `sink_expect`: the number of messages to expect at the sink. This allows
-       directly relying on received output for timing control. Default: None
-       Should be a list of `len(sinks)`.
-    - `sink_expect_timeout`: the timeout in seconds to use when awaiting an
-      expected number of messages at the sink. Raise an error if timeout
-      elapses. Default: 30
-      Can be a number or a list of numbers of `len(sinks)`.
+        directly relying on received output for timing control. Default: None
+        Should be a list of `len(sinks)`.
+    - `sink_await`: a list of (binary) strings to await for at the sink.
+        Once all of the await values have been seen at the sink, the test may
+        be stopped.
+    - `sink_stop_timeout`: the timeout in seconds to use when awaiting an
+        expected number of messages at the sink. Raise an error if timeout
+        elapses. Default: 30
+        Can be a number or a list of numbers of `len(sinks)`.
     - `delay`: If None, and `sink_expect` is also None, the pipeline test
-      will wait until metrics messages have a 0 throughput or have stopped
-      arriving. If set to a number > 0, the minimum delay in seconds to
-      wait after data sending has completed before checking the sink's
-      data. Default: None.
+        will wait until metrics messages have a 0 throughput or have stopped
+        arriving. If set to a number > 0, the minimum delay in seconds to
+        wait after data sending has completed before checking the sink's
+        data. Default: None.
     - `validate_file`: save sink data to a file to be validated by an external
-      process.
+        process.
     - `giles_mode`: if True, include a 64-bit timestamp between the length
-      header and the payload when saving sink data to file. This is a backward
-      compatibility mode for validators that expected giles-receiver format.
+        header and the payload when saving sink data to file. This is a
+        backward compatibility mode for validators that expected
+        giles-receiver format.
     - `host`: the network host address to use in workers, senders, and
-      receivers. Default '127.0.0.1'
+        receivers. Default '127.0.0.1'
     - `listen_attempts`: attempt to start an applicatin listening on ports
-      that are provided by the system. After `listen_attempts` fail, raise
-      an appropriate error. For tests that experience TCP_WAIT related
-      errors, this value should be set higher than 1.
-      Default 1.
+        that are provided by the system. After `listen_attempts` fail, raise
+        an appropriate error. For tests that experience TCP_WAIT related
+        errors, this value should be set higher than 1.
+        Default 1.
     - `ready_timeout`: number of seconds before an error is raised if the
-      application does not report as ready. Default 30
+        application does not report as ready. Default 30
     - `resilience_dir`: The directory where resilience file are kept. This
-      path will be cleaned up before and after each run.
+        path will be cleaned up before and after each run.
+    - `spikes`: A dict of 3-tuples with the worker index as its key, and
+        the spike parameters (probability, margin, seed) as its value.
 
     `expected` and the processed sink(s) data should be directly equatable.
     The test fails if they fail an equality assertion.
@@ -1012,7 +1056,10 @@ def pipeline_test(generator, expected, command, workers=1, sources=1,
         num_sinks = sinks
         if sink_expect is not None:
             if not isinstance(sink_expect, (list, tuple)):
-                sink_expect = [sink_expect for x in range(len(num_sinks))]
+                sink_expect = [sink_expect for x in range(num_sinks)]
+        elif sink_await is not None:
+            if len(sink_await) != num_sinks:
+                sink_await = [sink_await[:] for x in range(num_sinks)]
         outputs = []
         sinks = []
         for x in range(num_sinks):
@@ -1042,7 +1089,8 @@ def pipeline_test(generator, expected, command, workers=1, sources=1,
                                    input_ports])
                 start_runners(runners, command, host, inputs, outputs,
                               metrics_port, control_port, external_port,
-                              data_port, resilience_dir, workers)
+                              data_port, resilience_dir, workers,
+                              spikes=spikes)
                 break
             except PipelineTestError as err:
                 # terminate runners, prepare to retry
@@ -1092,14 +1140,36 @@ def pipeline_test(generator, expected, command, workers=1, sources=1,
         # Use sink, metrics, or a timer to determine when to stop the
         # runners and sinks and begin validation
         if sink_expect:
-            if sink_expect_timeout is None:
-                sink_expect_timeout = DEFAULT_SINK_EXPECT_TIMEOUT
+            if sink_stop_timeout is None:
+                sink_stop_timeout = DEFAULT_SINK_STOP_TIMEOUT
             logging.debug('Waiting for {} messages at the sinks with a timeout'
                           ' of {} seconds'.format(sink_expect,
-                                                  sink_expect_timeout))
+                                                  sink_stop_timeout))
             stoppers = []
             for sink, sink_expect_val in zip(sinks, sink_expect):
-                stopper = SinkExpect(sink, sink_expect_val, sink_expect_timeout)
+                stopper = SinkExpect(sink, sink_expect_val, sink_stop_timeout)
+                stopper.start()
+                stoppers.append(stopper)
+            for stopper in stoppers:
+                stopper.join()
+                if stopper.error:
+                    print '\nSinkStopper Error. Runner output below.\n'
+                    for r in runners:
+                        print '==='
+                        print 'Runner: ', r.name
+                        print '---'
+                        print r.get_output()[0]
+                    raise stopper.error
+        elif sink_await:
+            if sink_stop_timeout is None:
+                sink_stop_timeout = DEFAULT_SINK_STOP_TIMEOUT
+            logging.debug('Awaiting {} values at the sinks with a timeout of '
+                          '{} seconds'.format(sum(map(len, sink_await)),
+                                              sink_stop_timeout))
+            stoppers = []
+            for sink, sink_await_vals in zip(sinks, sink_await):
+                stopper = SinkAwaitValue(sink, sink_await_vals,
+                                         sink_stop_timeout)
                 stopper.start()
                 stoppers.append(stopper)
             for stopper in stoppers:
@@ -1170,7 +1240,6 @@ def pipeline_test(generator, expected, command, workers=1, sources=1,
                 processed = pre_processor(decoded)
             else:
                 processed = decoded
-
 
             # Validate captured output against expected output
             if isinstance(expected, basestring):

--- a/testing/tools/integration/integration_test
+++ b/testing/tools/integration/integration_test
@@ -1,10 +1,12 @@
 #!/usr/bin/env python2
 
 import argparse
+from collections import namedtuple
 import logging
 import os
 import random
 import re
+import struct
 
 # set up basic logging
 logging.root.name = 'integration'
@@ -206,6 +208,74 @@ class CSVStringAction(argparse.Action):
         setattr(namespace, self.dest, values.split(','))
 
 
+SpikeConfig = namedtuple('SpikeConfig', ['probability', 'margin', 'seed'])
+
+
+class SpikeAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        """
+        Parameters (values): (index, probability, margin, seed)
+        defaults: index = 0, probability = 0.001, margin = 100, seed = None
+        """
+        if len(values) == 1:
+            index = int(values[0])  # Parse index
+            prob = 0.001
+            margin = 100
+            seed = None
+        elif len(values) == 2:
+            index = int(values[0])  # Parse index
+            prob = float(values[1]) # Parse probability
+            margin = 100
+            seed = None
+        elif len(values) == 3:
+            index = int(values[0])  # Parse index
+            prob = float(values[1]) # Parse probability
+            margin = int(values[2]) # Parse margin
+            seed = None
+        elif len(values) == 4:
+            index = int(values[0])  # Parse index
+            prob = float(values[1]) # Parse probability
+            margin = int(values[2]) # Parse margin
+            seed = int(values[3])   # Parse seed
+        else:
+            msg = ('Argument "{f}" requires 1, 2, 3 or 4 arguments specifying '
+                   'index [, probability [, margin [, seed]]].'
+                   .format(f=self.dest))
+            raise argparse.ArgumentTypeError(msg)
+
+        try:
+            dest = getattr(namespace, self.dest)
+            if not dest:
+                dest= {}
+                setattr(namespace, self.dest, dest)
+        except AttributeError:
+            dest = {}
+            setattr(namespace, self.dest, dest)
+        dest[index] = SpikeConfig(prob, margin, seed)
+
+
+class SinkAwaitAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        """
+        Parameters (values): [value, header]
+        Encode header with struct.pack using len(value)
+        """
+        if len(values) == 1:
+            values.append('>I')
+        elif len(values) != 2:
+            msg = ('Argumet "{f}" requires 1 or 2 arguments specifying '
+                   'value [header]'.format(f=self.dest))
+            raise argparse.ArgumentTypeError(msg)
+        dest = getattr(namespace, self.dest)
+        if not dest:
+            dest = []
+            setattr(namespace, self.dest, dest)
+        if values[1]:
+            dest.append(struct.pack(values[1], len(values[0])) + values[0])
+        else:
+            dest.append(values[0])
+
+
 LOG_LEVELS = {'none': 0,
               'debug': 10,
               'info': 20,
@@ -276,10 +346,14 @@ def CLI():
                       metavar=('item1,item2,...', 'source_index', 'header_format'),
                       help="Send values from a comma delimited string")
 
+    # Network parameters
     net1 = parser.add_argument_group('Network')
     net1.add_argument('--host', help=("The host address to use in "
                                            "networked components."),
                            default='127.0.0.1')
+    net1.add_argument('--spike', nargs='+', action=SpikeAction, default=[],
+                      metavar=('index', 'probability', 'margin', 'seed'),
+                      help=("Spike the connection on the specified worker"))
 
     # Expected data foir validation
     exp_group = parser.add_mutually_exclusive_group()
@@ -334,7 +408,11 @@ def CLI():
     expect = stopper.add_argument_group('Sink Expect')
     expect.add_argument('--sink-expect', type=int, action='append',
                         help=("How many messages to expect at each sink."))
-    expect.add_argument('--sink-expect-timeout', type=float,
+    stopper.add_argument('--sink-await', nargs='+', action=SinkAwaitAction,
+                         metavar=('value', 'header'),
+                         help=("Stop after receiving all await values in the"
+                               "sink"))
+    expect.add_argument('--sink-stop-timeout', type=float,
                         help=("Timeout in seconds before raising a "
                               "TimeoutError"))
     stopper.add_argument('--delay', type=float, default=None,
@@ -389,13 +467,15 @@ def CLI():
                       mode = args.sink_mode,
                       batch_size = args.batch_size,
                       sink_expect = args.sink_expect,
-                      sink_expect_timeout = args.sink_expect_timeout,
+                      sink_stop_timeout = args.sink_stop_timeout,
+                      sink_await = args.sink_await,
                       delay = args.delay,
                       validate_file = (args.output if args.validation_cmd else
                                        False),
                       giles_mode = 'giles' if args.giles_mode else None,
                       host=args.host,
-                      resilience_dir=args.resilience_dir))
+                      resilience_dir=args.resilience_dir,
+                      spikes=args.spike))
     except Exception as err:
         logging.exception("Encountered an error while running the test for %r\n===\n"
                       % args.command)
@@ -413,10 +493,11 @@ def CLI():
         else:
             outputs = [(o[0], o[1][0]) for o in outputs]
             outputs = '\n===\n'.join(('\n---\n'.join(t) for t in outputs))
+            logging.error("Application outputs:\n===\n{}\n===\n"
+                          .format(outputs))
             logging.error("Validation command '%s' failed with the output:\n"
-                          "--\n%s\n\nThe application had the following"
-                          " outputs:\n===\n%s",
-                         ' '.join(cmd), out, outputs)
+                          "--\n%s\nThe application output is shown above.\n",
+                          ' '.join(cmd), out)
 
         if logging.root.level > logging.ERROR:
             # If failed, and logging level means we didn't log error, include it

--- a/testing/tools/integration/metrics_parser.py
+++ b/testing/tools/integration/metrics_parser.py
@@ -2,12 +2,12 @@ from io import BytesIO, BufferedReader
 from struct import unpack
 
 
-## Message Types
+# Message Types
 #   1: Connect
 #   2: Join
 #   3: Metrics
 
-## Format types
+# Format types
 #   U8: B
 #   U16: H
 #   U32: I
@@ -17,8 +17,10 @@ from struct import unpack
 
 MSG_TYPES = {1: 'connect', 2: 'join', 3: 'metrics'}
 
+
 def _s(n):
     return '{}s'.format(n)
+
 
 class MetricsParser(object):
     def __init__(self):


### PR DESCRIPTION
Two new options in the `integration_test` CLI:
1. `--spike` takes: index, [probability [, margin [, seed]]]
    Run the worker at {index} with the spike parameters provided.
    For the optional parameters, the defaults are: 0.001, 100, None.
2. `--sink-await` takes: string [, header_format_string]
    Invoke this once for each value to be awaited at the sink.
    e.g. `--sink-await 123 --sink-await 456`
    The default header_format_string is '>I'.

One new make option:
1. spike=true|false (default: false)
    This will build your wallaroo app with '-D spike', which enables
    spike in the code.

As well as adding spike test parameters to `seqnence_window_simple_state`
integration test, and increases the total messages sent from 1000 to
10,000 so there's more room for spiking (if spike was enabled!).

Fixes style in integration python code to be pep8 compatible

closes #1779