### PR TITLE
Ensure that all running workers migrate to joiners

### DIFF
--- a/lib/wallaroo/core/messages/channel_messages.pony
+++ b/lib/wallaroo/core/messages/channel_messages.pony
@@ -223,6 +223,11 @@ primitive ChannelMsgEncoder
   =>
     _encode(JoiningWorkerInitializedMsg(worker_name, c_addr, d_addr), auth)?
 
+  fun initiate_join_migration(new_workers: Array[String] val,
+    auth: AmbientAuth): Array[ByteSeq] val ?
+  =>
+    _encode(InitiateJoinMigrationMsg(new_workers), auth)?
+
   fun leaving_worker_done_migrating(worker_name: String, auth: AmbientAuth):
     Array[ByteSeq] val ?
   =>
@@ -657,6 +662,12 @@ class val JoiningWorkerInitializedMsg is ChannelMsg
     worker_name = name
     control_addr = c_addr
     data_addr = d_addr
+
+class val InitiateJoinMigrationMsg is ChannelMsg
+  let new_workers: Array[String] val
+
+  new val create(ws: Array[String] val) =>
+    new_workers = ws
 
 class val LeavingWorkerDoneMigratingMsg is ChannelMsg
   let worker_name: String

--- a/lib/wallaroo/core/messages/channel_messages.pony
+++ b/lib/wallaroo/core/messages/channel_messages.pony
@@ -84,6 +84,12 @@ primitive ChannelMsgEncoder
     leaving_workers: Array[String] val, auth: AmbientAuth):
     Array[ByteSeq] val ?
   =>
+    """
+    This message is sent by the current worker coordinating autoscale shrink to
+    all leaving workers once all in-flight messages have finished processing
+    after stopping the world. At that point, it's safe for leaving workers to
+    migrate steps to the remaining workers.
+    """
     _encode(BeginLeavingMigrationMsg(remaining_workers, leaving_workers),
       auth)?
 
@@ -91,12 +97,20 @@ primitive ChannelMsgEncoder
     leaving_workers: Array[String] val, auth: AmbientAuth):
     Array[ByteSeq] val ?
   =>
+    """
+    The worker initially contacted for autoscale shrink sends this message to
+    all other remaining workers so they can prepare for the shrink event.
+    """
     _encode(PrepareShrinkMsg(remaining_workers, leaving_workers), auth)?
 
-  fun mute_request(originating_worker: String, auth: AmbientAuth): Array[ByteSeq] val ? =>
+  fun mute_request(originating_worker: String, auth: AmbientAuth):
+    Array[ByteSeq] val ?
+  =>
     _encode(MuteRequestMsg(originating_worker), auth)?
 
-  fun unmute_request(originating_worker: String, auth: AmbientAuth): Array[ByteSeq] val ? =>
+  fun unmute_request(originating_worker: String, auth: AmbientAuth):
+    Array[ByteSeq] val ?
+  =>
     _encode(UnmuteRequestMsg(originating_worker), auth)?
 
   fun delivery[D: Any val](target_id: U128,
@@ -221,16 +235,31 @@ primitive ChannelMsgEncoder
   fun joining_worker_initialized(worker_name: String, c_addr: (String, String),
     d_addr: (String, String), auth: AmbientAuth): Array[ByteSeq] val ?
   =>
+    """
+    This message is sent after a joining worker uses partition blueprints and
+    other topology information to initialize its topology. It indicates that
+    it is ready to receive migrated steps.
+    """
     _encode(JoiningWorkerInitializedMsg(worker_name, c_addr, d_addr), auth)?
 
   fun initiate_join_migration(new_workers: Array[String] val,
     auth: AmbientAuth): Array[ByteSeq] val ?
   =>
+    """
+    One worker is contacted by all joining workers and initially coordinates
+    state migration to those workers. When it is ready to migrate steps, it
+    sends this message to every other current worker informing them to begin
+    migration as well.
+    """
     _encode(InitiateJoinMigrationMsg(new_workers), auth)?
 
   fun leaving_worker_done_migrating(worker_name: String, auth: AmbientAuth):
     Array[ByteSeq] val ?
   =>
+    """
+    A leaving worker sends this to indicate it has migrated all steps back to
+    remaining workers.
+    """
     _encode(LeavingWorkerDoneMigratingMsg(worker_name), auth)?
 
   fun request_boundary_count(sender: String, auth: AmbientAuth):

--- a/lib/wallaroo/ent/network/control_channel_tcp.pony
+++ b/lib/wallaroo/ent/network/control_channel_tcp.pony
@@ -309,6 +309,8 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
         else
           Fail()
         end
+      | let m: InitiateJoinMigrationMsg =>
+        _router_registry.remote_migration_request(m.new_workers)
       | let m: LeavingWorkerDoneMigratingMsg =>
         _router_registry.disconnect_from_leaving_worker(m.worker_name)
       | let m: AckMigrationBatchCompleteMsg =>

--- a/lib/wallaroo/ent/router_registry/router_registry.pony
+++ b/lib/wallaroo/ent/router_registry/router_registry.pony
@@ -543,6 +543,11 @@ actor RouterRegistry
     _joining_worker_count = count
 
   be joining_worker_initialized(worker: String) =>
+    """
+    When a joining worker has initialized its topology, it contacts all
+    current workers. This behavior is called when that control
+    message is received.
+    """
     if _joining_worker_count == 0 then
       ifdef debug then
         @printf[I32](("Joining worker reported as initialized, but we're " +
@@ -571,6 +576,13 @@ actor RouterRegistry
     end
 
   be remote_migration_request(new_workers: Array[String] val) =>
+    """
+    Only one worker is contacted by all joining workers to indicate that a
+    join is requested. That worker, when it's ready to begin step migration,
+    then sends a message to all other current workers, telling them to begin
+    migration to the joining workers as well. This behavior is called when
+    that message is received.
+    """
     if not ArrayHelpers[String].contains[String](new_workers, _worker_name)
     then
       migrate_onto_new_workers(new_workers)
@@ -865,6 +877,12 @@ actor RouterRegistry
   be prepare_shrink(remaining_workers: Array[String] val,
     leaving_workers: Array[String] val)
   =>
+    """
+    One worker is contacted via external message to begin autoscale
+    shrink. That worker then informs every other worker to prepare for
+    shrink. This behavior is called in response to receiving that message
+    from the contacted worker.
+    """
     _prepare_shrink(remaining_workers, leaving_workers)
 
   fun ref _prepare_shrink(remaining_workers: Array[String] val,


### PR DESCRIPTION
Fixes a bug where only the contacted worker was
migrating state to the joining workers.

Closes #2026