### PR TITLE
Update market_spread w/ structs to the new API

### DIFF
--- a/testing/performance/apps/python/market_spread/Makefile
+++ b/testing/performance/apps/python/market_spread/Makefile
@@ -43,7 +43,7 @@ include $(rules_mk_path)
 build-testing-performance-apps-python-market_spread: build-machida
 integration-tests-testing-performance-apps-python-market_spread: build-testing-performance-apps-python-market_spread
 
-#integration-tests-testing-performance-apps-python-market_spread: struct_market_spread_py_test
+integration-tests-testing-performance-apps-python-market_spread: struct_market_spread_py_test
 
 struct_market_spread_py_test:
 	cd $(STRUCT_MARKET_SPREAD_PY_PATH) && \

--- a/testing/performance/apps/python/market_spread/_test/gen.py
+++ b/testing/performance/apps/python/market_spread/_test/gen.py
@@ -28,7 +28,6 @@ SIDETYPE_SELL = 2
 from market_spread import (FIXTYPE_MARKET_DATA,
                            FIXTYPE_ORDER,
                            OrderResult,
-                           OrderResultEncoder,
                            SIDETYPE_BUY,
                            SIDETYPE_SELL)
 

--- a/testing/performance/apps/python/market_spread/market_spread.py
+++ b/testing/performance/apps/python/market_spread/market_spread.py
@@ -12,10 +12,10 @@
 #  implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 
-import struct
-import time
 
 from enum import IntEnum
+import struct
+import time
 
 import wallaroo
 
@@ -25,10 +25,6 @@ FIXTYPE_MARKET_DATA = 2
 
 SIDETYPE_BUY = 1
 SIDETYPE_SELL = 2
-
-
-def test_python():
-    return "hello python"
 
 
 def str_to_partition(stringable):
@@ -56,19 +52,19 @@ def application_setup(args):
     ab = wallaroo.ApplicationBuilder("market-spread")
     ab.new_pipeline(
             "Orders",
-            wallaroo.TCPSourceConfig(order_host, order_port, OrderDecoder())
+            wallaroo.TCPSourceConfig(order_host, order_port, order_decoder)
         ).to_state_partition_u64(
-            CheckOrder(), SymbolDataBuilder(), "symbol-data",
-            SymbolPartitionFunction(), symbol_partitions
-        ).to_sink(
-                wallaroo.TCPSinkConfig(
-                    out_host, out_port, OrderResultEncoder())
+            check_order, SymbolData, "symbol-data",
+            symbol_partition_function, symbol_partitions
+        ).to_sink(wallaroo.TCPSinkConfig(out_host, out_port,
+                                        order_result_encoder)
         ).new_pipeline(
             "Market Data",
-            wallaroo.TCPSourceConfig(nbbo_host, nbbo_port, MarketDataDecoder())
+            wallaroo.TCPSourceConfig(nbbo_host, nbbo_port,
+                                     market_data_decoder)
         ).to_state_partition_u64(
-            UpdateMarketData(), SymbolDataBuilder(), "symbol-data",
-            SymbolPartitionFunction(), symbol_partitions
+            update_market_data, SymbolData, "symbol-data",
+            symbol_partition_function, symbol_partitions
         ).done()
     return ab.build()
 
@@ -95,43 +91,45 @@ def serialize(o):
     0 - 4b object class (SerializedTypes)
     1 - ?b object data (if required)
     """
-    if type(o) is UpdateMarketData:
+    if isinstance(o, update_market_data.__class__):
         s = struct.Struct('>I')
         return s.pack(SerializedTypes.UPDATEMARKETDATA)
-    elif type(o) is SymbolPartitionFunction:
+    elif isinstance(o, symbol_partition_function.__class__):
         s = struct.Struct('>I')
         return s.pack(SerializedTypes.SYMBOLPARTITIONFUNCTION)
-    elif type(o) is CheckOrder:
+    elif isinstance(o, check_order.__class__):
         s = struct.Struct('>I')
         return s.pack(SerializedTypes.CHECKORDER)
-    elif type(o) is SymbolDataBuilder:
-        s = struct.Struct('>I')
-        return s.pack(SerializedTypes.SYMBOLDATABUILDER)
-    elif type(o) is OrderResultEncoder:
+    elif isinstance(o, order_result_encoder.__class__):
         s = struct.Struct('>I')
         return s.pack(SerializedTypes.ORDERRESULTENCODER)
-    elif type(o) is MarketDataMessage:
+    elif isinstance(o, MarketDataMessage):
         s = struct.Struct('>I4s21sdd')
         return s.pack(SerializedTypes.MARKETDATAMESSAGE,
                       o.symbol, o.transact_time, o.bid, o.offer)
-    elif type(o) is MarketDataDecoder:
+    elif isinstance(o, market_data_decoder.__class__):
         s = struct.Struct('>I')
         return s.pack(SerializedTypes.MARKETDATADECODER)
-    elif type(o) is Order:
+    elif isinstance(o, Order):
         s = struct.Struct('>IBI6s4sdd21s')
         return s.pack(SerializedTypes.ORDERMESSAGE, o.side, o.account,
                       o.order_id, o.symbol, o.qty, o.price, o.transact_time)
-    elif type(o) is OrderDecoder:
+    elif isinstance(o, order_decoder.__class__):
         s = struct.Struct('>I')
         return s.pack(SerializedTypes.ORDERDECODER)
-    elif type(o) is SymbolData:
+    elif isinstance(o, SymbolData):
         s = struct.Struct('>Idd?')
         return s.pack(SerializedTypes.SYMBOLDATA,
             o.last_bid, o.last_offer, o.should_reject_trades)
+    elif isinstance(o, wallaroo.StateBuilder):
+        if o.state_cls is SymbolData:
+            s = struct.Struct('>I')
+            return s.pack(SerializedTypes.SYMBOLDATABUILDER)
+        else:
+            print("Unknown state class {}".format(type(o.state_cls).__name__))
     else:
         print("Don't know how to serialize {}".format(type(o).__name__))
     return None
-
 
 def deserialize(bs):
     """
@@ -141,66 +139,54 @@ def deserialize(bs):
     """
     (obj_type,), bs = struct.unpack('>I', bs[:4]), bs[4:]
     if obj_type == SerializedTypes.UPDATEMARKETDATA:
-        return UpdateMarketData()
+        return update_market_data
     elif obj_type == SerializedTypes.SYMBOLPARTITIONFUNCTION:
-        return SymbolPartitionFunction()
+        return symbol_partition_function
     elif obj_type == SerializedTypes.CHECKORDER:
-        return CheckOrder()
+        return check_order
     elif obj_type == SerializedTypes.SYMBOLDATABUILDER:
-        return SymbolDataBuilder()
+        return wallaroo.StateBuilder("symbol-data", SymbolData)
     elif obj_type == SerializedTypes.ORDERRESULTENCODER:
-        return OrderResultEncoder()
+        return order_result_encoder
     elif obj_type == SerializedTypes.MARKETDATAMESSAGE:
         (symbol, time, bid, offer) = struct.unpack('>4s21sdd', bs)
         return MarketDataMessage(symbol, time, bid, offer)
     elif obj_type == SerializedTypes.MARKETDATADECODER:
-        return MarketDataDecoder()
+        return market_data_decoder
     elif obj_type == SerializedTypes.ORDERMESSAGE:
         (side, acct, oid, symbol, qty, price, t_time) = struct.unpack(
                 '>BI6s4sdd21s', bs)
         return Order(side, acct, oid, symbol, qty, price, t_time)
     elif obj_type == SerializedTypes.ORDERDECODER:
-        return OrderDecoder()
+        return order_decoder
     elif obj_type == SerializedTypes.SYMBOLDATA:
         (last_bid, last_offer, should_reject_trades) = struct.unpack('>dd?', bs)
         return SymbolData(last_bid, last_offer, should_reject_trades)
     else:
         print("Don't know how to deserialize: {}".format(obj_type))
     return None
-
-
 class MarketSpreadError(Exception):
     pass
 
 
 class SymbolData(object):
-    def __init__(self, last_bid, last_offer, should_reject_trades):
+    def __init__(self, last_bid=0.0, last_offer=0.0, should_reject_trades=True):
         self.last_bid = last_bid
         self.last_offer = last_offer
         self.should_reject_trades = should_reject_trades
 
 
-class SymbolDataBuilder(object):
-    def build(self):
-        return SymbolData(0.0, 0.0, True)
+@wallaroo.partition
+def symbol_partition_function(data):
+    return str_to_partition(data.symbol)
 
 
-class SymbolPartitionFunction(object):
-    def partition(self, data):
-        return str_to_partition(data.symbol)
-
-
-class CheckOrder(object):
-    def name(self):
-        return "Check Order"
-
-    def compute(self, data, state):
-        if state.should_reject_trades:
-            ts = int(time.time() * 100000)
-            return (OrderResult(data, state.last_bid,
-                                state.last_offer, ts),
-                    False)
-        return (None, False)
+@wallaroo.state_computation(name="Check Order")
+def check_order(data, state):
+    if state.should_reject_trades:
+        ts = int(time.time() * 100000)
+        return (OrderResult(data, state.last_bid, state.last_offer, ts), False)
+    return (None, False)
 
 
 class Order(object):
@@ -215,39 +201,32 @@ class Order(object):
         self.transact_time = transact_time
 
 
-class OrderDecoder(object):
-    def header_length(self):
-        return 4
+@wallaroo.decoder(header_length=4, length_fmt=">I")
+def order_decoder(bs):
+    """
+    0 -  1b - FixType (U8)
+    1 -  1b - side (U8)
+    2 -  4b - account (U32)
+    6 -  6b - order id (String)
+    12 -  4b - symbol (String)
+    16 -  8b - order qty (F64)
+    24 -  8b - price (F64)
+    32 - 21b - transact_time (String)
+    """
+    order_type = struct.unpack(">B", bs[0:1])[0]
+    if order_type != FIXTYPE_ORDER:
+        raise MarketSpreadError("Wrong Fix message type. Did you connect "
+                                "the senders the wrong way around?")
+    side = struct.unpack(">B", bs[1:2])[0]
+    account = struct.unpack(">I", bs[2:6])[0]
+    order_id = struct.unpack("6s", bs[6:12])[0]
+    symbol = struct.unpack("4s", bs[12:16])[0]
+    qty = struct.unpack(">d", bs[16:24])[0]
+    price = struct.unpack(">d", bs[24:32])[0]
+    transact_time = struct.unpack("21s", bs[32:53])[0]
 
-    def payload_length(self, bs):
-        return struct.unpack(">I", bs)[0]
-
-    def decode(self, bs):
-        """
-        0 -  1b - FixType (U8)
-        1 -  1b - side (U8)
-        2 -  4b - account (U32)
-        6 -  6b - order id (String)
-        12 -  4b - symbol (String)
-        16 -  8b - order qty (F64)
-        24 -  8b - price (F64)
-        32 - 21b - transact_time (String)
-        """
-        order_type = struct.unpack(">B", bs[0:1])[0]
-        if order_type != FIXTYPE_ORDER:
-            raise MarketSpreadError("Wrong Fix message type {}. Did you "
-                                    "connect the senders the wrong way "
-                                    "around?".format(order_type))
-        side = struct.unpack(">B", bs[1:2])[0]
-        account = struct.unpack(">I", bs[2:6])[0]
-        order_id = struct.unpack("6s", bs[6:12])[0]
-        symbol = struct.unpack("4s", bs[12:16])[0]
-        qty = struct.unpack(">d", bs[16:24])[0]
-        price = struct.unpack(">d", bs[24:32])[0]
-        transact_time = struct.unpack("21s", bs[32:53])[0]
-
-        return Order(side, account, order_id, symbol, qty, price,
-                     transact_time)
+    return Order(side, account, order_id, symbol, qty, price,
+                 transact_time)
 
 
 class OrderResult(object):
@@ -258,20 +237,20 @@ class OrderResult(object):
         self.timestamp = timestamp
 
 
-class OrderResultEncoder(object):
-    def encode(self, data):
-        p = struct.pack(">HI6s4sddddQ",
-                        data.order.side,
-                        data.order.account,
-                        data.order.order_id,
-                        data.order.symbol,
-                        data.order.qty,
-                        data.order.price,
-                        data.bid,
-                        data.offer,
-                        data.timestamp)
-        out = struct.pack('>I{}s'.format(len(p)), len(p), p)
-        return out
+@wallaroo.encoder
+def order_result_encoder(data):
+    p = struct.pack(">HI6s4sddddQ",
+                    data.order.side,
+                    data.order.account,
+                    data.order.order_id,
+                    data.order.symbol,
+                    data.order.qty,
+                    data.order.price,
+                    data.bid,
+                    data.offer,
+                    data.timestamp)
+    out = struct.pack('>I{}s'.format(len(p)), len(p), p)
+    return out
 
 
 class MarketDataMessage(object):
@@ -283,44 +262,35 @@ class MarketDataMessage(object):
         self.mid = (bid + offer) / 2.0
 
 
-class MarketDataDecoder(object):
-    def header_length(self):
-        return 4
-
-    def payload_length(self, bs):
-        return struct.unpack(">I", bs)[0]
-
-    def decode(self, bs):
-        """
-        0 -  1b - FixType (U8)
-        1 -  4b - symbol (String)
-        5 -  21b - transact_time (String)
-        26 - 8b - bid_px (F64)
-        34 - 8b - offer_px (F64)
-        """
-        order_type = struct.unpack(">B", bs[0:1])[0]
-        if order_type != FIXTYPE_MARKET_DATA:
-            raise MarketSpreadError("Wrong Fix message type. Did you connect "
-                                    "the senders the wrong way around?")
-        symbol = struct.unpack(">4s", bs[1:5])[0]
-        transact_time = struct.unpack(">21s", bs[5:26])[0]
-        bid = struct.unpack(">d", bs[26:34])[0]
-        offer = struct.unpack(">d", bs[34:42])[0]
-        return MarketDataMessage(symbol, transact_time, bid, offer)
+@wallaroo.decoder(header_length=4, length_fmt=">I")
+def market_data_decoder(bs):
+    """
+    0 -  1b - FixType (U8)
+    1 -  4b - symbol (String)
+    5 -  21b - transact_time (String)
+    26 - 8b - bid_px (F64)
+    34 - 8b - offer_px (F64)
+    """
+    order_type = struct.unpack(">B", bs[0:1])[0]
+    if order_type != FIXTYPE_MARKET_DATA:
+        raise MarketSpreadError("Wrong Fix message type. Did you connect "
+                                "the senders the wrong way around?")
+    symbol = struct.unpack(">4s", bs[1:5])[0]
+    transact_time = struct.unpack(">21s", bs[5:26])[0]
+    bid = struct.unpack(">d", bs[26:34])[0]
+    offer = struct.unpack(">d", bs[34:42])[0]
+    return MarketDataMessage(symbol, transact_time, bid, offer)
 
 
-class UpdateMarketData(object):
-    def name(self):
-        return "Update Market Data"
+@wallaroo.state_computation(name="Update Market Data")
+def update_market_data(data, state):
+    offer_bid_difference = data.offer - data.bid
 
-    def compute(self, data, state):
-        offer_bid_difference = data.offer - data.bid
+    should_reject_trades = ((offer_bid_difference >= 0.05) or
+                            ((offer_bid_difference / data.mid) >= 0.05))
 
-        should_reject_trades = ((offer_bid_difference >= 0.05) or
-                                ((offer_bid_difference / data.mid) >= 0.05))
+    state.last_bid = data.bid
+    state.last_offer = data.offer
+    state.should_reject_trades = should_reject_trades
 
-        state.last_bid = data.bid
-        state.last_offer = data.offer
-        state.should_reject_trades = should_reject_trades
-
-        return (None, True)
+    return (None, True)


### PR DESCRIPTION
The user-defined serialize/deserialize functions need to make use of
wallaroo.StateBuilder, but the speed improvement is still worth it.
Therefore this updates the example to work with the new decorator-based
Python API.