### PR TITLE
Change Python Alphabet Partitioned encoding to I from L

### DIFF
--- a/examples/python/alphabet_partitioned/alphabet_partitioned.py
+++ b/examples/python/alphabet_partitioned/alphabet_partitioned.py
@@ -99,4 +99,4 @@ class Encoder(object):
         votes = data.votes
         print "letter is " + str(letter)
         print "votes is " + str(votes)
-        return struct.pack(">LsQ", 9, data.letter, data.votes)
+        return struct.pack(">IsQ", 9, data.letter, data.votes)


### PR DESCRIPTION
We were incorrectly encoding the Python Alphabet Partitioned app data
using L instead of I which lead to Giles Receiver incorrectly interpreting
the results. Giles Receiver can now correctly interpret the results with the
use of I.

Fixes #1793 