### PR TITLE
Update Travis for release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,3 +56,8 @@ install:
 
 script:
   - bash travis/script.sh
+
+deploy:
+  skip_cleanup: true
+  provider: script
+  script: travis/docker_release.sh

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -137,8 +137,14 @@ install_python_dependencies() {
   echo "** Python dependencies installed"
 }
 
+turn_off_o_nonblock() {
+  echo "Turning off O_NONBLOCK"
+  python -c 'import os,sys,fcntl; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags&~os.O_NONBLOCK);'
+}
+
 echo "----- Installing dependencies"
 
+turn_off_o_nonblock
 install_cpuset
 install_ponyc
 install_pony_stable

--- a/travis/script.sh
+++ b/travis/script.sh
@@ -8,5 +8,3 @@ make test debug=true
 make clean
 # Run the correctness tests that require a resilience build
 make integration-tests-testing-correctness-tests-all resilience=on debug=true
-# Release Wallaroo docker image (if needed)
-bash travis/docker_release.sh


### PR DESCRIPTION
Adds removal of O_NONBLOCK to circumvent `tar: write error` failures.

Moves Docker release script under `deploy` job due to intermittent failures where the current `script` job takes longer than 50 minutes and automatically fails due to the max allowed time for a single job.