### PR TITLE
Fix typo in Python 3 binding date

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Currently, Python 2.7 is our primary focus. As we add features to the Wallaroo, 
 
 - Python 3
 
-We are currently working with a client who needs Python 3 bindings. We plan to introduce Python 3 bindings in early 2017. 
+We are currently working with a client who needs Python 3 bindings. We plan to introduce Python 3 bindings in early 2018.
 
 - C++
 


### PR DESCRIPTION
Fixes #1830 

[skip ci]