### PR TITLE
Update Python Writing Your Own Stateful App Encoder doc

### DIFF
--- a/book/python/writing-your-own-stateful-application.md
+++ b/book/python/writing-your-own-stateful-application.md
@@ -82,7 +82,7 @@ class LetterStateBuilder(object):
 ```
 
 ### Encoder
-The encoder is going to receive a `Votes` instance and encode into a string with the letter, followed by the vote count as a big-endian 32-bit unsigned integer:
+The encoder is going to receive a `Votes` instance and encode into a string with the letter, followed by the vote count as a big-endian 64-bit unsigned integer:
 
 ```python
 class Encoder(object):


### PR DESCRIPTION
The Encoder section in the docs improperly stated that the data is encoded
as a 32-bit unsigned integer. This updates the doc to properly state that
the encoding is a 64-bit unsigned integer.

[skip ci]

Closes #1796