### PR TITLE
 Allow joined worker to recover with original command line

### DIFF
--- a/lib/wallaroo/core/initialization/local_topology.pony
+++ b/lib/wallaroo/core/initialization/local_topology.pony
@@ -528,8 +528,6 @@ actor LocalTopologyInitializer is LayoutInitializer
       @printf[I32]("FAIL: cannot create data channel\n".cstring())
     end
 
-    _connections.recover_connections(this)
-
   fun ref _save_worker_names()
   =>
     """

--- a/lib/wallaroo/core/initialization/local_topology.pony
+++ b/lib/wallaroo/core/initialization/local_topology.pony
@@ -1791,10 +1791,27 @@ actor LocalTopologyInitializer is LayoutInitializer
       end
     end
 
-  be inform_joining_worker(conn: TCPConnection, worker_name: String) =>
+  be inform_joining_worker(conn: TCPConnection, worker_name: String,
+    worker_count: USize)
+  =>
     match _topology
     | let t: LocalTopology =>
-      _router_registry.inform_joining_worker(conn, worker_name, t)
+      if ArrayHelpers[String].contains[String](t.worker_names, worker_name)
+      then
+        // We know this worker name, which indicates that it is recovering
+        // instead of joining.
+        try
+          @printf[I32]("Previously joined worker %s is recovering\n".cstring(),
+            worker_name.cstring())
+          let msg = ChannelMsgEncoder.inform_recover_not_join(_auth)?
+          conn.writev(msg)
+        else
+          Fail()
+        end
+      else
+        _router_registry.update_joining_worker_count(worker_count)
+        _router_registry.inform_joining_worker(conn, worker_name, t)
+      end
     else
       Fail()
     end

--- a/lib/wallaroo/core/messages/channel_messages.pony
+++ b/lib/wallaroo/core/messages/channel_messages.pony
@@ -215,6 +215,14 @@ primitive ChannelMsgEncoder
       partition_blueprints, stateless_partition_blueprints,
       omni_router_blueprint), auth)?
 
+  fun inform_recover_not_join(auth: AmbientAuth): Array[ByteSeq] val ? =>
+    """
+    This message is sent as a response to a JoinCluster message when we
+    already know the worker name (which indicates that it is recovering, not
+    joining)
+    """
+    _encode(InformRecoverNotJoinMsg, auth)?
+
   fun joining_worker_initialized(worker_name: String, c_addr: (String, String),
     d_addr: (String, String), auth: AmbientAuth): Array[ByteSeq] val ?
   =>
@@ -639,6 +647,8 @@ class val InformJoiningWorkerMsg is ChannelMsg
     partition_router_blueprints = p_blueprints
     stateless_partition_router_blueprints = stateless_p_blueprints
     omni_router_blueprint = omr_blueprint
+
+primitive InformRecoverNotJoinMsg is ChannelMsg
 
 // TODO: Don't send host over since we need to determine that on receipt
 class val JoiningWorkerInitializedMsg is ChannelMsg

--- a/lib/wallaroo/ent/network/connections.pony
+++ b/lib/wallaroo/ent/network/connections.pony
@@ -521,9 +521,7 @@ actor Connections is Cluster
       else
         ControlConnection
       end
-    if not _control_conns.contains(target_name) then
-      _control_conns(target_name) = tcp_conn_wrapper
-    end
+    _control_conns(target_name) = tcp_conn_wrapper
     _register_disposable(tcp_conn_wrapper)
     let control_notifier: TCPConnectionNotify iso =
       ControlSenderConnectNotifier(_auth, target_name, tcp_conn_wrapper)

--- a/lib/wallaroo/ent/network/control_channel_tcp.pony
+++ b/lib/wallaroo/ent/network/control_channel_tcp.pony
@@ -358,14 +358,14 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
     true
 
   fun ref connected(conn: TCPConnection ref) =>
-    @printf[I32]((_name + " is connected.\n").cstring())
+    @printf[I32]("ControlChannelConnectNotifier: connected.\n".cstring())
 
   fun ref connect_failed(conn: TCPConnection ref) =>
-    @printf[I32]((_name + ": connection failed!\n").cstring())
+    @printf[I32]("ControlChannelConnectNotifier: connection failed!\n"
+      .cstring())
 
   fun ref closed(conn: TCPConnection ref) =>
-    @printf[I32](("ControlChannelConnectNotifier:" + _name +
-      ": server closed\n").cstring())
+    @printf[I32](("ControlChannelConnectNotifier: server closed\n").cstring())
 
 class JoiningControlSenderConnectNotifier is TCPConnectionNotify
   let _auth: AmbientAuth

--- a/lib/wallaroo/ent/network/control_channel_tcp.pony
+++ b/lib/wallaroo/ent/network/control_channel_tcp.pony
@@ -182,6 +182,8 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
           end
           _connections.create_control_connection(m.worker_name, host,
             m.service)
+        else
+          @printf[I32]("Error retrieving remote control address\n".cstring())
         end
       | let m: IdentifyDataPortMsg =>
         ifdef "trace" then
@@ -276,8 +278,7 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
         ifdef "autoscale" then
           match _layout_initializer
           | let lti: LocalTopologyInitializer =>
-            lti.inform_joining_worker(conn, m.worker_name)
-            _router_registry.update_joining_worker_count(m.worker_count)
+            lti.inform_joining_worker(conn, m.worker_name, m.worker_count)
           else
             Fail()
           end
@@ -422,6 +423,9 @@ class JoiningControlSenderConnectNotifier is TCPConnectionNotify
         else
           Fail()
         end
+      | let m: InformRecoverNotJoinMsg =>
+        @printf[I32]("Informed that we should recover.\n".cstring())
+        _startup.recover_not_join()
       | let m: CleanShutdownMsg =>
         @printf[I32]("Shutting down early: %s\n".cstring(), m.msg.cstring())
         _startup.dispose()

--- a/lib/wallaroo/ent/network/control_sender_connect_notifier.pony
+++ b/lib/wallaroo/ent/network/control_sender_connect_notifier.pony
@@ -43,3 +43,4 @@ class ControlSenderConnectNotifier is TCPConnectionNotify
 
   fun ref closed(conn: TCPConnection ref) =>
     @printf[I32]("ControlSenderConnectNotifier: server closed\n".cstring())
+    _tcp_conn_wrapper.closed(conn)

--- a/lib/wallaroo/ent/network/control_sender_connect_notifier.pony
+++ b/lib/wallaroo/ent/network/control_sender_connect_notifier.pony
@@ -38,9 +38,10 @@ class ControlSenderConnectNotifier is TCPConnectionNotify
     true
 
   fun ref connect_failed(conn: TCPConnection ref) =>
-    @printf[I32]("ControlSenderConnectNotifier: connection failed!\n"
-      .cstring())
+    @printf[I32]("ControlSenderConnectNotifier (to %s): connection failed!\n"
+      .cstring(), _worker_name.cstring())
 
   fun ref closed(conn: TCPConnection ref) =>
-    @printf[I32]("ControlSenderConnectNotifier: server closed\n".cstring())
+    @printf[I32]("ControlSenderConnectNotifier (to %s): server closed\n"
+      .cstring(), _worker_name.cstring())
     _tcp_conn_wrapper.closed(conn)

--- a/lib/wallaroo/ent/network/tcp_connection_wrapper.pony
+++ b/lib/wallaroo/ent/network/tcp_connection_wrapper.pony
@@ -20,6 +20,9 @@ actor ControlConnection
     _control_sender.flush(conn)
     _control_sender = _PostTCPConnectionControlSender(conn)
 
+  be closed(conn: TCPConnection) =>
+    _control_sender = _PreTCPConnectionControlSender
+
   be write(data: ByteSeq) =>
     _control_sender.write(data)
 

--- a/lib/wallaroo/startup.pony
+++ b/lib/wallaroo/startup.pony
@@ -369,6 +369,14 @@ actor Startup
           control_channel_filepath, _startup_options.my_d_host,
           _startup_options.my_d_service, event_log, this)
 
+      // We need to recover connections before creating our control
+      // channel listener, since it's at that point that we notify
+      // the cluster of our control address. If the cluster connection
+      // addresses were not yet recovered, we'd only notify the initializer.
+      if is_recovering then
+        connections.recover_connections(local_topology_initializer)
+      end
+
       if _startup_options.is_initializer then
         connections.make_and_register_recoverable_listener(
           auth, consume control_notifier, control_channel_filepath,

--- a/lib/wallaroo/startup.pony
+++ b/lib/wallaroo/startup.pony
@@ -566,6 +566,21 @@ actor Startup
       Fail()
     end
 
+  be recover_not_join() =>
+    """
+    Called when the cluster informs us we should be recovering instead of
+    joining (i.e. we've already joined, so we must be coming back up).
+    """
+    // Dispose of temporary listener
+    match _joining_listener
+    | let tcp_l: TCPListener =>
+      tcp_l.dispose()
+    else
+      Fail()
+    end
+
+    initialize()
+
   fun ref _set_recovery_file_names(auth: AmbientAuth) =>
     try
       _event_log_dir_filepath = FilePath(auth, _startup_options.resilience_dir)?


### PR DESCRIPTION
Prior to this change, reusing a joined worker's command
line would cause the worker to try to join as if it were
new. This ensures that we first check if the worker should
be recovering. If it should, we notify the worker, which
recovers accordingly.

Closes #1128 