### PR TITLE
Fix shutdown tool path in Python celsius example README

### DIFF
--- a/examples/python/celsius/README.md
+++ b/examples/python/celsius/README.md
@@ -102,7 +102,7 @@ export PATH="$PATH:$HOME/wallaroo-tutorial/wallaroo/machida/build:$HOME/wallaroo
 You can shut down the cluster with this command once processing has finished:
 
 ```bash
-../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
+cluster_shutdown 127.0.0.1:5050
 ```
 
 You can shut down Giles Sender by pressing `Ctrl-c` from its shell.


### PR DESCRIPTION
The instructions tell the user to set their PATH to include the
cluster shutdown tool, so the releative path is no longer to run the
tool. This should make the instructions easier to follow.

Fixes #1912

[skip ci]