### PR TITLE
Clean up recovery files during shrink

### DIFF
--- a/lib/wallaroo/core/data_channel/_test.pony
+++ b/lib/wallaroo/core/data_channel/_test.pony
@@ -82,7 +82,8 @@ class _TestDataChannel is DataChannelListenNotify
         true, "/tmp/foo_connections.txt", false
         where event_log = event_log)
       let dr = DataReceivers(auth, conns, "worker_name")
-      let rr = RouterRegistry(auth, "worker_name", dr, conns, 1)
+      let rr = RouterRegistry(auth, "worker_name", dr, conns,
+        _DummyRecoveryFileCleaner, 1)
       h.dispose_when_done(DataChannelListener(auth, consume this, rr))
       h.dispose_when_done(conns)
       h.complete_action("server create")
@@ -519,4 +520,8 @@ actor _NullMetricsSink
     None
 
   be dispose() =>
+    None
+
+actor _DummyRecoveryFileCleaner
+  be clean_recovery_files() =>
     None

--- a/lib/wallaroo/core/topology/_test_router_equality.pony
+++ b/lib/wallaroo/core/topology/_test_router_equality.pony
@@ -287,7 +287,7 @@ primitive _BoundaryGenerator
 primitive _RouterRegistryGenerator
   fun apply(env: Env, auth: AmbientAuth): RouterRegistry =>
     RouterRegistry(auth, "", _DataReceiversGenerator(env, auth),
-      _ConnectionsGenerator(env, auth), 0)
+      _ConnectionsGenerator(env, auth), _DummyRecoveryFileCleaner, 0)
 
 primitive _DataReceiversGenerator
   fun apply(env: Env, auth: AmbientAuth): DataReceivers =>
@@ -327,4 +327,8 @@ actor _NullMetricsSink
     None
 
   be dispose() =>
+    None
+
+actor _DummyRecoveryFileCleaner
+  be clean_recovery_files() =>
     None

--- a/lib/wallaroo/startup.pony
+++ b/lib/wallaroo/startup.pony
@@ -313,7 +313,7 @@ actor Startup
 
       let router_registry = RouterRegistry(auth,
         _startup_options.worker_name, data_receivers,
-        connections, _startup_options.stop_the_world_pause)
+        connections, this, _startup_options.stop_the_world_pause)
       router_registry.set_event_log(event_log)
       event_log.set_router_registry(router_registry)
 
@@ -475,7 +475,7 @@ actor Startup
 
       let router_registry = RouterRegistry(auth,
         _startup_options.worker_name, data_receivers,
-        connections, _startup_options.stop_the_world_pause)
+        connections, this, _startup_options.stop_the_world_pause)
       router_registry.set_event_log(event_log)
       event_log.set_router_registry(router_registry)
 


### PR DESCRIPTION
This ensures that when a worker leaves the cluster permanently during a shrink, it cleans up after itself by deleting its recovery files.

Closes #2013