### PR TITLE
Update Machida README to use make to build

### DIFF
--- a/machida/README.md
+++ b/machida/README.md
@@ -3,38 +3,16 @@
 Machida is a Wallaroo-Python Runtime that enables a Wallaroo application to be written in Python.
 
 ## Requirements
-- clang >=3.5 on MacOS or gcc >=5 on Linux
-- python-dev
-- wallaroolabs-ponyc
-- giles-sender
 
-You will also need your environment to be [set up with a working
+You will need your environment to be [set up with a working
 Wallaroo](/book/getting-started/setup.md).
 
 ## Build
 
-Create the `build` directory if it doesn't already exist.
-
-```
-mkdir build
-```
-
 Build the program.
 
-**On MacOS**:
-
 ```bash
-clang -g -o build/python-wallaroo.o -c cpp/python-wallaroo.c
-ar rvs build/libpython-wallaroo.a build/python-wallaroo.o
-ponyc --debug --output=build --path=build --path=../lib/ .
-```
-
-**On Linux**:
-
-```bash
-gcc -g -o build/python-wallaroo.o -c cpp/python-wallaroo.c
-ar rvs build/libpython-wallaroo.a build/python-wallaroo.o
-ponyc --debug --output=build --path=build --path=../lib/ .
+make build-machida
 ```
 
 ## Next Steps


### PR DESCRIPTION
Removes mention of clang and ponyc to build Machida, replaces
with `make build-machida`. Also removes mention of dependencies
as they're all now listed in the setup instructions.

[skip ci]

closes #1694 