### PR TITLE
Point to code examples for current version in book landing page

### DIFF
--- a/intro.md
+++ b/intro.md
@@ -57,7 +57,7 @@ The Wallaroo Go API section takes you through a number of examples applications 
 
 ### Code Examples
 
-The [Wallaroo Examples](https://github.com/WallarooLabs/wallaroo/tree/0.1.0/examples) section has examples for each of the languages currently supported by Wallaroo.
+The [Wallaroo Examples](https://github.com/WallarooLabs/wallaroo/tree/{{ book.wallaroo_version }}/examples) section has examples for each of the languages currently supported by Wallaroo.
 
 ### Appendix
 


### PR DESCRIPTION
Prior to this commit the landing page had a link to code examples, but
it was hard-coded to point to tag 0.1.0. This change will allow people
to click the link and see the current examples.

Fixes #1919

[skip ci]