### PR TITLE
Ensure that new sources don't try to connect to old workers

### DIFF
--- a/lib/wallaroo/core/boundary/boundary.pony
+++ b/lib/wallaroo/core/boundary/boundary.pony
@@ -979,6 +979,8 @@ class BoundaryNotify is WallarooOutgoingNetworkActorNotify
           @printf[I32]("Received AckDataConnectMsg at Boundary\n".cstring())
         end
         conn.receive_connect_ack(ac.last_id_seen)
+      | let dd: DataDisconnectMsg =>
+        _outgoing_boundary.dispose()
       | let sn: StartNormalDataSendingMsg =>
         ifdef "trace" then
           @printf[I32]("Received StartNormalDataSendingMsg at Boundary\n"

--- a/lib/wallaroo/core/data_channel/data_channel.pony
+++ b/lib/wallaroo/core/data_channel/data_channel.pony
@@ -182,6 +182,9 @@ actor DataChannel
     end
 
   be writev(data: ByteSeqIter) =>
+    _writev(data)
+
+  fun ref _writev(data: ByteSeqIter) =>
     """
     Write a sequence of sequences of bytes.
     """

--- a/lib/wallaroo/core/messages/channel_messages.pony
+++ b/lib/wallaroo/core/messages/channel_messages.pony
@@ -165,6 +165,9 @@ primitive ChannelMsgEncoder
   =>
     _encode(AckDataConnectMsg(last_id_seen), auth)?
 
+  fun data_disconnect(auth: AmbientAuth): Array[ByteSeq] val ? =>
+    _encode(DataDisconnectMsg, auth)?
+
   fun start_normal_data_sending(last_id_seen: SeqId, auth: AmbientAuth):
     Array[ByteSeq] val ?
   =>
@@ -347,6 +350,8 @@ class val DataConnectMsg is ChannelMsg
   new val create(sender_name': String, sender_boundary_id': U128) =>
     sender_name = sender_name'
     sender_boundary_id = sender_boundary_id'
+
+primitive DataDisconnectMsg is ChannelMsg
 
 class val AckDataConnectMsg is ChannelMsg
   let last_id_seen: SeqId

--- a/lib/wallaroo/core/source/kafka_source/kafka_source_listener.pony
+++ b/lib/wallaroo/core/source/kafka_source/kafka_source_listener.pony
@@ -294,5 +294,10 @@ actor KafkaSourceListener[In: Any val] is (SourceListener & KafkaClientManager)
     end
     _outgoing_boundary_builders = consume new_builders
 
+  be update_boundary_builders(
+    boundary_builders: Map[String, OutgoingBoundaryBuilder] val)
+  =>
+    _outgoing_boundary_builders = boundary_builders
+
   be dispose() =>
     None

--- a/lib/wallaroo/core/source/source.pony
+++ b/lib/wallaroo/core/source/source.pony
@@ -103,3 +103,5 @@ interface tag SourceListener is DisposableActor
   be update_router(router: PartitionRouter)
   be add_boundary_builders(
     boundary_builders: Map[String, OutgoingBoundaryBuilder] val)
+  be update_boundary_builders(
+    boundary_builders: Map[String, OutgoingBoundaryBuilder] val)

--- a/lib/wallaroo/core/source/tcp_source/tcp_source_listener.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source_listener.pony
@@ -137,6 +137,11 @@ actor TCPSourceListener is SourceListener
     end
     _outgoing_boundary_builders = consume new_builders
 
+  be update_boundary_builders(
+    boundary_builders: Map[String, OutgoingBoundaryBuilder] val)
+  =>
+    _outgoing_boundary_builders = boundary_builders
+
   be dispose() =>
     @printf[I32]("Shutting down TCPSourceListener\n".cstring())
     _close()

--- a/lib/wallaroo/ent/data_receiver/data_receiver.pony
+++ b/lib/wallaroo/ent/data_receiver/data_receiver.pony
@@ -238,6 +238,12 @@ actor DataReceiver is Producer
     _timers.dispose()
     match _latest_conn
     | let conn: DataChannel =>
+      try
+        let msg = ChannelMsgEncoder.data_disconnect(_auth)?
+        conn.writev(msg)
+      else
+        Fail()
+      end
       conn.dispose()
     end
 


### PR DESCRIPTION
This was caused by two issues:

1) When a DataReceiver was disposed (when a worker leaves the
cluster, it calls dispose() on all DataReceivers), it wasn't
telling its corresponding Boundary that it's out for good.
So the Boundary kept trying to reconnect.

2) When new sources connected after a shrink, they were given
outdated boundary builders.  This led them to try to connect
to workers that were no longer part of the cluster.

This commit fixes both.

Closes #2001