### PR TITLE
Add Wallaroo Languages Supported page

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -10,6 +10,9 @@
 * [Working with State](book/core-concepts/working-with-state.md)
 * [Partitioning](book/core-concepts/partitioning.md)
 
+## Wallaroo Language Support
+* [Wallaroo Languages Supported](book/language_support.md)
+
 <!--
 ### Wallaroo C++ API
 * [C++ API Introduction](book/cpp/intro.md)
@@ -38,7 +41,7 @@
    * [UserFunctions](book/cpp/api/user-functions.md)
 -->
 
-## Wallaroo with Python
+### Wallaroo with Python
 * [Wallaroo with Python Introduction](book/python/intro.md)
 
 * [Setting up Your Environment](book/getting-started/setting-up-your-environment.md)
@@ -65,7 +68,7 @@
 * Debugging Python Wallaroo Applications
   * [Debugging](book/python/debugging.md)
 
-## Wallaroo with Go
+### Wallaroo with Go
 * [Go API Introduction](book/go/intro.md)
 
 * [Setting up Your Environment](book/go/getting-started/setting-up-your-environment.md)

--- a/book/language_support.md
+++ b/book/language_support.md
@@ -1,0 +1,6 @@
+# Wallaroo Languages Supported
+
+Wallaroo currently supports the Python and Go programming languages.
+
+* Learn more about how to use [Wallaroo with Python](python/intro.md).
+* Learn more about how to use [Wallaroo with Go](go/intro.md).


### PR DESCRIPTION
This commit adds the "Wallaroo Languages Supported" page to direct
people to their language api of choice.

resolves #1887.