### PR TITLE
Fix bug when using cluster_shrinker with non-initializer

### DIFF
--- a/lib/wallaroo/core/initialization/local_topology.pony
+++ b/lib/wallaroo/core/initialization/local_topology.pony
@@ -1656,7 +1656,7 @@ actor LocalTopologyInitializer is LayoutInitializer
     match _topology
     | let t: LocalTopology =>
       for w in t.worker_names.values() do
-        if not t.non_shrinkable.contains(w) then
+        if not SetHelpers[String].contains[String](t.non_shrinkable, w) then
           available.push(w)
         end
       end

--- a/lib/wallaroo/core/initialization/local_topology.pony
+++ b/lib/wallaroo/core/initialization/local_topology.pony
@@ -359,6 +359,18 @@ actor LocalTopologyInitializer is LayoutInitializer
       conn.writev(error_reply)
     end
 
+  be take_over_initiate_shrink(remaining_workers: Array[String] val,
+    leaving_workers: Array[String] val)
+  =>
+    _remove_worker_names(leaving_workers)
+    _router_registry.initiate_shrink(remaining_workers, leaving_workers)
+
+  be prepare_shrink(remaining_workers: Array[String] val,
+    leaving_workers: Array[String] val)
+  =>
+    _remove_worker_names(leaving_workers)
+    _router_registry.prepare_shrink(remaining_workers, leaving_workers)
+
   fun _are_valid_shrink_candidates(candidates: Array[String] val): Bool =>
     match _topology
     | let t: LocalTopology =>

--- a/lib/wallaroo/core/messages/channel_messages.pony
+++ b/lib/wallaroo/core/messages/channel_messages.pony
@@ -87,6 +87,12 @@ primitive ChannelMsgEncoder
     _encode(BeginLeavingMigrationMsg(remaining_workers, leaving_workers),
       auth)?
 
+  fun initiate_shrink(remaining_workers: Array[String] val,
+    leaving_workers: Array[String] val, auth: AmbientAuth):
+    Array[ByteSeq] val ?
+  =>
+    _encode(InitiateShrinkMsg(remaining_workers, leaving_workers), auth)?
+
   fun prepare_shrink(remaining_workers: Array[String] val,
     leaving_workers: Array[String] val, auth: AmbientAuth):
     Array[ByteSeq] val ?
@@ -453,6 +459,16 @@ class val StepMigrationCompleteMsg is ChannelMsg
     step_id = step_id'
 
 class val BeginLeavingMigrationMsg is ChannelMsg
+  let remaining_workers: Array[String] val
+  let leaving_workers: Array[String] val
+
+  new val create(remaining_workers': Array[String] val,
+    leaving_workers': Array[String] val)
+  =>
+    remaining_workers = remaining_workers'
+    leaving_workers = leaving_workers'
+
+class val InitiateShrinkMsg is ChannelMsg
   let remaining_workers: Array[String] val
   let leaving_workers: Array[String] val
 

--- a/lib/wallaroo/ent/network/control_channel_tcp.pony
+++ b/lib/wallaroo/ent/network/control_channel_tcp.pony
@@ -324,12 +324,25 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
         end
         _router_registry.begin_leaving_migration(m.remaining_workers,
           m.leaving_workers)
+      | let m: InitiateShrinkMsg =>
+        match _layout_initializer
+        | let lti: LocalTopologyInitializer =>
+          lti.take_over_initiate_shrink(m.remaining_workers,
+            m.leaving_workers)
+        else
+          Fail()
+        end
       | let m: PrepareShrinkMsg =>
         ifdef "trace" then
           @printf[I32](("Received PrepareShrinkMsg on Control " +
             "Channel\n").cstring())
         end
-        _router_registry.prepare_shrink(m.remaining_workers, m.leaving_workers)
+        match _layout_initializer
+        | let lti: LocalTopologyInitializer =>
+          lti.prepare_shrink(m.remaining_workers, m.leaving_workers)
+        else
+          Fail()
+        end
       | let m: MuteRequestMsg =>
         @printf[I32]("Control Ch: Received Mute Request from %s\n".cstring(),
           m.originating_worker.cstring())

--- a/lib/wallaroo/ent/router_registry/router_registry.pony
+++ b/lib/wallaroo/ent/router_registry/router_registry.pony
@@ -818,31 +818,47 @@ actor RouterRegistry
     This should only be called on the worker contacted via an external
     message to initiate a shrink.
     """
-    @printf[I32]("~~~Initiating shrink~~~\n".cstring())
-    @printf[I32]("-- Remaining workers: \n".cstring())
-    for w in remaining_workers.values() do
-      @printf[I32]("-- -- %s\n".cstring(), w.cstring())
-    end
-    @printf[I32]("-- Leaving workers: \n".cstring())
-    for w in leaving_workers.values() do
-      @printf[I32]("-- -- %s\n".cstring(), w.cstring())
-    end
-    _stop_the_world_in_process = true
-    _stop_the_world_for_shrink()
-    let timers = Timers
-    let timer = Timer(PauseBeforeShrinkNotify(_auth, _connections,
-      remaining_workers, leaving_workers), _stop_the_world_pause)
-    timers(consume timer)
-    try
-      let msg = ChannelMsgEncoder.prepare_shrink(remaining_workers,
-        leaving_workers, _auth)?
-      for w in remaining_workers.values() do
-        _connections.send_control(w, msg)
+
+    if ArrayHelpers[String].contains[String](leaving_workers, _worker_name)
+    then
+      // Since we're one of the leaving workers, we're handing off
+      // responsibility for the shrink to one of the remaining workers.
+      try
+        let shrink_initiator = remaining_workers(0)?
+        let msg = ChannelMsgEncoder.initiate_shrink(remaining_workers,
+          leaving_workers, _auth)?
+        _connections.send_control(shrink_initiator, msg)
+      else
+        Fail()
       end
     else
-      Fail()
+      @printf[I32]("~~~Initiating shrink~~~\n".cstring())
+      @printf[I32]("-- Remaining workers: \n".cstring())
+      for w in remaining_workers.values() do
+        @printf[I32]("-- -- %s\n".cstring(), w.cstring())
+      end
+      @printf[I32]("-- Leaving workers: \n".cstring())
+      for w in leaving_workers.values() do
+        @printf[I32]("-- -- %s\n".cstring(), w.cstring())
+      end
+      _stop_the_world_in_process = true
+      _stop_the_world_for_shrink()
+      let timers = Timers
+      let timer = Timer(PauseBeforeShrinkNotify(_auth, _worker_name,
+        _connections, remaining_workers, leaving_workers),
+        _stop_the_world_pause)
+      timers(consume timer)
+      try
+        let msg = ChannelMsgEncoder.prepare_shrink(remaining_workers,
+          leaving_workers, _auth)?
+        for w in remaining_workers.values() do
+          _connections.send_control(w, msg)
+        end
+      else
+        Fail()
+      end
+      _prepare_shrink(remaining_workers, leaving_workers)
     end
-    _prepare_shrink(remaining_workers, leaving_workers)
 
   be prepare_shrink(remaining_workers: Array[String] val,
     leaving_workers: Array[String] val)
@@ -1086,14 +1102,17 @@ class PauseBeforeMigrationNotify is TimerNotify
 
 class PauseBeforeShrinkNotify is TimerNotify
   let _auth: AmbientAuth
+  let _worker_name: String
   let _connections: Connections
   let _remaining_workers: Array[String] val
   let _leaving_workers: Array[String] val
 
-  new iso create(auth: AmbientAuth, connections: Connections,
-    remaining_workers: Array[String] val, leaving_workers: Array[String] val)
+  new iso create(auth: AmbientAuth, worker_name: String,
+    connections: Connections, remaining_workers: Array[String] val,
+    leaving_workers: Array[String] val)
   =>
     _auth = auth
+    _worker_name = worker_name
     _connections = connections
     _remaining_workers = remaining_workers
     _leaving_workers = leaving_workers
@@ -1103,7 +1122,12 @@ class PauseBeforeShrinkNotify is TimerNotify
       let msg = ChannelMsgEncoder.begin_leaving_migration(_remaining_workers,
         _leaving_workers, _auth)?
       for w in _leaving_workers.values() do
-        _connections.send_control(w, msg)?
+        if w == _worker_name then
+          // Leaving workers shouldn't be managing the shrink process.
+          Fail()
+        else
+          _connections.send_control(w, msg)?
+        end
       end
     else
       Fail()


### PR DESCRIPTION
This PR fixes two problems with using cluster_shrinker to contact a non-initializer:
1) Queries now return the correct worker list.
2) If the non-initializer that's contacted is chosen to leave, then it will delegate responsibility to a remaining worker.

Closes #2010 