### PR TITLE
Kafka Client update to latest pony-kafka master

### DIFF
--- a/examples/pony/celsius-kafka/bundle.json
+++ b/examples/pony/celsius-kafka/bundle.json
@@ -5,7 +5,7 @@
       },
       { "type": "github",
         "repo": "WallarooLabs/pony-kafka",
-        "tag": "0.3.0"
+        "tag": "ca9156b"
       }
   ]
 }

--- a/examples/pony/celsius-kafka/celsius.pony
+++ b/examples/pony/celsius-kafka/celsius.pony
@@ -25,8 +25,8 @@ use "wallaroo/core/topology"
 
 actor Main
   new create(env: Env) =>
-    let ksource_clip = KafkaSourceConfigCLIParser(env.out, "src")
-    let ksink_clip = KafkaSinkConfigCLIParser(env.out, "snk")
+    let ksource_clip = KafkaSourceConfigCLIParser(env.out)
+    let ksink_clip = KafkaSinkConfigCLIParser(env.out)
 
     try
       if (env.args(1)? == "--help") or (env.args(1)? == "-h") then
@@ -44,12 +44,12 @@ actor Main
       let application = recover val
         Application("Celsius Conversion App")
           .new_pipeline[F32, F32]("Celsius Conversion",
-            KafkaSourceConfig[F32](ksource_clip.parse(env.args)?,
+            KafkaSourceConfig[F32](ksource_clip.parse_options(env.args)?,
             env.root as AmbientAuth, CelsiusKafkaDecoder))
             .to[F32]({(): Multiply => Multiply})
             .to[F32]({(): Add => Add})
             .to_sink(KafkaSinkConfig[F32](FahrenheitEncoder,
-              ksink_clip.parse(env.args)?,
+              ksink_clip.parse_options(env.args)?,
               env.root as AmbientAuth))
       end
       Startup(env, application, "celsius-conversion")

--- a/examples/pony/celsius-kafka/celsius.pony
+++ b/examples/pony/celsius-kafka/celsius.pony
@@ -25,15 +25,18 @@ use "wallaroo/core/topology"
 
 actor Main
   new create(env: Env) =>
+    let ksource_clip = KafkaSourceConfigCLIParser(env.out, "src")
+    let ksink_clip = KafkaSinkConfigCLIParser(env.out, "snk")
+
     try
       if (env.args(1)? == "--help") or (env.args(1)? == "-h") then
-        KafkaSourceConfigCLIParser.print_usage(env.out)
-        KafkaSinkConfigCLIParser.print_usage(env.out)
+        ksource_clip.print_usage()
+        ksink_clip.print_usage()
         return
       end
     else
-      KafkaSourceConfigCLIParser.print_usage(env.out)
-      KafkaSinkConfigCLIParser.print_usage(env.out)
+      ksource_clip.print_usage()
+      ksink_clip.print_usage()
       return
     end
 
@@ -41,12 +44,12 @@ actor Main
       let application = recover val
         Application("Celsius Conversion App")
           .new_pipeline[F32, F32]("Celsius Conversion",
-            KafkaSourceConfig[F32](KafkaSourceConfigCLIParser(env.args,
-              env.out)?, env.root as AmbientAuth, CelsiusKafkaDecoder))
+            KafkaSourceConfig[F32](ksource_clip.parse(env.args)?,
+            env.root as AmbientAuth, CelsiusKafkaDecoder))
             .to[F32]({(): Multiply => Multiply})
             .to[F32]({(): Add => Add})
             .to_sink(KafkaSinkConfig[F32](FahrenheitEncoder,
-              KafkaSinkConfigCLIParser(env.args, env.out)?,
+              ksink_clip.parse(env.args)?,
               env.root as AmbientAuth))
       end
       Startup(env, application, "celsius-conversion")

--- a/lib/wallaroo/core/sink/empty_sink.pony
+++ b/lib/wallaroo/core/sink/empty_sink.pony
@@ -67,3 +67,6 @@ actor EmptySink is Consumer
     None
 
   be receive_state(state: ByteSeq val) => Fail()
+
+  be dispose() =>
+    None

--- a/lib/wallaroo/core/sink/kafka_sink/kafka_sink.pony
+++ b/lib/wallaroo/core/sink/kafka_sink/kafka_sink.pony
@@ -81,7 +81,7 @@ actor KafkaSink is (Consumer & KafkaClientManager & KafkaProducer)
                ""
              end
 
-  fun ref update_producer_mapping(mapping: KafkaProducerMapping):
+  fun ref create_producer_mapping(mapping: KafkaProducerMapping):
     (KafkaProducerMapping | None)
   =>
     _kafka_producer_mapping = mapping

--- a/lib/wallaroo/core/sink/kafka_sink/kafka_sink.pony
+++ b/lib/wallaroo/core/sink/kafka_sink/kafka_sink.pony
@@ -46,7 +46,6 @@ actor KafkaSink is (Consumer & KafkaClientManager & KafkaProducer)
 
   var _kc: (KafkaClient tag | None) = None
   let _conf: KafkaConfig val
-  let _env: Env
   let _auth: TCPConnectionAuth
 
   // Producer (Resilience)
@@ -68,12 +67,11 @@ actor KafkaSink is (Consumer & KafkaClientManager & KafkaProducer)
 
   new create(encoder_wrapper: KafkaEncoderWrapper,
     metrics_reporter: MetricsReporter iso, conf: KafkaConfig val,
-    env: Env, auth: TCPConnectionAuth)
+    auth: TCPConnectionAuth)
   =>
     _encoder = encoder_wrapper
     _metrics_reporter = consume metrics_reporter
     _conf = conf
-    _env = env
     _auth = auth
 
     _topic = try

--- a/lib/wallaroo/core/sink/kafka_sink/kafka_sink_config.pony
+++ b/lib/wallaroo/core/sink/kafka_sink/kafka_sink_config.pony
@@ -20,6 +20,7 @@ use "net"
 use "options"
 use "pony-kafka"
 use "pony-kafka/customlogger"
+use "wallaroo_labs/mort"
 use "wallaroo/core/messages"
 use "wallaroo/core/metrics"
 use "wallaroo/core/sink"
@@ -36,67 +37,96 @@ class val KafkaSinkConfigError
 
 
 primitive KafkaSinkConfigFactory
-  fun apply(kafka_topic: String,
-    kafka_brokers: Array[(String, I32)] val,
-    kafka_log_level: String,
-    kafka_max_produce_buffer_ms: U64,
-    kafka_max_message_size: I32,
-    out: OutStream):
+  fun apply(ksco: KafkaSinkConfigOptions val, out: OutStream):
     (KafkaConfig val | KafkaSinkConfigError)
   =>
-    let log_level = match kafka_log_level
+    let log_level = match ksco.kafka_log_level
       | "Fine" => Fine
       | "Info" => Info
       | "Warn" => Warn
       | "Error" => Error
       else
-        return KafkaSinkConfigError("Error! Invalid kafka_sink_log_level: " + kafka_log_level)
+        return KafkaSinkConfigError("Error! Invalid kafka_sink_log_level: " +
+          ksco.kafka_log_level)
       end
 
     let logger = StringLogger(log_level, out)
 
-    if (kafka_brokers.size() == 0) or (kafka_topic == "") then
-      return KafkaSinkConfigError("Error! Either brokers is empty or topics is empty!")
+    if (ksco.kafka_brokers.size() == 0) or (ksco.kafka_topic == "") then
+      return
+        KafkaSinkConfigError("Error! Either brokers is empty or topics is empty!")
     end
 
     recover
-      let kc = KafkaConfig(logger, "Wallaroo Kafka Sink " + kafka_topic where
-        max_message_size' = kafka_max_message_size,
-        max_produce_buffer_ms' = kafka_max_produce_buffer_ms)
+      let kc = KafkaConfig(logger, "Wallaroo Kafka Sink " + ksco.kafka_topic
+        where max_message_size' = ksco.kafka_max_message_size,
+        max_produce_buffer_ms' = ksco.kafka_max_produce_buffer_ms)
 
       // add topic config to consumer
-      kc.add_topic_config(kafka_topic, KafkaProduceOnly)
+      kc.add_topic_config(ksco.kafka_topic, KafkaProduceOnly)
 
-      for (host, port) in kafka_brokers.values() do
+      for (host, port) in ksco.kafka_brokers.values() do
         kc.add_broker(host, port)
       end
 
       kc
     end
 
-primitive KafkaSinkConfigCLIParser
-  fun opts(): Array[(String, (None | String), ArgumentType, (Required |
-    Optional), String)]
+class KafkaSinkConfigOptions
+  let kafka_topic: String
+  let kafka_brokers: Array[(String, I32)] val
+  let kafka_log_level: String
+  let kafka_max_produce_buffer_ms: U64
+  let kafka_max_message_size: I32
+
+  new val create(kafka_topic': String,
+    kafka_brokers': Array[(String, I32)] val,
+    kafka_log_level': String,
+    kafka_max_produce_buffer_ms': U64,
+    kafka_max_message_size': I32)
+  =>
+    kafka_topic = kafka_topic'
+    kafka_brokers = kafka_brokers'
+    kafka_log_level = kafka_log_level'
+    kafka_max_produce_buffer_ms = kafka_max_produce_buffer_ms'
+    kafka_max_message_size = kafka_max_message_size'
+
+class KafkaSinkConfigCLIParser
+  let _pre: String
+  let _out: OutStream
+
+  new create(out: OutStream, prefix: (String | None) = None) =>
+    _out = out
+    _pre = _prefix(prefix)
+
+  fun tag _prefix(prefix: (String | None) = None): String =>
+    match prefix
+    | let s: String => s + "_"
+    else ""
+    end
+
+  fun opts(): Array[(String, (None | String),
+    ArgumentType, (Required | Optional), String)]
   =>
     // items in the tuple are: Argument Name, Argument Short Name,
     //   Argument Type, Required or Optional, Help Text
     let opts_array = Array[(String, (None | String), ArgumentType, (Required |
       Optional), String)]
 
-    opts_array.push(("kafka_sink_topic", None, StringArgument, Required,
+    opts_array.push((_pre + "kafka_sink_topic", None, StringArgument, Required,
       "Kafka topic to consume from"))
-    opts_array.push(("kafka_sink_brokers", None, StringArgument, Required,
+    opts_array.push((_pre + "kafka_sink_brokers", None, StringArgument, Required,
       "Initial brokers to connect to. Format: 'host:port,host:port,...'"))
-    opts_array.push(("kafka_sink_log_level", None, StringArgument, Required,
+    opts_array.push((_pre + "kafka_sink_log_level", None, StringArgument, Required,
       "Log Level (Fine, Info, Warn, Error)"))
-    opts_array.push(("kafka_sink_max_produce_buffer_ms", None, I64Argument,
+    opts_array.push((_pre + "kafka_sink_max_produce_buffer_ms", None, I64Argument,
       Required, "# ms to buffer for producing to kafka"))
-    opts_array.push(("kafka_sink_max_message_size", None, I64Argument, Required,
+    opts_array.push((_pre + "kafka_sink_max_message_size", None, I64Argument, Required,
       "Max message size in bytes for producing to kafka"))
 
     opts_array
 
-  fun print_usage(out: OutStream) =>
+  fun print_usage() =>
     for (long, short, arg_type, arg_req, help) in opts().values() do
       let short_str = match short
              | let s: String => "/-" + s
@@ -108,11 +138,13 @@ primitive KafkaSinkConfigCLIParser
              | F64Argument => "(Float)"
              else "" end
 
-      out.print("--" + long + short_str + "       " + arg_type_str + "    "
+      _out.print("--" + long + short_str + "       " + arg_type_str + "    "
         + help)
     end
 
-  fun apply(args: Array[String] val, out: OutStream): KafkaConfig val ? =>
+  fun parse(args: Array[String] val):
+    KafkaSinkConfigOptions val ?
+  =>
     var log_level = "Warn"
 
     var topic = ""
@@ -130,29 +162,21 @@ primitive KafkaSinkConfigCLIParser
     // TODO: implement all the other options that kafka client supports
     for option in options do
       match option
-      | ("kafka_sink_max_produce_buffer_ms", let input: I64) =>
+      | (_pre + "kafka_sink_max_produce_buffer_ms", let input: I64) =>
         max_produce_buffer_ms = input.u64()
-      | ("kafka_sink_max_message_size", let input: I64) =>
+      | (_pre + "kafka_sink_max_message_size", let input: I64) =>
         max_message_size = input.i32()
-      | ("kafka_sink_topic", let input: String) =>
+      | (_pre + "kafka_sink_topic", let input: String) =>
         topic = input
-      | ("kafka_sink_brokers", let input: String) =>
+      | (_pre + "kafka_sink_brokers", let input: String) =>
         brokers = _brokers_from_input_string(input)?
-      | ("kafka_sink_log_level", let input: String) =>
+      | (_pre + "kafka_sink_log_level", let input: String) =>
         log_level = input
       end
     end
 
-    // create kafka config
-
-    match KafkaSinkConfigFactory(topic, brokers, log_level,
-      max_produce_buffer_ms, max_message_size, out)
-    | let kc: KafkaConfig val =>
-      kc
-    | let ksce: KafkaSinkConfigError =>
-      @printf[U32]("%s\n".cstring(), ksce.message().cstring())
-      error
-    end
+    KafkaSinkConfigOptions(topic, brokers, log_level,
+      max_produce_buffer_ms, max_message_size)
 
   fun _brokers_from_input_string(inputs: String): Array[(String, I32)] val ? =>
     let brokers = recover trn Array[(String, I32)] end
@@ -177,32 +201,41 @@ primitive KafkaSinkConfigCLIParser
 
 class val KafkaSinkConfig[Out: Any val] is SinkConfig[Out]
   let _encoder: KafkaSinkEncoder[Out]
-  let _conf: KafkaConfig val
+  let _ksco: KafkaSinkConfigOptions val
   let _auth: TCPConnectionAuth
 
-  new val create(encoder: KafkaSinkEncoder[Out], conf: KafkaConfig val,
+  new val create(encoder: KafkaSinkEncoder[Out],
+    ksco: KafkaSinkConfigOptions val,
     auth: TCPConnectionAuth)
   =>
     _encoder = encoder
-    _conf = conf
+    _ksco = ksco
     _auth = auth
 
   fun apply(): SinkBuilder =>
-    KafkaSinkBuilder(TypedKafkaEncoderWrapper[Out](_encoder), _conf, _auth)
+    KafkaSinkBuilder(TypedKafkaEncoderWrapper[Out](_encoder), _ksco, _auth)
 
 class val KafkaSinkBuilder
   let _encoder_wrapper: KafkaEncoderWrapper
-  let _conf: KafkaConfig val
+  let _ksco: KafkaSinkConfigOptions val
   let _auth: TCPConnectionAuth
 
-  new val create(encoder_wrapper: KafkaEncoderWrapper, conf: KafkaConfig val,
+  new val create(encoder_wrapper: KafkaEncoderWrapper,
+    ksco: KafkaSinkConfigOptions val,
     auth: TCPConnectionAuth)
   =>
     _encoder_wrapper = encoder_wrapper
-    _conf = conf
+    _ksco = ksco
     _auth = auth
 
   fun apply(reporter: MetricsReporter iso, env: Env): Sink =>
-    @printf[I32]("Creating Kafka Sink\n".cstring())
+    // create kafka config
 
-    KafkaSink(_encoder_wrapper, consume reporter, _conf, env, _auth)
+    match KafkaSinkConfigFactory(_ksco, env.out)
+    | let kc: KafkaConfig val =>
+      KafkaSink(_encoder_wrapper, consume reporter, kc, _auth)
+    | let ksce: KafkaSinkConfigError =>
+      @printf[U32]("%s\n".cstring(), ksce.message().cstring())
+      Fail()
+      EmptySink
+    end

--- a/lib/wallaroo/core/sink/kafka_sink/kafka_sink_config.pony
+++ b/lib/wallaroo/core/sink/kafka_sink/kafka_sink_config.pony
@@ -26,190 +26,22 @@ use "wallaroo/core/metrics"
 use "wallaroo/core/sink"
 
 
-class val KafkaSinkConfigError
-  let _message: String
-
-  new val create(m: String) =>
-    _message = m
-
-  fun message(): String =>
-    _message
-
-
-primitive KafkaSinkConfigFactory
-  fun apply(ksco: KafkaSinkConfigOptions val, out: OutStream):
-    (KafkaConfig val | KafkaSinkConfigError)
-  =>
-    let log_level = match ksco.kafka_log_level
-      | "Fine" => Fine
-      | "Info" => Info
-      | "Warn" => Warn
-      | "Error" => Error
-      else
-        return KafkaSinkConfigError("Error! Invalid kafka_sink_log_level: " +
-          ksco.kafka_log_level)
-      end
-
-    let logger = StringLogger(log_level, out)
-
-    if (ksco.kafka_brokers.size() == 0) or (ksco.kafka_topic == "") then
-      return
-        KafkaSinkConfigError("Error! Either brokers is empty or topics is empty!")
-    end
-
-    recover
-      let kc = KafkaConfig(logger, "Wallaroo Kafka Sink " + ksco.kafka_topic
-        where max_message_size' = ksco.kafka_max_message_size,
-        max_produce_buffer_ms' = ksco.kafka_max_produce_buffer_ms)
-
-      // add topic config to consumer
-      kc.add_topic_config(ksco.kafka_topic, KafkaProduceOnly)
-
-      for (host, port) in ksco.kafka_brokers.values() do
-        kc.add_broker(host, port)
-      end
-
-      kc
-    end
-
-class KafkaSinkConfigOptions
-  let kafka_topic: String
-  let kafka_brokers: Array[(String, I32)] val
-  let kafka_log_level: String
-  let kafka_max_produce_buffer_ms: U64
-  let kafka_max_message_size: I32
-
-  new val create(kafka_topic': String,
-    kafka_brokers': Array[(String, I32)] val,
-    kafka_log_level': String,
-    kafka_max_produce_buffer_ms': U64,
-    kafka_max_message_size': I32)
-  =>
-    kafka_topic = kafka_topic'
-    kafka_brokers = kafka_brokers'
-    kafka_log_level = kafka_log_level'
-    kafka_max_produce_buffer_ms = kafka_max_produce_buffer_ms'
-    kafka_max_message_size = kafka_max_message_size'
-
-class KafkaSinkConfigCLIParser
-  let _pre: String
-  let _out: OutStream
-
-  new create(out: OutStream, prefix: (String | None) = None) =>
-    _out = out
-    _pre = _prefix(prefix)
-
-  fun tag _prefix(prefix: (String | None) = None): String =>
-    match prefix
-    | let s: String => s + "_"
-    else ""
-    end
-
-  fun opts(): Array[(String, (None | String),
-    ArgumentType, (Required | Optional), String)]
-  =>
-    // items in the tuple are: Argument Name, Argument Short Name,
-    //   Argument Type, Required or Optional, Help Text
-    let opts_array = Array[(String, (None | String), ArgumentType, (Required |
-      Optional), String)]
-
-    opts_array.push((_pre + "kafka_sink_topic", None, StringArgument, Required,
-      "Kafka topic to consume from"))
-    opts_array.push((_pre + "kafka_sink_brokers", None, StringArgument, Required,
-      "Initial brokers to connect to. Format: 'host:port,host:port,...'"))
-    opts_array.push((_pre + "kafka_sink_log_level", None, StringArgument, Required,
-      "Log Level (Fine, Info, Warn, Error)"))
-    opts_array.push((_pre + "kafka_sink_max_produce_buffer_ms", None, I64Argument,
-      Required, "# ms to buffer for producing to kafka"))
-    opts_array.push((_pre + "kafka_sink_max_message_size", None, I64Argument, Required,
-      "Max message size in bytes for producing to kafka"))
-
-    opts_array
-
-  fun print_usage() =>
-    for (long, short, arg_type, arg_req, help) in opts().values() do
-      let short_str = match short
-             | let s: String => "/-" + s
-             else "" end
-
-      let arg_type_str = match arg_type
-             | StringArgument => "(String)"
-             | I64Argument => "(Integer)"
-             | F64Argument => "(Float)"
-             else "" end
-
-      _out.print("--" + long + short_str + "       " + arg_type_str + "    "
-        + help)
-    end
-
-  fun parse(args: Array[String] val):
-    KafkaSinkConfigOptions val ?
-  =>
-    var log_level = "Warn"
-
-    var topic = ""
-    var brokers = recover val Array[(String, I32)] end
-
-    var max_message_size: I32 = 1000000
-    var max_produce_buffer_ms: U64 = 0
-
-    let options = Options(args, false)
-
-    for (long, short, arg_type, arg_req, _) in opts().values() do
-      options.add(long, short, arg_type, arg_req)
-    end
-
-    // TODO: implement all the other options that kafka client supports
-    for option in options do
-      match option
-      | (_pre + "kafka_sink_max_produce_buffer_ms", let input: I64) =>
-        max_produce_buffer_ms = input.u64()
-      | (_pre + "kafka_sink_max_message_size", let input: I64) =>
-        max_message_size = input.i32()
-      | (_pre + "kafka_sink_topic", let input: String) =>
-        topic = input
-      | (_pre + "kafka_sink_brokers", let input: String) =>
-        brokers = _brokers_from_input_string(input)?
-      | (_pre + "kafka_sink_log_level", let input: String) =>
-        log_level = input
-      end
-    end
-
-    KafkaSinkConfigOptions(topic, brokers, log_level,
-      max_produce_buffer_ms, max_message_size)
-
-  fun _brokers_from_input_string(inputs: String): Array[(String, I32)] val ? =>
-    let brokers = recover trn Array[(String, I32)] end
-
-    for input in inputs.split(",").values() do
-      let i = input.split(":")
-      let host = i(0)?
-      let port: I32 = try i(1)?.i32()? else 9092 end
-      brokers.push((host, port))
-    end
-
-    consume brokers
-
-  fun _topics_from_input_string(inputs: String): Array[String] val =>
-    let topics = recover trn Array[String] end
-
-    for input in inputs.split(",").values() do
-      topics.push(input)
-    end
-
-    consume topics
+primitive KafkaSinkConfigCLIParser
+  fun apply(out: OutStream, prefix: String = "kafka_sink"): KafkaConfigCLIParser =>
+    KafkaConfigCLIParser(out, KafkaProduceOnly where prefix = prefix)
 
 class val KafkaSinkConfig[Out: Any val] is SinkConfig[Out]
   let _encoder: KafkaSinkEncoder[Out]
-  let _ksco: KafkaSinkConfigOptions val
+  let _ksco: KafkaConfigOptions val
   let _auth: TCPConnectionAuth
 
   new val create(encoder: KafkaSinkEncoder[Out],
-    ksco: KafkaSinkConfigOptions val,
+    ksco: KafkaConfigOptions iso,
     auth: TCPConnectionAuth)
   =>
+    ksco.client_name = "Wallaroo Kafka Sink " + ksco.topic
     _encoder = encoder
-    _ksco = ksco
+    _ksco = consume ksco
     _auth = auth
 
   fun apply(): SinkBuilder =>
@@ -217,11 +49,11 @@ class val KafkaSinkConfig[Out: Any val] is SinkConfig[Out]
 
 class val KafkaSinkBuilder
   let _encoder_wrapper: KafkaEncoderWrapper
-  let _ksco: KafkaSinkConfigOptions val
+  let _ksco: KafkaConfigOptions val
   let _auth: TCPConnectionAuth
 
   new val create(encoder_wrapper: KafkaEncoderWrapper,
-    ksco: KafkaSinkConfigOptions val,
+    ksco: KafkaConfigOptions val,
     auth: TCPConnectionAuth)
   =>
     _encoder_wrapper = encoder_wrapper
@@ -231,10 +63,10 @@ class val KafkaSinkBuilder
   fun apply(reporter: MetricsReporter iso, env: Env): Sink =>
     // create kafka config
 
-    match KafkaSinkConfigFactory(_ksco, env.out)
+    match KafkaConfigFactory(_ksco, env.out)
     | let kc: KafkaConfig val =>
       KafkaSink(_encoder_wrapper, consume reporter, kc, _auth)
-    | let ksce: KafkaSinkConfigError =>
+    | let ksce: KafkaConfigError =>
       @printf[U32]("%s\n".cstring(), ksce.message().cstring())
       Fail()
       EmptySink

--- a/lib/wallaroo/core/source/kafka_source/kafka_source.pony
+++ b/lib/wallaroo/core/source/kafka_source/kafka_source.pony
@@ -237,17 +237,18 @@ actor KafkaSource[In: Any val] is (Producer & KafkaConsumer)
   fun ref is_muted(): Bool =>
     _muted
 
-  be receive_kafka_message(msg: KafkaMessage val,
+  be receive_kafka_message(value: Array[U8] iso, key: (Array[U8] val | None),
+    msg_metadata: KafkaMessageMetadata val,
     network_received_timestamp: U64)
   =>
-    if (msg.get_topic() != _topic)
-      or (msg.get_partition_id() != _partition_id) then
-      @printf[I32](("Msg topic: " + msg.get_topic() + " != _topic: " + _topic
-        + " or Msg partition: " + msg.get_partition_id().string() + " != "
+    if (msg_metadata.get_topic() != _topic)
+      or (msg_metadata.get_partition_id() != _partition_id) then
+      @printf[I32](("Msg topic: " + msg_metadata.get_topic() + " != _topic: " + _topic
+        + " or Msg partition: " + msg_metadata.get_partition_id().string() + " != "
         + " _partition_id: " + _partition_id.string() + "!").cstring())
       Fail()
     end
-    _notify.received(this, msg, network_received_timestamp)
+    _notify.received(this, consume value, key, msg_metadata, network_received_timestamp)
 
   be dispose() =>
     @printf[I32]("Shutting down KafkaSource\n".cstring())

--- a/lib/wallaroo/core/source/kafka_source/kafka_source_config.pony
+++ b/lib/wallaroo/core/source/kafka_source/kafka_source_config.pony
@@ -23,171 +23,22 @@ use "pony-kafka/customlogger"
 use "wallaroo/core/source"
 
 
-class val KafkaSourceConfigError
-  let _message: String
-
-  new val create(m: String) =>
-    _message = m
-
-  fun message(): String =>
-    _message
-
-
-primitive KafkaSourceConfigFactory
-  fun apply(ksco: KafkaSourceConfigOptions val, out: OutStream):
-    (KafkaConfig val | KafkaSourceConfigError)
-  =>
-    let log_level = match ksco.kafka_log_level
-      | "Fine" => Fine
-      | "Info" => Info
-      | "Warn" => Warn
-      | "Error" => Error
-      else
-        return KafkaSourceConfigError("Error! Invalid kafka_source_log_level: "
-          + ksco.kafka_log_level)
-      end
-
-    if (ksco.kafka_brokers.size() == 0) or (ksco.kafka_topic == "") then
-      return KafkaSourceConfigError(
-        "Error! Either brokers is empty or topics is empty!")
-    end
-
-    recover
-      let logger = StringLogger(log_level, out)
-
-      let kc = KafkaConfig(logger, "Kafka Wallaroo Source " + ksco.kafka_topic)
-
-      // add topic config to consumer
-      kc.add_topic_config(ksco.kafka_topic, KafkaConsumeOnly)
-
-      for (host, port) in ksco.kafka_brokers.values() do
-        kc.add_broker(host, port)
-      end
-
-      kc
-    end
-
-class KafkaSourceConfigOptions
-  let kafka_topic: String
-  let kafka_brokers: Array[(String, I32)] val
-  let kafka_log_level: String
-
-  new val create(kafka_topic': String,
-    kafka_brokers': Array[(String, I32)] val,
-    kafka_log_level': String)
-  =>
-    kafka_topic = kafka_topic'
-    kafka_brokers = kafka_brokers'
-    kafka_log_level = kafka_log_level'
-
-class KafkaSourceConfigCLIParser
-  let _pre: String
-  let _out: OutStream
-
-  new create(out: OutStream, prefix: (String | None) = None) =>
-    _out = out
-    _pre = _prefix(prefix)
-
-  fun tag _prefix(prefix: (String | None) = None): String =>
-    match prefix
-    | let s: String => s + "_"
-    else ""
-    end
-
-  fun opts(): Array[(String, (None | String),
-    ArgumentType, (Required | Optional), String)]
-  =>
-    // items in the tuple are: Argument Name, Argument Short Name,
-    //   Argument Type, Required or Optional, Help Text
-    let opts_array = Array[(String, (None | String), ArgumentType,
-      (Required | Optional), String)]
-
-    opts_array.push((_pre + "kafka_source_topic", None, StringArgument, Required,
-      "Kafka topic to consume from"))
-    opts_array.push((_pre + "kafka_source_brokers", None, StringArgument, Required,
-      "Initial brokers to connect to. Format: 'host:port,host:port,...'"))
-    opts_array.push((_pre + "kafka_source_log_level", None, StringArgument, Required,
-      "Log Level (Fine, Info, Warn, Error)"))
-
-    opts_array
-
-  fun print_usage() =>
-    for (long, short, arg_type, arg_req, help) in opts().values() do
-      let short_str = match short
-             | let s: String => "/-" + s
-             else "" end
-
-      let arg_type_str = match arg_type
-             | StringArgument => "(String)"
-             | I64Argument => "(Integer)"
-             | F64Argument => "(Float)"
-             else "" end
-
-      _out.print("--" + long + short_str + "       " + arg_type_str + "    "
-        + help)
-    end
-
-  fun parse(args: Array[String] val):
-    KafkaSourceConfigOptions val ?
-  =>
-    var log_level = "Warn"
-
-    var topic = ""
-    var brokers = recover val Array[(String, I32)] end
-
-    let options = Options(args, false)
-
-    for (long, short, arg_type, arg_req, _) in opts().values() do
-      options.add(long, short, arg_type, arg_req)
-    end
-
-    // TODO: implement all the other options that kafka client supports
-    for option in options do
-      match option
-      | (_pre + "kafka_source_topic", let input: String) =>
-        topic = input
-      | (_pre + "kafka_source_brokers", let input: String) =>
-        brokers = _brokers_from_input_string(input)?
-      | (_pre + "kafka_source_log_level", let input: String) =>
-        log_level = input
-      end
-    end
-
-    KafkaSourceConfigOptions(topic, brokers, log_level)
-
-  fun _brokers_from_input_string(inputs: String): Array[(String, I32)] val ? =>
-    let brokers = recover trn Array[(String, I32)] end
-
-    for input in inputs.split(",").values() do
-      let i = input.split(":")
-      let host = i(0)?
-      let port: I32 = try i(1)?.i32()? else 9092 end
-      brokers.push((host, port))
-    end
-
-    consume brokers
-
-  fun _topics_from_input_string(inputs: String): Array[String] val =>
-    let topics = recover trn Array[String] end
-
-    for input in inputs.split(",").values() do
-      topics.push(input)
-    end
-
-    consume topics
-
+primitive KafkaSourceConfigCLIParser
+  fun apply(out: OutStream, prefix: String = "kafka_source"): KafkaConfigCLIParser =>
+    KafkaConfigCLIParser(out, KafkaConsumeOnly where prefix = prefix)
 
 class val KafkaSourceConfig[In: Any val] is SourceConfig[In]
-  let _ksco: KafkaSourceConfigOptions val
+  let _ksco: KafkaConfigOptions val
   let _auth: TCPConnectionAuth
   let _handler: SourceHandler[In] val
 
-  new val create(ksco: KafkaSourceConfigOptions val, auth: TCPConnectionAuth,
+  new val create(ksco: KafkaConfigOptions iso, auth: TCPConnectionAuth,
     handler: SourceHandler[In] val)
   =>
+    ksco.client_name = "Wallaroo Kafka Source " + ksco.topic
     _handler = handler
     _auth = auth
-    _ksco = ksco
+    _ksco = consume ksco
 
   fun source_listener_builder_builder(): KafkaSourceListenerBuilderBuilder[In]
   =>

--- a/lib/wallaroo/core/source/kafka_source/kafka_source_config.pony
+++ b/lib/wallaroo/core/source/kafka_source/kafka_source_config.pony
@@ -34,60 +34,84 @@ class val KafkaSourceConfigError
 
 
 primitive KafkaSourceConfigFactory
-  fun apply(kafka_topic: String,
-    kafka_brokers: Array[(String, I32)] val,
-    kafka_log_level: String,
-    out: OutStream):
+  fun apply(ksco: KafkaSourceConfigOptions val, out: OutStream):
     (KafkaConfig val | KafkaSourceConfigError)
   =>
-    let log_level = match kafka_log_level
+    let log_level = match ksco.kafka_log_level
       | "Fine" => Fine
       | "Info" => Info
       | "Warn" => Warn
       | "Error" => Error
       else
-        return KafkaSourceConfigError("Error! Invalid kafka_source_log_level: " + kafka_log_level)
+        return KafkaSourceConfigError("Error! Invalid kafka_source_log_level: "
+          + ksco.kafka_log_level)
       end
 
-    if (kafka_brokers.size() == 0) or (kafka_topic == "") then
-      return KafkaSourceConfigError("Error! Either brokers is empty or topics is empty!")
+    if (ksco.kafka_brokers.size() == 0) or (ksco.kafka_topic == "") then
+      return KafkaSourceConfigError(
+        "Error! Either brokers is empty or topics is empty!")
     end
 
     recover
       let logger = StringLogger(log_level, out)
 
-      let kc = KafkaConfig(logger, "Kafka Wallaroo Source " + kafka_topic)
+      let kc = KafkaConfig(logger, "Kafka Wallaroo Source " + ksco.kafka_topic)
 
       // add topic config to consumer
-      kc.add_topic_config(kafka_topic, KafkaConsumeOnly)
+      kc.add_topic_config(ksco.kafka_topic, KafkaConsumeOnly)
 
-      for (host, port) in kafka_brokers.values() do
+      for (host, port) in ksco.kafka_brokers.values() do
         kc.add_broker(host, port)
       end
 
       kc
     end
 
+class KafkaSourceConfigOptions
+  let kafka_topic: String
+  let kafka_brokers: Array[(String, I32)] val
+  let kafka_log_level: String
 
-primitive KafkaSourceConfigCLIParser
-  fun opts(): Array[(String, (None | String), ArgumentType,
-    (Required | Optional), String)]
+  new val create(kafka_topic': String,
+    kafka_brokers': Array[(String, I32)] val,
+    kafka_log_level': String)
+  =>
+    kafka_topic = kafka_topic'
+    kafka_brokers = kafka_brokers'
+    kafka_log_level = kafka_log_level'
+
+class KafkaSourceConfigCLIParser
+  let _pre: String
+  let _out: OutStream
+
+  new create(out: OutStream, prefix: (String | None) = None) =>
+    _out = out
+    _pre = _prefix(prefix)
+
+  fun tag _prefix(prefix: (String | None) = None): String =>
+    match prefix
+    | let s: String => s + "_"
+    else ""
+    end
+
+  fun opts(): Array[(String, (None | String),
+    ArgumentType, (Required | Optional), String)]
   =>
     // items in the tuple are: Argument Name, Argument Short Name,
     //   Argument Type, Required or Optional, Help Text
     let opts_array = Array[(String, (None | String), ArgumentType,
       (Required | Optional), String)]
 
-    opts_array.push(("kafka_source_topic", None, StringArgument, Required,
+    opts_array.push((_pre + "kafka_source_topic", None, StringArgument, Required,
       "Kafka topic to consume from"))
-    opts_array.push(("kafka_source_brokers", None, StringArgument, Required,
+    opts_array.push((_pre + "kafka_source_brokers", None, StringArgument, Required,
       "Initial brokers to connect to. Format: 'host:port,host:port,...'"))
-    opts_array.push(("kafka_source_log_level", None, StringArgument, Required,
+    opts_array.push((_pre + "kafka_source_log_level", None, StringArgument, Required,
       "Log Level (Fine, Info, Warn, Error)"))
 
     opts_array
 
-  fun print_usage(out: OutStream) =>
+  fun print_usage() =>
     for (long, short, arg_type, arg_req, help) in opts().values() do
       let short_str = match short
              | let s: String => "/-" + s
@@ -99,11 +123,13 @@ primitive KafkaSourceConfigCLIParser
              | F64Argument => "(Float)"
              else "" end
 
-      out.print("--" + long + short_str + "       " + arg_type_str + "    "
+      _out.print("--" + long + short_str + "       " + arg_type_str + "    "
         + help)
     end
 
-  fun apply(args: Array[String] val, out: OutStream): KafkaConfig val ? =>
+  fun parse(args: Array[String] val):
+    KafkaSourceConfigOptions val ?
+  =>
     var log_level = "Warn"
 
     var topic = ""
@@ -118,22 +144,16 @@ primitive KafkaSourceConfigCLIParser
     // TODO: implement all the other options that kafka client supports
     for option in options do
       match option
-      | ("kafka_source_topic", let input: String) =>
+      | (_pre + "kafka_source_topic", let input: String) =>
         topic = input
-      | ("kafka_source_brokers", let input: String) =>
+      | (_pre + "kafka_source_brokers", let input: String) =>
         brokers = _brokers_from_input_string(input)?
-      | ("kafka_source_log_level", let input: String) =>
+      | (_pre + "kafka_source_log_level", let input: String) =>
         log_level = input
       end
     end
 
-    match KafkaSourceConfigFactory(topic, brokers, log_level, out)
-    | let kc: KafkaConfig val =>
-      kc
-    | let e: KafkaSourceConfigError =>
-      @printf[U32]("%s\n".cstring(), e.message().cstring())
-      error
-    end
+    KafkaSourceConfigOptions(topic, brokers, log_level)
 
   fun _brokers_from_input_string(inputs: String): Array[(String, I32)] val ? =>
     let brokers = recover trn Array[(String, I32)] end
@@ -158,20 +178,20 @@ primitive KafkaSourceConfigCLIParser
 
 
 class val KafkaSourceConfig[In: Any val] is SourceConfig[In]
-  let _conf: KafkaConfig val
+  let _ksco: KafkaSourceConfigOptions val
   let _auth: TCPConnectionAuth
   let _handler: SourceHandler[In] val
 
-  new val create(conf: KafkaConfig val, auth: TCPConnectionAuth,
+  new val create(ksco: KafkaSourceConfigOptions val, auth: TCPConnectionAuth,
     handler: SourceHandler[In] val)
   =>
     _handler = handler
     _auth = auth
-    _conf = conf
+    _ksco = ksco
 
   fun source_listener_builder_builder(): KafkaSourceListenerBuilderBuilder[In]
   =>
-    KafkaSourceListenerBuilderBuilder[In](_conf, _auth)
+    KafkaSourceListenerBuilderBuilder[In](_ksco, _auth)
 
   fun source_builder(app_name: String, name: String):
     KafkaSourceBuilderBuilder[In]

--- a/lib/wallaroo/core/source/kafka_source/kafka_source_notify.pony
+++ b/lib/wallaroo/core/source/kafka_source/kafka_source_notify.pony
@@ -68,7 +68,9 @@ class KafkaSourceNotify[In: Any val]
   fun routes(): Array[Consumer] val =>
     _router.routes()
 
-  fun ref received(src: KafkaSource[In] ref, msg: KafkaMessage val,
+  fun ref received(src: KafkaSource[In] ref, kafka_msg_value: Array[U8] iso,
+    kafka_msg_key: (Array[U8] val | None),
+    kafka_msg_metadata: KafkaMessageMetadata val,
     network_received_timestamp: U64)
   =>
     _metrics_reporter.pipeline_ingest(_pipeline_name, _source_name)
@@ -83,7 +85,7 @@ class KafkaSourceNotify[In: Any val]
       latest_metrics_id = latest_metrics_id + 1
     end
 
-    let data = msg.get_value()
+    let data = consume kafka_msg_value
 
     ifdef "trace" then
       @printf[I32](("Rcvd msg at " + _pipeline_name + " source\n").cstring())

--- a/machida/bundle.json
+++ b/machida/bundle.json
@@ -5,7 +5,7 @@
       },
       { "type": "github",
         "repo": "WallarooLabs/pony-kafka",
-        "tag": "0.3.0"
+        "tag": "ca9156b"
       }
   ]
 }

--- a/machida/machida.pony
+++ b/machida/machida.pony
@@ -920,7 +920,7 @@ primitive _SourceConfig
 
       TCPSourceConfig[PyData val](decoder, host, port)
     | "kafka" =>
-      let conf = _kafka_config(source_config_tuple, env.out)?
+      let ksco = _kafka_config_options(source_config_tuple)
 
       let decoder = recover val
         let d = @PyTuple_GetItem(source_config_tuple, 4)
@@ -928,12 +928,12 @@ primitive _SourceConfig
         PySourceHandler(d)
       end
 
-      KafkaSourceConfig[PyData val](conf, (env.root as TCPConnectionAuth), decoder)
+      KafkaSourceConfig[PyData val](ksco, (env.root as TCPConnectionAuth), decoder)
     else
       error
     end
 
-  fun _kafka_config(source_config_tuple: Pointer[U8] val, out: OutStream): KafkaConfig val ? =>
+  fun _kafka_config_options(source_config_tuple: Pointer[U8] val): KafkaSourceConfigOptions val =>
     let topic = recover val
       String.copy_cstring(@PyString_AsString(@PyTuple_GetItem(source_config_tuple, 1)))
     end
@@ -961,13 +961,7 @@ primitive _SourceConfig
       String.copy_cstring(@PyString_AsString(@PyTuple_GetItem(source_config_tuple, 3)))
     end
 
-    match KafkaSourceConfigFactory(topic, brokers, log_level, out)
-    | let conf: KafkaConfig val =>
-      conf
-    | let kce: KafkaSourceConfigError =>
-      @printf[U32]("%s\n".cstring(), kce.message().cstring())
-      error
-    end
+    KafkaSourceConfigOptions(topic, brokers, log_level)
 
 primitive _SinkConfig
   fun from_tuple(sink_config_tuple: Pointer[U8] val, env: Env):
@@ -995,7 +989,7 @@ primitive _SinkConfig
 
       TCPSinkConfig[PyData val](encoder, host, port)
     | "kafka" =>
-      let conf = _kafka_config(sink_config_tuple, env.out)?
+      let ksco = _kafka_config_options(sink_config_tuple)
 
       let encoderp = @PyTuple_GetItem(sink_config_tuple, 6)
       Machida.inc_ref(encoderp)
@@ -1003,12 +997,12 @@ primitive _SinkConfig
         PyKafkaEncoder(encoderp)
       end
 
-      KafkaSinkConfig[PyData val](encoder, conf, (env.root as TCPConnectionAuth))
+      KafkaSinkConfig[PyData val](encoder, ksco, (env.root as TCPConnectionAuth))
     else
       error
     end
 
-  fun _kafka_config(source_config_tuple: Pointer[U8] val, out: OutStream): KafkaConfig val ? =>
+  fun _kafka_config_options(source_config_tuple: Pointer[U8] val): KafkaSinkConfigOptions val =>
     let topic = recover val
       String.copy_cstring(@PyString_AsString(@PyTuple_GetItem(source_config_tuple, 1)))
     end
@@ -1040,10 +1034,4 @@ primitive _SinkConfig
 
     let max_message_size = @PyInt_AsLong(@PyTuple_GetItem(source_config_tuple, 5)).i32()
 
-    match KafkaSinkConfigFactory(topic, brokers, log_level, max_produce_buffer_ms, max_message_size, out)
-    | let conf: KafkaConfig val =>
-      conf
-    | let kce: KafkaSinkConfigError =>
-      @printf[U32]("%s\n".cstring(), kce.message().cstring())
-      error
-    end
+    KafkaSinkConfigOptions(topic, brokers, log_level, max_produce_buffer_ms, max_message_size)

--- a/machida/machida.pony
+++ b/machida/machida.pony
@@ -928,12 +928,12 @@ primitive _SourceConfig
         PySourceHandler(d)
       end
 
-      KafkaSourceConfig[PyData val](ksco, (env.root as TCPConnectionAuth), decoder)
+      KafkaSourceConfig[PyData val](consume ksco, (env.root as TCPConnectionAuth), decoder)
     else
       error
     end
 
-  fun _kafka_config_options(source_config_tuple: Pointer[U8] val): KafkaSourceConfigOptions val =>
+  fun _kafka_config_options(source_config_tuple: Pointer[U8] val): KafkaConfigOptions iso^ =>
     let topic = recover val
       String.copy_cstring(@PyString_AsString(@PyTuple_GetItem(source_config_tuple, 1)))
     end
@@ -961,7 +961,7 @@ primitive _SourceConfig
       String.copy_cstring(@PyString_AsString(@PyTuple_GetItem(source_config_tuple, 3)))
     end
 
-    KafkaSourceConfigOptions(topic, brokers, log_level)
+    KafkaConfigOptions("Wallaroo Kafka Source", KafkaConsumeOnly, topic, brokers, log_level)
 
 primitive _SinkConfig
   fun from_tuple(sink_config_tuple: Pointer[U8] val, env: Env):
@@ -997,12 +997,12 @@ primitive _SinkConfig
         PyKafkaEncoder(encoderp)
       end
 
-      KafkaSinkConfig[PyData val](encoder, ksco, (env.root as TCPConnectionAuth))
+      KafkaSinkConfig[PyData val](encoder, consume ksco, (env.root as TCPConnectionAuth))
     else
       error
     end
 
-  fun _kafka_config_options(source_config_tuple: Pointer[U8] val): KafkaSinkConfigOptions val =>
+  fun _kafka_config_options(source_config_tuple: Pointer[U8] val): KafkaConfigOptions iso^ =>
     let topic = recover val
       String.copy_cstring(@PyString_AsString(@PyTuple_GetItem(source_config_tuple, 1)))
     end
@@ -1034,4 +1034,4 @@ primitive _SinkConfig
 
     let max_message_size = @PyInt_AsLong(@PyTuple_GetItem(source_config_tuple, 5)).i32()
 
-    KafkaSinkConfigOptions(topic, brokers, log_level, max_produce_buffer_ms, max_message_size)
+    KafkaConfigOptions("Wallaroo Kafka Sink", KafkaProduceOnly, topic, brokers, log_level, max_produce_buffer_ms, max_message_size)


### PR DESCRIPTION
* Defer creating `KafkaConfig` to avoid segfaults due to `out` in logger (Resolves #1202)
* Update kafka sink/source/examples/machida to work with pony-kafka master (NOTE: machida/python examples haven't been updated to use all new config options that the pony cli parser in pony-kafka can now handle)


NOTE: The current `pony-kafka` master doesn't fully work for leader failover at the moment (still have some debugging/testing/logic fixing to finish off in that regard) but the API for wallaroo will not change because of that. The only change needed would be to update the relevant `bundle.json` files to point to the correct `tag` or `commit` in `pony-kafka` to use.