### PR TITLE
Wait on runners's subprocesses to exit

### DIFF
--- a/testing/tools/integration/integration_test
+++ b/testing/tools/integration/integration_test
@@ -412,7 +412,7 @@ def CLI():
                          metavar=('value', 'header'),
                          help=("Stop after receiving all await values in the"
                                "sink"))
-    expect.add_argument('--sink-stop-timeout', type=float,
+    expect.add_argument('--sink-stop-timeout', type=float, default=30,
                         help=("Timeout in seconds before raising a "
                               "TimeoutError"))
     stopper.add_argument('--delay', type=float, default=None,
@@ -432,6 +432,12 @@ def CLI():
                            choices=['none', 'debug', 'info', 'warning',
                                     'error', 'critical'],
                            default='info')
+
+    term_group = parser.add_argument_group('Termination')
+    term_group.add_argument('--runner-join_timeout', type=float, default=30,
+                            help=("Timeout in seconds before killing any "
+                                  "remaining live workers and raising an "
+                                  "error."))
 
     args = parser.parse_args()
     set_log_level(args.log_level)
@@ -474,6 +480,7 @@ def CLI():
                                        False),
                       giles_mode = 'giles' if args.giles_mode else None,
                       host=args.host,
+                      runner_join_timeout=args.runner_join_timeout,
                       resilience_dir=args.resilience_dir,
                       spikes=args.spike))
     except Exception as err:


### PR DESCRIPTION
This should prevent the CI error in https://github.com/WallarooLabs/wallaroo/issues/1829 from arising unless the terminating test's worker processes legitimately _fail_ to clean up.

The change is:
**before**: 
 - if the test reaches the end of the `finally` block, the `Runner` threads will terminate immediately
    - because they are set to be `daemon` threads which means they will be terminated when the Python runtime exits. 
    - This means that they do not necessarily wait for their subprocesses to finish exiting. 
    - This mostly doesn't result in test errors because they termination command has already been sent to the subprocess, and most of the time the subprocesses complete the clean up before the next test is run.
    - Sometimes the clean up isn't finished before the next test's `setup_resilience_path` call, which results in the error in #1829

**after**: 
- The test will wait on the `Runner` threads to join
- and the runner threads in turn wait on their subprocesses to exit
- this should result in clean up completing before the test returns, which should prevent this bug from occurring unless clean up actually fails to do a proper clean up.

closes #1829