### PR TITLE
Update python examples README to new API

### DIFF
--- a/examples/python/alphabet/README.md
+++ b/examples/python/alphabet/README.md
@@ -30,7 +30,7 @@ The outputs of the alphabet application are the letter that received the votes t
 
 ### Processing
 
-The `Decoder`'s `decode(...)` method creates a `Votes` object with the letter being voted on and the number of votes it is receiving with this message. The `Votes` object is passed with the `AddVotes` computation to the state object that stores all of the vote totals, and the `compute(...)` function modifies the state to record the new total number of votes for the letter. It then creates an `AllVotes` message, which is sent to `Encode`'s `encode(...)` method, which converts it into an outgoing message.
+The `decoder` function creates a `Votes` object with the letter being voted on and the number of votes it is receiving with this message. The `Votes` object is passed along with the state object that stores all of the vote totals to the `add_votes` computation. The `add_votes` computation then modifies the state to record the new total number of votes for the letter. It then creates a new `Votes` message, which is sent to the `encoder` function, which converts it into an outgoing message.
 
 ## Running Alphabet
 

--- a/examples/python/alphabet_partitioned/README.md
+++ b/examples/python/alphabet_partitioned/README.md
@@ -30,7 +30,7 @@ The outputs of the alphabet application are the letter that received the votes t
 
 ### Processing
 
-The `Decoder`'s `decode(...)` method creates a `Votes` object with the letter being voted on and the number of votes it is receiving with this message. The `Votes` object is passed with the `AddVotes` computation to the state object that handles the letter being voted on, and the `AddVotes` function modifies the state to record the new total number of votes for the letter. It then creates an `AllVotes` message, which is sent to `Encode`'s `encode(...)` method, which converts it into an outgoing message.
+The `decoder` creates a `Votes` object with the letter being voted on and the number of votes it is receiving with this message. The `Votes` object is passed to the `partition` function, which determines which partition the message should be sent to. Then the `Votes` message is passed along with the correct `TotalVotes` state to an `add_votes` State Computation, which modifies the state to record the new total number of votes for the letter. The computation then returns a new `Votes` object representing the new total count for that letter, which is sent to the `encoder` function that converts it into an outgoing message.
 
 ## Running Alphabet Partitioned
 

--- a/examples/python/celsius-kafka/README.md
+++ b/examples/python/celsius-kafka/README.md
@@ -17,7 +17,7 @@ The inputs and outputs of the "Celsius Kafka" application are binary 32-bit floa
 
 ### Processing
 
-The `Decoder`'s `decode(...)` method creates a float from the value represented by the payload. The float value is then sent to the `Multiply` computation where it is multiplied by `1.8`, and the result of that computation is sent to the `Add` computation where `32` is added to it. The resulting float is then sent to the `Encoder`, which converts it to an outgoing sequence of bytes.
+The `decoder` function creates a float from the value represented by the payload. The float value is then sent to the `multiply` computation where it is multiplied by `1.8`, and the result of that computation is sent to the `add` computation where `32` is added to it. The resulting float is then sent to the `encoder` function, which converts it to an outgoing sequence of bytes.
 
 ## Running Celsius Kafka
 

--- a/examples/python/celsius/README.md
+++ b/examples/python/celsius/README.md
@@ -18,7 +18,7 @@ The inputs and outputs of the "Celsius" application are binary 32-bits float enc
 
 ### Processing
 
-The `Decoder`'s `decode(...)` method creates a float from the value represented by the payload. The float value is then sent to the `Multiply` computation where it is multiplied by `1.8`, and the result of that computation is sent to the `Add` computation where `32` is added to it. The resulting float is then sent to the `Encoder`, which converts it to an outgoing sequence of bytes.
+The `decoder` function creates a float from the value represented by the payload. The float value is then sent to the `multiply` computation where it is multiplied by `1.8`, and the result of that computation is sent to the `add` computation where `32` is added to it. The resulting float is then sent to the `encoder` function, which converts it to an outgoing sequence of bytes.
 
 ## Running Celsius
 

--- a/examples/python/market_spread/README.md
+++ b/examples/python/market_spread/README.md
@@ -53,9 +53,9 @@ The output messages use the [source message framing protocol](https://docs.walla
 
 ### Processing
 
-The NBBO messages are handled by the `MarketDataDecoder`'s `decode(...)` method, which takes the input bytes and turns them into `MarketDataMessage` objects, which are then sent to the state partition that handles the state for the stock symbol given by the message, along with the `UpdateMarketData` object. The `UpdateMarketData`'s `compute(...)` method is called on the incoming message and the current state for the stock symbol and the state is updated with new price information.
+The NBBO messages are handled by the `market_data_decoder` function, which takes the input bytes and turns them into `MarketDataMessage` objects, which are then sent to the partition function to determine which state partition to forward the message to. At the state partition, the `MarketDataMessage` is passed, along with the `SymbolData` state for that partition, to the `update_market_data` state computation that updates the price information for the stock symbol given by the message.
 
-The Order messages are handled by the `OrderDecoder`'s `decode(...)` method, which takes the input bytes and turns them into `Order` object, which are then sent to the state partition that handles the state for the stock symbol given in the message, along with the `CheckOrder` object. The `CheckOrder`'s `compute(...)` method is called on the incoming message and the current state for the stock symbol, and if the order is accepted based on the order price and the market price then an `OrderResult` message is sent out. The `Encoder`'s `encode(...)` method turns `OrderResult` messages into byte strings that are then sent out.
+The Order messages are handled by the `order_decoder` function, which takes the input bytes and turns them into an `Order` object, which is then sent to the partition function to determine the state partition to forward the message to. The Order message is then passed, along with the `SymbolData` state object, to the `check_order` State Computation, which will determine whether the order is accepted or rejected. If accepted, the `check_order` State Computation will return an `OrderResult` object which is then encoded by the `order_result_encoder` function into output byte strings.
 
 ## Running Market Spread
 

--- a/examples/python/reverse/README.md
+++ b/examples/python/reverse/README.md
@@ -24,7 +24,7 @@ The outputs of the application are strings followed by newlines. Here's an examp
 
 ### Processing
 
-The `Decoders`'s `decode(...)` method creates a string from the value represented by the payload. The string is then sent to the `Reverse` computation where it is reversed. The reversed string is then sent to `Encode`'s `encode(...)` method, where a newline is appended to the string.
+The `decoder` function creates a string from the value represented by the payload. The string is then sent to the `reverse` computation where it is reversed. The reversed string is then sent to the `encoder` function, where a newline is appended to the string before it sent out via the sink.
 
 ## Running Reverse
 

--- a/examples/python/word_count/README.md
+++ b/examples/python/word_count/README.md
@@ -22,7 +22,7 @@ The messages are strings terminated with a newline, with the form `WORD => COUNT
 
 ### Processing
 
-The `Decoder`'s `decode(...)` method turns the input message into a string. That string is then passed to `Split`'s `compute_multi(...)` method, which breaks the string into individual words and returns a list containing these words. Each item in the list is sent as a separate message to the state partition for that word, along with the `CountWords` `compute(...)` method, which updates the existing state with a new count for the word and returns a `WordCount` object. The `WordCount` object is then sent to the `Encoder`'s `encode(...)` method where it is turned into an output message as described above.
+The `decoder` function turns the input message into a string. That string is then passed to the `split` one-to-many computation, which breaks the string into individual words and returns a list containing these words. Each item in the list is sent as a separate message to the partition function which determines which state partition it will go to. At each partition, the word and the `WordTotals` state object for that partition are sent to the `count_word` State Computation, which updates word's count by 1, and returns the current count for this word as its output. That count is then sent to the `encoder` function with formats it for output.
 
 ## Running Word Count
 


### PR DESCRIPTION
Updates the README descriptions that referred to Wallaroo components that changed between the old and new python API.

[skip ci]
closes #1985