### PR TITLE
Enble spike and sink-await in integration tests

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -123,6 +123,8 @@ ponyc_tag ?= wallaroolabs-$(strip $(latest_ponyc_tag))-release## tag for ponyc d
 ponyc_runner ?= wallaroolabs/ponyc## ponyc docker image to use
 debug ?= false## Use ponyc debug option (-d)
 debug_arg :=# Final argument string for debug option
+spike ?= false ## use ponycflags -D spike
+spike_arg :=# Final argument string for spike option
 docker_host ?= $(DOCKER_HOST)## docker host to build/run containers on
 ifeq ($(docker_host),)
   docker_host := unix:///var/run/docker.sock
@@ -203,6 +205,10 @@ ifeq ($(debug),true)
   debug_arg := --debug
 endif
 
+ifeq ($(spike), true)
+	spike_arg := -D spike
+endif
+
 # validation of variable
 ifdef arch
   $(eval $(call check-values,arch,amd64 native))
@@ -248,11 +254,11 @@ define PONYC
   $(QUIET)cd $(1) && $(ponyc_docker_args) $(PONYSTABLE) fetch \
     $(if $(filter $(ponyc_docker_args),docker),$(quote))
   $(QUIET)cd $(1) && $(ponyc_docker_args) $(PONYSTABLE) env $(PONYCC) $(ponyc_arch_args) \
-    $(debug_arg) $(autoscale_arg) $(clustering_arg) $(resilience_arg) \
+    $(debug_arg) $(spike_arg) $(autoscale_arg) $(clustering_arg) $(resilience_arg) \
     $(PONYCFLAGS) $(target_cpu_arg) . $(if $(filter $(ponyc_docker_args),docker),$(quote))
   $(QUIET)cd $(1) && echo "$@: $(abspath $(1))/bundle.json" | tr '\n' ' ' > $(notdir $(abspath $(1:%/=%))).d
   $(QUIET)cd $(1) && $(ponyc_docker_args) $(PONYSTABLE) env $(PONYCC) $(ponyc_arch_args) \
-    $(debug_arg) $(autoscale_arg) $(clustering_arg) $(resilience_arg) \
+    $(debug_arg) $(spike_arg) $(autoscale_arg) $(clustering_arg) $(resilience_arg) \
     $(PONYCFLAGS) $(target_cpu_arg) . --pass import --files $(if $(filter \
     $(ponyc_docker_args),docker),$(quote)) 2>/dev/null | grep -o "$(abs_wallaroo_dir).*.pony" \
     | awk 'BEGIN { a="" } {a=a$$1":\n"; printf "%s ",$$1} END {print "\n"a}' \

--- a/testing/correctness/apps/sequence_window_simple_state/Makefile
+++ b/testing/correctness/apps/sequence_window_simple_state/Makefile
@@ -50,15 +50,18 @@ integration-tests-testing-correctness-apps-sequence_window_simple_state: sequenc
 
 sequence_window_simple_state_test:
 	cd $(SEQUENCE_WINDOW_SIMPLE_STATE_PATH) && \
-	integration_test --sequence-sender '(0,1000]' \
+	integration_test --sequence-sender '(0,10000]' \
 	  --log-level error \
 		--command './sequence_window_simple_state' \
-		--validation-cmd 'validator -e 1000 -a -i' \
+		--validation-cmd 'validator -e 10000 -a -i' \
 		--output 'received.txt' \
 		--giles-mode \
 		--workers 2 \
 		--batch-size 10 \
-		--sink-expect 1000
+		--sink-await '[9994,9996,9998,10000]' \
+		--sink-await '[9993,9995,9997,9999]' \
+		--spike 0 0.001 200 1
+
 
 clean-testing-correctness-apps-sequence_window_simple_state: sequence_window_simple_state_clean
 

--- a/testing/tools/integration/__init__.py
+++ b/testing/tools/integration/__init__.py
@@ -27,8 +27,8 @@ It has:
     - files_generator: a file source supporting both newlines and framed modes
     - sequence_generator: a framed source encoded U64 sequence generator
         (binary)
-    - iter_generator: a generic framed source encoded generator that operates on
-        iterators. It takes an optional `to_string` lambda for converting
+    - iter_generator: a generic framed source encoded generator that operates
+        on iterators. It takes an optional `to_string` lambda for converting
         iterator items to strings.
     - files_generator: a generic
     - Runner: Runs a single Wallaroo worker with command line parameters.

--- a/testing/tools/integration/integration_test
+++ b/testing/tools/integration/integration_test
@@ -1,10 +1,12 @@
 #!/usr/bin/env python2
 
 import argparse
+from collections import namedtuple
 import logging
 import os
 import random
 import re
+import struct
 
 # set up basic logging
 logging.root.name = 'integration'
@@ -206,6 +208,74 @@ class CSVStringAction(argparse.Action):
         setattr(namespace, self.dest, values.split(','))
 
 
+SpikeConfig = namedtuple('SpikeConfig', ['probability', 'margin', 'seed'])
+
+
+class SpikeAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        """
+        Parameters (values): (index, probability, margin, seed)
+        defaults: index = 0, probability = 0.001, margin = 100, seed = None
+        """
+        if len(values) == 1:
+            index = int(values[0])  # Parse index
+            prob = 0.001
+            margin = 100
+            seed = None
+        elif len(values) == 2:
+            index = int(values[0])  # Parse index
+            prob = float(values[1]) # Parse probability
+            margin = 100
+            seed = None
+        elif len(values) == 3:
+            index = int(values[0])  # Parse index
+            prob = float(values[1]) # Parse probability
+            margin = int(values[2]) # Parse margin
+            seed = None
+        elif len(values) == 4:
+            index = int(values[0])  # Parse index
+            prob = float(values[1]) # Parse probability
+            margin = int(values[2]) # Parse margin
+            seed = int(values[3])   # Parse seed
+        else:
+            msg = ('Argument "{f}" requires 1, 2, 3 or 4 arguments specifying '
+                   'index [, probability [, margin [, seed]]].'
+                   .format(f=self.dest))
+            raise argparse.ArgumentTypeError(msg)
+
+        try:
+            dest = getattr(namespace, self.dest)
+            if not dest:
+                dest= {}
+                setattr(namespace, self.dest, dest)
+        except AttributeError:
+            dest = {}
+            setattr(namespace, self.dest, dest)
+        dest[index] = SpikeConfig(prob, margin, seed)
+
+
+class SinkAwaitAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        """
+        Parameters (values): [value, header]
+        Encode header with struct.pack using len(value)
+        """
+        if len(values) == 1:
+            values.append('>I')
+        elif len(values) != 2:
+            msg = ('Argumet "{f}" requires 1 or 2 arguments specifying '
+                   'value [header]'.format(f=self.dest))
+            raise argparse.ArgumentTypeError(msg)
+        dest = getattr(namespace, self.dest)
+        if not dest:
+            dest = []
+            setattr(namespace, self.dest, dest)
+        if values[1]:
+            dest.append(struct.pack(values[1], len(values[0])) + values[0])
+        else:
+            dest.append(values[0])
+
+
 LOG_LEVELS = {'none': 0,
               'debug': 10,
               'info': 20,
@@ -276,10 +346,14 @@ def CLI():
                       metavar=('item1,item2,...', 'source_index', 'header_format'),
                       help="Send values from a comma delimited string")
 
+    # Network parameters
     net1 = parser.add_argument_group('Network')
     net1.add_argument('--host', help=("The host address to use in "
                                            "networked components."),
                            default='127.0.0.1')
+    net1.add_argument('--spike', nargs='+', action=SpikeAction,
+                      metavar=('index', 'probability', 'margin', 'seed'),
+                      help=("Spike the connection on the specified worker"))
 
     # Expected data foir validation
     exp_group = parser.add_mutually_exclusive_group()
@@ -334,7 +408,11 @@ def CLI():
     expect = stopper.add_argument_group('Sink Expect')
     expect.add_argument('--sink-expect', type=int, action='append',
                         help=("How many messages to expect at each sink."))
-    expect.add_argument('--sink-expect-timeout', type=float,
+    stopper.add_argument('--sink-await', nargs='+', action=SinkAwaitAction,
+                         metavar=('value', 'header'),
+                         help=("Stop after receiving all await values in the"
+                               "sink"))
+    expect.add_argument('--sink-stop-timeout', type=float,
                         help=("Timeout in seconds before raising a "
                               "TimeoutError"))
     stopper.add_argument('--delay', type=float, default=None,
@@ -389,13 +467,15 @@ def CLI():
                       mode = args.sink_mode,
                       batch_size = args.batch_size,
                       sink_expect = args.sink_expect,
-                      sink_expect_timeout = args.sink_expect_timeout,
+                      sink_stop_timeout = args.sink_stop_timeout,
+                      sink_await = args.sink_await,
                       delay = args.delay,
                       validate_file = (args.output if args.validation_cmd else
                                        False),
                       giles_mode = 'giles' if args.giles_mode else None,
                       host=args.host,
-                      resilience_dir=args.resilience_dir))
+                      resilience_dir=args.resilience_dir,
+                      spikes=args.spike))
     except Exception as err:
         logging.exception("Encountered an error while running the test for %r\n===\n"
                       % args.command)
@@ -413,10 +493,11 @@ def CLI():
         else:
             outputs = [(o[0], o[1][0]) for o in outputs]
             outputs = '\n===\n'.join(('\n---\n'.join(t) for t in outputs))
+            logging.error("Application outputs:\n===\n{}\n===\n"
+                          .format(outputs))
             logging.error("Validation command '%s' failed with the output:\n"
-                          "--\n%s\n\nThe application had the following"
-                          " outputs:\n===\n%s",
-                         ' '.join(cmd), out, outputs)
+                          "--\n%s\nThe application output is shown above.\n",
+                          ' '.join(cmd), out)
 
         if logging.root.level > logging.ERROR:
             # If failed, and logging level means we didn't log error, include it

--- a/testing/tools/integration/metrics_parser.py
+++ b/testing/tools/integration/metrics_parser.py
@@ -2,12 +2,12 @@ from io import BytesIO, BufferedReader
 from struct import unpack
 
 
-## Message Types
+# Message Types
 #   1: Connect
 #   2: Join
 #   3: Metrics
 
-## Format types
+# Format types
 #   U8: B
 #   U16: H
 #   U32: I
@@ -17,8 +17,10 @@ from struct import unpack
 
 MSG_TYPES = {1: 'connect', 2: 'join', 3: 'metrics'}
 
+
 def _s(n):
     return '{}s'.format(n)
+
 
 class MetricsParser(object):
     def __init__(self):


### PR DESCRIPTION
@slfritchie , this is the same as https://github.com/WallarooLabs/wallaroo/pull/1780, but based on the last commit to `master` before the missing-data fix. It's a separate PR because there are merge conflicts between this and `master` due to other updates related to the multi-worker join tests.

To enable spike in the `sequence_window_simple_state` integration test:

```bash
make clean
make integration-tests-testing-correctness-apps-sequence_window_simple_state debug=true spike=true
```

You can edit the spike parameters in the `sequence_window_simple_state` Makefile.
The two of interest are the 2nd and 3rd numbers to the `--spike` option: probability (float, out of 1.0), and margin (minimum number of boundary messages between connection drops. This count includes replay messages.)