### PR TITLE
Add note about Docker in book Intro as a supported env

### DIFF
--- a/intro.md
+++ b/intro.md
@@ -23,6 +23,8 @@ Although not required, you will get the most out of this tutorial if you have pr
 
 It is currently possible to develop Wallaroo applications on MacOS and Linux. This guide has installation instructions for MacOS, and Ubuntu Linux. It's assumed if you are using a different Linux distribution that you are able to translate the Ubuntu instructions to your distribution of choice.
 
+We also support development using a Docker container, installation instructions are included for MacOS and Ubuntu Linux.
+
 ## What to Expect
 
 This document is organized into a number of sections. We recommend that you start in a linear fashion through this book. To that end, please consider reading in order:


### PR DESCRIPTION
We previously only mentioned MacOS and Linux. This change adds
mention of Docker as well.

closes #1841

[skip ci]