### PR TITLE
Step 1 towards not hosting docs on Gitbook.com

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ install:
 stages:
   - tests
   - deploy
+  - gitbook
 
 jobs:
   include:
@@ -65,5 +66,8 @@ jobs:
       env:
         - RESILIENCE_INTEGRATION_TESTS=t
     - stage: deploy
-      if: branch =~ ^release$ OR branch =~ ^release-(\d).(\d).(\d)$
+      if: type != pull_request AND ( branch = release OR branch =~ ^release-(\d).(\d).(\d)$ )
       script: /bin/bash travis/docker_release.sh
+    - stage: gitbook
+      if: type != pull_request AND ( branch = release OR branch = master OR branch =~ ^release-(\d).(\d).(\d)$ )
+      script: /bin/bash travis/build-gitbook.sh

--- a/travis/build-gitbook.sh
+++ b/travis/build-gitbook.sh
@@ -1,0 +1,41 @@
+#! /bin/bash
+
+set -o errexit
+set -o nounset
+
+# determine remote branch to use
+if [[ "$TRAVIS_BRANCH" == "master" ]]
+then
+  remote_branch=master
+elif [[ "$TRAVIS_BRANCH" == "release" ]]
+then
+  remote_branch=release
+elif [[ "$TRAVIS_BRANCH" == *"release-"* ]]
+then
+  remote_branch=rc
+else
+  echo "No remote repo to push book to. Exiting"
+  exit 0
+fi
+
+echo "Building book..."
+gitbook build
+
+echo "Uploading book..."
+# gitbook puts generated content in _book
+pushd _book
+
+# git magic. without all this, our ghp-import command won't work
+git remote add doc-site "https://${DOCUMENTATION_REPO_TOKEN}@github.com/wallaroolabs/docs.wallaroolabs.com"
+git fetch doc-site
+git reset doc-site/$remote_branch
+
+mkdir to-upload
+# there's a ton of crap because we build from wallaroo repo root.
+# *everything from the repo* is in this directory. only get the index page,
+# search index, book content and gitbook support css & javascript.
+cp -R index.html search_index.json book gitbook to-upload
+
+ghp-import -p -r doc-site -b $remote_branch -f to-upload
+
+popd

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -137,6 +137,17 @@ install_python_dependencies() {
   echo "** Python dependencies installed"
 }
 
+install_gitbook_dependencies() {
+  # we need npm
+  sudo apt-get install npm
+  # install gitbook
+  npm install gitbook-cli -g
+  # install any required plugins - this checks book.json for plugin list
+  gitbook install
+  # for uploading generated docs to repo
+  sudo python2 -m pip install ghp-import
+}
+
 echo "----- Installing dependencies"
 
 install_cpuset
@@ -145,5 +156,6 @@ install_pony_stable
 install_kafka_compression_libraries
 install_monitoring_hub_dependencies
 install_python_dependencies
+install_gitbook_dependencies
 
 echo "----- Dependencies installed"

--- a/travis/unit-tests.sh
+++ b/travis/unit-tests.sh
@@ -7,5 +7,3 @@ set -o nounset
 make build debug=true
 # Validate that unit tests are passing
 make unit-tests debug=true
-
-


### PR DESCRIPTION
Currently docs are built by:

Webhook fires that lets Gitbook (hosted) know there was a change to our
repo. This might cause a build for a book on Gitbook. This has a couple
problem:

Our release deploy might fail but the docs will have been updated
anyway.

Sometimes gitbook doesn't build.

Hosted Gitbook site is difficult to work with as a maintainer.

With this commit, we continue to use gitbook (non-hosted) to build our
docs. When a commit is made to master, release or a release candidate
branch, we as part of normal CI will update another repo with the
generated html content.

Netlify is monitoring that repo for changes to its master, release and
rc branches and will generate a new netlify hosted site as a change.

This removes having to use hosted Gitbook. However, no new docs will be
built if the skip ci tag is used with a commit. We currently do this
with "docs only" changes.

We never do "skip ci" for releases so it has no impact there. For
release candidate and master, we often do "skip ci" for doc only
changes. If we do "skip ci", the netlify sites will not be updated.

I'll be working towards being able to skip running our standard tests
and only update documentation but right now, we have to go through the
30 minutes delay of CI tests passing before we get to the "gitbook"
stage that will generate new documentation.  