### PR TITLE
Remove "name()" from StateBuilder interface

### DIFF
--- a/book/go/api/api.md
+++ b/book/go/api/api.md
@@ -364,10 +364,6 @@ A `StateBuilder` is used by Wallaroo to create an initial state object for a `St
 
 #### `wallarooapi.StateBuilder` Methods
 
-##### `Name() string`
-
-Return a string representing the name of the state.
-
 ##### `Build() interface{}`
 
 Return a new state instance.
@@ -378,10 +374,6 @@ Return a `RunningVoteTotal` object with the values initialized to defaults.
 
 ```go
 type RunningVotesTotalBuilder struct {}
-
-func (rvtb *RunningVotesTotalBuilder) Name() string {
-	return "running votes total builder"
-}
 
 func (rvtb *RunningVotesTotalBuilder) Build() interface{} {
 	return &RunningVoteTotal{}

--- a/book/go/api/writing-your-own-stateful-application.md
+++ b/book/go/api/writing-your-own-stateful-application.md
@@ -71,10 +71,6 @@ Lastly, a stateful application's pipeline is going to need a `StateBuilder`, so 
 ```go
 type RunningVotesTotalBuilder struct {}
 
-func (rvtb *RunningVotesTotalBuilder) Name() string {
-  return "running votes total builder"
-}
-
 func (rvtb *RunningVotesTotalBuilder) Build() interface{} {
   return &RunningVoteTotal{}
 }

--- a/examples/go/alphabet/go/src/alphabet/alphabet.go
+++ b/examples/go/alphabet/go/src/alphabet/alphabet.go
@@ -89,10 +89,6 @@ func (tv *RunningVoteTotal) GetVotes() *LetterAndVotes {
 
 type RunningVotesTotalBuilder struct {}
 
-func (rvtb *RunningVotesTotalBuilder) Name() string {
-  return "running votes total builder"
-}
-
 func (rvtb *RunningVotesTotalBuilder) Build() interface{} {
   return &RunningVoteTotal{}
 }

--- a/examples/go/word_count/go/src/word_count/word_count.go
+++ b/examples/go/word_count/go/src/word_count/word_count.go
@@ -173,10 +173,6 @@ func (wordTotals *WordTotals) GetCount(word string) *WordCount {
 
 type WordTotalsBuilder struct {}
 
-func (wtb *WordTotalsBuilder) Name() string {
-	return "word totals builder"
-}
-
 func (wtb *WordTotalsBuilder) Build() interface{} {
 	return MakeWordTotals()
 }

--- a/examples/pony/alphabet/alphabet.pony
+++ b/examples/pony/alphabet/alphabet.pony
@@ -55,7 +55,6 @@ actor Main
 
 class val LetterStateBuilder
   fun apply(): LetterState => LetterState
-  fun name(): String => "Letter State"
 
 class LetterState is State
   var letter: String = " "

--- a/go_api/go/src/wallarooapi/statecomputation.go
+++ b/go_api/go/src/wallarooapi/statecomputation.go
@@ -67,14 +67,7 @@ func StateComputationMultiCompute(computationId uint64, dataId uint64, stateId u
 }
 
 type StateBuilder interface {
-	Name() string
 	Build() interface {}
-}
-
-//export StateBuilderName
-func StateBuilderName(stateBuilderId uint64) *C.char {
-	stateBuilder := GetComponent(stateBuilderId, StateBuilderTypeId).(StateBuilder)
-	return C.CString(stateBuilder.Name())
 }
 
 //export StateBuilderBuild

--- a/go_api/pony/go_api/state_computation.pony
+++ b/go_api/pony/go_api/state_computation.pony
@@ -10,7 +10,6 @@ use @StateComputationName[Pointer[U8] ref](cid: U64)
 use @StateComputationCompute[U64](cid: U64, did: U64, sid: U64,
   sc: Pointer[U64])
 
-use @StateBuilderName[Pointer[U8] ref](sbid: U64)
 use @StateBuilderBuild[U64](sbid: U64)
 
 class val StateComputation is w.StateComputation[GoData, GoData, GoState]
@@ -127,14 +126,6 @@ class val StateBuilder
 
   new val create(state_builder_id: U64) =>
     _state_builder_id = state_builder_id
-
-  fun name(): String =>
-    recover val
-      let sp = @StateBuilderName(_state_builder_id)
-      let n = String.copy_cstring(sp)
-      @free(sp)
-      n
-    end
 
   fun apply(): GoState =>
     GoState(@StateBuilderBuild(_state_builder_id))

--- a/lib/wallaroo/core/topology/computations.pony
+++ b/lib/wallaroo/core/topology/computations.pony
@@ -153,4 +153,3 @@ interface val ComputationBuilder[In: Any val, Out: Any val]
 
 interface val StateBuilder[S: State ref]
   fun apply(): S
-  fun name(): String

--- a/lib/wallaroo/core/topology/runner.pony
+++ b/lib/wallaroo/core/topology/runner.pony
@@ -333,7 +333,7 @@ class val StateRunnerBuilder[S: State ref] is RunnerBuilder
     end
     sr
 
-  fun name(): String => _state_builder.name()
+  fun name(): String => _state_name + " StateRunnerBuilder"
   fun state_name(): String => _state_name
   fun is_stateful(): Bool => true
   fun id(): U128 => _id

--- a/machida/machida.pony
+++ b/machida/machida.pony
@@ -153,9 +153,6 @@ class PyStateBuilder
   new create(state_builder: Pointer[U8] val) =>
     _state_builder = state_builder
 
-  fun name(): String =>
-    Machida.get_name(_state_builder)
-
   fun apply(): PyState =>
     PyState(@state_builder_build_state(_state_builder))
 


### PR DESCRIPTION
We don't currently use the StateBuilder name for any
reason and it creates more boilerplate when creating
stateful apps. This removes name() from the interface
and updates Python and Go APIs as well as example
apps and book examples accordingly. Instead of the
StateBuilder name, we now use the state partition
name, which would do the trick if we ever end up
needing it for logging purposes.

Closes #1809