### PR TITLE
Fix path to data_receiver in Go examples

### DIFF
--- a/examples/go/celsius/README.md
+++ b/examples/go/celsius/README.md
@@ -33,7 +33,7 @@ You will need three separate shells to run this application. Open each shell and
 Run `data_receiver` to listen for TCP output on `127.0.0.1` port `7002`:
 
 ```bash
-../../../utils/data_receiver --listen 127.0.0.1:7002
+../../../utils/data_receiver/data_receiver --listen 127.0.0.1:7002
 ```
 
 ### Shell 2

--- a/examples/go/reverse/README.md
+++ b/examples/go/reverse/README.md
@@ -41,7 +41,7 @@ You will need three separate shells to run this application. Open each shell and
 Run `data_receiver` to listen for TCP output on `127.0.0.1` port `7002`:
 
 ```bash
-../../../utils/data_receiver --listen 127.0.0.1:7002
+../../../utils/data_receiver/data_receiver --listen 127.0.0.1:7002
 ```
 
 ### Shell 2

--- a/examples/go/word_count/README.md
+++ b/examples/go/word_count/README.md
@@ -37,7 +37,7 @@ You will need three separate shells to run this application. Open each shell and
 Run `data_receiver` to listen for TCP output on `127.0.0.1` port `7002`:
 
 ```bash
-../../../utils/data_receiver --listen 127.0.0.1:7002
+../../../utils/data_receiver/data_receiver --listen 127.0.0.1:7002
 ```
 
 ### Shell 2


### PR DESCRIPTION
The path to `data_receiver` was off by one level in the celsius, reverse, and word_count example READMEs.

[skip ci]