### PR TITLE
Move Python API intro to be first "Wallaroo with Python" section

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -39,6 +39,8 @@
 -->
 
 ## Wallaroo with Python
+* [Wallaroo with Python Introduction](book/python/intro.md)
+
 ### Setting up Your Environment
 * [Choosing an Installation Option](book/getting-started/choosing-an-installation-option.md)
 * Installing with Docker
@@ -52,7 +54,6 @@
 * [Conclusion](book/getting-started/conclusion.md)
 
 ### Wallaroo Python API
-* [Python API Introduction](book/python/intro.md)
 * [Running a Wallaroo Python Application](book/python/running-a-wallaroo-python-application.md)
 * [Writing Your Own Application](book/python/writing-your-own-application.md)
 * [Writing Your Own Stateful Application](book/python/writing-your-own-stateful-application.md)

--- a/book/python/intro.md
+++ b/book/python/intro.md
@@ -20,12 +20,4 @@ We recommend using [virtualenv](https://virtualenv.pypa.io/en/stable/) with Wall
 
 ## Next Steps
 
-To set up your environment for writing and running Wallaroo Python application, refer to [Running a Wallaroo Python Application](running-a-wallaroo-python-application.md).
-
-To learn how to write your own application, refer to [Writing Your Own Application](writing-your-own-application.md).
-
-To read about the structure and requirements of each API class, refer to [Wallaroo Python API Classes](api.md).
-
-To read about the command-line arguments Wallaroo takes, refer to [Appendix: Wallaroo Command-Line Options](/book/appendix/wallaroo-command-line-options.md).
-
-To browse complete examples, go to [Wallaroo Python Examples](https://github.com/WallarooLabs/wallaroo/tree/{{ book.wallaroo_version }}/examples/python).
+To set up your environment for writing and running Wallaroo Python application, refer to [our installation instructions](/book/getting-started/choosing-an-installation-option.md).


### PR DESCRIPTION
Previously, we only had the Python API so we took people through
installation then introduced Wallaroo with Python in the API section.

With the addition of a Go API, it makes sense to reorganize so we
have...

intro to Python
how to install
Python API

as a general flow.

[skip ci]