### PR TITLE
Fix link in Python example README for getting setup

### DIFF
--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -2,7 +2,7 @@
 
 In this section you will find the complete examples from the [Wallaroo Python](/book/python/intro.md) section, as well as some additional examples. Each example includes a README describing its purpose and how to set it up and run it.
 
-To get set up for running examples, if you haven't already, refer to [Building a Python application](/book/python/building.md).
+To get set up for running examples, if you haven't already, refer to [Choosing an Installation Option for Wallaroo](https://docs.wallaroolabs.com/book/getting-started/choosing-an-installation-option.html).
 
 ## Examples by Category
 
@@ -20,4 +20,3 @@ To get set up for running examples, if you haven't already, refer to [Building a
 
 - [alphabet_partitioned](alphabet_partitioned/): a vote counting stream application using partitioning.
 - [market_spread](market_spread/): a stream application that keeps a state for market data and checks trade orders against it in real time. This application uses state, partitioning, and two pipelines, each with its own source.
-


### PR DESCRIPTION
The link in the Python example README pointed to a page called
"Building a Python application" that does not exist. The sentence that
contained the link was for people who were starting to use Wallaroo,
so it seemed like the closest match was linking to the "Choosing a
Wallaroo Installation Option" page. This should make it easier for
people to follow the examples.

Fixes #1957

[skip ci]