### PR TITLE
Add guard to machida to ensure it is running single threaded

### DIFF
--- a/machida/main.pony
+++ b/machida/main.pony
@@ -20,6 +20,7 @@ use "collections"
 use "signals"
 use "wallaroo_labs/mort"
 use "wallaroo_labs/options"
+use "wallaroo_labs/thread_count"
 use "wallaroo"
 use "wallaroo/core/sink/tcp_sink"
 use "wallaroo/core/source/tcp_source"
@@ -30,6 +31,12 @@ use "lib:python-wallaroo"
 
 actor Main
   new create(env: Env) =>
+    let pony_thread_count = ThreadCount()
+
+    if pony_thread_count != 1 then
+      FatalUserError("You must provide Machida with the '--ponythreads 1' argument to ensure it is single-threaded for the Python API or the cluster will crash.\n")
+    end
+
     Machida.start_python()
 
     try


### PR DESCRIPTION
Prior to this commit, if machida was run with more one ponythread
it would result in a crash because of how the Python integration
currently functions.

This commit adds in a check to machida to ensure that it is running
in single threaded mode. If the check fail, machida will exit with
the following error:

```
Error: You must provide Machida with the '--ponythreads 1' argument to ensure it is single-threaded for the Python API or the cluster will crash.
```