### PR TITLE
Corrections for go doc review, round 1

### DIFF
--- a/book/getting-started/linux-setup.md
+++ b/book/getting-started/linux-setup.md
@@ -144,7 +144,7 @@ sudo docker pull wallaroo-labs-docker-wallaroolabs.bintray.io/release/metrics_ui
 
 ## Set up Environment for the Wallaroo Tutorial
 
-If you haven't already done so, create a directory called `~/wallaroo-tutorial` and navigate there by running
+If you haven't already done so, create a directory called `~/wallaroo-tutorial` and navigate there by running:
 
 ```bash
 cd ~/

--- a/book/getting-started/macos-setup.md
+++ b/book/getting-started/macos-setup.md
@@ -52,7 +52,7 @@ brew install pony-stable
 
 ## Install Compression Development Libraries
 
-Wallaroo's Kakfa support requires a `libsnappy` and `liblz` to be installed.
+Wallaroo's Kafka support requires a `libsnappy` and `liblz` to be installed.
 
 ```bash
 brew install snappy lz4

--- a/book/getting-started/macos-setup.md
+++ b/book/getting-started/macos-setup.md
@@ -34,7 +34,7 @@ brew install git
 
 ### Installing ponyc
 
-Now you need to install the Wallaroo Labs fork of the Pony compiler `ponyc`.
+Now you need to install the Pony compiler `ponyc`.
 
 ```bash
 brew update

--- a/book/getting-started/macos-setup.md
+++ b/book/getting-started/macos-setup.md
@@ -78,7 +78,7 @@ docker pull wallaroo-labs-docker-wallaroolabs.bintray.io/release/metrics_ui:0.3.
 
 ## Set up Environment for the Wallaroo Tutorial
 
-If you haven't already done so, create a directory called `~/wallaroo-tutorial` and navigate there by running
+If you haven't already done so, create a directory called `~/wallaroo-tutorial` and navigate there by running:
 
 ```bash
 cd ~/

--- a/book/getting-started/run-a-wallaroo-application-docker.md
+++ b/book/getting-started/run-a-wallaroo-application-docker.md
@@ -2,14 +2,14 @@
 
 In this section, we're going to run an example Wallaroo application in Docker. By the time you are finished, you'll have validated that your Docker environment is set up and working correctly. If you haven't already completed the Docker setup [instructions](book/getting-started/docker-setup.md), please do so before continuing.
 
-There's a couple Wallaroo support applications that you'll be interacting with for the first time:
+There are a few Wallaroo support applications that you'll be interacting with for the first time:
 
 * Our Metrics UI that allows you to monitor the performance and health of your applications.
 * Giles receiver is designed to capture TCP output from Wallaroo applications.
 * Giles sender is used to send test data into Wallaroo applications over TCP.
 * Machida, our program for running Wallaroo Python applications.
 
-You're going to set up our "Celsius to Fahrenheit" example application. Giles sender will be used to pump data into the application. Giles receiver will receive the output and our Metrics UI will be running so you can observe the overall performance.
+You're going to set up our "Celsius to Fahrenheit" example application. Giles sender will be used to pump data into the application. Giles receiver will receive the output, and our Metrics UI will be running so you can observe the overall performance.
 
 The Metrics UI process will be run in the background. The other three processes \(receiver, sender, and Wallaroo\) will run in the foreground. We recommend that you run each process in a separate terminal.
 

--- a/book/getting-started/run-a-wallaroo-application.md
+++ b/book/getting-started/run-a-wallaroo-application.md
@@ -2,14 +2,14 @@
 
 In this section, we're going to run an example Wallaroo application. By the time you are finished, you'll have validated that your environment is set up and working correctly.
 
-There's a couple Wallaroo support applications that you'll be interacting with for the first time:
+There are a few Wallaroo support applications that you'll be interacting with for the first time:
 
 - Our Metrics UI that allows you to monitor the performance and health of your applications.
 - Giles receiver is designed to capture TCP output from Wallaroo applications.
 - Giles sender is used to send test data into Wallaroo applications over TCP.
 - Machida, our program for running Wallaroo Python applications.
 
-You're going to set up our "Celsius to Fahrenheit" example application. Giles sender will be used to pump data into the application. Giles receiver will receive the output and our Metrics UI will be running so you can observe the overall performance.
+You're going to set up our "Celsius to Fahrenheit" example application. Giles sender will be used to pump data into the application. Giles receiver will receive the output, and our Metrics UI will be running so you can observe the overall performance.
 
 The Metrics UI process will be run in the background via Docker.  The other three processes (receiver, sender, and Wallaroo) will run in the foreground.  We recommend that you run each process in a separate terminal.
 

--- a/book/go/api/interworker-serialization-and-resilience.md
+++ b/book/go/api/interworker-serialization-and-resilience.md
@@ -67,13 +67,13 @@ func Serialize(c interface{}) []byte {
 ```
 
 The switch statement handles all of the types that need to be serialized.
-* partition functions -- not applicable to this program
+* partition functions -- not applicable to the Reverse application
 * decoders -- the `Decoder` class
 * encoders -- the `Encoder` class
 * computations -- the `Reverse` class
 * computation builders -- the `ReverseBuilder` class
-* state computations -- not applicable to this program
-* state objects -- not applicable to this program
+* state computations -- not applicable to the Reverse application
+* state objects -- not applicable to the Reverse application
 * messages that pass between steps in a topology -- the `string` class
 
 You are free to select any encoding mechanism that you would like. In

--- a/book/go/api/interworker-serialization-and-resilience.md
+++ b/book/go/api/interworker-serialization-and-resilience.md
@@ -67,14 +67,15 @@ func Serialize(c interface{}) []byte {
 ```
 
 The switch statement handles all of the types that need to be serialized.
-* partition functions -- not applicable to the Reverse application
 * decoders -- the `Decoder` class
 * encoders -- the `Encoder` class
 * computations -- the `Reverse` class
 * computation builders -- the `ReverseBuilder` class
-* state computations -- not applicable to the Reverse application
-* state objects -- not applicable to the Reverse application
 * messages that pass between steps in a topology -- the `string` class
+* types not shown in the example code above but are required by stateful computations. (The Reverse application does not use stateful computations).
+  * partition functions
+  * state computations
+  * state objects
 
 You are free to select any encoding mechanism that you would like. In
 this example we have used a 32-bit integer to represent the type of

--- a/book/go/api/interworker-serialization-and-resilience.md
+++ b/book/go/api/interworker-serialization-and-resilience.md
@@ -24,7 +24,7 @@ Your application must handle all of these type of objects in its serialization a
 * state objects
 * messages that pass between steps in a topology
 
-### An Example
+### An Example Serializing Function
 
 As an example of serialization, let's look at the Reverse
 application. It converts a `byte` slice into a string, reverses
@@ -83,6 +83,8 @@ the `string` class, you will need to encode that data as well. Go
 provides the `gob` module which can encode and decode objects for you;
 we recommend you use this unless you have a specific need that it does
 not satisfy.
+
+### An Example Deserializing Function
 
 The decoder function performs the opposite operation, taking an
 serialized representation and converting it into the object that is

--- a/book/go/api/interworker-serialization-and-resilience.md
+++ b/book/go/api/interworker-serialization-and-resilience.md
@@ -66,16 +66,13 @@ func Serialize(c interface{}) []byte {
 }
 ```
 
-The switch statement handles all of the types that need to be serialized.
+The switch statement handles all of the types that need to be serialized.  (Remember, the Reverse application does not use stateful computations.  Cases for partition functions, state computations, and state objects do not appear in this example).
+
 * decoders -- the `Decoder` class
 * encoders -- the `Encoder` class
 * computations -- the `Reverse` class
 * computation builders -- the `ReverseBuilder` class
 * messages that pass between steps in a topology -- the `string` class
-* types not shown in the example code above but are required by stateful computations. (The Reverse application does not use stateful computations).
-  * partition functions
-  * state computations
-  * state objects
 
 You are free to select any encoding mechanism that you would like. In
 this example we have used a 32-bit integer to represent the type of

--- a/book/go/api/intro.md
+++ b/book/go/api/intro.md
@@ -2,7 +2,7 @@
 
 The Wallaroo Go API can be used to write Wallaroo applications using Go. 
 
-In order to write a Wallaroo application in Go, the developer creates a series of functions and types that provide methods expected by Wallaroo (see [Wallaroo Go API Classes](api.md) for more detail on this). Additionally, the developer writes an entry point function that Wallaroo uses to lay out the application. 
+In order to write a Wallaroo application in Go, the developer creates a series of functions and types that provide methods expected by Wallaroo (see [Wallaroo Go API Classes](api.md) for more detail). Additionally, the developer writes an entry point function that Wallaroo uses to lay out the application.
 
 For a basic overview of what Wallaroo does, read [What is Wallaroo](/book/what-is-wallaroo.md) and [Core Concepts](/book/core-concepts/intro.md). These documents will help you understand the system at a high level so that you can see how the pieces of the Go API fit into it.
 

--- a/book/go/api/intro.md
+++ b/book/go/api/intro.md
@@ -10,7 +10,7 @@ For a basic overview of what Wallaroo does, read [What is Wallaroo](/book/what-i
 
 A Wallaroo Go application is a combination of Go library (technically Cgo, we'll cover that in more detail later) and Wallaroo framework code provided by Wallaroo Labs.
 
-You, the application developer, write your application in Go and then compile it into a Go library that will be linked into a final binary using the Pony compiler.
+You, the application developer, write your application in Go and then compile it into a Go library that will be linked into a final executable file using the Pony compiler.
 
 ## Next Steps
 

--- a/book/go/api/start-a-project.md
+++ b/book/go/api/start-a-project.md
@@ -18,7 +18,7 @@ You will not need to modify this file at all if you follow these instructions fo
 
 `stable` is a tool for managing Pony dependencies and building Pony projects. `stable` reads a file called `bundle.json` to figure out where to find dependencies. This file can be created using `stable add ...` to add the dependencies. You should run these commands in the project directory so that the `bundle.json` file will be created there.
 
-The easiest thing to do would be to create a shell variable that contains the path to where you have cloned the Wallaroo repo. For example, if it is your home directory then your shell variable would be set with
+The easiest thing to do would be to create a shell variable that contains the path to where you have cloned the Wallaroo repo. For example, if it is your home directory then your shell variable would be set with:
 
 ```bash
 WALLAROO_HOME=$HOME/wallaroo

--- a/book/go/api/start-a-project.md
+++ b/book/go/api/start-a-project.md
@@ -83,7 +83,7 @@ mkdir -p go/src/PROJECT_NAME
 
 ## Create a Wallaroo Go Application
 
-The code for your application should be under the `go/src/PROJECT_NAME` directory that you created. There must be a `main` package with an empty `main()` function, and your program must export a C function called `ApplicationSetup`. You must also set the `wallarooapi.Serialize` and `wallaroo.Deserialize` variables. Here's an outline of what the application file might look like:
+The code for your application should be under the `go/src/PROJECT_NAME` directory that you created. There must be a `main` package with an empty `main()` function, and your program must export a C function called `ApplicationSetup`. You must also set the `wallarooapi.Serialize` and `wallarooapi.Deserialize` variables. Here's an outline of what the application file might look like:
 
 ```go
 package main

--- a/book/go/api/start-a-project.md
+++ b/book/go/api/start-a-project.md
@@ -18,7 +18,7 @@ You will not need to modify this file at all if you follow these instructions fo
 
 `stable` is a tool for managing Pony dependencies and building Pony projects. `stable` reads a file called `bundle.json` to figure out where to find dependencies. This file can be created using `stable add ...` to add the dependencies. You should run these commands in the project directory so that the `bundle.json` file will be created there.
 
-The easiest thing to do would be to create a shell variable that contains the path to where you have cloned the wallaroo repo. For example, if it is your home directory then your shell variable would be set with
+The easiest thing to do would be to create a shell variable that contains the path to where you have cloned the Wallaroo repo. For example, if it is your home directory then your shell variable would be set with
 
 ```bash
 WALLAROO_HOME=$HOME/wallaroo

--- a/book/go/api/word-count.md
+++ b/book/go/api/word-count.md
@@ -134,7 +134,7 @@ func (s *Split) Compute(data interface{}) []interface{} {
 }
 ```
 
-Did you catch what is going on? Previously, we've seen our stateless computations have a `Compute` method that returns an `interface{}`. `Split` returns a `[]interface{}`. Each item in the slice is a new message that is send individually to the next step in the pipeline. This allows us to then route each one based on its first letter for counting. If you look below, you can see that our word partitioning function is expecting words, not a list, which makes sense:
+Did you catch what is going on? Previously, we've seen our stateless computations have a `Compute` method that returns an `interface{}`. `Split` returns a `[]interface{}`. Each item in the slice is a new message that is sent individually to the next step in the pipeline. This allows us to then route each one based on its first letter for counting. If you look below, you can see that our word partitioning function is expecting words, not a list, which makes sense:
 
 ```go
 type WordPartitionFunction struct {}

--- a/book/go/api/word-count.md
+++ b/book/go/api/word-count.md
@@ -60,7 +60,7 @@ By now, hopefully, most of this looks somewhat familiar. We're building on conce
 	inPort := inHostsPorts[0][1]
 ```
 
-We point the Wallaro serialization and deserialization functions to our serializer and deserializer:
+We point the Wallaroo serialization and deserialization functions to our serializer and deserializer:
 
 ```go
 	wa.Serialize = Serialize

--- a/book/go/api/word-count.md
+++ b/book/go/api/word-count.md
@@ -134,7 +134,7 @@ func (s *Split) Compute(data interface{}) []interface{} {
 }
 ```
 
-Did you catch what is going on? Previously, we've seen our stateless computations have a `Compute` method that returns an `interface{}`. `Split` returns a `[]interface{}`. Each item in the slice is a new message that is sent individually to the next step in the pipeline. This allows us to then route each one based on its first letter for counting. If you look below, you can see that our word partitioning function is expecting words, not a list, which makes sense:
+Did you catch what is going on? Previously, we've seen our stateless computations have a `Compute` method that returns an `interface{}`. `Split` returns a `[]interface{}`. Each item in the slice is a new message that is sent individually to the next step in the pipeline. This allows us to then route each message based on its first letter for counting. If you look below, you can see that our word partitioning function is expecting words, not a list, which makes sense:
 
 ```go
 type WordPartitionFunction struct {}

--- a/book/go/api/word-count.md
+++ b/book/go/api/word-count.md
@@ -196,7 +196,7 @@ func (wordTotals *WordTotals) GetCount(word string) *WordCount {
 
 ### Hello World! I'm a `WordCount`.
 
-By this point, our word has almost made it to the end of the line. The only thing left is the sink and encoding. We don't do anything fancy with our encoding. We take the word and its count, and format it into a single line of text that our receiver can record.
+By this point, our word has almost made it to the end of the pipeline. The only thing left is the sink and encoding. We don't do anything fancy with our encoding. We take the word and its count, and we format it into a single line of text that our receiver can record.
 
 ```go
 type Encoder struct {}

--- a/book/go/api/writing-your-own-stateful-application.md
+++ b/book/go/api/writing-your-own-stateful-application.md
@@ -204,7 +204,7 @@ func (lpf *LetterPartitionFunction) Partition(data interface{}) uint64 {
 }
 ```
 
-When we set up our state partition, we pass both as arguments to `ToStatePartition` as we saw earlier:
+When we set up our state partition, we pass both functions above as arguments to `ToStatePartition` as we saw earlier:
 
 ```go
 ToStatePartition(&AddVotes{}, &RunningVotesTotalBuilder{}, "running vote totals", &LetterPartitionFunction{}, MakeLetterPartitions(), true).

--- a/book/go/api/writing-your-own-stateful-application.md
+++ b/book/go/api/writing-your-own-stateful-application.md
@@ -13,7 +13,7 @@ As with the Reverse Word example, we will list the components required:
 * Computation for adding votes
 * State objects
 * State change management
-* A list of key that are valid for partitioning our state objects
+* A list of keys that are valid for partitioning our state objects
 * A partitioning function
 
 ### Computation

--- a/book/go/api/writing-your-own-stateful-application.md
+++ b/book/go/api/writing-your-own-stateful-application.md
@@ -4,7 +4,7 @@ In this section, we will go over how to write a stateful application with the Wa
 
 ## A Stateful Application - Alphabet
 
-Our stateful application is going to be a vote counter, called Alphabet. It receives as its input a message containing an alphabet character and a number of votes, which it then increments in its internal state. After each update, it sends the new updated vote count or that character to its output.
+Our stateful application is going to be a vote counter, called Alphabet. It receives as its input a message containing an alphabet character and a number of votes, which it then increments in its internal state. After each update, it sends the new updated vote count of that character to its output.
 
 As with the Reverse Word example, we will list the components required:
 

--- a/book/go/getting-started/linux-setup.md
+++ b/book/go/getting-started/linux-setup.md
@@ -142,7 +142,7 @@ sudo docker pull wallaroo-labs-docker-wallaroolabs.bintray.io/release/metrics_ui
 
 ## Set up Environment for the Wallaroo Tutorial
 
-If you haven't already done so, create a directory called `~/wallaroo-tutorial` and navigate there by running
+If you haven't already done so, create a directory called `~/wallaroo-tutorial` and navigate there by running:
 
 ```bash
 cd ~/

--- a/book/go/getting-started/macos-setup.md
+++ b/book/go/getting-started/macos-setup.md
@@ -76,7 +76,7 @@ docker pull wallaroo-labs-docker-wallaroolabs.bintray.io/release/metrics_ui:0.3.
 
 ## Set up Environment for the Wallaroo Tutorial
 
-If you haven't already done so, create a directory called `~/wallaroo-tutorial` and navigate there by running
+If you haven't already done so, create a directory called `~/wallaroo-tutorial` and navigate there by running:
 
 ```bash
 cd ~/

--- a/book/go/getting-started/run-a-wallaroo-go-application.md
+++ b/book/go/getting-started/run-a-wallaroo-go-application.md
@@ -2,13 +2,13 @@
 
 In this section, we're going to run an example Wallaroo Go application. By the time you are finished, you'll have validated that your environment is set up and working correctly.
 
-There's a couple Wallaroo support applications that you'll be interacting with for the first time:
+There are a few Wallaroo support applications that you'll be interacting with for the first time:
 
 - Our Metrics UI allows you to monitor the performance and health of your applications.
 - Data Receiver is designed to capture TCP output from Wallaroo applications.
 - Giles sender is used to send test data into Wallaroo applications over TCP.
 
-You're going to set up our "Celsius to Fahrenheit" example application. Giles sender will be used to pump data into the application. Data Receiver will receive the output and our Metrics UI will be running so you can observe the overall performance.
+You're going to set up our "Celsius to Fahrenheit" example application. Giles sender will be used to pump data into the application. Data Receiver will receive the output, and our Metrics UI will be running so you can observe the overall performance.
 
 The Metrics UI process will be run in the background via Docker.  The other three processes (receiver, sender, and Wallaroo) will run in the foreground.  We recommend that you run each process in a separate terminal.
 

--- a/book/go/getting-started/run-a-wallaroo-go-application.md
+++ b/book/go/getting-started/run-a-wallaroo-go-application.md
@@ -65,7 +65,7 @@ cd ~/wallaroo-tutorial/wallaroo/examples/go/celsius
 make
 ```
 
-Now start up the "Celsius to Fahrenheit" application
+Now start up the "Celsius to Fahrenheit" application.
 
 ```bash
 cd ~/wallaroo-tutorial/wallaroo/examples/go/celsius

--- a/book/python/word-count.md
+++ b/book/python/word-count.md
@@ -181,7 +181,7 @@ class WordTotals(object):
 
 ### Hello world! I'm a `WordCount`.
 
-By this point, our word has almost made it to the end of the line. The only thing left is the sink and encoding. We don't do anything fancy with our encoding. We take the word, its count and format it into a single line of text that our receiver can record.
+By this point, our word has almost made it to the end of the pipeline. The only thing left is the sink and encoding. We don't do anything fancy with our encoding. We take the word and its count, and we format it into a single line of text that our receiver can record.
 
 ```python
 class Encoder(object):

--- a/book/python/writing-your-own-application.md
+++ b/book/python/writing-your-own-application.md
@@ -59,7 +59,7 @@ class Decoder(object):
         return bs.decode("utf-8")
 ```
 
-This one is different. Wallaroo handles _streams of bytes_, and in order to do that efficiently, it uses a method called message framing. This means that Wallaroo requires input data to follow a special structure, as well as for the application to provide the mechanism with which to decode this data.
+This one is different. When using a TCP source, Wallaroo handles _streams of bytes_, and in order to do that efficiently, it uses a method called message framing. This means that Wallaroo requires input data to follow a special structure, as well as for the application to provide the mechanism with which to decode this data.
 
 To read more about this, please refer to the [Creating A Decoder](/book/appendix/tcp-decoders-and-encoders.md#creating-a-decoder) section.
 

--- a/book/python/writing-your-own-stateful-application.md
+++ b/book/python/writing-your-own-stateful-application.md
@@ -4,7 +4,7 @@ In this section, we will go over how to write a stateful application with the Wa
 
 ## A Stateful Application - Alphabet
 
-Our stateful application is going to be a vote counter, called Alphabet. It receives as its input a message containing an alphabet character and a number of votes, which it then increments in its internal state. After each update, it sends the new updated vote count or that character to its output.
+Our stateful application is going to be a vote counter, called Alphabet. It receives as its input a message containing an alphabet character and a number of votes, which it then increments in its internal state. After each update, it sends the new updated vote count of that character to its output.
 
 As with the Reverse Word example, we will list the components required:
 


### PR DESCRIPTION
This is related to #1865's review of the first Go documentation.  Any & all of these corrections can be cherry-picked or discarded or whatever ... but many of them are good corrections.  `^_^`

Also included are non-Go doc fixes: small bits of anti-entropy across related book chapters.  If they must move to another PR, that's OK, but I think that the corrections are necessary, and creating tiny bug reports for each seemed like far too much work.

None of these address the 'is the code correct and up to date?' requirement of #1865.