### PR TITLE
Do not force shrink count to a minimum of 1

### DIFF
--- a/lib/wallaroo_labs/messages/_test.pony
+++ b/lib/wallaroo_labs/messages/_test.pony
@@ -220,11 +220,7 @@ class iso _TestGeneralExtEncDecShrink is UnitTest
         for j in extracted.node_names.keys() do
           h.assert_eq[String](node_names(j)?, extracted.node_names(j)?)
         end
-        if (i == 0) then
-          h.assert_eq[USize](1, extracted.num_nodes) // ah-hah
-        else
-          h.assert_eq[USize](0, extracted.num_nodes)
-        end
+        h.assert_eq[USize](0, extracted.num_nodes)
       else
         h.assert_eq[String]("error", "case 1")
       end
@@ -239,11 +235,7 @@ class iso _TestGeneralExtEncDecShrink is UnitTest
       | let extracted: ExternalShrinkMsg =>
         h.assert_eq[Bool](false, extracted.query)
         h.assert_eq[USize](0, extracted.node_names.size())
-        if (i == 0) then
-          h.assert_eq[USize](1, extracted.num_nodes) // ah-hah
-        else
-          h.assert_eq[USize](i, extracted.num_nodes)
-        end
+        h.assert_eq[USize](i, extracted.num_nodes)
       else
         h.assert_eq[String]("error", "case 2")
       end

--- a/lib/wallaroo_labs/messages/_test.pony
+++ b/lib/wallaroo_labs/messages/_test.pony
@@ -198,10 +198,6 @@ class iso _TestGeneralExtEncDecShrink is UnitTest
   fun apply(h: TestHelper) ? =>
     """
     Test round-trip serialization of ExternalShrinkMsg.
-
-    Note an "ah-hah" requirement: if both the node_names array
-    empty and also num_nodes is zero, then by default we should
-    observe node_names empty and num_nodes equal to *one*.
     """
     let node_names: Array[String] = [""; "a"; "lovely b"; ""; "node c"]
 

--- a/lib/wallaroo_labs/messages/external_messages.pony
+++ b/lib/wallaroo_labs/messages/external_messages.pony
@@ -135,8 +135,6 @@ primitive ExternalMsgEncoder
   =>
     if (query is true) then
       _encode_shrink(_Shrink(), true, Array[String], 0, wb)
-    elseif (node_names.size() == 0) and (num_nodes == 0) then
-      _encode_shrink(_Shrink(), false, node_names, 1, wb)
     else
       _encode_shrink(_Shrink(), false, node_names, num_nodes, wb)
     end


### PR DESCRIPTION
During message encoding for shrink external messages, if there
was a shrink count of 0 and no workers listed, the shrink count
was forced to 1. This causes unexpected behaviors, so it is
removed by this commit.

Closes #1930