### PR TITLE
Implement working shrink to fit autoscale

### DIFF
--- a/lib/wallaroo/core/data_channel/_test.pony
+++ b/lib/wallaroo/core/data_channel/_test.pony
@@ -78,7 +78,6 @@ class _TestDataChannel is DataChannelListenNotify
       let conns = Connections("app_name", "worker_name", auth,
         "127.0.0.1", "0",
         "127.0.0.1", "0",
-        "", "",
         _NullMetricsSink, "127.0.0.1", "0",
         true, "/tmp/foo_connections.txt", false
         where event_log = event_log)

--- a/lib/wallaroo/core/data_channel/data_channel_tcp.pony
+++ b/lib/wallaroo/core/data_channel/data_channel_tcp.pony
@@ -114,7 +114,7 @@ class DataChannelListenNotifier is DataChannelListenNotify
       f.sync()
       f.dispose()
     else
-      @printf[I32]((_name + " data : couldn't get local address\n").cstring())
+      @printf[I32]((_name + " data: couldn't get local address\n").cstring())
       listen.close()
     end
 
@@ -124,7 +124,7 @@ class DataChannelListenNotifier is DataChannelListenNotify
     else
       listen.requested_address()
     end
-    @printf[I32]((_name + " data : unable to listen on (%s:%s)\n").cstring(),
+    @printf[I32]((_name + " data: unable to listen on (%s:%s)\n").cstring(),
       h.cstring(), s.cstring())
     Fail()
 
@@ -294,7 +294,7 @@ class DataChannelConnectNotifier is DataChannelNotify
     @printf[I32]("incoming connected on data channel\n".cstring())
 
   fun ref closed(conn: DataChannel ref) =>
-    @printf[I32]("DataChannelConnectNotifier : server closed\n".cstring())
+    @printf[I32]("DataChannelConnectNotifier: server closed\n".cstring())
     //TODO: Initiate reconnect to downstream node here. We need to
     //      create a new connection in OutgoingBoundary
 

--- a/lib/wallaroo/core/initialization/_test.pony
+++ b/lib/wallaroo/core/initialization/_test.pony
@@ -69,7 +69,8 @@ primitive _BaseLocalTopologyGenerator
   =>
     LocalTopology("test", "w1", dag, _StepMapGenerator(),
       _BaseStateBuildersGenerator(rb, pf), psd, _ProxyIdsGenerator(),
-      default_target, "test-default", 1, _BaseWorkerNamesGenerator())
+      default_target, "test-default", 1, _BaseWorkerNamesGenerator(),
+      recover val SetIs[String] end)
 
 primitive _TargetLocalTopologyGenerator
   fun apply(dag: Dag[StepInitializer] val,
@@ -80,7 +81,8 @@ primitive _TargetLocalTopologyGenerator
   =>
     LocalTopology("test", "w1", dag, _StepMapGenerator(),
       _TargetStateBuildersGenerator(rb, pf), psd, _ProxyIdsGenerator(),
-      default_target, "test-default", 1, _TargetWorkerNamesGenerator())
+      default_target, "test-default", 1, _TargetWorkerNamesGenerator(),
+      recover val SetIs[String] end)
 
 primitive _DagGenerator
   fun apply(): Dag[StepInitializer] val =>

--- a/lib/wallaroo/core/initialization/application_distributor.pony
+++ b/lib/wallaroo/core/initialization/application_distributor.pony
@@ -402,6 +402,8 @@ actor ApplicationDistributor is Distributor
           pipeline.source_listener_builder_builder(),
           source_pre_state_target_id)
 
+        non_shrinkable.set(initializer_name)
+
         @printf[I32](("\nPreparing to spin up " + source_seq_builder.name() +
           " on source on initializer\n").cstring())
 

--- a/lib/wallaroo/core/topology/_test_router_equality.pony
+++ b/lib/wallaroo/core/topology/_test_router_equality.pony
@@ -295,7 +295,7 @@ primitive _DataReceiversGenerator
 
 primitive _ConnectionsGenerator
   fun apply(env: Env, auth: AmbientAuth): Connections =>
-    Connections("", "", auth, "", "", "", "", "", "",
+    Connections("", "", auth, "", "", "", "",
       _NullMetricsSink, "", "", false, "", false
       where event_log = EventLog())
 

--- a/lib/wallaroo/ent/network/connections.pony
+++ b/lib/wallaroo/ent/network/connections.pony
@@ -66,7 +66,6 @@ actor Connections is Cluster
   new create(app_name: String, worker_name: String,
     auth: AmbientAuth, c_host: String, c_service: String,
     d_host: String, d_service: String,
-    external_host: String, external_service: String,
     metrics_conn: MetricsSink, metrics_host: String, metrics_service: String,
     is_initializer: Bool, connection_addresses_file: String,
     is_joining: Bool, spike_config: (SpikeConfig | None) = None,
@@ -93,22 +92,6 @@ actor Connections is Cluster
       _my_data_addr = (d_host, d_service)
     else
       create_control_connection("initializer", c_host, c_service)
-    end
-
-    if (external_host != "") or (external_service != "") then
-      match recovery_file_cleaner
-      | let rfc: RecoveryFileCleaner =>
-        let external_channel_notifier =
-          ExternalChannelListenNotifier(_worker_name, _auth, this, rfc)
-        let external_listener = TCPListener(_auth,
-          consume external_channel_notifier, external_host, external_service)
-        _register_listener(external_listener)
-      else
-        @printf[I32]("Need RecoveryFileCleaner to create external channel\n"
-          .cstring())
-      end
-      @printf[I32]("Set up external channel listener on %s:%s\n".cstring(),
-        external_host.cstring(), external_service.cstring())
     end
 
     _register_disposable(_metrics_conn)

--- a/lib/wallaroo/ent/network/connections.pony
+++ b/lib/wallaroo/ent/network/connections.pony
@@ -231,10 +231,8 @@ actor Connections is Cluster
 
   be disconnect_from(worker: String) =>
     try
-      // _data_conns(worker).dispose()
       (_, let d) = _data_conns.remove(worker)?
       d.dispose()
-      // _control_conns(worker).dispose()
       (_, let c) = _control_conns.remove(worker)?
       c.dispose()
     else

--- a/lib/wallaroo/ent/network/connections.pony
+++ b/lib/wallaroo/ent/network/connections.pony
@@ -266,6 +266,19 @@ actor Connections is Cluster
       _send_data(worker, data)
     end
 
+  be disconnect_from(worker: String) =>
+    try
+      // _data_conns(worker).dispose()
+      (_, let d) = _data_conns.remove(worker)?
+      d.dispose()
+      // _control_conns(worker).dispose()
+      (_, let c) = _control_conns.remove(worker)?
+      c.dispose()
+    else
+      @printf[I32]("Couldn't find worker %s for disconnection\n".cstring(),
+        worker.cstring())
+    end
+
   be notify_cluster_of_new_stateful_step[K: (Hashable val & Equatable[K] val)](
     id: U128, key: K, state_name: String, exclusions: Array[String] val =
     recover Array[String] end)

--- a/lib/wallaroo/ent/network/control_channel_tcp.pony
+++ b/lib/wallaroo/ent/network/control_channel_tcp.pony
@@ -314,7 +314,8 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
           @printf[I32](("Received BeginLeavingMigrationMsg on Control " +
             "Channel\n").cstring())
         end
-        _router_registry.prepare_shrink(m.remaining_workers, m.leaving_workers)
+        _router_registry.begin_leaving_migration(m.remaining_workers,
+          m.leaving_workers)
       | let m: PrepareShrinkMsg =>
         ifdef "trace" then
           @printf[I32](("Received PrepareShrinkMsg on Control " +

--- a/lib/wallaroo/ent/network/control_channel_tcp.pony
+++ b/lib/wallaroo/ent/network/control_channel_tcp.pony
@@ -301,12 +301,26 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
         else
           Fail()
         end
+      | let m: LeavingWorkerDoneMigratingMsg =>
+        _router_registry.disconnect_from_leaving_worker(m.worker_name)
       | let m: AckMigrationBatchCompleteMsg =>
         ifdef "trace" then
           @printf[I32](("Received AckMigrationBatchCompleteMsg on Control " +
             "Channel\n").cstring())
         end
         _router_registry.process_migrating_target_ack(m.sender_name)
+      | let m: BeginLeavingMigrationMsg =>
+        ifdef "trace" then
+          @printf[I32](("Received BeginLeavingMigrationMsg on Control " +
+            "Channel\n").cstring())
+        end
+        _router_registry.prepare_shrink(m.remaining_workers, m.leaving_workers)
+      | let m: PrepareShrinkMsg =>
+        ifdef "trace" then
+          @printf[I32](("Received PrepareShrinkMsg on Control " +
+            "Channel\n").cstring())
+        end
+        _router_registry.prepare_shrink(m.remaining_workers, m.leaving_workers)
       | let m: MuteRequestMsg =>
         @printf[I32]("Control Ch: Received Mute Request from %s\n".cstring(),
           m.originating_worker.cstring())

--- a/lib/wallaroo/ent/network/control_sender_connect_notifier.pony
+++ b/lib/wallaroo/ent/network/control_sender_connect_notifier.pony
@@ -40,3 +40,6 @@ class ControlSenderConnectNotifier is TCPConnectionNotify
   fun ref connect_failed(conn: TCPConnection ref) =>
     @printf[I32]("ControlSenderConnectNotifier: connection failed!\n"
       .cstring())
+
+  fun ref closed(conn: TCPConnection ref) =>
+    @printf[I32]("ControlSenderConnectNotifier: server closed\n".cstring())

--- a/lib/wallaroo/ent/network/external_channel_tcp.pony
+++ b/lib/wallaroo/ent/network/external_channel_tcp.pony
@@ -142,10 +142,6 @@ class ExternalChannelConnectNotifier is TCPConnectionNotify
           else
             _local_topology_initializer.initiate_shrink(m.node_names,
               m.num_nodes)
-            // let wb = recover ref Writer end
-            // let available: Array[String] = ["todo-flopsy"; "mopsy"; "cottontail"]
-            // let todo_reply = ExternalMsgEncoder.shrink(false, available, available.size(), wb)?
-            // conn.writev(todo_reply)
           end
         else
           @printf[I32](("Incoming External Message type not handled by " +

--- a/lib/wallaroo/ent/network/external_channel_tcp.pony
+++ b/lib/wallaroo/ent/network/external_channel_tcp.pony
@@ -60,9 +60,13 @@ class ExternalChannelListenNotifier is TCPListenNotify
       _worker_name.cstring())
     listen.close()
 
-  fun ref connected(listen: TCPListener ref) : TCPConnectionNotify iso^ =>
+  fun ref connected(listen: TCPListener ref): TCPConnectionNotify iso^ =>
     ExternalChannelConnectNotifier(_worker_name, _auth, _connections,
       _recovery_file_cleaner, _local_topology_initializer)
+
+  fun ref closed(listen: TCPListener ref) =>
+    @printf[I32]("&s external: listener closed\n".cstring(),
+      _worker_name.cstring())
 
 class ExternalChannelConnectNotifier is TCPConnectionNotify
   let _auth: AmbientAuth

--- a/lib/wallaroo/ent/network/external_channel_tcp.pony
+++ b/lib/wallaroo/ent/network/external_channel_tcp.pony
@@ -10,6 +10,7 @@ the License. You may obtain a copy of the License at
 
 */
 
+use "buffered"
 use "net"
 use "collections"
 use "time"
@@ -122,6 +123,15 @@ class ExternalChannelConnectNotifier is TCPConnectionNotify
             _recovery_file_cleaner.clean_recovery_files()
           else
             Fail()
+          end
+        | let m: ExternalShrinkMsg =>
+          @printf[I32]("TODO: query %s node_names size %d num_nodes %d\n".cstring(),
+            m.query.string().cstring(), m.node_names.size(), m.num_nodes)
+          if m.query is true then
+            let wb = recover ref Writer end
+            let available: Array[String] = ["todo-flopsy"; "mopsy"; "cottontail"]
+            let todo_reply = ExternalMsgEncoder.shrink(false, available, available.size(), wb)?
+            conn.writev(todo_reply)
           end
         else
           @printf[I32](("Incoming External Message type not handled by " +

--- a/lib/wallaroo/ent/network/joining_tcp.pony
+++ b/lib/wallaroo/ent/network/joining_tcp.pony
@@ -33,8 +33,11 @@ class iso JoiningListenNotifier is TCPListenNotify
     @printf[I32]("Joining Worker Listener: couldn't listen\n".cstring())
     listen.close()
 
-  fun ref connected(listen: TCPListener ref) : TCPConnectionNotify iso^ =>
+  fun ref connected(listen: TCPListener ref): TCPConnectionNotify iso^ =>
     JoiningConnectNotifier
+
+  fun ref closed(listen: TCPListener ref) =>
+    @printf[I32]("Joining Worker Listener: listener closed\n".cstring())
 
 class JoiningConnectNotifier is TCPConnectionNotify
   fun ref connected(conn: TCPConnection ref) =>
@@ -47,3 +50,6 @@ class JoiningConnectNotifier is TCPConnectionNotify
 
   fun ref connect_failed(conn: TCPConnection ref) =>
     @printf[I32](("JoiningConnectNotifier: connection failed!\n").cstring())
+
+  fun ref closed(conn: TCPConnection ref) =>
+    @printf[I32]("JoiningConnectNotifier: server closed\n".cstring())

--- a/lib/wallaroo/ent/network/output_tcp.pony
+++ b/lib/wallaroo/ent/network/output_tcp.pony
@@ -30,3 +30,6 @@ class OutNotify is TCPConnectionNotify
 
   fun ref connect_failed(conn: TCPConnection ref) =>
     @printf[I32](("%s: connection failed!\n").cstring(), _name.cstring())
+
+  fun ref closed(conn: TCPConnection ref) =>
+    @printf[I32](("%s: connection closed!\n").cstring(), _name.cstring())

--- a/lib/wallaroo/ent/rebalancing/rebalancer.pony
+++ b/lib/wallaroo/ent/rebalancing/rebalancer.pony
@@ -11,6 +11,7 @@ the License. You may obtain a copy of the License at
 */
 
 use "collections"
+use "wallaroo_labs/mort"
 
 primitive PartitionRebalancer
   fun step_counts_to_send(total_steps: USize, worker_portion: USize,
@@ -69,3 +70,23 @@ primitive PartitionRebalancer
       end
     end
     (try_to_send, consume counts_to_send)
+
+  fun step_counts_to_send_on_leaving(total_steps: USize,
+    remaining_workers_count: USize): Array[USize] val
+  =>
+    var remaining_steps = total_steps
+    let counts = recover trn Array[USize] end
+    for i in Range(0, remaining_workers_count) do
+      counts.push(0)
+    end
+    var idx: USize = 0
+    while remaining_steps > 0 do
+      try
+        counts(idx)? = counts(idx)? + 1
+      else
+        Fail()
+      end
+      remaining_steps = remaining_steps - 1
+      idx = (idx + 1) % remaining_workers_count
+    end
+    consume counts

--- a/lib/wallaroo/ent/router_registry/router_registry.pony
+++ b/lib/wallaroo/ent/router_registry/router_registry.pony
@@ -18,12 +18,14 @@ use "wallaroo/core/common"
 use "wallaroo/core/data_channel"
 use "wallaroo/core/initialization"
 use "wallaroo/core/invariant"
+use "wallaroo/core/messages"
 use "wallaroo/core/routing"
 use "wallaroo/core/source"
 use "wallaroo/core/topology"
 use "wallaroo/ent/data_receiver"
 use "wallaroo/ent/network"
 use "wallaroo/ent/recovery"
+use "wallaroo_labs/collection_helpers"
 use "wallaroo_labs/mort"
 
 
@@ -79,6 +81,7 @@ actor RouterRegistry
   // Partition Migration
   //////
   var _stop_the_world_in_process: Bool = false
+  var _leaving_in_process: Bool = false
   var _joining_worker_count: USize = 0
   let _initialized_joining_workers: SetIs[String] = SetIs[String]
   // Steps migrated out and waiting for acknowledgement
@@ -89,6 +92,9 @@ actor RouterRegistry
   // Migration targets that have not yet acked migration batch complete
   let _migration_target_ack_list: _StringSet =
     _migration_target_ack_list.create()
+
+  // For keeping track of leaving workers during an autoscale shrink
+  let _leaving_workers: SetIs[String] = _leaving_workers.create()
   // Used as a proxy for RouterRegistry when muting and unmuting sources
   // and data channel.
   // TODO: Probably change mute()/unmute() interface so we don't need this
@@ -626,7 +632,11 @@ actor RouterRegistry
     """
     _step_waiting_list.unset(step_id)
     if (_step_waiting_list.size() == 0) then
-      _send_migration_batch_complete()
+      if _leaving_in_process then
+        _send_leaving_worker_done_migrating()
+      else
+        _send_migration_batch_complete()
+      end
     end
 
   fun _send_migration_batch_complete() =>
@@ -641,6 +651,20 @@ actor RouterRegistry
       else
         Fail()
       end
+    end
+
+  fun _send_leaving_worker_done_migrating() =>
+    """
+    Inform migration target that the entire migration batch has been sent.
+    """
+    @printf[I32]("--Sending leaving worker done migration msg to cluster\n"
+      .cstring())
+    try
+      let msg = ChannelMsgEncoder.leaving_worker_done_migrating(_worker_name,
+        _auth)?
+      _connections.send_control_to_cluster(msg)
+    else
+      Fail()
     end
 
   be remote_mute_request(originating_worker: String) =>
@@ -662,11 +686,13 @@ actor RouterRegistry
   fun ref _unmute_request(originating_worker: String) =>
     _stopped_worker_waiting_list.unset(originating_worker)
     if (_stopped_worker_waiting_list.size() == 0) then
-      if _migration_target_ack_list.size() == 0 then
+      if (_migration_target_ack_list.size() == 0) and
+        (_leaving_workers.size() == 0)
+      then
         _resume_the_world()
       else
         // We should only unmute ourselves once _migration_target_ack_list is
-        // empty, which means we should never reach this line
+        // empty for grow and _leaving_workers is empty for shrink
         Fail()
       end
     end
@@ -709,7 +735,7 @@ actor RouterRegistry
       source.unmute(_dummy_consumer)
     end
 
-  be try_to_resume_processing_immediately() =>
+  fun ref try_to_resume_processing_immediately() =>
     if _step_waiting_list.size() == 0 then
       _send_migration_batch_complete()
     end
@@ -721,7 +747,7 @@ actor RouterRegistry
     """
     _connections.ack_migration_batch_complete(sender_name)
 
-  fun _migrate_partition_steps(state_name: String,
+  fun ref _migrate_partition_steps(state_name: String,
     target_workers: Array[String] val)
   =>
     """
@@ -733,8 +759,12 @@ actor RouterRegistry
         @printf[I32]("Migrating steps for %s partition to %s\n".cstring(),
           state_name.cstring(), w.cstring())
       end
+
+      let sorted_target_workers =
+        ArrayHelpers[String].sorted[String](target_workers)
+
       let tws = recover trn Array[(String, OutgoingBoundary)] end
-      for w in target_workers.values() do
+      for w in sorted_target_workers.values() do
         let boundary = _outgoing_boundaries(w)?
         tws.push((w, boundary))
       end
@@ -745,7 +775,7 @@ actor RouterRegistry
       Fail()
     end
 
-  fun _migrate_all_partition_steps(state_name: String,
+  fun ref _migrate_all_partition_steps(state_name: String,
     target_workers: Array[(String, OutgoingBoundary)] val)
   =>
     """
@@ -753,28 +783,131 @@ actor RouterRegistry
     workers.
     """
     try
-      @printf[I32]("Migrating steps for %s partition to %d workers\n".cstring(),
-        state_name.cstring(), target_workers.size())
+      @printf[I32]("Migrating steps for %s partition to %d workers\n"
+        .cstring(), state_name.cstring(), target_workers.size())
       let partition_router = _partition_routers(state_name)?
       partition_router.rebalance_steps_shrink(target_workers, state_name, this)
+    else
+      Fail()
     end
 
-
-  be add_to_step_waiting_list(step_id: StepId) =>
+  fun ref add_to_step_waiting_list(step_id: StepId) =>
     _step_waiting_list.set(step_id)
 
+  /////////////////
+  // Shrink to Fit
+  /////////////////
+  be initiate_shrink(remaining_workers: Array[String] val,
+    leaving_workers: Array[String] val)
+  =>
+    """
+    This should only be called on the worker contacted via an external
+    message to initiate a shrink.
+    """
+    _stop_the_world_in_process = true
+    _stop_the_world_for_shrink()
+    let timers = Timers
+    let timer = Timer(PauseBeforeShrinkNotify(_auth, _connections,
+      remaining_workers, leaving_workers), _stop_the_world_pause)
+    timers(consume timer)
+    try
+      let msg = ChannelMsgEncoder.prepare_shrink(remaining_workers,
+        leaving_workers, _auth)?
+      for w in remaining_workers.values() do
+        _connections.send_control(w, msg)
+      end
+    else
+      Fail()
+    end
+    _prepare_shrink(remaining_workers, leaving_workers)
+
+  be prepare_shrink(remaining_workers: Array[String] val,
+    leaving_workers: Array[String] val)
+  =>
+    _prepare_shrink(remaining_workers, leaving_workers)
+
+  fun ref _prepare_shrink(remaining_workers: Array[String] val,
+    leaving_workers: Array[String] val)
+  =>
+    ifdef debug then
+      Invariant(_leaving_workers.size() == 0)
+    end
+    if not _stop_the_world_in_process then
+      _stop_the_world_in_process = true
+      _stop_the_world_for_shrink()
+    end
+
+    for w in leaving_workers.values() do
+      _leaving_workers.set(w)
+    end
+    for (p_id, router) in _stateless_partition_routers.pairs() do
+      let new_router = router.calculate_shrink(remaining_workers)
+      _distribute_stateless_partition_router(new_router)
+      _stateless_partition_routers(p_id) = new_router
+    end
+
+  be begin_leaving_migration(remaining_workers: Array[String] val,
+    leaving_workers: Array[String] val)
+  =>
+    """
+    This should only be called on a worker designated to leave the cluster
+    as part of shrink to fit.
+    """
+    _leaving_in_process = true
+    if _partition_routers.size() == 0 then
+      //no steps have been migrated
+      @printf[I32](("No partitions to migrate.\n").cstring())
+      _send_leaving_worker_done_migrating()
+      return
+    end
+
+    let sorted_remaining_workers =
+      ArrayHelpers[String].sorted[String](remaining_workers)
+
+    let rws_trn = recover trn Array[(String, OutgoingBoundary)] end
+    for w in sorted_remaining_workers.values() do
+      try
+        let boundary = _outgoing_boundaries(w)?
+        rws_trn.push((w, boundary))
+      else
+        Fail()
+      end
+    end
+    let rws = consume val rws_trn
+
+    @printf[I32]("Migrating all partitions to %d remaining workers\n"
+      .cstring(), remaining_workers.size())
+    for state_name in _partition_routers.keys() do
+      _migrate_all_partition_steps(state_name, rws)
+    end
+
+  fun ref _stop_the_world_for_shrink() =>
+    """
+    We currently stop all message processing before migrating partitions and
+    updating routers/routes.
+    """
+    @printf[I32]("~~~Stopping message processing for leaving workers.~~~\n"
+      .cstring())
+    _mute_request(_worker_name)
+    _connections.stop_the_world(recover Array[String] end)
+
+  be disconnect_from_leaving_worker(worker: String) =>
+    _connections.disconnect_from(worker)
+    if not _leaving_in_process then
+      ifdef debug then
+        Invariant(_leaving_workers.size() > 0)
+      end
+      _leaving_workers.unset(worker)
+      if _leaving_workers.size() == 0 then
+        _connections.request_cluster_unmute()
+        _unmute_request(_worker_name)
+      end
+    end
 
   /////
   // Step moved off this worker or new step added to another worker
   /////
-  be move_step_to_proxy(id: U128, proxy_address: ProxyAddress) =>
-    """
-    Called when a stateless step has been migrated off this worker to another
-    worker
-    """
-    _move_step_to_proxy(id, proxy_address)
-
-  be move_stateful_step_to_proxy[K: (Hashable val & Equatable[K] val)](
+  fun ref move_stateful_step_to_proxy[K: (Hashable val & Equatable[K] val)](
     id: U128, proxy_address: ProxyAddress, key: K, state_name: String)
   =>
     """
@@ -844,15 +977,6 @@ actor RouterRegistry
   /////
   // Step moved onto this worker
   /////
-  be move_proxy_to_step(id: U128, target: Consumer,
-    source_worker: String)
-  =>
-    """
-    Called when a stateless step has been migrated to this worker from another
-    worker
-    """
-    _move_proxy_to_step(id, target, source_worker)
-
   be move_proxy_to_stateful_step[K: (Hashable val & Equatable[K] val)](
     id: U128, target: Consumer, key: K, state_name: String,
     source_worker: String)
@@ -930,6 +1054,32 @@ class PauseBeforeMigrationNotify is TimerNotify
 
   fun ref apply(timer: Timer, count: U64): Bool =>
     _registry.begin_migration(_target_workers)
+    false
+
+class PauseBeforeShrinkNotify is TimerNotify
+  let _auth: AmbientAuth
+  let _connections: Connections
+  let _remaining_workers: Array[String] val
+  let _leaving_workers: Array[String] val
+
+  new iso create(auth: AmbientAuth, connections: Connections,
+    remaining_workers: Array[String] val, leaving_workers: Array[String] val)
+  =>
+    _auth = auth
+    _connections = connections
+    _remaining_workers = remaining_workers
+    _leaving_workers = leaving_workers
+
+  fun ref apply(timer: Timer, count: U64): Bool =>
+    try
+      let msg = ChannelMsgEncoder.begin_leaving_migration(_remaining_workers,
+        _leaving_workers, _auth)?
+      for w in _leaving_workers.values() do
+        _connections.send_control(w, msg)?
+      end
+    else
+      Fail()
+    end
     false
 
 class PauseBeforeLogRotationNotify is TimerNotify

--- a/lib/wallaroo/startup.pony
+++ b/lib/wallaroo/startup.pony
@@ -299,7 +299,6 @@ actor Startup
         _startup_options.worker_name, auth,
         _startup_options.c_host, _startup_options.c_service,
         _startup_options.d_host, _startup_options.d_service,
-        _external_host, _external_service,
         metrics_conn, m_addr(0)?, m_addr(1)?, _startup_options.is_initializer,
         _connection_addresses_file, _startup_options.is_joining,
         _startup_options.spike_config, event_log,
@@ -331,6 +330,17 @@ actor Startup
           _startup_options.is_initializer, data_receivers, event_log, recovery,
           recovery_replayer, _local_topology_file, _data_channel_file,
           _worker_names_file)
+
+      if (_external_host != "") or (_external_service != "") then
+        let external_channel_notifier =
+          ExternalChannelListenNotifier(_startup_options.worker_name, auth,
+            connections, this, local_topology_initializer)
+        let external_listener = TCPListener(auth,
+          consume external_channel_notifier, _external_host, _external_service)
+        connections.register_listener(external_listener)
+        @printf[I32]("Set up external channel listener on %s:%s\n".cstring(),
+          _external_host.cstring(), _external_service.cstring())
+      end
 
       if _startup_options.is_initializer then
         @printf[I32]("Running as Initializer...\n".cstring())
@@ -449,7 +459,6 @@ actor Startup
       let connections = Connections(_application.name(),
         _startup_options.worker_name,
         auth, c_host, c_service, d_host, d_service,
-        _external_host, _external_service,
         metrics_conn, m.metrics_host, m.metrics_service,
         _startup_options.is_initializer,
         _connection_addresses_file, _startup_options.is_joining,
@@ -483,6 +492,17 @@ actor Startup
           event_log, recovery, recovery_replayer,
           _local_topology_file, _data_channel_file, _worker_names_file
           where is_joining = _startup_options.is_joining)
+
+      if (_external_host != "") or (_external_service != "") then
+        let external_channel_notifier =
+          ExternalChannelListenNotifier(_startup_options.worker_name, auth,
+            connections, this, local_topology_initializer)
+        let external_listener = TCPListener(auth,
+          consume external_channel_notifier, _external_host, _external_service)
+        connections.register_listener(external_listener)
+        @printf[I32]("Set up external channel listener on %s:%s\n".cstring(),
+          _external_host.cstring(), _external_service.cstring())
+      end
 
       router_registry.set_data_router(DataRouter)
       local_topology_initializer.update_topology(m.local_topology)

--- a/lib/wallaroo/startup.pony
+++ b/lib/wallaroo/startup.pony
@@ -619,6 +619,7 @@ actor Startup
     end
 
   be dispose() =>
+    @printf[I32]("Shutting down Startup...\n".cstring())
     for d in _join_disposables.values() do
       d.dispose()
     end

--- a/lib/wallaroo_labs/collection_helpers/collections_helpers.pony
+++ b/lib/wallaroo_labs/collection_helpers/collections_helpers.pony
@@ -43,3 +43,10 @@ primitive ArrayHelpers[V]
       if pred(v) then return true end
     end
     false
+
+  fun sorted[A: Comparable[A] val](arr: Array[A] val): Array[A] =>
+    let unsorted = Array[A]
+    for a in arr.values() do
+      unsorted.push(a)
+    end
+    Sort[Array[A], A](unsorted)

--- a/lib/wallaroo_labs/collection_helpers/collections_helpers.pony
+++ b/lib/wallaroo_labs/collection_helpers/collections_helpers.pony
@@ -31,6 +31,12 @@ primitive SetHelpers[V]
     end
     false
 
+  fun contains[A: Equatable[A] #read](arr: SetIs[A] box, v: A): Bool =>
+    for a in arr.values() do
+      if a == v then return true end
+    end
+    false
+
 primitive ArrayHelpers[V]
   fun forall(arr: Array[V] box, pred: {(box->V!): Bool}): Bool =>
     for v in arr.values() do
@@ -50,3 +56,9 @@ primitive ArrayHelpers[V]
       unsorted.push(a)
     end
     Sort[Array[A], A](unsorted)
+
+  fun contains[A: Equatable[A] #read](arr: Array[A] box, v: A): Bool =>
+    for a in arr.values() do
+      if a == v then return true end
+    end
+    false

--- a/lib/wallaroo_labs/messages/_test.pony
+++ b/lib/wallaroo_labs/messages/_test.pony
@@ -208,7 +208,7 @@ class iso _TestGeneralExtEncDecShrink is UnitTest
     // Use Range so that num_nodes array size 0 is tested.
     for i in Range[USize](0, node_names.size()) do
       let e1: Array[ByteSeq] val =
-        ExternalMsgEncoder.shrink(false, node_names.slice(0, i), 0)?
+        ExternalMsgEncoder.shrink(false, node_names.slice(0, i), 0)
       // encode & decode are not symmetric -- we need to chop off
       // the first 4 bytes before we can decode.
       let e1': Array[U8] val = recover Help.flatten(e1).slice(4) end
@@ -232,7 +232,7 @@ class iso _TestGeneralExtEncDecShrink is UnitTest
 
     // Use Range so that num_nodes = 0 is included
     for i in Range[USize](0, 4) do
-      let e1: Array[ByteSeq] val = ExternalMsgEncoder.shrink(false, [], i)?
+      let e1: Array[ByteSeq] val = ExternalMsgEncoder.shrink(false, [], i)
       let e1': Array[U8] val = recover Help.flatten(e1).slice(4) end
 
       match ExternalMsgDecoder(e1')?
@@ -250,7 +250,7 @@ class iso _TestGeneralExtEncDecShrink is UnitTest
     end
 
     // Let's now try a round trip for a query
-    let e2: Array[ByteSeq] val = ExternalMsgEncoder.shrink(true, [], 0)?
+    let e2: Array[ByteSeq] val = ExternalMsgEncoder.shrink(true, [], 0)
     let e2': Array[U8] val = recover Help.flatten(e2).slice(4) end
 
     match ExternalMsgDecoder(e2')?

--- a/lib/wallaroo_labs/messages/external_messages.pony
+++ b/lib/wallaroo_labs/messages/external_messages.pony
@@ -134,9 +134,12 @@ primitive ExternalMsgEncoder
     num_nodes: USize = 0, wb: Writer = Writer): Array[ByteSeq] val
   =>
     if (query is true) then
-      return _encode_shrink(_Shrink(), true, Array[String], 0, wb)
+      _encode_shrink(_Shrink(), true, Array[String], 0, wb)
+    elseif (node_names.size() == 0) and (num_nodes == 0) then
+      _encode_shrink(_Shrink(), false, node_names, 1, wb)
+    else
+      _encode_shrink(_Shrink(), false, node_names, num_nodes, wb)
     end
-    _encode_shrink(_Shrink(), false, node_names, num_nodes, wb)
 
 class BufferedExternalMsgEncoder
   let _buffer: Writer

--- a/lib/wallaroo_labs/messages/external_messages.pony
+++ b/lib/wallaroo_labs/messages/external_messages.pony
@@ -130,23 +130,13 @@ primitive ExternalMsgEncoder
   =>
     _encode(_CleanShutdown(), msg, wb)
 
-  fun shrink(query: Bool, node_names: Array[String] = [],
-    num_nodes: USize = 0, wb: Writer = Writer): Array[ByteSeq] val ?
+  fun shrink(query: Bool, node_names: Array[String] = Array[String],
+    num_nodes: USize = 0, wb: Writer = Writer): Array[ByteSeq] val
   =>
     if (query is true) then
-      return _encode_shrink(_Shrink(), true, [], 0, wb)
+      return _encode_shrink(_Shrink(), true, Array[String], 0, wb)
     end
-    if (node_names.size() > 0) and (num_nodes > 0) then
-      error
-    end
-    if (num_nodes < 0) then
-      error
-    end
-    if (node_names.size() == 0) and (num_nodes == 0) then
-      _encode_shrink(_Shrink(), false, node_names, 1, wb)
-    else
-      _encode_shrink(_Shrink(), false, node_names, num_nodes, wb)
-    end
+    _encode_shrink(_Shrink(), false, node_names, num_nodes, wb)
 
 class BufferedExternalMsgEncoder
   let _buffer: Writer
@@ -334,9 +324,19 @@ class val ExternalShrinkMsg is ExternalMsg
   let query: Bool
   let node_names: Array[String] val
   let num_nodes: USize
+  var _header: Bool = true
 
   new val create(query': Bool,
     node_names': Array[String] val, num_nodes': USize) =>
     query = query'
     node_names = node_names'
     num_nodes = num_nodes'
+
+  fun string(): String =>
+    var nodes = "|"
+    for n in node_names.values() do
+      nodes = nodes + " " + n + " |"
+    end
+    "Query: " + query.string() + " Node count: " + num_nodes.string() +
+      "Nodes: " + nodes
+


### PR DESCRIPTION
Adds support for shrinking cluster.  

There are two ways to specify that workers should be removed from the cluster.  You can either specify the worker names or the total count of workers to be removed.  You must know the external channel address of one worker in the running cluster.  You can use the `external_sender` tool to send a shrink message to this channel.  For example, if the external address is `127.0.0.1:5050` and we want to remove 2 workers from the cluster, we can run the following:

```
./external_sender --type shrink --external 127.0.0.1:5050 --message 2
```

The `--message` argument is used either to pass in a count or to pass in a list of comma-separated worker names.  To request that workers `w2` and `w3` be removed, we can run:

```
./external_sender --type shrink --external 127.0.0.1:5050 --message w2,w3
```

To qualify for removal from the cluster, a worker must meet two criteria:
1. It must have no sources.
2. It must have no non-parallelized stateless computations.

If you send in a list of worker names that includes at least one invalid worker (either because the worker does not meet the 2 criteria or because it is an invalid name) then the shrink will not happen.  If you send in a shrink count that’s higher than the number of workers meeting the 2 criteria, then Wallaroo will shrink by the maximum number of workers that do meet those criteria (which could be 0).

Closes #983 
Closes #1618 
Closes #1620 