### PR TITLE
Update Write Your Own Python App to correctly mention source/sink types

### DIFF
--- a/book/python/writing-your-own-application.md
+++ b/book/python/writing-your-own-application.md
@@ -124,7 +124,7 @@ def application_setup(args):
     return ab.build()
 ```
 
-Configuration objects are used to pass information about sources and sinks to the application builder. Currently the only supported source is the TCP source, and the only supported sink is the TCP sink.
+Configuration objects are used to pass information about sources and sinks to the application builder. Currently the only supported source and sink types are TCP and Kafka.
 
 Wallaroo provides convenience the functions `tcp_parse_input_addrs` and `tcp_parse_output_addrs` to parse host and port information that is passed on the command line, or the user can supply their own code for getting these values. When using the convenience functions, host/port pairs are represented on the command line as colon-separated values and multiple host/port values are represented by a comma-separated list of host/port values. The functions assume that `--in` is used for input addresses, and `--out` is used for output addresses. For example, this set of command line arguments would specify two input host/port values and one output:
 


### PR DESCRIPTION
The documentation now mentions both TCP and Kafka sources/sinks as the only
supported types. It previously incorrectly stated that only TCP sources/sinks
were supported.

[skip ci]

Closes #1787 