### PR TITLE
Use unique ports in `--my-control` and `--my-data` channels for each worker

### DIFF
--- a/testing/correctness/tests/autoscale_grow/autoscale_grow.py
+++ b/testing/correctness/tests/autoscale_grow/autoscale_grow.py
@@ -189,7 +189,7 @@ def _test_autoscale_grow(command, worker_count=1):
                 print('RunnerChecker error for Join check on {}'
                       .format(jc.runner_name))
 
-                outputs = [(r.name, r.get_output()[0]) for r in runners]
+                outputs = [(r.name, r.get_output()) for r in runners]
                 outputs = '\n===\n'.join(('\n---\n'.join(t) for t in outputs))
                 raise TimeoutError(
                     'Worker {} join timed out in {} '
@@ -251,7 +251,7 @@ def _test_autoscale_grow(command, worker_count=1):
             try:
                 assert(len(filtered) > 0)
             except AssertionError:
-                outputs = [(r.name, r.get_output()[0]) for r in runners]
+                outputs = [(r.name, r.get_output()) for r in runners]
                 outputs = '\n===\n'.join(('\n---\n'.join(t) for t in outputs))
                 raise AssertionError('{} did not process any data! '
                                      'Worker outputs are included below:'
@@ -262,7 +262,7 @@ def _test_autoscale_grow(command, worker_count=1):
         try:
             validate(sink.data, expected)
         except AssertionError:
-            outputs = [(r.name, r.get_output()[0]) for r in runners]
+            outputs = [(r.name, r.get_output()) for r in runners]
             outputs = '\n===\n'.join(('\n---\n'.join(t) for t in outputs))
             raise AssertionError('Validation failed on expected output. '
                                  'Worker outputs are included below:'

--- a/testing/correctness/tests/autoscale_grow/autoscale_grow.py
+++ b/testing/correctness/tests/autoscale_grow/autoscale_grow.py
@@ -169,7 +169,7 @@ def _test_autoscale_grow(command, worker_count=1):
 
         # create a new worker and have it join
         new_ports = get_port_values(num=(joiners * 2), host=host,
-                                    base_port=55000)
+                                    base_port=25000)
         joiner_ports = zip(new_ports[::2], new_ports[1::2])
         for i in range(joiners):
             add_runner(runners, command, host, inputs, outputs, metrics_port,

--- a/testing/correctness/tests/log_rotation/log_rotation.py
+++ b/testing/correctness/tests/log_rotation/log_rotation.py
@@ -147,7 +147,7 @@ def _test_log_rotation_external_trigger_no_recovery(command):
         if stopper.error:
             for r in runners:
                 print r.name
-                print r.get_output()[0]
+                print r.get_output()
                 print '---'
             raise stopper.error
 
@@ -174,17 +174,17 @@ def _test_log_rotation_external_trigger_no_recovery(command):
             assert(success)
         except AssertionError:
             print runners[0].name
-            print runners[0].get_output()[0]
+            print runners[0].get_output()
             print '---'
             print runners[1].name
-            print runners[1].get_output()[0]
+            print runners[1].get_output()
             print '---'
             raise AssertionError('Validation failed with the following '
                                  'error:\n{}'.format(stdout))
 
         # Validate all workers underwent log rotation
         for r in runners[1:]:
-            stdout, stderr = r.get_output()
+            stdout = r.get_output()
             try:
                 assert(re.search(log_rotated_pattern, stdout, re.M | re.S)
                        is not None)
@@ -318,7 +318,7 @@ def _test_log_rotation_external_trigger_recovery(command):
         if stopper.error:
             for r in runners:
                 print r.name
-                print r.get_output()[0]
+                print r.get_output()
                 print '---'
             raise stopper.error
 
@@ -345,17 +345,17 @@ def _test_log_rotation_external_trigger_recovery(command):
             assert(success)
         except AssertionError:
             print runners[0].name
-            print runners[0].get_output()[0]
+            print runners[0].get_output()
             print '---'
             print runners[1].name
-            print runners[1].get_output()[0]
+            print runners[1].get_output()
             print '---'
             raise AssertionError('Validation failed with the following '
                                  'error:\n{}'.format(stdout))
 
         # Validate all workers underwent log rotation
         r = runners[1]
-        stdout, stderr = r.get_output()
+        stdout = r.get_output()
         try:
             assert(re.search(log_rotated_pattern, stdout, re.M | re.S)
                    is not None)
@@ -369,17 +369,16 @@ def _test_log_rotation_external_trigger_recovery(command):
                                  % (1, r.name, log_rotated_pattern, stdout))
         # Validate worker actually underwent recovery
         pattern = "RESILIENCE\: Replayed \d+ entries from recovery log file\."
-        stdout, stderr = runners[-1].get_output()
+        stdout = runners[-1].get_output()
         try:
             assert(re.search(pattern, stdout) is not None)
         except AssertionError:
             raise AssertionError('Worker %d.%r does not appear to have '
                                  'performed recovery as expected. Worker '
                                  'output is '
-                                 'included below.\nSTDOUT\n---\n%s\n---\n'
-                                 'STDERR\n---\n%s'
+                                 'included below.\nSTDOUT\n---\n%s'
                                  % (len(runners)-1, runners[-1].name,
-                                    stdout, stderr))
+                                    stdout))
     finally:
         for r in runners:
             r.stop()
@@ -477,7 +476,7 @@ def _test_log_rotation_file_size_trigger_no_recovery(command):
         if stopper.error:
             for r in runners:
                 print r.name
-                print r.get_output()[0]
+                print r.get_output()
                 print '---'
             raise stopper.error
 
@@ -502,16 +501,16 @@ def _test_log_rotation_file_size_trigger_no_recovery(command):
         try:
             assert(success)
         except AssertionError:
-            print runners[0].get_output()[0]
+            print runners[0].get_output()
             print '---'
-            print runners[1].get_output()[0]
+            print runners[1].get_output()
             print '---'
             raise AssertionError('Validation failed with the following '
                                  'error:\n{}'.format(stdout))
 
         # Validate all workers underwent log rotation
         for r in runners:
-            stdout, stderr = r.get_output()
+            stdout = r.get_output()
             try:
                 assert(re.search(log_rotated_pattern, stdout, re.M | re.S)
                        is not None)
@@ -635,7 +634,7 @@ def _test_log_rotation_file_size_trigger_recovery(command):
         if stopper.error:
             for r in runners:
                 print r.name
-                print r.get_output()[0]
+                print r.get_output()
                 print '---'
             raise stopper.error
 
@@ -661,17 +660,17 @@ def _test_log_rotation_file_size_trigger_recovery(command):
             assert(success)
         except AssertionError:
             print runners[-1].name
-            print runners[-1].get_output()[0]
+            print runners[-1].get_output()
             print '---'
             print runners[-2].name
-            print runners[-2].get_output()[0]
+            print runners[-2].get_output()
             print '---'
             raise AssertionError('Validation failed with the following '
                                  'error:\n{}'.format(stdout))
 
         # Validate worker underwent log rotation, but not initializer
         i, r = 1, runners[1]
-        stdout, stderr = r.get_output()
+        stdout = r.get_output()
         try:
             assert(re.search(log_rotated_pattern, stdout, re.M | re.S)
                    is not None)
@@ -687,14 +686,14 @@ def _test_log_rotation_file_size_trigger_recovery(command):
 
         # Validate worker actually underwent recovery
         pattern = "RESILIENCE\: Replayed \d+ entries from recovery log file\."
-        stdout, stderr = runners[-1].get_output()
+        stdout = runners[-1].get_output()
         try:
             assert(re.search(pattern, stdout) is not None)
         except AssertionError:
             raise AssertionError('Worker does not appear to have performed '
                                  'recovery as expected. Worker output is '
-                                 'included below.\nSTDOUT\n---\n%s\n---\n'
-                                 'STDERR\n---\n%s' % (stdout, stderr))
+                                 'included below.\nSTDOUT\n---\n%s'
+                                 % stdout)
     finally:
         for r in runners:
             r.stop()

--- a/testing/correctness/tests/log_rotation/log_rotation.py
+++ b/testing/correctness/tests/log_rotation/log_rotation.py
@@ -92,14 +92,19 @@ def _test_log_rotation_external_trigger_no_recovery(command):
         metrics_host, metrics_port = metrics.get_connection_info()
         time.sleep(0.05)
 
-        input_ports, control_port, external_port, data_port = (
-            get_port_values(host, sources))
+        num_ports = sources + 3 + (2 * (workers - 1))
+        ports = get_port_values(num=num_ports, host=host)
+        (input_ports, (control_port, data_port, external_port),
+         worker_ports) = (ports[:sources],
+                          ports[sources:sources+3],
+                          zip(ports[-(2*(workers-1)):][::2],
+                              ports[-(2*(workers-1)):][1::2]))
         inputs = ','.join(['{}:{}'.format(host, p) for p in
                            input_ports])
 
         start_runners(runners, command, host, inputs, outputs,
                       metrics_port, control_port, external_port, data_port,
-                      res_dir, workers)
+                      res_dir, workers, worker_ports)
 
         # Wait for first runner (initializer) to report application ready
         runner_ready_checker = RunnerReadyChecker(runners, timeout=30)
@@ -242,14 +247,19 @@ def _test_log_rotation_external_trigger_recovery(command):
         metrics_host, metrics_port = metrics.get_connection_info()
         time.sleep(0.05)
 
-        input_ports, control_port, external_port, data_port = (
-            get_port_values(host, sources))
+        num_ports = sources + 3 + (2 * (workers - 1))
+        ports = get_port_values(num=num_ports, host=host)
+        (input_ports, (control_port, data_port, external_port),
+         worker_ports) = (ports[:sources],
+                          ports[sources:sources+3],
+                          zip(ports[-(2*(workers-1)):][::2],
+                              ports[-(2*(workers-1)):][1::2]))
         inputs = ','.join(['{}:{}'.format(host, p) for p in
                            input_ports])
 
         start_runners(runners, command, host, inputs, outputs,
                       metrics_port, control_port, external_port, data_port,
-                      res_dir, workers)
+                      res_dir, workers, worker_ports)
 
         # Wait for first runner (initializer) to report application ready
         runner_ready_checker = RunnerReadyChecker(runners, timeout=30)
@@ -423,14 +433,19 @@ def _test_log_rotation_file_size_trigger_no_recovery(command):
         metrics_host, metrics_port = metrics.get_connection_info()
         time.sleep(0.05)
 
-        input_ports, control_port, external_port, data_port = (
-            get_port_values(host, sources))
+        num_ports = sources + 3 + (2 * (workers - 1))
+        ports = get_port_values(num=num_ports, host=host)
+        (input_ports, (control_port, data_port, external_port),
+         worker_ports) = (ports[:sources],
+                          ports[sources:sources+3],
+                          zip(ports[-(2*(workers-1)):][::2],
+                              ports[-(2*(workers-1)):][1::2]))
         inputs = ','.join(['{}:{}'.format(host, p) for p in
                            input_ports])
 
         start_runners(runners, command, host, inputs, outputs,
                       metrics_port, control_port, external_port, data_port,
-                      res_dir, workers)
+                      res_dir, workers, worker_ports)
 
         # Wait for first runner (initializer) to report application ready
         runner_ready_checker = RunnerReadyChecker(runners, timeout=30)
@@ -562,14 +577,19 @@ def _test_log_rotation_file_size_trigger_recovery(command):
         metrics_host, metrics_port = metrics.get_connection_info()
         time.sleep(0.05)
 
-        input_ports, control_port, external_port, data_port = (
-            get_port_values(host, sources))
+        num_ports = sources + 3 + (2 * (workers - 1))
+        ports = get_port_values(num=num_ports, host=host)
+        (input_ports, (control_port, data_port, external_port),
+         worker_ports) = (ports[:sources],
+                          ports[sources:sources+3],
+                          zip(ports[-(2*(workers-1)):][::2],
+                              ports[-(2*(workers-1)):][1::2]))
         inputs = ','.join(['{}:{}'.format(host, p) for p in
                            input_ports])
 
         start_runners(runners, command, host, inputs, outputs,
                       metrics_port, control_port, external_port, data_port,
-                      res_dir, workers, alt_block, alt_func)
+                      res_dir, workers, worker_ports, alt_block, alt_func)
 
         # Wait for first runner (initializer) to report application ready
         runner_ready_checker = RunnerReadyChecker(runners, timeout=30)

--- a/testing/correctness/tests/recovery/recovery.py
+++ b/testing/correctness/tests/recovery/recovery.py
@@ -74,14 +74,19 @@ def _test_recovery(command):
         metrics_host, metrics_port = metrics.get_connection_info()
         time.sleep(0.05)
 
-        input_ports, control_port, external_port, data_port = (
-            get_port_values(host, sources))
+        num_ports = sources + 3 + (2 * (workers - 1))
+        ports = get_port_values(num=num_ports, host=host)
+        (input_ports, (control_port, data_port, external_port),
+         worker_ports) = (ports[:sources],
+                          ports[sources:sources+3],
+                          zip(ports[-(2*(workers-1)):][::2],
+                              ports[-(2*(workers-1)):][1::2]))
         inputs = ','.join(['{}:{}'.format(host, p) for p in
                            input_ports])
 
         start_runners(runners, command, host, inputs, outputs,
                       metrics_port, control_port, external_port, data_port,
-                      res_dir, workers)
+                      res_dir, workers, worker_ports)
 
         # Wait for first runner (initializer) to report application ready
         runner_ready_checker = RunnerReadyChecker(runners, timeout=30)

--- a/testing/correctness/tests/recovery/recovery.py
+++ b/testing/correctness/tests/recovery/recovery.py
@@ -147,23 +147,23 @@ def _test_recovery(command):
         try:
             assert(success)
         except AssertionError:
-            print runners[-1].get_output()[0]
+            print runners[-1].get_output()
             print '---'
-            print runners[-2].get_output()[0]
+            print runners[-2].get_output()
             print '---'
             raise AssertionError('Validation failed with the following '
                                  'error:\n{}'.format(stdout))
 
         # Validate worker actually underwent recovery
         pattern = "RESILIENCE\: Replayed \d+ entries from recovery log file\."
-        stdout, stderr = runners[-1].get_output()
+        stdout = runners[-1].get_output()
         try:
             assert(re.search(pattern, stdout) is not None)
         except AssertionError:
             raise AssertionError('Worker does not appear to have performed '
                                  'recovery as expected. Worker output is '
-                                 'included below.\nSTDOUT\n---\n%s\n---\n'
-                                 'STDERR\n---\n%s' % (stdout, stderr))
+                                 'included below.\nSTDOUT\n---\n%s'
+                                 % stdout)
 
     finally:
         for r in runners:

--- a/testing/correctness/tests/restart_without_resilience/restart_without_resilience.py
+++ b/testing/correctness/tests/restart_without_resilience/restart_without_resilience.py
@@ -74,14 +74,19 @@ def _test_restart(command):
         metrics_host, metrics_port = metrics.get_connection_info()
         time.sleep(0.05)
 
-        input_ports, control_port, external_port, data_port = (
-            get_port_values(host, sources))
+        num_ports = sources + 3 + (2 * (workers - 1))
+        ports = get_port_values(num=num_ports, host=host)
+        (input_ports, (control_port, data_port, external_port),
+         worker_ports) = (ports[:sources],
+                          ports[sources:sources+3],
+                          zip(ports[-(2*(workers-1)):][::2],
+                              ports[-(2*(workers-1)):][1::2]))
         inputs = ','.join(['{}:{}'.format(host, p) for p in
                            input_ports])
 
         start_runners(runners, command, host, inputs, outputs,
                       metrics_port, control_port, external_port, data_port,
-                      res_dir, workers)
+                      res_dir, workers, worker_ports)
 
         # Wait for first runner (initializer) to report application ready
         runner_ready_checker = RunnerReadyChecker(runners, timeout=30)

--- a/testing/correctness/tests/restart_without_resilience/restart_without_resilience.py
+++ b/testing/correctness/tests/restart_without_resilience/restart_without_resilience.py
@@ -125,7 +125,7 @@ def _test_restart(command):
         if stopper.error:
             for r in runners:
                 print r.name
-                print r.get_output()[0]
+                print r.get_output()
                 print '---'
             print 'sink data'
             print sink.data
@@ -141,14 +141,14 @@ def _test_restart(command):
 
         # Validate worker actually underwent recovery
         pattern_restarting = "Restarting a listener ..."
-        stdout, stderr = runners[-1].get_output()
+        stdout = runners[-1].get_output()
         try:
             assert(re.search(pattern_restarting, stdout) is not None)
         except AssertionError:
             raise AssertionError('Worker does not appear to have reconnected '
                                  'as expected. Worker output is '
-                                 'included below.\nSTDOUT\n---\n%s\n---\n'
-                                 'STDERR\n---\n%s' % (stdout, stderr))
+                                 'included below.\nSTDOUT\n---\n%s'
+                                 % stdout)
     finally:
         for r in runners:
             r.stop()

--- a/testing/tools/integration/integration.py
+++ b/testing/tools/integration/integration.py
@@ -781,7 +781,7 @@ class PipelineTestError(Exception):
 def get_port_values(num=1, host='127.0.0.1', base_port=20000):
     """
     Get the requested number (default: 1) of free ports for a given host
-    (defult: '127.0.0.1'), starting from base_port (default: 50000).
+    (default: '127.0.0.1'), starting from base_port (default: 20000).
     """
 
     ports = []

--- a/testing/tools/integration/integration.py
+++ b/testing/tools/integration/integration.py
@@ -779,7 +779,7 @@ class PipelineTestError(Exception):
     pass
 
 
-def get_port_values(num=1, host='127.0.0.1', base_port=50000):
+def get_port_values(num=1, host='127.0.0.1', base_port=20000):
     """
     Get the requested number (default: 1) of free ports for a given host
     (defult: '127.0.0.1'), starting from base_port (default: 50000).

--- a/testing/tools/integration/integration_test
+++ b/testing/tools/integration/integration_test
@@ -491,7 +491,7 @@ def CLI():
                 logging.info("Validation command '%s' completed successfully",
                              ' '.join(cmd))
         else:
-            outputs = [(o[0], o[1][0]) for o in outputs]
+            outputs = [(o[0], o[1]) for o in outputs]
             outputs = '\n===\n'.join(('\n---\n'.join(t) for t in outputs))
             logging.error("Application outputs:\n===\n{}\n===\n"
                           .format(outputs))


### PR DESCRIPTION
Each worker now receives unique ports for their `--my-control` and `--my-data` ports, to avoid the intermittent errors we seem to be getting as a result of port collisions when the workers obtain a randomly selected port from the OS for these channels.

- This change also includes updates to the scripted tests in `testing/correctness/tests` to accommodate the new behaviour of `get_port_values` and to avoid collisions between multiple calls to that function.
- @slfritchie ran into scrambled-output related errors during his testing of this code, so this PR now includes a fix for this as well:
  - the STDOUT and STDERR of each Wallaroo worker are both piped to the same temporary file instead of to separate files
  - Whenever this file is read, it is now done in a safe manner via a new, read-only file object, in order to avoid changes to the file position as it is being written to.

**Testing**: CI should pass.

closes #1769