### PR TITLE
Update makefile for demo go word count

### DIFF
--- a/demos/go_word_count/Makefile
+++ b/demos/go_word_count/Makefile
@@ -41,16 +41,21 @@ WORD_COUNT_DEMO_GOPATH := $(WORD_COUNT_GO_DEMO_PATH)/go:$(GO_PONY_LIB)
 # standard rules generation makefile
 include $(rules_mk_path)
 
-build-demos-go_word_count: word_count_go_demo_clean word_count_go_demo_build
+build-demos-go_word_count: word_count_go_demo_build
+unit-tests-demos-go_word_count: build-demos-go_word_count
 clean-demos-go_word_count: word_count_go_demo_clean
 
-word_count_go_demo_build:
-	$(QUIET)export GOPATH=$(WORD_COUNT_DEMO_GOPATH) && go build -buildmode=c-archive -o $(WORD_COUNT_GO_DEMO_PATH)lib/libwallaroo.a word_count
-	$(QUIET)stable fetch
-	$(QUIET)stable env ponyc
+word_count_go_demo_build: $(WORD_COUNT_GO_DEMO_PATH)/go_word_count
 
 word_count_go_demo_clean:
-	$(QUIET)rm -rf $(WORD_COUNT_GO_PATH)/lib $(WORD_COUNT_GO_DEMO_PATH)/.deps $(WORD_COUNT_GO_DEMO_PATH)/word_count
+	$(QUIET)rm -rf $(WORD_COUNT_GO_DEMO_PATH)/lib $(WORD_COUNT_GO_DEMO_PATH)/.deps $(WORD_COUNT_GO_DEMO_PATH)/go_word_count $(WORD_COUNT_GO_DEMO_PATH)/go_word_count.d
+
+-include $(WORD_COUNT_GO_DEMO_PATH)/go_word_count.d
+$(WORD_COUNT_GO_DEMO_PATH)/go_word_count: $(WORD_COUNT_GO_DEMO_PATH)/lib/libwallaroo.a
+	$(call PONYC,$(abspath $(WORD_COUNT_GO_DEMO_PATH:%/=%)))
+
+$(WORD_COUNT_GO_DEMO_PATH)/lib/libwallaroo.a: $(WORD_COUNT_GO_DEMO_PATH)/go/src/word_count/word_count.go
+	$(QUIET)export GOPATH=$(WORD_COUNT_DEMO_GOPATH) && go build -buildmode=c-archive -o $(WORD_COUNT_GO_DEMO_PATH)lib/libwallaroo.a word_count
 
 # end of prevent rules from being evaluated/included multiple times
 endif

--- a/examples/go/alphabet/Makefile
+++ b/examples/go/alphabet/Makefile
@@ -48,7 +48,7 @@ clean-examples-go-alphabet: alphabet_go_clean
 alphabet_go_build: $(ALPHABET_GO_PATH)/alphabet
 
 alphabet_go_clean:
-	$(QUIET)rm -rf $(ALPHABET_GO_PATH)/lib $(ALPHABET_GO_PATH)/.deps $(ALPHABET_GO_PATH)/alphabet
+	$(QUIET)rm -rf $(ALPHABET_GO_PATH)/lib $(ALPHABET_GO_PATH)/.deps $(ALPHABET_GO_PATH)/alphabet $(ALPHABET_GO_PATH)/alphabet.d
 
 -include $(ALPHABET_GO_PATH)/alphabet.d
 $(ALPHABET_GO_PATH)/alphabet: $(ALPHABET_GO_PATH)/lib/libwallaroo.a

--- a/examples/go/celsius/Makefile
+++ b/examples/go/celsius/Makefile
@@ -48,7 +48,7 @@ clean-examples-go-celsius: celsius_go_clean
 celsius_go_build: $(CELSIUS_GO_PATH)/celsius
 
 celsius_go_clean:
-	$(QUIET)rm -rf $(CELSIUS_GO_PATH)/lib $(CELSIUS_GO_PATH)/.deps $(CELSIUS_GO_PATH)/celsius
+	$(QUIET)rm -rf $(CELSIUS_GO_PATH)/lib $(CELSIUS_GO_PATH)/.deps $(CELSIUS_GO_PATH)/celsius $(CELSIUS_GO_PATH)/celsius.d
 
 -include $(CELSIUS_GO_PATH)/celsius.d
 $(CELSIUS_GO_PATH)/celsius: $(CELSIUS_GO_PATH)/lib/libwallaroo.a

--- a/examples/go/reverse/Makefile
+++ b/examples/go/reverse/Makefile
@@ -48,7 +48,7 @@ clean-examples-go-reverse: reverse_go_clean
 reverse_go_build: $(REVERSE_GO_PATH)/reverse
 
 reverse_go_clean:
-	$(QUIET)rm -rf $(REVERSE_GO_PATH)/lib $(REVERSE_GO_PATH)/.deps $(REVERSE_GO_PATH)/reverse
+	$(QUIET)rm -rf $(REVERSE_GO_PATH)/lib $(REVERSE_GO_PATH)/.deps $(REVERSE_GO_PATH)/reverse $(REVERSE_GO_PATH)/reverse.d
 
 -include $(REVERSE_GO_PATH)/reverse.d
 $(REVERSE_GO_PATH)/reverse: $(REVERSE_GO_PATH)/lib/libwallaroo.a

--- a/examples/go/word_count/Makefile
+++ b/examples/go/word_count/Makefile
@@ -48,7 +48,7 @@ clean-examples-go-word_count: word_count_go_clean
 word_count_go_build: $(WORD_COUNT_GO_PATH)/word_count
 
 word_count_go_clean:
-	$(QUIET)rm -rf $(WORD_COUNT_GO_PATH)/lib $(WORD_COUNT_GO_PATH)/.deps $(WORD_COUNT_GO_PATH)/word_count
+	$(QUIET)rm -rf $(WORD_COUNT_GO_PATH)/lib $(WORD_COUNT_GO_PATH)/.deps $(WORD_COUNT_GO_PATH)/word_count $(WORD_COUNT_GO_PATH)/word_count.d
 
 -include $(WORD_COUNT_GO_PATH)/word_count.d
 $(WORD_COUNT_GO_PATH)/word_count: $(WORD_COUNT_GO_PATH)/lib/libwallaroo.a


### PR DESCRIPTION
also fix makefiles for example go applications to properly delete
"*.d" files.

Prior to this commit, running `make test` in CI did not build the
go word count demo. This commit fixes that and includes the following
changes:

* Define the `build` target as a dependency of the `test` target
  so that `make test` will force a build of the go api examples
  like with other examples
* Update `Makefile` logic for incremental building of the go api
  examples (based on the machida `Makefile`)
* Update `Makefile` logic to use standard `ponyc` invocation via
  a `make` `macro` (like how the machida `Makefile` does it) in
  order to inherit all the same benefits as used to compile all
  other `ponyc` code (incremental building, location independence,
  etc)

[skip ci]