### PR TITLE
Fix shrink autoscale query reply

### DIFF
--- a/lib/wallaroo/ent/network/external_channel_tcp.pony
+++ b/lib/wallaroo/ent/network/external_channel_tcp.pony
@@ -88,6 +88,7 @@ class ExternalChannelConnectNotifier is TCPConnectionNotify
 
   fun ref accepted(conn: TCPConnection ref) =>
     conn.expect(4)
+    _connections.register_disposable(conn)
 
   fun ref received(conn: TCPConnection ref, data: Array[U8] iso,
     n: USize): Bool

--- a/lib/wallaroo_labs/messages/external_messages.pony
+++ b/lib/wallaroo_labs/messages/external_messages.pony
@@ -336,10 +336,15 @@ class val ExternalShrinkMsg is ExternalMsg
     num_nodes = num_nodes'
 
   fun string(): String =>
-    var nodes = "|"
+    let nodes = Array[String]
     for n in node_names.values() do
-      nodes = nodes + " " + n + " |"
+      nodes.push(n)
     end
-    "Query: " + query.string() + " Node count: " + num_nodes.string() +
-      "Nodes: " + nodes
+    var nodes_string = "|"
+    for n in nodes.values() do
+      nodes_string = nodes_string + "," + n
+    end
+    nodes_string = nodes_string + "|"
+    "Query: " + query.string() + ", Node count: " + num_nodes.string() +
+      ", Nodes: " + nodes_string
 


### PR DESCRIPTION
Before this change, the reply sent to an external system after a
shrink query had two problems: (1) we did not add the connection
to our disposables, so shut down would not happen cleanly if there
was still such a connection, and (2) our external sender did not
correctly handle the incoming data for a query reply. This fixes
both.

Closes #1861