### PR TITLE
Remove sed and external versioning dependency for Metrics UI build

### DIFF
--- a/monitoring_hub/apps/metrics_reporter_ui/.gitignore
+++ b/monitoring_hub/apps/metrics_reporter_ui/.gitignore
@@ -18,6 +18,7 @@ erl_crash.dump
 # Since we are building assets from web/static,
 # we ignore priv/static. You may want to comment
 # this depending on your deployment strategy.
+/priv/*
 /priv/static/*
 /priv/static/cache_manifest.json
 

--- a/monitoring_hub/apps/metrics_reporter_ui/package.json
+++ b/monitoring_hub/apps/metrics_reporter_ui/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "main": "main.js",
   "scripts": {
-    "compile": "mkdir -p priv/static/js && browserify web/static/js/main.js -t [ babelify --presets [ env react ] ] --outfile priv/static/js/bundle.js",
+    "compile": "mkdir -p priv/static/js && browserify web/static/js/main.js -t [ babelify --presets [ env react ] --plugins [ transform-inline-environment-variables ] ] --outfile priv/static/js/bundle.js",
     "build:css": "mkdir -p priv/static/css && node-sass --include-path web/static/css web/static/css/style.scss priv/static/css/style.css && cp web/static/css/bootstrap-flatly.min.css priv/static/css/bootstrap-flatly.min.css  && cp web/static/css/bootstrap-3.3.5.min.css priv/static/css/bootstrap-3.3.5.min.css",
     "build:assets": "mkdir -p priv/static/fonts && mkdir -p priv/static/images && cp web/static/fonts/* priv/static/fonts/ && cp web/static/images/* priv/static/images/",
     "build": "npm run compile && npm run build:css && npm run build:assets",
@@ -22,6 +22,7 @@
   "license": "ISC",
   "devDependencies": {
     "babel-core": "^6.0.20",
+    "babel-plugin-transform-inline-environment-variables": "0.2.0",
     "babel-preset-env": "1.6.1",
     "babel-preset-react": "6.24.1",
     "babelify": "^8.0.0",

--- a/monitoring_hub/apps/metrics_reporter_ui/web/static/js/buffy-ui/components/applications/VersionAlert.js
+++ b/monitoring_hub/apps/metrics_reporter_ui/web/static/js/buffy-ui/components/applications/VersionAlert.js
@@ -4,7 +4,9 @@ import { Alert, Button } from "react-bootstrap"
 export default class VersionAlert extends React.Component {
 	constructor(props) {
 		super(props);
+		const version = process.env.WALLAROO_VERSION || "dev"
 		this.state = {
+			version: version,
 			alertVisible: true,
 		};
 	}
@@ -13,10 +15,11 @@ export default class VersionAlert extends React.Component {
 	}
 
 	render() {
+		const {version} = this.state;
 		if (this.state.alertVisible) {
 		     return (
 		        <Alert bsStyle="info">
-		          <p>You're on version <strong>{{ book.wallaroo_version }}</strong>, click <a href="https://www.wallaroolabs.com/ui/latest?version={{ book.wallaroo_version }}" target="_blank">here</a> to verify you're up to date!</p>
+		          <p>You're on version <strong>{version}</strong>, click <a href={"https://www.wallaroolabs.com/ui/latest?version=" + version } target="_blank" >here</a> to verify you're up to date!</p>
 		        </Alert>
 		     );
 		}

--- a/rules.mk
+++ b/rules.mk
@@ -80,6 +80,8 @@ ifndef ponyc_arch_args
   ponyc_arch_args :=
 endif
 
+wallaroo_version = $(shell cat $(ROOT_PATH)/VERSION)
+
 # function to lazily initialize a variable on first use and to only evaluate the expression once
 # see: http://www.oreilly.com/openbook/make3/book/ch10.pdf
 # $(call lazy-init,variable-name,value)
@@ -296,7 +298,7 @@ define MONHUBR
     $(if $(filter $(monhub_docker_args),docker),$(quote))
   $(QUIET)cd $(1) && $(monhub_docker_args) npm install \
     $(if $(filter $(monhub_docker_args),docker),$(quote))
-  $(QUIET)cd $(1) && $(monhub_docker_args) npm run build:production \
+  $(QUIET)cd $(1) && $(monhub_docker_args) WALLAROO_VERSION=$(wallaroo_version) npm run build:production \
     $(if $(filter $(monhub_docker_args),docker),$(quote))
   $(QUIET)cd $(1) && $(monhub_docker_args) MIX_ENV=prod mix phx.digest \
     $(if $(filter $(monhub_docker_args),docker),$(quote))

--- a/travis/docker_release.sh
+++ b/travis/docker_release.sh
@@ -28,9 +28,6 @@ then
 	echo "Docker image: $wallaroo_docker_image_path already exists."
 	exit 0
 else
-	# insert version into UI
-	version=$(< VERSION)
-	sed -i -- "s/{{ book.wallaroo_version }}/$version/g" monitoring_hub/apps/metrics_reporter_ui/web/static/js/buffy-ui/components/applications/VersionAlert.js
 	# build the image
 	docker login -u wallaroolabs -p $DOCKER_PASSWORD $wallaroo_docker_repo_host
 	make release-monitoring_hub-apps-metrics_reporter_ui


### PR DESCRIPTION
Currently, we depend on `sed` to insert the Wallaroo version to the Metrics UI prior to building the Javascript. The version is also being set in a script prior to running the `sed` command. 

This PR removes our dependency of `sed` and replaces it with Babel's inline environmental variable transform plugin in order for the version to be set by an environmental variable. The rules.mk file is updated to automatically set the Wallaroo version to the contents of the `VERSION` file and assigns the `WALLAROO_VERSION` variable to those contents prior to running the Javascript build command. The build commands remain as they are and the end user no longer needs to set the version prior to building the Metrics UI.
