### PR TITLE
Correctly update routers after shrink

### DIFF
--- a/lib/wallaroo/core/source/kafka_source/kafka_source.pony
+++ b/lib/wallaroo/core/source/kafka_source/kafka_source.pony
@@ -129,6 +129,12 @@ actor KafkaSource[In: Any val] is (Producer & KafkaConsumer)
       else
         router
       end
+
+    for target in new_router.routes().values() do
+      if not _routes.contains(target) then
+        _routes(target) = _route_builder(this, target, _metrics_reporter)
+      end
+    end
     _notify.update_router(new_router)
 
   be add_boundary_builders(

--- a/lib/wallaroo/core/source/kafka_source/kafka_source_listener.pony
+++ b/lib/wallaroo/core/source/kafka_source/kafka_source_listener.pony
@@ -123,7 +123,7 @@ class MapPartitionConsumerMessageHandler is KafkaConsumerMessageHandler
 actor KafkaSourceListener[In: Any val] is (SourceListener & KafkaClientManager)
   let _env: Env
   let _notify: KafkaSourceListenerNotify[In]
-  let _router: Router
+  var _router: Router
   let _router_registry: RouterRegistry
   let _route_builder: RouteBuilder
   let _default_in_route_builder: (RouteBuilder | None)
@@ -273,6 +273,7 @@ actor KafkaSourceListener[In: Any val] is (SourceListener & KafkaClientManager)
     end
 
   be update_router(router: Router) =>
+    _router = router
     _notify.update_router(router)
 
   be remove_route_for(moving_step: Consumer) =>

--- a/lib/wallaroo/core/source/tcp_source/tcp_source.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source.pony
@@ -182,6 +182,13 @@ actor TCPSource is Producer
       else
         router
       end
+
+    for target in new_router.routes().values() do
+      if not _routes.contains(target) then
+        _routes(target) = _route_builder(this, target, _metrics_reporter)
+      end
+    end
+
     _notify.update_router(new_router)
 
   be add_boundary_builders(

--- a/lib/wallaroo/core/source/tcp_source/tcp_source_listener.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source_listener.pony
@@ -47,7 +47,7 @@ actor TCPSourceListener is SourceListener
   """
 
   let _env: Env
-  let _router: Router
+  var _router: Router
   let _router_registry: RouterRegistry
   let _route_builder: RouteBuilder
   let _default_in_route_builder: (RouteBuilder | None)
@@ -118,6 +118,7 @@ actor TCPSourceListener is SourceListener
 
   be update_router(router: Router) =>
     _source_builder = _source_builder.update_router(router)
+    _router = router
 
   be remove_route_for(moving_step: Consumer) =>
     None

--- a/lib/wallaroo/core/topology/router.pony
+++ b/lib/wallaroo/core/topology/router.pony
@@ -830,7 +830,7 @@ class val LocalPartitionRouter[In: Any val,
                 latest_ts, metrics_id, worker_ingress_ts)
               (false, keep_sending, latest_ts)
             else
-              // TODO: What do we do if we get None?
+              Fail()
               (true, true, latest_ts)
             end
           | let p: ProxyRouter =>
@@ -868,9 +868,11 @@ class val LocalPartitionRouter[In: Any val,
           @printf[I32](("LocalPartitionRouter.route: InputWrapper doesn't " +
             "contain data of type In\n").cstring())
         end
+        Fail()
         (true, true, latest_ts)
       end
     else
+      Fail()
       (true, true, latest_ts)
     end
 
@@ -1072,8 +1074,8 @@ class val LocalPartitionRouter[In: Any val,
       router_registry.move_stateful_step_to_proxy[Key](step_id,
         ProxyAddress(target_worker, step_id), key, state_name')
       @printf[I32](
-        "^^Migrating step %lx to outgoing boundary %s/%lx\n".cstring(),
-        step, target_worker.cstring(), boundary)
+        "^^Migrating step %s to outgoing boundary %s/%lx\n".cstring(),
+        step_id.string().cstring(), target_worker.cstring(), boundary)
     end
 
   fun blueprint(): PartitionRouterBlueprint =>

--- a/lib/wallaroo/core/topology/steps.pony
+++ b/lib/wallaroo/core/topology/steps.pony
@@ -210,18 +210,16 @@ actor Step is (Producer & Consumer)
     end
 
   be update_omni_router(omni_router: OmniRouter) =>
-    try
-      let old_router = _omni_router
-      _omni_router = omni_router
-      for outdated_consumer in old_router.routes_not_in(_omni_router).values()
-      do
+    let old_router = _omni_router
+    _omni_router = omni_router
+    for outdated_consumer in old_router.routes_not_in(_omni_router).values()
+    do
+      try
         let outdated_route = _routes(outdated_consumer)?
         _acker_x.remove_route(outdated_route)
       end
-      _add_boundaries(omni_router.boundaries())
-    else
-      Fail()
     end
+    _add_boundaries(omni_router.boundaries())
 
   be add_boundaries(boundaries: Map[String, OutgoingBoundary] val) =>
     _add_boundaries(boundaries)

--- a/lib/wallaroo/ent/router_registry/router_registry.pony
+++ b/lib/wallaroo/ent/router_registry/router_registry.pony
@@ -1019,7 +1019,7 @@ actor RouterRegistry
         _data_router = _data_router.add_route(id, step)
         _distribute_data_router()
         _register_omni_router_step(step)
-         _distribute_omni_router()
+        _distribute_omni_router()
         let partition_router =
           _partition_routers(state_name)?.update_route[K](key, step)?
         _distribute_partition_router(partition_router)
@@ -1049,7 +1049,7 @@ actor RouterRegistry
     else
       Fail()
     end
-    // _move_proxy_to_step(id, target, source_worker)
+    _move_proxy_to_step(id, target, source_worker)
     _connections.notify_cluster_of_new_stateful_step[K](id, key, state_name,
       recover [source_worker] end)
 
@@ -1059,10 +1059,6 @@ actor RouterRegistry
     """
     Called when a step has been migrated to this worker from another worker
     """
-    let new_data_router = _data_router.add_route(id, target)
-    _data_router = new_data_router
-    _distribute_data_router()
-
     match _omni_router
     | let o: OmniRouter =>
       _omni_router = o.update_route_to_step(id, target)


### PR DESCRIPTION
After shrink to fit, not all routers were being
correctly updated to point to the new state steps.
This was not caught immediately because we weren't
failing when there was no route found at a partition
router, which is also fixed in this commit.

Closes #2000