### PR TITLE
Remove multiworker option for stateful computations in Go API

### DIFF
--- a/book/go/api/api.md
+++ b/book/go/api/api.md
@@ -66,7 +66,7 @@ Add a stateless computation that only returns one message to the current pipelin
 
 Similar to `To`, but the computation can return more than one message.
 
-##### `ToStatePartition(stateComputation wallarooapi.StateComputation, stateBuilder wallarooapi.StateBuilder, stateName string, partitionFunction wa.PartitionFunction, partitions []uint64, multiworker bool) *pipelineBuilder`
+##### `ToStatePartition(stateComputation wallarooapi.StateComputation, stateBuilder wallarooapi.StateBuilder, stateName string, partitionFunction wa.PartitionFunction, partitions []uint64) *pipelineBuilder`
 
 Add a partitioned state computation that only returns one message to the pipeline.
 
@@ -78,9 +78,7 @@ Add a partitioned state computation that only returns one message to the pipelin
 
 `partitions` is a list of all of the partitions for the partitioned state.
 
-`multiworker` determines how partitions are distributed across workers and should always be true.
-
-##### `ToStatePartitionMulti(stateComputation wallarooapi.StateComputationMulti, stateBuilder wallarooapi.StateBuilder, stateName string, partitionFunction wa.PartitionFunction, partitions []uint64, multiworker bool) *pipelineBuilder`
+##### `ToStatePartitionMulti(stateComputation wallarooapi.StateComputationMulti, stateBuilder wallarooapi.StateBuilder, stateName string, partitionFunction wa.PartitionFunction, partitions []uint64) *pipelineBuilder`
 
 Similar to `ToStatePartition`, but the computation can return more than one message.
 

--- a/book/go/api/word-count.md
+++ b/book/go/api/word-count.md
@@ -36,7 +36,7 @@ func ApplicationSetup() *C.char {
 	application := app.MakeApplication("Word Count Application")
 	application.NewPipeline("Split and Count", app.MakeTCPSourceConfig(inHost, inPort, &Decoder{})).
 		ToMulti(&SplitBuilder{}).
-		ToStatePartition(&CountWord{}, &WordTotalsBuilder{}, "word totals", &WordPartitionFunction{}, LetterPartition(), true).
+		ToStatePartition(&CountWord{}, &WordTotalsBuilder{}, "word totals", &WordPartitionFunction{}, LetterPartition()).
 		ToSink(app.MakeTCPSinkConfig(outHost, outPort, &Encoder{}))
 
 	json := application.ToJson()
@@ -73,7 +73,7 @@ We set up a new application with a single pipeline:
 	application := app.MakeApplication("Word Count Application")
 	application.NewPipeline("Split and Count", app.MakeTCPSourceConfig(inHost, inPort, &Decoder{})).
 		ToMulti(&SplitBuilder{}).
-		ToStatePartition(&CountWord{}, &WordTotalsBuilder{}, "word totals", &WordPartitionFunction{}, LetterPartition(), true).
+		ToStatePartition(&CountWord{}, &WordTotalsBuilder{}, "word totals", &WordPartitionFunction{}, LetterPartition()).
 		ToSink(app.MakeTCPSinkConfig(outHost, outPort, &Encoder{}))
 ```
 
@@ -86,7 +86,7 @@ Upon receiving some textual input, our word count application will route it to a
 After we split our text chunks into words, they get routed to a state partition where they are counted:
 
 ```go
-		ToStatePartition(&CountWord{}, &WordTotalsBuilder{}, "word totals", &WordPartitionFunction{}, LetterPartition(), true).
+		ToStatePartition(&CountWord{}, &WordTotalsBuilder{}, "word totals", &WordPartitionFunction{}, LetterPartition()).
 ```
 
 Note we set up 27 partitions to count our words, one for each letter plus one called "!" which will handle any "word" that doesn't start with a letter:

--- a/book/go/api/writing-your-own-stateful-application.md
+++ b/book/go/api/writing-your-own-stateful-application.md
@@ -146,7 +146,7 @@ func ApplicationSetup() *C.char {
 
   application := app.MakeApplication("Alphabet")
   application.NewPipeline("Alphabet", app.MakeTCPSourceConfig(inHost, inPort, &Decoder{})).
-    ToStatePartition(&AddVotes{}, &RunningVotesTotalBuilder{}, "running vote totals", &LetterPartitionFunction{}, MakeLetterPartitions(), true).
+    ToStatePartition(&AddVotes{}, &RunningVotesTotalBuilder{}, "running vote totals", &LetterPartitionFunction{}, MakeLetterPartitions()).
     ToSink(app.MakeTCPSinkConfig(outHost, outPort, &Encoder{}))
 
   return C.CString(application.ToJson())
@@ -162,7 +162,7 @@ To(&ReverseBuilder{}).
 here we use:
 
 ```go
-ToStatePartition(&AddVotes{}, &RunningVotesTotalBuilder{}, "running vote totals", &LetterPartitionFunction{}, MakeLetterPartitions(), true).
+ToStatePartition(&AddVotes{}, &RunningVotesTotalBuilder{}, "running vote totals", &LetterPartitionFunction{}, MakeLetterPartitions()).
 ```
 
 That is, while the stateless computation constructor `To` took only a computation class as its argument, the stateful computation constructor `ToStatePartition` takes a computation _instance_, as well as a state-builder _instance_, along with the name of that state. Additionally, it takes two arguments for needed to partition our state.
@@ -207,7 +207,7 @@ func (lpf *LetterPartitionFunction) Partition(data interface{}) uint64 {
 When we set up our state partition, we pass both functions above as arguments to `ToStatePartition` as we saw earlier:
 
 ```go
-ToStatePartition(&AddVotes{}, &RunningVotesTotalBuilder{}, "running vote totals", &LetterPartitionFunction{}, MakeLetterPartitions(), true).
+ToStatePartition(&AddVotes{}, &RunningVotesTotalBuilder{}, "running vote totals", &LetterPartitionFunction{}, MakeLetterPartitions()).
 ```
 
 ## Next Steps

--- a/demos/go_word_count/go/src/word_count/word_count.go
+++ b/demos/go_word_count/go/src/word_count/word_count.go
@@ -50,7 +50,7 @@ func ApplicationSetup() *C.char {
 	application := app.MakeApplication("Word Count Application")
 	application.NewPipeline("Split and Count", app.MakeTCPSourceConfig(inHost, inPort, &Decoder{})).
 		ToMulti(&SplitBuilder{}).
-		ToStatePartition(&CountWord{}, &WordTotalsBuilder{}, "word totals", &WordPartitionFunction{}, LetterPartition(), true).
+		ToStatePartition(&CountWord{}, &WordTotalsBuilder{}, "word totals", &WordPartitionFunction{}, LetterPartition()).
 		ToSink(app.MakeTCPSinkConfig(outHost, outPort, &Encoder{}))
 
 	json := application.ToJson()

--- a/examples/go/alphabet/go/src/alphabet/alphabet.go
+++ b/examples/go/alphabet/go/src/alphabet/alphabet.go
@@ -49,7 +49,7 @@ func ApplicationSetup() *C.char {
 
   application := app.MakeApplication("Alphabet")
   application.NewPipeline("Alphabet", app.MakeTCPSourceConfig(inHost, inPort, &Decoder{})).
-    ToStatePartition(&AddVotes{}, &RunningVotesTotalBuilder{}, "running vote totals", &LetterPartitionFunction{}, MakeLetterPartitions(), true).
+    ToStatePartition(&AddVotes{}, &RunningVotesTotalBuilder{}, "running vote totals", &LetterPartitionFunction{}, MakeLetterPartitions()).
     ToSink(app.MakeTCPSinkConfig(outHost, outPort, &Encoder{}))
 
   return C.CString(application.ToJson())

--- a/examples/go/word_count/go/src/word_count/word_count.go
+++ b/examples/go/word_count/go/src/word_count/word_count.go
@@ -50,7 +50,7 @@ func ApplicationSetup() *C.char {
 	application := app.MakeApplication("Word Count Application")
 	application.NewPipeline("Split and Count", app.MakeTCPSourceConfig(inHost, inPort, &Decoder{})).
 		ToMulti(&SplitBuilder{}).
-		ToStatePartition(&CountWord{}, &WordTotalsBuilder{}, "word totals", &WordPartitionFunction{}, LetterPartition(), true).
+		ToStatePartition(&CountWord{}, &WordTotalsBuilder{}, "word totals", &WordPartitionFunction{}, LetterPartition()).
 		ToSink(app.MakeTCPSinkConfig(outHost, outPort, &Encoder{}))
 
 	json := application.ToJson()

--- a/go_api/examples/market_spread/go/src/market_spread/market_spread.go
+++ b/go_api/examples/market_spread/go/src/market_spread/market_spread.go
@@ -37,11 +37,11 @@ func ApplicationSetup() *C.char {
 
 	application := app.MakeApplication("market-spread")
 	application.NewPipeline("Orders", app.MakeTCPSourceConfig(orderHost, orderPort, &ms.OrderDecoder{})).
-		ToStatePartition(&ms.CheckOrder{}, &ms.SymbolDataBuilder{}, "symbol-data", &ms.SymbolPartitionFunction{}, symbols, true).
+		ToStatePartition(&ms.CheckOrder{}, &ms.SymbolDataBuilder{}, "symbol-data", &ms.SymbolPartitionFunction{}, symbols).
 		ToSink(app.MakeTCPSinkConfig(outHost, outPort, &ms.OrderResultEncoder{}))
 
 	application.NewPipeline("Market Data", app.MakeTCPSourceConfig(marketDataHost, marketDataPort, &ms.MarketDataDecoder{})).
-		ToStatePartition(&ms.UpdateMarketData{}, &ms.SymbolDataBuilder{}, "symbol-data", &ms.SymbolPartitionFunction{}, symbols, true).
+		ToStatePartition(&ms.UpdateMarketData{}, &ms.SymbolDataBuilder{}, "symbol-data", &ms.SymbolPartitionFunction{}, symbols).
 		Done()
 
 	json := application.ToJson()

--- a/go_api/go/src/wallarooapi/application/application.go
+++ b/go_api/go/src/wallarooapi/application/application.go
@@ -57,21 +57,21 @@ func (pb *pipelineBuilder) ToMulti(computationBuilder wa.ComputationMultiBuilder
 	return makePipelineBuilder(newStepId, pb.app, pb.pipeline)
 }
 
-func (pb *pipelineBuilder) ToStatePartition(stateComputation wa.StateComputation, stateBuilder wa.StateBuilder, stateName string, partitionFunction wa.PartitionFunction, partitions []uint64, multiWorker bool) *pipelineBuilder {
+func (pb *pipelineBuilder) ToStatePartition(stateComputation wa.StateComputation, stateBuilder wa.StateBuilder, stateName string, partitionFunction wa.PartitionFunction, partitions []uint64) *pipelineBuilder {
 	computationId := wa.AddComponent(stateComputation, wa.StateComputationTypeId)
 	stateBuilderId := wa.AddComponent(stateBuilder, wa.StateBuilderTypeId)
 	partitionFunctionId := wa.AddComponent(partitionFunction, wa.PartitionFunctionTypeId)
 	partitionId := wa.AddComponent(partitions, wa.PartitionListTypeId)
-	newStepId := pb.pipeline.AddToStatePartition(pb.lastStepId, computationId, stateBuilderId, stateName, partitionFunctionId, partitionId, multiWorker)
+	newStepId := pb.pipeline.AddToStatePartition(pb.lastStepId, computationId, stateBuilderId, stateName, partitionFunctionId, partitionId)
 	return makePipelineBuilder(newStepId, pb.app, pb.pipeline)
 }
 
-func (pb *pipelineBuilder) ToStatePartitionMulti(stateComputation wa.StateComputationMulti, stateBuilder wa.StateBuilder, stateName string, partitionFunction wa.PartitionFunction, partitions []uint64, multiWorker bool) *pipelineBuilder {
+func (pb *pipelineBuilder) ToStatePartitionMulti(stateComputation wa.StateComputationMulti, stateBuilder wa.StateBuilder, stateName string, partitionFunction wa.PartitionFunction, partitions []uint64) *pipelineBuilder {
 	computationId := wa.AddComponent(stateComputation, wa.StateComputationTypeId)
 	stateBuilderId := wa.AddComponent(stateBuilder, wa.StateBuilderTypeId)
 	partitionFunctionId := wa.AddComponent(partitionFunction, wa.PartitionFunctionTypeId)
 	partitionId := wa.AddComponent(partitions, wa.PartitionListTypeId)
-	newStepId := pb.pipeline.AddToStatePartitionMulti(pb.lastStepId, computationId, stateBuilderId, stateName, partitionFunctionId, partitionId, multiWorker)
+	newStepId := pb.pipeline.AddToStatePartitionMulti(pb.lastStepId, computationId, stateBuilderId, stateName, partitionFunctionId, partitionId)
 	return makePipelineBuilder(newStepId, pb.app, pb.pipeline)
 }
 

--- a/go_api/go/src/wallarooapi/application/connection.go
+++ b/go_api/go/src/wallarooapi/application/connection.go
@@ -20,8 +20,8 @@ func (to *To) Repr() interface{} {
 	return repr.MakeTo(to.stepId, to.fromStepId, to.computationBuilderId)
 }
 
-func makeToStatePartition(stepId uint64, fromStepId uint64, stateComputationId uint64, stateBuilderId uint64, stateName string, partitionFunctionId uint64, partitionId uint64, multiWorker bool) *ToStatePartition {
-	return &ToStatePartition{&Step{stepId, fromStepId}, stateComputationId, stateBuilderId, stateName, partitionFunctionId, partitionId, multiWorker}
+func makeToStatePartition(stepId uint64, fromStepId uint64, stateComputationId uint64, stateBuilderId uint64, stateName string, partitionFunctionId uint64, partitionId uint64) *ToStatePartition {
+	return &ToStatePartition{&Step{stepId, fromStepId}, stateComputationId, stateBuilderId, stateName, partitionFunctionId, partitionId}
 }
 
 type ToStatePartition struct {
@@ -31,11 +31,10 @@ type ToStatePartition struct {
 	stateName string
 	partitionFunctionId uint64
 	partitionId uint64
-	multiWorker bool
 }
 
 func (tsp *ToStatePartition) Repr() interface{} {
-	return repr.MakeToStatePartition(tsp.stepId, tsp.fromStepId, tsp.stateComputationId, tsp.stateBuilderId, tsp.stateName, tsp.partitionId, tsp.multiWorker)
+	return repr.MakeToStatePartition(tsp.stepId, tsp.fromStepId, tsp.stateComputationId, tsp.stateBuilderId, tsp.stateName, tsp.partitionId)
 }
 
 func makeToSink(stepId uint64, fromStepId uint64, sinkConfig SinkConfig) *ToSink {

--- a/go_api/go/src/wallarooapi/application/pipeline.go
+++ b/go_api/go/src/wallarooapi/application/pipeline.go
@@ -57,23 +57,23 @@ func (p *pipeline) AddToComputationMulti(fromStepId uint64, id uint64) uint64 {
 	return newStepId
 }
 
-func (p *pipeline) AddToStatePartition(fromStepId uint64, computationId uint64, stateBuilderId uint64, stateName string, partitionFunctionId uint64, partitionListId uint64, multiWorker bool) uint64 {
+func (p *pipeline) AddToStatePartition(fromStepId uint64, computationId uint64, stateBuilderId uint64, stateName string, partitionFunctionId uint64, partitionListId uint64) uint64 {
 	p.components = append(p.components, makeStateComputation(computationId))
 	p.components = append(p.components, makeStateBuilder(stateBuilderId))
 	partitionId := uint64(len(p.partitions))
 	p.partitions = append(p.partitions, MakePartition(partitionFunctionId, partitionListId))
 	newStepId := p.newStepId()
-	p.connections = append(p.connections, makeToStatePartition(newStepId, fromStepId, computationId, stateBuilderId, stateName, partitionFunctionId, partitionId, multiWorker))
+	p.connections = append(p.connections, makeToStatePartition(newStepId, fromStepId, computationId, stateBuilderId, stateName, partitionFunctionId, partitionId))
 	return newStepId
 }
 
-func (p *pipeline) AddToStatePartitionMulti(fromStepId uint64, computationId uint64, stateBuilderId uint64, stateName string, partitionFunctionId uint64, partitionListId uint64, multiWorker bool) uint64 {
+func (p *pipeline) AddToStatePartitionMulti(fromStepId uint64, computationId uint64, stateBuilderId uint64, stateName string, partitionFunctionId uint64, partitionListId uint64) uint64 {
 	p.components = append(p.components, makeStateComputationMulti(computationId))
 	p.components = append(p.components, makeStateBuilder(stateBuilderId))
 	partitionId := uint64(len(p.partitions))
 	p.partitions = append(p.partitions, MakePartition(partitionFunctionId, partitionListId))
 	newStepId := p.newStepId()
-	p.connections = append(p.connections, makeToStatePartition(newStepId, fromStepId, computationId, stateBuilderId, stateName, partitionFunctionId, partitionId, multiWorker))
+	p.connections = append(p.connections, makeToStatePartition(newStepId, fromStepId, computationId, stateBuilderId, stateName, partitionFunctionId, partitionId))
 	return newStepId
 }
 

--- a/go_api/go/src/wallarooapi/application/repr/connection.go
+++ b/go_api/go/src/wallarooapi/application/repr/connection.go
@@ -15,8 +15,8 @@ type To struct {
 	ComputationBuilderId uint64
 }
 
-func MakeToStatePartition(stepId uint64, fromStepId uint64, stateComputationId uint64, stateBuilderId uint64, stateName string, partitionId uint64, multiWorker bool) interface {} {
-	return &ToStatePartition{"ToStatePartition", stepId, fromStepId, stateComputationId, stateBuilderId, stateName, partitionId, multiWorker}
+func MakeToStatePartition(stepId uint64, fromStepId uint64, stateComputationId uint64, stateBuilderId uint64, stateName string, partitionId uint64) interface {} {
+	return &ToStatePartition{"ToStatePartition", stepId, fromStepId, stateComputationId, stateBuilderId, stateName, partitionId}
 }
 
 type ToStatePartition struct {
@@ -27,7 +27,6 @@ type ToStatePartition struct {
 	StateBuilderId uint64
 	StateName string
 	PartitionId uint64
-	MultiWorker bool
 }
 
 func MakeToSink(stepId uint64, fromStepId uint64, sinkConfig interface{}) *ToSink {


### PR DESCRIPTION
The multiworker option shouldn't be exposed to API users because
there's no reason for an application developer not to set it to true
for all state computations. Removing it simplifies the documentation
and avoids user confusion.

The API, examples, and documentation have been changed to reflect
this.

Fixes #1872