### PR TITLE
Add apt-get update instruction for Linux

### DIFF
--- a/book/getting-started/linux-setup.md
+++ b/book/getting-started/linux-setup.md
@@ -8,6 +8,14 @@ There are a few applications/tools which are required to be installed before you
 
 In order to compile the Wallaroo example applications, your system will need to have approximately 6 GB working memory (this can be RAM or swap). If you don't have enough memory, you are likely to see that the compile process is `Killed` by the OS.
 
+## Update apt-get
+
+Ensures you'll have the latest available packages:
+
+```bash
+sudo apt-get update
+```
+
 ## Installing git
 
 If you do not already have Git installed, install it:


### PR DESCRIPTION
Adds `sudo apt-get update` as first command to run as part of
installation to verify user will get the latest packages available.

[skip ci]

closes #1642