### PR TITLE
Update a missed doc example to the new Python API

### DIFF
--- a/book/python/writing-your-own-partitioned-stateful-application.md
+++ b/book/python/writing-your-own-partitioned-stateful-application.md
@@ -14,7 +14,7 @@ Partitioning is a key aspect of how work is distributed in Wallaroo. From the ap
 
 Our partitioned application is going to be very similar to the Alphabet application. The difference is that it is going to use partitioning to distribute the work, and the state classes will need to reflect that.
 
-**Encode**, **Decode**, **StateComputation**, and **Votes** are exactly the same as before, so we will not include them here.
+**encode**, **decode**, **add_votes**, and **Votes** are exactly the same as before, so we will not include them here.
 
 ### Partition
 
@@ -27,9 +27,9 @@ letter_partitions = list(string.ascii_lowercase)
 And then we define a partitioning function which returns a key from the above list for input data:
 
 ```python
-class LetterPartitionFunction(object):
-    def partition(self, data):
-        return data.letter[0]
+@wallaroo.partition
+def partition(self, data):
+    return data.letter[0]
 ```
 
 Later when we build the application topology, we will pass both the keys and the function to the builder.
@@ -60,26 +60,15 @@ class TotalVotes(object):
         return Votes(self.letter, self.votes)
 ```
 
-And since we changed the name of the state class from `AllVotes` to `TotalVotes`, the State Builder needs to be updated to reflect this:
-
-```python
-class LetterStateBuilder(object):
-    def name(self):
-        return "Letter State Builder"
-
-    def build(self):
-        return TotalVotes()
-```
-
 ### Application Setup
 
 Finally, the application setup is a little different now that we use partitioning. A partition is an intrinsic part of a pipeline's definition, as it changes how Wallaroo connects elements behind the scenes, so we have to distinguish partitioned state from non-partitioned state. This is done with `to_state_partition` and `to_state_partition_u64` respectively (compared with `to_stateful` in the non-partitioned case, as in the previous section).
 
-As with `to_stateful`, `to_state_partition` takes a StateComputation, a StateBuilder, and a state name. In addition, it takes a partition function and a partition keys list:
+As with `to_stateful`, `to_state_partition` takes a state computation _function_, a state _class_ and its name. In addition, it takes a partition function and a partition keys list:
 
 ```python
-ab.to_state_partition(AddVotes(), LetterStateBuilder(), "letter state",
-                      LetterPartitionFunction(), letter_partitions)
+ab.to_state_partition(add_votes, TotalVotes, "letter state",
+                      partition, letter_partitions)
 ```
 
 So the new `application_setup` is going to look like
@@ -91,10 +80,10 @@ def application_setup(args):
     letter_partitions = list(string.ascii_lowercase)
     ab = wallaroo.ApplicationBuilder("alphabet")
     ab.new_pipeline("alphabet",
-                    wallaroo.TCPSourceConfig(in_host, in_port, Decoder()))
-    ab.to_state_partition(AddVotes(), LetterStateBuilder(), "letter state",
-                          LetterPartitionFunction(), letter_partitions)
-    ab.to_sink(wallaroo.TCPSinkConfig(out_host, out_port, Encoder()))
+                    wallaroo.TCPSourceConfig(in_host, in_port, decoder))
+    ab.to_state_partition(add_votes, TotalVotes, "letter state",
+                          partition, letter_partitions)
+    ab.to_sink(wallaroo.TCPSinkConfig(out_host, out_port, encoder))
     return ab.build()
 ```
 


### PR DESCRIPTION
writing-your-own-partitioned-stateful-application was missed in the new
API release and still referenced the old Python API pre-0.4.0

fixes #1996