### PR TITLE
Update go api to be compatible with kafka client api changes and some makefile fixes

### DIFF
--- a/demos/go_word_count/bundle.json
+++ b/demos/go_word_count/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "0.3.0"
+      "tag": "ca9156b"
     }
   ]
 }

--- a/examples/go/Makefile
+++ b/examples/go/Makefile
@@ -1,6 +1,6 @@
 # include root makefile
 ifndef ROOT_MAKEFILE_MK
-include ../Makefile
+include ../../Makefile
 endif
 
 # prevent rules from being evaluated/included multiple times

--- a/examples/go/alphabet/Makefile
+++ b/examples/go/alphabet/Makefile
@@ -41,16 +41,21 @@ ALPHABET_GOPATH := $(ALPHABET_GO_PATH)/go:$(GO_PONY_LIB)
 # standard rules generation makefile
 include $(rules_mk_path)
 
-build-examples-go-alphabet: alphabet_go_clean alphabet_go_build
+build-examples-go-alphabet: alphabet_go_build
+test-examples-go-alphabet: build-examples-go-alphabet
 clean-examples-go-alphabet: alphabet_go_clean
 
-alphabet_go_build:
-	$(QUIET)export GOPATH=$(ALPHABET_GOPATH) && go build -buildmode=c-archive -o $(ALPHABET_GO_PATH)lib/libwallaroo.a alphabet
-	$(QUIET)stable fetch
-	$(QUIET)stable env ponyc -D clustering
+alphabet_go_build: $(ALPHABET_GO_PATH)/alphabet
 
 alphabet_go_clean:
 	$(QUIET)rm -rf $(ALPHABET_GO_PATH)/lib $(ALPHABET_GO_PATH)/.deps $(ALPHABET_GO_PATH)/alphabet
+
+-include $(ALPHABET_GO_PATH)/alphabet.d
+$(ALPHABET_GO_PATH)/alphabet: $(ALPHABET_GO_PATH)/lib/libwallaroo.a
+	$(call PONYC,$(abspath $(ALPHABET_GO_PATH:%/=%)))
+
+$(ALPHABET_GO_PATH)/lib/libwallaroo.a: $(ALPHABET_GO_PATH)/go/src/alphabet/alphabet.go
+	$(QUIET)export GOPATH=$(ALPHABET_GOPATH) && go build -buildmode=c-archive -o $(ALPHABET_GO_PATH)lib/libwallaroo.a alphabet
 
 # end of prevent rules from being evaluated/included multiple times
 endif

--- a/examples/go/alphabet/Makefile
+++ b/examples/go/alphabet/Makefile
@@ -42,7 +42,7 @@ ALPHABET_GOPATH := $(ALPHABET_GO_PATH)/go:$(GO_PONY_LIB)
 include $(rules_mk_path)
 
 build-examples-go-alphabet: alphabet_go_build
-test-examples-go-alphabet: build-examples-go-alphabet
+unit-tests-examples-go-alphabet: build-examples-go-alphabet
 clean-examples-go-alphabet: alphabet_go_clean
 
 alphabet_go_build: $(ALPHABET_GO_PATH)/alphabet

--- a/examples/go/alphabet/bundle.json
+++ b/examples/go/alphabet/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "0.3.0"
+      "tag": "ca9156b"
     }
   ]
 }

--- a/examples/go/celsius/Makefile
+++ b/examples/go/celsius/Makefile
@@ -41,16 +41,21 @@ CELSIUS_GOPATH := $(CELSIUS_GO_PATH)/go:$(GO_PONY_LIB)
 # standard rules generation makefile
 include $(rules_mk_path)
 
-build-examples-go-celsius: celsius_go_clean celsius_go_build
+build-examples-go-celsius: celsius_go_build
+test-examples-go-celsius: build-examples-go-celsius
 clean-examples-go-celsius: celsius_go_clean
 
-celsius_go_build:
-	$(QUIET)export GOPATH=$(CELSIUS_GOPATH) && go build -buildmode=c-archive -o $(CELSIUS_GO_PATH)lib/libwallaroo.a celsius
-	$(QUIET)stable fetch
-	$(QUIET)stable env ponyc
+celsius_go_build: $(CELSIUS_GO_PATH)/celsius
 
 celsius_go_clean:
 	$(QUIET)rm -rf $(CELSIUS_GO_PATH)/lib $(CELSIUS_GO_PATH)/.deps $(CELSIUS_GO_PATH)/celsius
+
+-include $(CELSIUS_GO_PATH)/celsius.d
+$(CELSIUS_GO_PATH)/celsius: $(CELSIUS_GO_PATH)/lib/libwallaroo.a
+	$(call PONYC,$(abspath $(CELSIUS_GO_PATH:%/=%)))
+
+$(CELSIUS_GO_PATH)/lib/libwallaroo.a: $(CELSIUS_GO_PATH)/go/src/celsius/celsius.go
+	$(QUIET)export GOPATH=$(CELSIUS_GOPATH) && go build -buildmode=c-archive -o $(CELSIUS_GO_PATH)lib/libwallaroo.a celsius
 
 # end of prevent rules from being evaluated/included multiple times
 endif

--- a/examples/go/celsius/Makefile
+++ b/examples/go/celsius/Makefile
@@ -42,7 +42,7 @@ CELSIUS_GOPATH := $(CELSIUS_GO_PATH)/go:$(GO_PONY_LIB)
 include $(rules_mk_path)
 
 build-examples-go-celsius: celsius_go_build
-test-examples-go-celsius: build-examples-go-celsius
+unit-tests-examples-go-celsius: build-examples-go-celsius
 clean-examples-go-celsius: celsius_go_clean
 
 celsius_go_build: $(CELSIUS_GO_PATH)/celsius

--- a/examples/go/celsius/bundle.json
+++ b/examples/go/celsius/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "0.3.0"
+      "tag": "ca9156b"
     }
   ]
 }

--- a/examples/go/reverse/Makefile
+++ b/examples/go/reverse/Makefile
@@ -42,7 +42,7 @@ REVERSE_GOPATH := $(REVERSE_GO_PATH)/go:$(GO_PONY_LIB)
 include $(rules_mk_path)
 
 build-examples-go-reverse: reverse_go_build
-test-examples-go-reverse: build-examples-go-reverse
+unit-tests-examples-go-reverse: build-examples-go-reverse
 clean-examples-go-reverse: reverse_go_clean
 
 reverse_go_build: $(REVERSE_GO_PATH)/reverse

--- a/examples/go/reverse/Makefile
+++ b/examples/go/reverse/Makefile
@@ -41,16 +41,21 @@ REVERSE_GOPATH := $(REVERSE_GO_PATH)/go:$(GO_PONY_LIB)
 # standard rules generation makefile
 include $(rules_mk_path)
 
-build-examples-go-reverse: reverse_go_clean reverse_go_build
+build-examples-go-reverse: reverse_go_build
+test-examples-go-reverse: build-examples-go-reverse
 clean-examples-go-reverse: reverse_go_clean
 
-reverse_go_build:
-	$(QUIET)export GOPATH=$(REVERSE_GOPATH) && go build -buildmode=c-archive -o $(REVERSE_GO_PATH)lib/libwallaroo.a reverse
-	$(QUIET)stable fetch
-	$(QUIET)stable env ponyc
+reverse_go_build: $(REVERSE_GO_PATH)/reverse
 
 reverse_go_clean:
 	$(QUIET)rm -rf $(REVERSE_GO_PATH)/lib $(REVERSE_GO_PATH)/.deps $(REVERSE_GO_PATH)/reverse
+
+-include $(REVERSE_GO_PATH)/reverse.d
+$(REVERSE_GO_PATH)/reverse: $(REVERSE_GO_PATH)/lib/libwallaroo.a
+	$(call PONYC,$(abspath $(REVERSE_GO_PATH:%/=%)))
+
+$(REVERSE_GO_PATH)/lib/libwallaroo.a: $(REVERSE_GO_PATH)/go/src/reverse/reverse.go
+	$(QUIET)export GOPATH=$(REVERSE_GOPATH) && go build -buildmode=c-archive -o $(REVERSE_GO_PATH)lib/libwallaroo.a reverse
 
 # end of prevent rules from being evaluated/included multiple times
 endif

--- a/examples/go/reverse/bundle.json
+++ b/examples/go/reverse/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "0.3.0"
+      "tag": "ca9156b"
     }
   ]
 }

--- a/examples/go/word_count/Makefile
+++ b/examples/go/word_count/Makefile
@@ -42,7 +42,7 @@ WORD_COUNT_GOPATH := $(WORD_COUNT_GO_PATH)/go:$(GO_PONY_LIB)
 include $(rules_mk_path)
 
 build-examples-go-word_count: word_count_go_build
-test-examples-go-word_count: build-examples-go-word_count
+unit-tests-examples-go-word_count: build-examples-go-word_count
 clean-examples-go-word_count: word_count_go_clean
 
 word_count_go_build: $(WORD_COUNT_GO_PATH)/word_count

--- a/examples/go/word_count/Makefile
+++ b/examples/go/word_count/Makefile
@@ -41,16 +41,21 @@ WORD_COUNT_GOPATH := $(WORD_COUNT_GO_PATH)/go:$(GO_PONY_LIB)
 # standard rules generation makefile
 include $(rules_mk_path)
 
-build-examples-go-word_count: word_count_go_clean word_count_go_build
+build-examples-go-word_count: word_count_go_build
+test-examples-go-word_count: build-examples-go-word_count
 clean-examples-go-word_count: word_count_go_clean
 
-word_count_go_build:
-	$(QUIET)export GOPATH=$(WORD_COUNT_GOPATH) && go build -buildmode=c-archive -o $(WORD_COUNT_GO_PATH)lib/libwallaroo.a word_count
-	$(QUIET)stable fetch
-	$(QUIET)stable env ponyc
+word_count_go_build: $(WORD_COUNT_GO_PATH)/word_count
 
 word_count_go_clean:
 	$(QUIET)rm -rf $(WORD_COUNT_GO_PATH)/lib $(WORD_COUNT_GO_PATH)/.deps $(WORD_COUNT_GO_PATH)/word_count
+
+-include $(WORD_COUNT_GO_PATH)/word_count.d
+$(WORD_COUNT_GO_PATH)/word_count: $(WORD_COUNT_GO_PATH)/lib/libwallaroo.a
+	$(call PONYC,$(abspath $(WORD_COUNT_GO_PATH:%/=%)))
+
+$(WORD_COUNT_GO_PATH)/lib/libwallaroo.a: $(WORD_COUNT_GO_PATH)/go/src/word_count/word_count.go
+	$(QUIET)export GOPATH=$(WORD_COUNT_GOPATH) && go build -buildmode=c-archive -o $(WORD_COUNT_GO_PATH)lib/libwallaroo.a word_count
 
 # end of prevent rules from being evaluated/included multiple times
 endif

--- a/examples/go/word_count/bundle.json
+++ b/examples/go/word_count/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "0.3.0"
+      "tag": "ca9156b"
     }
   ]
 }

--- a/go_api/examples/kafka_reverse/bundle.json
+++ b/go_api/examples/kafka_reverse/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "0.3.0"
+      "tag": "ca9156b"
     }
   ]
 }

--- a/go_api/examples/market_spread/bundle.json
+++ b/go_api/examples/market_spread/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "0.3.0"
+      "tag": "ca9156b"
     }
   ]
 }

--- a/go_api/pony/go_api/build_application.pony
+++ b/go_api/pony/go_api/build_application.pony
@@ -264,13 +264,10 @@ primitive _SourceConfig
       let log_level = source("LogLevel")?.string()?
       let decoder_id = source("DecoderId")?.int()?.u64()
       let brokers_val: Array[(String, I32)] val = consume brokers
-      match recover KafkaSourceConfigFactory(topic, brokers_val, log_level, env.out) end
-      | let kc: KafkaConfig val =>
-        KafkaSourceConfig[GoData](kc, env.root as TCPConnectionAuth,
-          GoSourceHandler(decoder_id))
-      else
-        error
-      end
+      let ksco = KafkaConfigOptions("Wallaroo Kakfa Source", KafkaConsumeOnly,
+        topic, brokers_val, log_level)
+      KafkaSourceConfig[GoData](consume ksco, env.root as TCPConnectionAuth,
+        GoSourceHandler(decoder_id))
     else
       error
     end
@@ -298,14 +295,10 @@ primitive _SinkConfig
       let max_message_size = sink("MaxMessageSize")?.int()?.i32()
       let encoder_id = sink("EncoderId")?.int()?.u64()
       let brokers_val: Array[(String, I32)] val = consume brokers
-      match recover KafkaSinkConfigFactory(topic, brokers_val, log_level,
-        max_produce_buffer_ms, max_message_size ,env.out) end
-      | let kc: KafkaConfig val =>
-        KafkaSinkConfig[GoData](GoKafkaEncoder(encoder_id), kc,
-          env.root as TCPConnectionAuth)
-      else
-        error
-      end
+      let ksco = KafkaConfigOptions("Wallaroo Kakfa Sink", KafkaProduceOnly,
+        topic, brokers_val, log_level, max_produce_buffer_ms, max_message_size)
+      KafkaSinkConfig[GoData](GoKafkaEncoder(encoder_id), consume ksco,
+        env.root as TCPConnectionAuth)
     else
       error
     end


### PR DESCRIPTION
NOTE: I updated the `bundle.json` in `go_api/examples/*` and `demos/go_word_count` but I did not update the `Makefile`s in those directories.

----------------

This PR includes the following changes:

* Update go api to be compatible with kafka client api changes

  Prior to this commit, the go api would not compile successfully
  due to the changes from PR #1868.

  This commit updates the go api so that it can be compiled successfully
  with the latest kafka client changes.

* Update makefiles in go examples

  Prior to this commit, running `make test` in CI did not build the
  go examples. This commit fixes that and includes the following
  changes:

  * Define the `build` target as a dependency of the `test` target
    so that `make test` will force a build of the go api examples
    like with other examples
  * Update `Makefile` logic for incremental building of the go api
    examples (based on the machida `Makefile`)
  * Update `Makefile` logic to use standard `ponyc` invocation via
    a `make` `macro` (like how the machida `Makefile` does it) in
    order to inherit all the same benefits as used to compile all
    other `ponyc` code (incremental building, location independence,
    etc)