### PR TITLE
Add tool to allow an operator to shrink a Wallaroo cluster

### DIFF
--- a/book/getting-started/linux-setup.md
+++ b/book/getting-started/linux-setup.md
@@ -169,17 +169,20 @@ cd ~/wallaroo-tutorial/wallaroo/machida
 make
 ```
 
-## Compiling Giles Sender, Receiver, and the Cluster Shutdown tool
+## Compiling Giles Sender, Receiver, Cluster Shutdown, and Cluster Shrinker tools
 
 Giles Sender is used to supply data to Wallaroo applications over TCP, and Giles Receiver is used as a fast TCP Sink that writes the messages it receives to a file, along with a timestmap. The two together are useful when developing and testing applications that use TCP Sources and a TCP Sink.
 
 The Cluster Shutdown tool is used to instruct the cluster to shutdown cleanly, clearing away any resilience and recovery files it may have created.
 
+The Cluster Shrinker tool is used to tell a running cluster to reduce the number of workers in the cluster and to query the cluster for information about how many workers are eligible for removal.
+
 To compile all three, run
 
 ```bash
 cd ~/wallaroo-tutorial/wallaroo/
-make build-giles-all build-utils-cluster_shutdown-all
+make build-giles-all build-utils-cluster_shutdown-all \      
+    build-utils-cluster_shrinker-all
 ```
 
 ## Register

--- a/book/getting-started/linux-setup.md
+++ b/book/getting-started/linux-setup.md
@@ -181,7 +181,7 @@ To compile all three, run
 
 ```bash
 cd ~/wallaroo-tutorial/wallaroo/
-make build-utils-all
+make build-giles-all build-utils-all
 ```
 
 ## Register

--- a/book/getting-started/linux-setup.md
+++ b/book/getting-started/linux-setup.md
@@ -181,8 +181,7 @@ To compile all three, run
 
 ```bash
 cd ~/wallaroo-tutorial/wallaroo/
-make build-giles-all build-utils-cluster_shutdown-all \      
-    build-utils-cluster_shrinker-all
+make build-utils-all
 ```
 
 ## Register

--- a/book/getting-started/macos-setup.md
+++ b/book/getting-started/macos-setup.md
@@ -118,7 +118,7 @@ To compile all three, run
 
 ```bash
 cd ~/wallaroo-tutorial/wallaroo/
-make build-utils-all
+make build-giles-all build-utils-all
 ```
 
 ## Register

--- a/book/getting-started/macos-setup.md
+++ b/book/getting-started/macos-setup.md
@@ -106,17 +106,20 @@ cd ~/wallaroo-tutorial/wallaroo/machida
 make
 ```
 
-## Compiling Giles Sender, Receiver, and the Cluster Shutdown tool
+## Compiling Giles Sender, Receiver, Cluster Shutdown, and Cluster Shrinker tools
 
 Giles Sender is used to supply data to Wallaroo applications over TCP, and Giles Receiver is used as a fast TCP Sink that writes the messages it receives to a file, along with a timestmap. The two together are useful when developing and testing applications that use TCP Sources and a TCP Sink.
 
-The Cluster Shutdown tool is used to instruct the cluster to shutdown cleanly, clearing away any resilience and recovery files it may have created.
+The Cluster Shutdown tool is used to instruct the cluster to shutdown cleanly, clearing away any resilience and recovery files it may have created. 
+
+The Cluster Shrinker tool is used to tell a running cluster to reduce the number of workers in the cluster and to query the cluster for information about how many workers are eligible for removal.
 
 To compile all three, run
 
 ```bash
 cd ~/wallaroo-tutorial/wallaroo/
-make build-giles-all build-utils-cluster_shutdown-all
+make build-giles-all build-utils-cluster_shutdown-all \      
+  build-utils-cluster_shrinker-all
 ```
 
 ## Register

--- a/book/getting-started/macos-setup.md
+++ b/book/getting-started/macos-setup.md
@@ -118,8 +118,7 @@ To compile all three, run
 
 ```bash
 cd ~/wallaroo-tutorial/wallaroo/
-make build-giles-all build-utils-cluster_shutdown-all \      
-  build-utils-cluster_shrinker-all
+make build-utils-all
 ```
 
 ## Register

--- a/book/go/getting-started/linux-setup.md
+++ b/book/go/getting-started/linux-setup.md
@@ -169,7 +169,7 @@ To compile all three, run
 
 ```bash
 cd ~/wallaroo-tutorial/wallaroo/
-make build-utils-all
+make build-giles-all build-utils-all
 ```
 
 ## Register

--- a/book/go/getting-started/linux-setup.md
+++ b/book/go/getting-started/linux-setup.md
@@ -157,18 +157,20 @@ git clone https://github.com/WallarooLabs/wallaroo
 cd wallaroo
 git checkout {{ book.wallaroo_version }}
 ```
-## Compiling Giles Sender, Data Receiver, and the Cluster Shutdown tool
+## Compiling Giles Sender, Data Receiver, Cluster Shutdown, and Cluster Shrinker tools
 
 Giles Sender is used to supply data to Wallaroo applications over TCP, and Data Receiver is used as a fast TCP Sink that can write the messages it receives to STDOUT. The two together are useful when developing and testing applications that use TCP Sources and a TCP Sink.
 
 The Cluster Shutdown tool is used to instruct the cluster to shutdown cleanly, clearing away any resilience and recovery files it may have created.
+
+The Cluster Shrinker tool is used to tell a running cluster to reduce the number of workers in the cluster and to query the cluster for information about how many workers are eligible for removal.
 
 To compile all three, run
 
 ```bash
 cd ~/wallaroo-tutorial/wallaroo/
 make build-giles-all build-utils-cluster_shutdown-all \
-  build-utils-data_receiver-all
+  build-utils-cluster_shrinker-all build-utils-data_receiver-all
 ```
 
 ## Register

--- a/book/go/getting-started/linux-setup.md
+++ b/book/go/getting-started/linux-setup.md
@@ -169,8 +169,7 @@ To compile all three, run
 
 ```bash
 cd ~/wallaroo-tutorial/wallaroo/
-make build-giles-all build-utils-cluster_shutdown-all \
-  build-utils-cluster_shrinker-all build-utils-data_receiver-all
+make build-utils-all
 ```
 
 ## Register

--- a/book/go/getting-started/macos-setup.md
+++ b/book/go/getting-started/macos-setup.md
@@ -107,8 +107,7 @@ To compile all three, run
 
 ```bash
 cd ~/wallaroo-tutorial/wallaroo/
-make build-giles-all build-utils-cluster_shutdown-all \
-  build-utils-cluster_shrinker-all build-utils-data_receiver-all
+make build-utils-all
 ```
 
 ## Register

--- a/book/go/getting-started/macos-setup.md
+++ b/book/go/getting-started/macos-setup.md
@@ -107,7 +107,7 @@ To compile all three, run
 
 ```bash
 cd ~/wallaroo-tutorial/wallaroo/
-make build-utils-all
+make build-giles-all build-utils-all
 ```
 
 ## Register

--- a/book/go/getting-started/macos-setup.md
+++ b/book/go/getting-started/macos-setup.md
@@ -95,18 +95,20 @@ git checkout {{ book.wallaroo_version }}
 
 This will create a subdirectory called `wallaroo`.
 
-## Compiling Giles Sender, Data Receiver, and the Cluster Shutdown tool
+## Compiling Giles Sender, Data Receiver, Cluster Shutdown, and Cluster Shrinker tools
 
 Giles Sender is used to supply data to Wallaroo applications over TCP, and Data Receiver is used as a fast TCP Sink that can write the messages it receives to STDOUT. The two together are useful when developing and testing applications that use TCP Sources and a TCP Sink.
 
 The Cluster Shutdown tool is used to instruct the cluster to shutdown cleanly, clearing away any resilience and recovery files it may have created.
+
+The Cluster Shrinker tool is used to tell a running cluster to reduce the number of workers in the cluster and to query the cluster for information about how many workers are eligible for removal.
 
 To compile all three, run
 
 ```bash
 cd ~/wallaroo-tutorial/wallaroo/
 make build-giles-all build-utils-cluster_shutdown-all \
-  build-utils-data_receiver-all
+  build-utils-cluster_shrinker-all build-utils-data_receiver-all
 ```
 
 ## Register

--- a/book/running-wallaroo/autoscale.md
+++ b/book/running-wallaroo/autoscale.md
@@ -49,16 +49,16 @@ alphabet --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
 It is also possible to remove one or more workers from a running cluster. 
 There are two ways to specify that workers should be removed from the cluster.  You can either specify the worker names or the total count of workers to be removed.  You must know the external channel address of one worker in the running cluster. 
 
-You can use the `cluster_shrinker` tool to send a shrink message to this channel. For example, if the external address is `127.0.0.1:5050` and we want to remove 2 workers from the cluster, we can run the following:
+You can use the `cluster_shrinker` tool to send a shrink message to this channel. For example, if the external address is `127.0.0.1:5050` and we want to remove 2 workers from the cluster, we can run the following, using the `count` argument to specify the worker count to remove:
 
 ```
-cluster_shrinker --external 127.0.0.1:5050 --message 2
+cluster_shrinker --external 127.0.0.1:5050 --count 2
 ```
 
-The `--message` argument is used either to pass in a count or to pass in a list of comma-separated worker names.  To request that workers `w2` and `w3` be removed, we can run:
+To request that workers `w2` and `w3` be removed, we can pass a comma-separated list of worker names as the `--workers` argument:
 
 ```
-cluster_shrinker --external 127.0.0.1:5050 --message w2,w3
+cluster_shrinker --external 127.0.0.1:5050 --workers w2,w3
 ```
 
 To qualify for removal from the cluster, a worker must currently meet two criteria:
@@ -70,10 +70,9 @@ If you send in a list of worker names that includes at least one invalid worker 
 
 The leaving workers will migrate state to the remaining workers and then shut down. The remaining workers will then handle all work for the application.
 
-You can query a running cluster to get a list of workers eligible for shutdown. In order to do this, pass `?` as the argument to `--message` as below:
+You can query a running cluster to get a list of workers eligible for shutdown. In order to do this, pass the `--query` flag:
 
 ```
-cluster_shrinker --external 127.0.0.1:5050 --message \?
+cluster_shrinker --external 127.0.0.1:5050 --query
 ```
 
-In this example, we escape `?` in order to avoid bash globbing. 

--- a/book/running-wallaroo/autoscale.md
+++ b/book/running-wallaroo/autoscale.md
@@ -47,16 +47,18 @@ alphabet --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
 ## Shrink to Fit
 
 It is also possible to remove one or more workers from a running cluster. 
-There are two ways to specify that workers should be removed from the cluster.  You can either specify the worker names or the total count of workers to be removed.  You must know the external channel address of one worker in the running cluster.  You can use the `external_sender` tool to send a shrink message to this channel. For example, if the external address is `127.0.0.1:5050` and we want to remove 2 workers from the cluster, we can run the following:
+There are two ways to specify that workers should be removed from the cluster.  You can either specify the worker names or the total count of workers to be removed.  You must know the external channel address of one worker in the running cluster. 
+
+You can use the `cluster_shrinker` tool to send a shrink message to this channel. For example, if the external address is `127.0.0.1:5050` and we want to remove 2 workers from the cluster, we can run the following:
 
 ```
-external_sender --type shrink --external 127.0.0.1:5050 --message 2
+cluster_shrinker --external 127.0.0.1:5050 --message 2
 ```
 
 The `--message` argument is used either to pass in a count or to pass in a list of comma-separated worker names.  To request that workers `w2` and `w3` be removed, we can run:
 
 ```
-external_sender --type shrink --external 127.0.0.1:5050 --message w2,w3
+cluster_shrinker --external 127.0.0.1:5050 --message w2,w3
 ```
 
 To qualify for removal from the cluster, a worker must currently meet two criteria:
@@ -71,8 +73,7 @@ The leaving workers will migrate state to the remaining workers and then shut do
 You can query a running cluster to get a list of workers eligible for shutdown. In order to do this, pass `?` as the argument to `--message` as below:
 
 ```
-external_sender --type shrink --external 127.0.0.1:5050 --message \? \
-  --stay-alive
+cluster_shrinker --external 127.0.0.1:5050 --message \?
 ```
 
-In this example, we escape `?` in order to avoid bash globbing. We also pass the `--stay-alive` flag, since otherwise `external_sender` will exit before it has a chance to receive a reply to the query.
+In this example, we escape `?` in order to avoid bash globbing. 

--- a/demos/python_word_count/shrink-worker2
+++ b/demos/python_word_count/shrink-worker2
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-../../testing/tools/external_sender/external_sender --type shrink --external 127.0.0.1:6010 --message worker2
+../../utils/cluster_shrinker --external 127.0.0.1:6010 --workers worker2

--- a/demos/python_word_count/shrink-worker3
+++ b/demos/python_word_count/shrink-worker3
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-../../testing/tools/external_sender/external_sender --type shrink --external 127.0.0.1:6010 --message worker3
+../../utils/cluster_shrinker --external 127.0.0.1:6010 --workers worker3

--- a/lib/wallaroo/core/initialization/local_topology.pony
+++ b/lib/wallaroo/core/initialization/local_topology.pony
@@ -315,13 +315,21 @@ actor LocalTopologyInitializer is LayoutInitializer
     @printf[I32]("***New worker %s added to cluster!***\n".cstring(),
       w.cstring())
 
-  be initiate_shrink(target_workers: Array[String] val, shrink_count: U64) =>
+  be initiate_shrink(target_workers: Array[String] val, shrink_count: U64,
+    conn: TCPConnection)
+  =>
     if target_workers.size() > 0 then
       if _are_valid_shrink_candidates(target_workers) then
         let remaining_workers = _remove_worker_names(target_workers)
         _router_registry.initiate_shrink(remaining_workers, target_workers)
+        let reply = ExternalMsgEncoder.shrink_error_response(
+          "Shrinking by " + target_workers.size().string() + " workers!")
+        conn.writev(reply)
       else
         @printf[I32]("**Invalid shrink targets!**\n".cstring())
+        let error_reply = ExternalMsgEncoder.shrink_error_response(
+          "Invalid shrink targets!")
+        conn.writev(error_reply)
       end
     elseif shrink_count > 0 then
       let candidates = _get_shrink_candidates(shrink_count.usize())
@@ -335,11 +343,20 @@ actor LocalTopologyInitializer is LayoutInitializer
       if candidates.size() > 0 then
         let remaining_workers = _remove_worker_names(candidates)
         _router_registry.initiate_shrink(remaining_workers, candidates)
+        let reply = ExternalMsgEncoder.shrink_error_response(
+          "Shrinking by " + candidates.size().string() + " workers!")
+        conn.writev(reply)
       else
         @printf[I32]("**Cannot shrink 0 workers!**\n".cstring())
+        let error_reply = ExternalMsgEncoder.shrink_error_response(
+          "Cannot shrink 0 workers!")
+        conn.writev(error_reply)
       end
     else
       @printf[I32]("**Cannot shrink 0 workers!**\n".cstring())
+      let error_reply = ExternalMsgEncoder.shrink_error_response(
+        "Cannot shrink 0 workers!")
+      conn.writev(error_reply)
     end
 
   fun _are_valid_shrink_candidates(candidates: Array[String] val): Bool =>
@@ -1643,7 +1660,7 @@ actor LocalTopologyInitializer is LayoutInitializer
           available.push(w)
         end
       end
-      let query_reply = ExternalMsgEncoder.shrink(false, available,
+      let query_reply = ExternalMsgEncoder.shrink_query_response(available,
         available.size().u64())
       conn.writev(query_reply)
     else

--- a/lib/wallaroo/core/initialization/local_topology.pony
+++ b/lib/wallaroo/core/initialization/local_topology.pony
@@ -315,7 +315,7 @@ actor LocalTopologyInitializer is LayoutInitializer
     @printf[I32]("***New worker %s added to cluster!***\n".cstring(),
       w.cstring())
 
-  be initiate_shrink(target_workers: Array[String] val, shrink_count: USize) =>
+  be initiate_shrink(target_workers: Array[String] val, shrink_count: U64) =>
     if target_workers.size() > 0 then
       if _are_valid_shrink_candidates(target_workers) then
         let remaining_workers = _remove_worker_names(target_workers)
@@ -324,8 +324,8 @@ actor LocalTopologyInitializer is LayoutInitializer
         @printf[I32]("**Invalid shrink targets!**\n".cstring())
       end
     elseif shrink_count > 0 then
-      let candidates = _get_shrink_candidates(shrink_count)
-      if candidates.size() < shrink_count then
+      let candidates = _get_shrink_candidates(shrink_count.usize())
+      if candidates.size() < shrink_count.usize() then
         @printf[I32]("**Only %s candidates are eligible for removal\n"
           .cstring(), candidates.size().string().cstring())
       else
@@ -1644,7 +1644,7 @@ actor LocalTopologyInitializer is LayoutInitializer
         end
       end
       let query_reply = ExternalMsgEncoder.shrink(false, available,
-        available.size())
+        available.size().u64())
       conn.writev(query_reply)
     else
       Fail()

--- a/lib/wallaroo/ent/network/external_channel_tcp.pony
+++ b/lib/wallaroo/ent/network/external_channel_tcp.pony
@@ -135,12 +135,12 @@ class ExternalChannelConnectNotifier is TCPConnectionNotify
           else
             Fail()
           end
-        | let m: ExternalShrinkMsg =>
+        | let m: ExternalShrinkRequestMsg =>
           if m.query is true then
             _local_topology_initializer.shrinkable_query(conn)
           else
             _local_topology_initializer.initiate_shrink(m.node_names,
-              m.num_nodes)
+              m.num_nodes, conn)
           end
         else
           @printf[I32](("Incoming External Message type not handled by " +

--- a/lib/wallaroo_labs/messages/_test.pony
+++ b/lib/wallaroo_labs/messages/_test.pony
@@ -204,13 +204,14 @@ class iso _TestGeneralExtEncDecShrink is UnitTest
     // Use Range so that num_nodes array size 0 is tested.
     for i in Range[U64](0, node_names.size().u64()) do
       let e1: Array[ByteSeq] val =
-        ExternalMsgEncoder.shrink(false, node_names.slice(0, i.usize()), 0)
+        ExternalMsgEncoder.shrink_request(false, node_names.slice(0,
+          i.usize()), 0)
       // encode & decode are not symmetric -- we need to chop off
       // the first 4 bytes before we can decode.
       let e1': Array[U8] val = recover Help.flatten(e1).slice(4) end
 
       match ExternalMsgDecoder(e1')?
-      | let extracted: ExternalShrinkMsg =>
+      | let extracted: ExternalShrinkRequestMsg =>
         h.assert_eq[Bool](false, extracted.query)
         h.assert_eq[USize](i.usize(), extracted.node_names.size())
         for j in extracted.node_names.keys() do
@@ -224,11 +225,12 @@ class iso _TestGeneralExtEncDecShrink is UnitTest
 
     // Use Range so that num_nodes = 0 is included
     for i in Range[U64](0, 4) do
-      let e1: Array[ByteSeq] val = ExternalMsgEncoder.shrink(false, [], i)
+      let e1: Array[ByteSeq] val = ExternalMsgEncoder.shrink_request(false, [],
+        i)
       let e1': Array[U8] val = recover Help.flatten(e1).slice(4) end
 
       match ExternalMsgDecoder(e1')?
-      | let extracted: ExternalShrinkMsg =>
+      | let extracted: ExternalShrinkRequestMsg =>
         h.assert_eq[Bool](false, extracted.query)
         h.assert_eq[USize](0, extracted.node_names.size())
         h.assert_eq[U64](i, extracted.num_nodes)
@@ -238,11 +240,11 @@ class iso _TestGeneralExtEncDecShrink is UnitTest
     end
 
     // Let's now try a round trip for a query
-    let e2: Array[ByteSeq] val = ExternalMsgEncoder.shrink(true, [], 0)
+    let e2: Array[ByteSeq] val = ExternalMsgEncoder.shrink_request(true, [], 0)
     let e2': Array[U8] val = recover Help.flatten(e2).slice(4) end
 
     match ExternalMsgDecoder(e2')?
-    | let extracted: ExternalShrinkMsg =>
+    | let extracted: ExternalShrinkRequestMsg =>
       h.assert_eq[Bool](true, extracted.query)
       h.assert_eq[USize](0, extracted.node_names.size())
       h.assert_eq[U64](0, extracted.num_nodes)

--- a/lib/wallaroo_labs/messages/_test.pony
+++ b/lib/wallaroo_labs/messages/_test.pony
@@ -202,9 +202,9 @@ class iso _TestGeneralExtEncDecShrink is UnitTest
     let node_names: Array[String] = [""; "a"; "lovely b"; ""; "node c"]
 
     // Use Range so that num_nodes array size 0 is tested.
-    for i in Range[USize](0, node_names.size()) do
+    for i in Range[U64](0, node_names.size().u64()) do
       let e1: Array[ByteSeq] val =
-        ExternalMsgEncoder.shrink(false, node_names.slice(0, i), 0)
+        ExternalMsgEncoder.shrink(false, node_names.slice(0, i.usize()), 0)
       // encode & decode are not symmetric -- we need to chop off
       // the first 4 bytes before we can decode.
       let e1': Array[U8] val = recover Help.flatten(e1).slice(4) end
@@ -212,18 +212,18 @@ class iso _TestGeneralExtEncDecShrink is UnitTest
       match ExternalMsgDecoder(e1')?
       | let extracted: ExternalShrinkMsg =>
         h.assert_eq[Bool](false, extracted.query)
-        h.assert_eq[USize](i, extracted.node_names.size())
+        h.assert_eq[USize](i.usize(), extracted.node_names.size())
         for j in extracted.node_names.keys() do
           h.assert_eq[String](node_names(j)?, extracted.node_names(j)?)
         end
-        h.assert_eq[USize](0, extracted.num_nodes)
+        h.assert_eq[U64](0, extracted.num_nodes)
       else
         h.assert_eq[String]("error", "case 1")
       end
     end
 
     // Use Range so that num_nodes = 0 is included
-    for i in Range[USize](0, 4) do
+    for i in Range[U64](0, 4) do
       let e1: Array[ByteSeq] val = ExternalMsgEncoder.shrink(false, [], i)
       let e1': Array[U8] val = recover Help.flatten(e1).slice(4) end
 
@@ -231,7 +231,7 @@ class iso _TestGeneralExtEncDecShrink is UnitTest
       | let extracted: ExternalShrinkMsg =>
         h.assert_eq[Bool](false, extracted.query)
         h.assert_eq[USize](0, extracted.node_names.size())
-        h.assert_eq[USize](i, extracted.num_nodes)
+        h.assert_eq[U64](i, extracted.num_nodes)
       else
         h.assert_eq[String]("error", "case 2")
       end
@@ -245,7 +245,7 @@ class iso _TestGeneralExtEncDecShrink is UnitTest
     | let extracted: ExternalShrinkMsg =>
       h.assert_eq[Bool](true, extracted.query)
       h.assert_eq[USize](0, extracted.node_names.size())
-      h.assert_eq[USize](0, extracted.num_nodes)
+      h.assert_eq[U64](0, extracted.num_nodes)
     else
       h.assert_eq[String]("error", "case query")
     end

--- a/lib/wallaroo_labs/messages/external_messages.pony
+++ b/lib/wallaroo_labs/messages/external_messages.pony
@@ -48,7 +48,7 @@ primitive ExternalMsgEncoder
     wb.done()
 
   fun _encode_shrink(id: U16, query: Bool, node_names: Array[String],
-    num_nodes: USize, wb: Writer): Array[ByteSeq] val
+    num_nodes: U64, wb: Writer): Array[ByteSeq] val
   =>
     var num_bytes: U32 = 0
 
@@ -131,7 +131,7 @@ primitive ExternalMsgEncoder
     _encode(_CleanShutdown(), msg, wb)
 
   fun shrink(query: Bool, node_names: Array[String] = Array[String],
-    num_nodes: USize = 0, wb: Writer = Writer): Array[ByteSeq] val
+    num_nodes: U64 = 0, wb: Writer = Writer): Array[ByteSeq] val
   =>
     if (query is true) then
       _encode_shrink(_Shrink(), true, Array[String], 0, wb)
@@ -219,14 +219,14 @@ primitive ExternalMsgDecoder
     | (_CleanShutdown(), let s: String) =>
       ExternalCleanShutdownMsg(s)
     | (_Shrink(), let query: Bool,
-      let node_names: Array[String] val, let num_nodes: USize) =>
+      let node_names: Array[String] val, let num_nodes: U64) =>
       ExternalShrinkMsg(query, node_names, num_nodes)
     else
       error
     end
 
   fun _decode(data: Array[U8] val):
-    ((U16, String) | (U16, Bool, Array[String] val, USize)) ?
+    ((U16, String) | (U16, Bool, Array[String] val, U64)) ?
   =>
     let rb = Reader
     rb.append(data)
@@ -250,7 +250,7 @@ primitive ExternalMsgDecoder
         let n = String.from_array(rb.block(size)?)
         node_names.push(n)
       end
-      let num_nodes = USize.from[U32](rb.u32_be()?)
+      let num_nodes = U64.from[U32](rb.u32_be()?)
 
       (id, query, consume node_names, num_nodes)
     else
@@ -324,11 +324,11 @@ class val ExternalCleanShutdownMsg is ExternalMsg
 class val ExternalShrinkMsg is ExternalMsg
   let query: Bool
   let node_names: Array[String] val
-  let num_nodes: USize
+  let num_nodes: U64
   var _header: Bool = true
 
   new val create(query': Bool,
-    node_names': Array[String] val, num_nodes': USize) =>
+    node_names': Array[String] val, num_nodes': U64) =>
     query = query'
     node_names = node_names'
     num_nodes = num_nodes'

--- a/lib/wallaroo_labs/messages/external_messages.pony
+++ b/lib/wallaroo_labs/messages/external_messages.pony
@@ -33,21 +33,26 @@ primitive _GilesSendersStarted                  fun apply(): U16 => 10
 primitive _Print                                fun apply(): U16 => 11
 primitive _RotateLog                            fun apply(): U16 => 12
 primitive _CleanShutdown                        fun apply(): U16 => 13
-primitive _Shrink                               fun apply(): U16 => 14
+primitive _ShrinkRequest                        fun apply(): U16 => 14
+primitive _ShrinkQueryResponse                  fun apply(): U16 => 15
+primitive _ShrinkErrorResponse                  fun apply(): U16 => 16
 
+primitive _StringMessageDecodeTag               fun apply(): U8 => 1
+primitive _ShrinkRequestMessageDecodeTag        fun apply(): U8 => 2
+primitive _ShrinkQueryResponseMessageDecodeTag  fun apply(): U8 => 3
 
 primitive ExternalMsgEncoder
   fun _encode(id: U16, s: String, wb: Writer): Array[ByteSeq] val =>
     let s_array = s.array()
     let size = s_array.size()
     wb.u32_be(1 + 2 + 4 + size.u32())
-    wb.u8(1) // _encode serialization type tag
+    wb.u8(_StringMessageDecodeTag())
     wb.u16_be(id)
     wb.u32_be(size.u32())
     wb.write(s_array)
     wb.done()
 
-  fun _encode_shrink(id: U16, query: Bool, node_names: Array[String],
+  fun _encode_shrink_request(id: U16, query: Bool, node_names: Array[String],
     num_nodes: U64, wb: Writer): Array[ByteSeq] val
   =>
     var num_bytes: U32 = 0
@@ -57,9 +62,32 @@ primitive ExternalMsgEncoder
     end
 
     wb.u32_be(1 + 2 + 1 + 4 + num_bytes + 4)
-    wb.u8(2) // _encode serialization type tag
+    wb.u8(_ShrinkRequestMessageDecodeTag())
     wb.u16_be(id)
     wb.u8(if query is true then 1 else 0 end)
+    wb.u32_be(node_names.size().u32())
+    for n in node_names.values() do
+      let n_array = n.array()
+      let size = n_array.size()
+      wb.u32_be(size.u32())
+      wb.write(n_array)
+    end
+    wb.u32_be(num_nodes.u32())
+    wb.done()
+
+
+  fun _encode_shrink_query_response(id: U16, node_names: Array[String],
+    num_nodes: U64, wb: Writer): Array[ByteSeq] val
+  =>
+    var num_bytes: U32 = 0
+
+    for n in node_names.values() do
+      num_bytes = num_bytes + 4 + U32.from[USize](n.size())
+    end
+
+    wb.u32_be(1 + 2 + 4 + num_bytes + 4)
+    wb.u8(_ShrinkQueryResponseMessageDecodeTag())
+    wb.u16_be(id)
     wb.u32_be(node_names.size().u32())
     for n in node_names.values() do
       let n_array = n.array()
@@ -130,14 +158,26 @@ primitive ExternalMsgEncoder
   =>
     _encode(_CleanShutdown(), msg, wb)
 
-  fun shrink(query: Bool, node_names: Array[String] = Array[String],
+  fun shrink_request(query: Bool, node_names: Array[String] = Array[String],
     num_nodes: U64 = 0, wb: Writer = Writer): Array[ByteSeq] val
   =>
     if (query is true) then
-      _encode_shrink(_Shrink(), true, Array[String], 0, wb)
+      _encode_shrink_request(_ShrinkRequest(), true, Array[String], 0, wb)
     else
-      _encode_shrink(_Shrink(), false, node_names, num_nodes, wb)
+      _encode_shrink_request(_ShrinkRequest(), false, node_names, num_nodes,
+        wb)
     end
+
+  fun shrink_query_response(node_names: Array[String] = Array[String],
+    num_nodes: U64 = 0, wb: Writer = Writer): Array[ByteSeq] val
+  =>
+    _encode_shrink_query_response(_ShrinkQueryResponse(), node_names,
+      num_nodes, wb)
+
+  fun shrink_error_response(message: String, wb: Writer = Writer):
+    Array[ByteSeq] val
+  =>
+    _encode(_ShrinkErrorResponse(), message, wb)
 
 class BufferedExternalMsgEncoder
   let _buffer: Writer
@@ -218,33 +258,38 @@ primitive ExternalMsgDecoder
       ExternalRotateLogFilesMsg(s)
     | (_CleanShutdown(), let s: String) =>
       ExternalCleanShutdownMsg(s)
-    | (_Shrink(), let query: Bool,
+    | (_ShrinkRequest(), let query: Bool,
       let node_names: Array[String] val, let num_nodes: U64) =>
-      ExternalShrinkMsg(query, node_names, num_nodes)
+      ExternalShrinkRequestMsg(query, node_names, num_nodes)
+    | (_ShrinkQueryResponse(), let node_names: Array[String] val,
+      let num_nodes: U64) =>
+      ExternalShrinkQueryResponseMsg(node_names, num_nodes)
+    | (_ShrinkErrorResponse(), let s: String) =>
+      ExternalShrinkErrorResponseMsg(s)
     else
       error
     end
 
   fun _decode(data: Array[U8] val):
-    ((U16, String) | (U16, Bool, Array[String] val, U64)) ?
+    ((U16, String) | (U16, Bool, Array[String] val, U64) |
+      (U16, Array[String] val, U64)) ?
   =>
     let rb = Reader
     rb.append(data)
     let type_tag = rb.u8()? // serialization type tag
 
     match type_tag
-    | 1 =>
+    | _StringMessageDecodeTag() =>
       let id = rb.u16_be()?
       let s_len: USize = USize.from[U32](rb.u32_be()?)
       let s = String.from_array(rb.block(s_len)?)
       (id, s)
-    | 2 =>
+    | _ShrinkRequestMessageDecodeTag() =>
       let id = rb.u16_be()?
       let query: Bool = if (rb.u8()? == 1) then true else false end
       let node_names = recover trn Array[String] end
       let node_names_size = USize.from[U32](rb.u32_be()?)
 
-      // node_names.reserve(node_names_size)
       for i in Range[USize](0, node_names_size) do
         let size = USize.from[U32](rb.u32_be()?)
         let n = String.from_array(rb.block(size)?)
@@ -253,6 +298,19 @@ primitive ExternalMsgDecoder
       let num_nodes = U64.from[U32](rb.u32_be()?)
 
       (id, query, consume node_names, num_nodes)
+    | _ShrinkQueryResponseMessageDecodeTag() =>
+      let id = rb.u16_be()?
+      let node_names = recover trn Array[String] end
+      let node_names_size = USize.from[U32](rb.u32_be()?)
+
+      for i in Range[USize](0, node_names_size) do
+        let size = USize.from[U32](rb.u32_be()?)
+        let n = String.from_array(rb.block(size)?)
+        node_names.push(n)
+      end
+      let num_nodes = U64.from[U32](rb.u32_be()?)
+
+      (id, consume node_names, num_nodes)
     else
       error
     end
@@ -321,11 +379,10 @@ class val ExternalCleanShutdownMsg is ExternalMsg
   new val create(m: String) =>
     msg = m
 
-class val ExternalShrinkMsg is ExternalMsg
+class val ExternalShrinkRequestMsg is ExternalMsg
   let query: Bool
   let node_names: Array[String] val
   let num_nodes: U64
-  var _header: Bool = true
 
   new val create(query': Bool,
     node_names': Array[String] val, num_nodes': U64) =>
@@ -346,3 +403,28 @@ class val ExternalShrinkMsg is ExternalMsg
     "Query: " + query.string() + ", Node count: " + num_nodes.string() +
       ", Nodes: " + nodes_string
 
+class val ExternalShrinkQueryResponseMsg is ExternalMsg
+  let node_names: Array[String] val
+  let num_nodes: U64
+
+  new val create(node_names': Array[String] val, num_nodes': U64) =>
+    node_names = node_names'
+    num_nodes = num_nodes'
+
+  fun string(): String =>
+    let nodes = Array[String]
+    for n in node_names.values() do
+      nodes.push(n)
+    end
+    var nodes_string = "|"
+    for n in nodes.values() do
+      nodes_string = nodes_string + n + ","
+    end
+    nodes_string = nodes_string + "|"
+    "Node count: " + num_nodes.string() + ", Nodes: " + nodes_string
+
+class val ExternalShrinkErrorResponseMsg is ExternalMsg
+  let msg: String
+
+  new val create(m: String) =>
+    msg = m

--- a/testing/tools/external_sender/external_sender.pony
+++ b/testing/tools/external_sender/external_sender.pony
@@ -29,14 +29,12 @@ actor Main
       var x_service: String = "0"
       var message: String = ""
       var message_type: String = "Print"
-      var stay_alive: Bool = false
       let options = Options(env.args)
 
       options
         .add("external", "e", StringArgument)
         .add("type", "t", StringArgument)
         .add("message", "m", StringArgument)
-        .add("stay-alive", "s", None)
         .add("help", "h", None)
 
         for option in options do
@@ -47,7 +45,6 @@ actor Main
             x_service = x_addr(1)?
           | ("message", let arg: String) => message = arg
           | ("type", let arg: String) => message_type = arg
-          | ("stay-alive", None) => stay_alive = true
           | ("help", None) =>
             @printf[I32](
               """
@@ -55,17 +52,12 @@ actor Main
               -----------------------------------------------------------------------------------
               --external/-e [Specifies address to send message to]
               --type/-t [Specifies message type]
-                  clean-shutdown | rotate-log | shrink | print
+                  clean-shutdown | rotate-log | print
               --message/-m [Specifies message contents to send]
                   rotate-log
                       Node name to rotate log files
                   clean-shutdown | print
                       Text to embed in the message
-                  shrink
-                      Specify names of nodes or number of nodes.
-                      If 1st char is a digit, specify number of of nodes;
-                      else specify comma-separated list of node names.
-              --stay-alive/-s [Keep connection alive]
               -----------------------------------------------------------------------------------
               """.cstring())
             return
@@ -79,82 +71,35 @@ actor Main
           ExternalMsgEncoder.clean_shutdown(message)
         | "rotate-log" =>
           ExternalMsgEncoder.rotate_log(message)
-        | "shrink" =>
-          (let query: Bool,
-            let node_names: Array[String], let num_nodes: USize) =
-            parse_shrink_cmd_line(message)?
-          ExternalMsgEncoder.shrink(query, node_names, num_nodes)
         else // default to print
           ExternalMsgEncoder.print_message(message)
         end
       let tcp_auth = TCPConnectAuth(auth)
       _conn = TCPConnection(tcp_auth, ExternalSenderConnectNotifier(auth,
-        msg, stay_alive), x_host, x_service)
+        msg), x_host, x_service)
     else
       @printf[I32]("Error sending.\n".cstring())
     end
 
-    fun parse_shrink_cmd_line(s: String): (Bool, Array[String], USize) ? =>
-      let first: U8 = s(0)?
-
-      if (first == '?') then
-        return (true, [], 0)
-      elseif (first >= U8('0')) and (first <= U8('9')) then
-        return (false, [], s.usize()?)
-      else
-        return (false, s.split(","), 0)
-      end
-
 class ExternalSenderConnectNotifier is TCPConnectionNotify
   let _auth: AmbientAuth
   let _msg: Array[ByteSeq] val
-  let _stay_alive: Bool
   var _header: Bool = true
 
-  new iso create(auth: AmbientAuth, msg: Array[ByteSeq] val,
-    stay_alive: Bool)
+  new iso create(auth: AmbientAuth, msg: Array[ByteSeq] val)
   =>
     _auth = auth
     _msg = msg
-    _stay_alive = stay_alive
 
   fun ref connected(conn: TCPConnection ref) =>
     @printf[I32]("Connected...\n".cstring())
     conn.writev(_msg)
     @printf[I32]("Sent message!\n".cstring())
-    if _stay_alive then
-      conn.expect(4)
-    else
-      conn.dispose()
-    end
+    conn.dispose()
 
   fun ref received(conn: TCPConnection ref, data: Array[U8] iso,
     n: USize): Bool
   =>
-    if _header then
-      try
-        let expect = Bytes.to_u32(data(0)?, data(1)?, data(2)?, data(3)?)
-          .usize()
-        conn.expect(expect)
-        _header = false
-      else
-        @printf[I32]("Error reading header\n".cstring())
-      end
-    else
-      try
-        match ExternalMsgDecoder(consume data)?
-        | let m: ExternalShrinkMsg =>
-          @printf[I32]("Received ExternalShrinkMsg: %s\n".cstring(),
-            m.string().cstring())
-        else
-          @printf[I32]("Received non-shrink msg\n".cstring())
-        end
-      else
-        @printf[I32]("Received invalid msg\n".cstring())
-      end
-      conn.expect(4)
-      _header = true
-    end
     true
 
   fun ref connect_failed(conn: TCPConnection ref) =>

--- a/utils/cluster_shrinker/.gitignore
+++ b/utils/cluster_shrinker/.gitignore
@@ -1,0 +1,2 @@
+cluster_shrinker
+cluster_shrinker.o

--- a/utils/cluster_shrinker/Makefile
+++ b/utils/cluster_shrinker/Makefile
@@ -1,0 +1,45 @@
+# include root makefile
+ifndef ROOT_MAKEFILE_MK
+include ../../Makefile
+endif
+
+# prevent rules from being evaluated/included multiple times
+ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
+$(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
+
+
+# The following are control variables that determine what logic from `rules.mk` is enabled
+
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
+
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
+
+EXTERNAL_SENDER_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+# standard rules generation makefile
+include $(rules_mk_path)
+
+# end of prevent rules from being evaluated/included multiple times
+endif
+

--- a/utils/cluster_shrinker/Makefile
+++ b/utils/cluster_shrinker/Makefile
@@ -35,7 +35,7 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
 $(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
 
 
-EXTERNAL_SENDER_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+CLUSTER_SHRINKER_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/utils/cluster_shrinker/Makefile
+++ b/utils/cluster_shrinker/Makefile
@@ -34,12 +34,8 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
 # (and by recursion every makefile in the tree that is referenced)
 $(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
 
-
-CLUSTER_SHRINKER_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
-
 # standard rules generation makefile
 include $(rules_mk_path)
 
 # end of prevent rules from being evaluated/included multiple times
 endif
-

--- a/utils/cluster_shrinker/README.md
+++ b/utils/cluster_shrinker/README.md
@@ -1,0 +1,45 @@
+# Cluster Shrinker Tool
+
+`cluster_shrinker` is used to tell a running cluster to reduce the number of workers in the cluster or to query the cluster for information about how many workers are eligible for removal.
+
+## Build
+
+```bash
+make
+```
+
+## Run
+
+You must know the external address for a running worker in the cluster in order to send in a shrink message.
+
+There are three ways to use this tool:
+
+1) Specify the number of workers to remove from the cluster.
+
+Wallaroo will remove as many workers as are eligible for removal up to the number provided as the `--count` argument. For example (assuming a worker in the cluster is listening on `127.0.0.1:5050`),
+
+```bash
+./cluster_shrinker --external 127.0.0.1:5050 --count 2
+```
+
+would remove up to 2 workers from the cluster, depending on how many are eligible.
+
+2) Specify the names of workers to remove from the cluster.
+
+If you pass in the names (comma-separated) of running workers as the `--workers` argument, then Wallaroo will try to remove them. For example:
+
+```bash
+./cluster_shrinker --external 127.0.0.1:5050 --workers worker2,worker3
+```
+
+3) Query the cluster for information about workers eligible for removal.
+
+If you use the `--query` flag, then Wallaroo will inform you both how many workers and which workers are eligible for removal. This reply will be printed to stdout. For example:
+
+```bash
+./cluster_shrinker --external 127.0.0.1:5050 --query
+```
+
+
+
+

--- a/utils/cluster_shrinker/README.md
+++ b/utils/cluster_shrinker/README.md
@@ -10,9 +10,9 @@ make
 
 ## Run
 
-You must know the external address for a running worker in the cluster in order to send in a shrink message.
+You must know the external address for a running worker in the cluster in order to send in a shrink message. Pass in a string of the form `HOST:PORT` via the `--external` command line argument.
 
-There are three ways to use this tool:
+There are three ways to use this tool. You must specify exactly one of `--count`, `--workers`, or `--query`, depending on which of the three you choose. These are described in the following:
 
 1) Specify the number of workers to remove from the cluster.
 
@@ -39,7 +39,3 @@ If you use the `--query` flag, then Wallaroo will inform you both how many worke
 ```bash
 ./cluster_shrinker --external 127.0.0.1:5050 --query
 ```
-
-
-
-

--- a/utils/cluster_shrinker/bundle.json
+++ b/utils/cluster_shrinker/bundle.json
@@ -1,0 +1,7 @@
+{
+  "deps": [
+    { "type": "local",
+      "local-path": "../../lib/"
+    }
+  ]
+}

--- a/utils/cluster_shrinker/cluster_shrinker.pony
+++ b/utils/cluster_shrinker/cluster_shrinker.pony
@@ -1,0 +1,136 @@
+/*
+
+Copyright 2017 The Wallaroo Authors.
+
+Licensed as a Wallaroo Enterprise file under the Wallaroo Community
+License (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+     https://github.com/wallaroolabs/wallaroo/blob/master/LICENSE
+
+*/
+
+"""
+A tool for sending autoscale shrink messages.
+"""
+use "buffered"
+use "net"
+use "files"
+use "wallaroo_labs/bytes"
+use "wallaroo_labs/messages"
+use "wallaroo_labs/options"
+
+actor Main
+  var _conn: (TCPConnection | None) = None
+
+  new create(env: Env) =>
+    try
+      var x_host: String = ""
+      var x_service: String = "0"
+      var message: String = ""
+      let options = Options(env.args)
+
+      options
+        .add("external", "e", StringArgument)
+        .add("message", "m", StringArgument)
+        .add("help", "h", None)
+
+        for option in options do
+          match option
+          | ("external", let arg: String) =>
+            let x_addr = arg.split(":")
+            x_host = x_addr(0)?
+            x_service = x_addr(1)?
+          | ("message", let arg: String) => message = arg
+          | ("help", None) =>
+            @printf[I32](
+              """
+              PARAMETERS:
+              -----------------------------------------------------------------------------------
+              --external/-e [Specifies address to send message to]
+              --message/-m [Specifies message contents to send]
+                  Specify names of nodes or number of nodes.
+                  If 1st char is a digit, specify number of of nodes;
+                  else specify comma-separated list of node names.
+              -----------------------------------------------------------------------------------
+              """.cstring())
+            return
+          end
+        end
+
+      let auth = env.root as AmbientAuth
+      (let query: Bool, let node_names: Array[String], let num_nodes: USize) =
+        parse_shrink_cmd_line(message)?
+      let msg = ExternalMsgEncoder.shrink(query, node_names, num_nodes)
+      let tcp_auth = TCPConnectAuth(auth)
+      _conn = TCPConnection(tcp_auth, ExternalSenderConnectNotifier(auth,
+        msg, query), x_host, x_service)
+    else
+      @printf[I32]("Error sending.\n".cstring())
+    end
+
+    fun parse_shrink_cmd_line(s: String): (Bool, Array[String], USize) ? =>
+      let first: U8 = s(0)?
+
+      if (first == '?') then
+        return (true, [], 0)
+      elseif (first >= U8('0')) and (first <= U8('9')) then
+        return (false, [], s.usize()?)
+      else
+        return (false, s.split(","), 0)
+      end
+
+class ExternalSenderConnectNotifier is TCPConnectionNotify
+  let _auth: AmbientAuth
+  let _msg: Array[ByteSeq] val
+  let _stay_alive: Bool
+  var _header: Bool = true
+
+  new iso create(auth: AmbientAuth, msg: Array[ByteSeq] val,
+    stay_alive: Bool)
+  =>
+    _auth = auth
+    _msg = msg
+    _stay_alive = stay_alive
+
+  fun ref connected(conn: TCPConnection ref) =>
+    @printf[I32]("Connected...\n".cstring())
+    conn.writev(_msg)
+    @printf[I32]("Sent message!\n".cstring())
+    if _stay_alive then
+      conn.expect(4)
+    else
+      conn.dispose()
+    end
+
+  fun ref received(conn: TCPConnection ref, data: Array[U8] iso,
+    n: USize): Bool
+  =>
+    if _header then
+      try
+        let expect = Bytes.to_u32(data(0)?, data(1)?, data(2)?, data(3)?)
+          .usize()
+        conn.expect(expect)
+        _header = false
+      else
+        @printf[I32]("Error reading header\n".cstring())
+      end
+    else
+      try
+        match ExternalMsgDecoder(consume data)?
+        | let m: ExternalShrinkMsg =>
+          @printf[I32]("Received ExternalShrinkMsg: %s\n".cstring(),
+            m.string().cstring())
+        else
+          @printf[I32]("Received non-shrink msg\n".cstring())
+        end
+      else
+        @printf[I32]("Received invalid msg\n".cstring())
+      end
+      conn.expect(4)
+      _header = true
+    end
+    true
+
+  fun ref connect_failed(conn: TCPConnection ref) =>
+    None

--- a/utils/cluster_shutdown/README.md
+++ b/utils/cluster_shutdown/README.md
@@ -1,6 +1,6 @@
-# Cluster Shrinker Tool
+# Cluster Shutdown Tool
 
-`cluster_shrinker` is used to tell a running cluster to reduce the number of workers in the cluster or to query the cluster for information about how many workers are eligible for removal.
+`cluster_shutdown` is used to gracefully shutdown a running Wallaroo cluster.
 
 ## Build
 
@@ -10,36 +10,10 @@ make
 
 ## Run
 
-You must know the external address for a running worker in the cluster in order to send in a shrink message.
-
-There are three ways to use this tool:
-
-1) Specify the number of workers to remove from the cluster.
-
-Wallaroo will remove as many workers as are eligible for removal up to the number provided as the `--message` argument. For example (assuming a worker in the cluster is listening on `127.0.0.1:5050`),
-
 ```bash
-./cluster_shrinker --external 127.0.0.1:5050 --message 2
+./cluster_shutdown ADDRESS:PORT
 ```
 
-would remove up to 2 workers from the cluster, depending on how many are eligible.
-
-2) Specify the names of workers to remove from the cluster.
-
-If you pass in the names (comma-separated) of running workers as the `--message` argument, then Wallaroo will try to remove them. For example:
-
-```bash
-./cluster_shrinker --external 127.0.0.1:5050 --message worker2,worker3
-```
-
-3) Query the cluster for information about workers eligible for removal.
-
-If you pass `?` in as the `--message` argument, then Wallaroo will inform you both how many workers and which workers are eligible for removal. This reply will be printed to stdout. For example:
-
-```bash
-./cluster_shrinker --external 127.0.0.1:5050 --message /?
-```
-
-
+For example, if a cluster member had its external message channel running on port 8888 of 192.168.1.100 then running `./cluster_shutdown 192.168.1.100:8888` would send a clean shutdown message to the cluster.
 
 

--- a/utils/cluster_shutdown/README.md
+++ b/utils/cluster_shutdown/README.md
@@ -1,6 +1,6 @@
-# Cluster Shutdown Tool
+# Cluster Shrinker Tool
 
-`cluster_shutdown` is used to gracefully shutdown a running Wallaroo cluster.
+`cluster_shrinker` is used to tell a running cluster to reduce the number of workers in the cluster or to query the cluster for information about how many workers are eligible for removal.
 
 ## Build
 
@@ -10,10 +10,36 @@ make
 
 ## Run
 
+You must know the external address for a running worker in the cluster in order to send in a shrink message.
+
+There are three ways to use this tool:
+
+1) Specify the number of workers to remove from the cluster.
+
+Wallaroo will remove as many workers as are eligible for removal up to the number provided as the `--message` argument. For example (assuming a worker in the cluster is listening on `127.0.0.1:5050`),
+
 ```bash
-./cluster_shutdown ADDRESS:PORT
+./cluster_shrinker --external 127.0.0.1:5050 --message 2
 ```
 
-For example, if a cluster member had its external message channel running on port 8888 of 192.168.1.100 then running `./cluster_shutdown 192.168.1.100:8888` would send a clean shutdown message to the cluster.
+would remove up to 2 workers from the cluster, depending on how many are eligible.
+
+2) Specify the names of workers to remove from the cluster.
+
+If you pass in the names (comma-separated) of running workers as the `--message` argument, then Wallaroo will try to remove them. For example:
+
+```bash
+./cluster_shrinker --external 127.0.0.1:5050 --message worker2,worker3
+```
+
+3) Query the cluster for information about workers eligible for removal.
+
+If you pass `?` in as the `--message` argument, then Wallaroo will inform you both how many workers and which workers are eligible for removal. This reply will be printed to stdout. For example:
+
+```bash
+./cluster_shrinker --external 127.0.0.1:5050 --message /?
+```
+
+
 
 


### PR DESCRIPTION
This tool allows you to send messages specifying the
number or names of workers to remove from cluster.
You can also send in queries asking Wallaroo how many
workers (and which ones by name) are available for
shrinking.

