### PR TITLE
Fail when control channel can't listen

### DIFF
--- a/lib/wallaroo/ent/network/control_channel_tcp.pony
+++ b/lib/wallaroo/ent/network/control_channel_tcp.pony
@@ -102,7 +102,7 @@ class ControlChannelListenNotifier is TCPListenNotify
   fun ref not_listening(listen: TCPListener ref) =>
     @printf[I32]((_name + " control: unable to listen on (%s:%s)\n").cstring(),
       _host.cstring(), _service.cstring())
-    listen.close()
+    Fail()
 
   fun ref connected(listen: TCPListener ref): TCPConnectionNotify iso^ =>
     ControlChannelConnectNotifier(_name, _auth, _connections,


### PR DESCRIPTION
We already follow this strategy for the data channel.
If the control channel can't listen, we're in trouble
and the best thing to do is exit.

Closes #1850