### PR TITLE
Turn off AXV512f

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to Wallaroo will be documented in this file.
 
 ### Changed
 
+- Turn off building with AVX512f CPU extensions to work around a LLVM bug ([PR #1932](https://github.com/WallarooLabs/wallaroo/pull/1932))
+
 ## [0.3.2] - 2017-12-28
 
 ### Fixed

--- a/rules.mk
+++ b/rules.mk
@@ -255,11 +255,11 @@ define PONYC
     $(if $(filter $(ponyc_docker_args),docker),$(quote))
   $(QUIET)cd $(1) && $(ponyc_docker_args) $(PONYSTABLE) env $(PONYCC) $(ponyc_arch_args) \
     $(debug_arg) $(spike_arg) $(autoscale_arg) $(clustering_arg) $(resilience_arg) \
-    $(PONYCFLAGS) $(target_cpu_arg) . $(if $(filter $(ponyc_docker_args),docker),$(quote))
+    $(PONYCFLAGS) $(target_cpu_arg) --features=-avx512f . $(if $(filter $(ponyc_docker_args),docker),$(quote))
   $(QUIET)cd $(1) && echo "$@: $(abspath $(1))/bundle.json" | tr '\n' ' ' > $(notdir $(abspath $(1:%/=%))).d
   $(QUIET)cd $(1) && $(ponyc_docker_args) $(PONYSTABLE) env $(PONYCC) $(ponyc_arch_args) \
     $(debug_arg) $(spike_arg) $(autoscale_arg) $(clustering_arg) $(resilience_arg) \
-    $(PONYCFLAGS) $(target_cpu_arg) . --pass import --files $(if $(filter \
+    $(PONYCFLAGS) $(target_cpu_arg) --features=-avx512f . --pass import --files $(if $(filter \
     $(ponyc_docker_args),docker),$(quote)) 2>/dev/null | grep -o "$(abs_wallaroo_dir).*.pony" \
     | awk 'BEGIN { a="" } {a=a$$1":\n"; printf "%s ",$$1} END {print "\n"a}' \
     >> $(notdir $(abspath $(1:%/=%))).d


### PR DESCRIPTION
We recommend that all users use LLVM 3.9.1. However, there is a bug that
in LLVM version prior to LLVM 5 that can cause the pony compiler to
crash during optimization. As seen in issue #1925, this is triggered by
the usage of the axv512f optimization. This patch turns off axv512f when
building Wallaroo.

Closes #1925