### PR TITLE
Misc bad behavior fixes to add to 1769

### DIFF
--- a/lib/wallaroo/core/data_channel/data_channel_listener.pony
+++ b/lib/wallaroo/core/data_channel/data_channel_listener.pony
@@ -47,6 +47,8 @@ actor DataChannelListener
   var _paused: Bool = false
   var _init_size: USize
   var _max_size: USize
+  let _requested_host: String
+  let _requested_service: String
 
   let _router_registry: RouterRegistry
 
@@ -59,6 +61,8 @@ actor DataChannelListener
     """
     Listens for both IPv4 and IPv6 connections.
     """
+    _requested_host = host
+    _requested_service = service
     _router_registry = router_registry
     _limit = limit
     _notify = consume notify
@@ -80,6 +84,14 @@ actor DataChannelListener
     Stop listening.
     """
     close()
+
+  fun requested_address(): (String, String) =>
+    """
+    Return the host and service that were originally provided to the
+    @pony_os_listen_tcp method.
+    Use this if `local_address().name()` fails.
+    """
+    (_requested_host, _requested_service)
 
   fun local_address(): NetAddress =>
     """

--- a/lib/wallaroo/core/data_channel/data_channel_tcp.pony
+++ b/lib/wallaroo/core/data_channel/data_channel_tcp.pony
@@ -114,12 +114,18 @@ class DataChannelListenNotifier is DataChannelListenNotify
       f.sync()
       f.dispose()
     else
-      @printf[I32]((_name + "data : couldn't get local address\n").cstring())
+      @printf[I32]((_name + " data : couldn't get local address\n").cstring())
       listen.close()
     end
 
   fun ref not_listening(listen: DataChannelListener ref) =>
-    @printf[I32]((_name + "data : unable to listen\n").cstring())
+    (let h, let s) = try
+      listen.local_address().name(None, false)?
+    else
+      listen.requested_address()
+    end
+    @printf[I32]((_name + " data : unable to listen on (%s:%s)\n").cstring(),
+      h.cstring(), s.cstring())
     Fail()
 
   fun ref connected(


### PR DESCRIPTION
Additional race & nondeterministic test failure fixes for #1769:

* Use 'netstat -na' to check for available TCP ports
* Fix `get_output()` to stop using `file_seek()` on actively-written files.
* Set base testing port from 50000 -> 20000 to avoid TCP ephemeral port range on Linux.
* Add debugging messages.