### PR TITLE
Update the performance testing docwith new metrics UI docker image

### DIFF
--- a/testing/performance/apps/WALLAROO_PERFORMANCE_TESTING.md
+++ b/testing/performance/apps/WALLAROO_PERFORMANCE_TESTING.md
@@ -57,13 +57,13 @@ To run the Metrics UI:
 
 ```bash
 docker run -d -u root --cpuset-cpus 0,18 --privileged  \
--v /usr/bin:/usr/bin:ro   -v /var/run/docker.sock:/var/run/docker.sock \
--v /bin:/bin:ro  -v /lib:/lib:ro  -v /lib64:/lib64:ro  -v /usr:/usr:ro  \
--v /tmp:/apps/metrics_reporter_ui/log  \
--p 0.0.0.0:4000:4000 -p 0.0.0.0:5001:5001 \
--e "BINS_TYPE=demo" -e "RELX_REPLACE_OS_VARS=true" \
---name mui -h mui --net=wallaroo-leader \
-docker.sendence.com:5043/sendence/monitoring_hub-apps-metrics_reporter_ui.amd64:sendence-2.3.0-2462-gf6421db
+  -v /usr/bin:/usr/bin:ro   -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /bin:/bin:ro  -v /lib:/lib:ro  -v /lib64:/lib64:ro  -v /usr:/usr:ro  \
+  -v /tmp:/apps/metrics_reporter_ui/log  \
+  -p 0.0.0.0:4000:4000 -p 0.0.0.0:5001:5001 \
+  -e "BINS_TYPE=demo" -e "RELX_REPLACE_OS_VARS=true" \
+  --name mui -h mui --net=wallaroo-leader \
+  wallaroo-labs-docker-wallaroolabs.bintray.io/release/metrics_ui:0.4.0
 ```
 
 #### Restarting UIs


### PR DESCRIPTION
The performance testing documentation pointed to a version of the
metrics UI that no longer exists. The command that it gave would
fail. It has been updated to piont to the new (0.4.0) image.

Fixes #2016