### PR TITLE
Fix but that caused worker joins to fail after the first successful round.

### DIFF
--- a/lib/wallaroo/ent/network/control_channel_tcp.pony
+++ b/lib/wallaroo/ent/network/control_channel_tcp.pony
@@ -269,6 +269,10 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
         _layout_initializer.create_data_channel_listener(m.workers,
           _d_host, _d_service)
       | let m: JoinClusterMsg =>
+        ifdef "trace" then
+          @printf[I32]("Received JoinClusterMsg on Control Channel\n"
+            .cstring())
+        end
         ifdef "autoscale" then
           match _layout_initializer
           | let lti: LocalTopologyInitializer =>


### PR DESCRIPTION
We were not resetting our list of joining workers between
joins, which meant that we always thought we had heard from
more joining workers than we had on subsequent joins.

Closes #1926 