### PR TITLE
Send folks to Go install rather than download page

### DIFF
--- a/book/go/getting-started/linux-setup.md
+++ b/book/go/getting-started/linux-setup.md
@@ -10,7 +10,7 @@ In order to compile the Wallaroo example applications, your system will need to 
 
 ## Install Go
 
-You'll need a Go 1.9.x compiler. You can get one from the [Go website](https://golang.org/dl/).
+You'll need a Go 1.9.x compiler. You can get one from the [Go website](https://golang.org/doc/install).
 
 ## Update apt-get
 

--- a/book/go/getting-started/macos-setup.md
+++ b/book/go/getting-started/macos-setup.md
@@ -6,7 +6,7 @@ There are a few applications/tools which are required to be installed before you
 
 ## Install Go
 
-You'll need a Go 1.9.x compiler. You can get one from the [Go website](https://golang.org/dl/).
+You'll need a Go 1.9.x compiler. You can get one from the [Go website](https://golang.org/doc/install).
 
 ## Installing Xcode Command Line Tools
 


### PR DESCRIPTION
Provides more informaton than the download page. Allows for more
informed choice of how to install.

Closes #1889

[skip ci]