### PR TITLE
Include host and service in connection related errors when possible

### DIFF
--- a/lib/wallaroo/core/data_channel/data_channel_listener.pony
+++ b/lib/wallaroo/core/data_channel/data_channel_listener.pony
@@ -47,6 +47,8 @@ actor DataChannelListener
   var _paused: Bool = false
   var _init_size: USize
   var _max_size: USize
+  let _requested_host: String
+  let _requested_service: String
 
   let _router_registry: RouterRegistry
 
@@ -59,6 +61,8 @@ actor DataChannelListener
     """
     Listens for both IPv4 and IPv6 connections.
     """
+    _requested_host = host
+    _requested_service = service
     _router_registry = router_registry
     _limit = limit
     _notify = consume notify
@@ -80,6 +84,14 @@ actor DataChannelListener
     Stop listening.
     """
     close()
+
+  fun requested_address(): (String, String) =>
+    """
+    Return the host and service that were originally provided to the
+    @pony_os_listen_tcp method.
+    Use this if `local_address().name()` fails.
+    """
+    (_requested_host, _requested_service)
 
   fun local_address(): NetAddress =>
     """

--- a/lib/wallaroo/core/data_channel/data_channel_tcp.pony
+++ b/lib/wallaroo/core/data_channel/data_channel_tcp.pony
@@ -114,12 +114,18 @@ class DataChannelListenNotifier is DataChannelListenNotify
       f.sync()
       f.dispose()
     else
-      @printf[I32]((_name + "data : couldn't get local address\n").cstring())
+      @printf[I32]((_name + " data : couldn't get local address\n").cstring())
       listen.close()
     end
 
   fun ref not_listening(listen: DataChannelListener ref) =>
-    @printf[I32]((_name + "data : unable to listen\n").cstring())
+    (let h, let s) = try
+      listen.local_address().name(None, false)?
+    else
+      listen.requested_address()
+    end
+    @printf[I32]((_name + " data : unable to listen on (%s:%s)\n").cstring(),
+      h.cstring(), s.cstring())
     Fail()
 
   fun ref connected(

--- a/lib/wallaroo/ent/network/control_channel_tcp.pony
+++ b/lib/wallaroo/ent/network/control_channel_tcp.pony
@@ -94,13 +94,14 @@ class ControlChannelListenNotifier is TCPListenNotify
       @printf[I32]((_name + " control: listening on " + _host + ":" + _service
         + "\n").cstring())
     else
-      @printf[I32]((_name + "control : couldn't get local address\n")
+      @printf[I32]((_name + " control : couldn't get local address\n")
         .cstring())
       listen.close()
     end
 
   fun ref not_listening(listen: TCPListener ref) =>
-    @printf[I32]((_name + "control : couldn't listen\n").cstring())
+    @printf[I32]((_name + " control : unable to listen on (%s:%s)\n").cstring(),
+      _host.cstring(), _service.cstring())
     listen.close()
 
   fun ref connected(listen: TCPListener ref) : TCPConnectionNotify iso^ =>


### PR DESCRIPTION
This change adds the address (host, service) information to error messages from failures to bind a TCP address.

This is done in `DataChannelListenNotifier` and `ControlChannelListenNotifier`'s `not_listening` method.

For `DataChannelListenNotifier`, since host and service are not available in the class, this change relies on the listener's `local_address().name()` method. But since this method only works in some cases, a fallback method, `requested_address` is added which returns the original `(host:String, service: String)` parameters that were used when the connection was opened.


closes #1692