### PR TITLE
Only try to shrink if supplied worker names are still in the cluster

### DIFF
--- a/lib/wallaroo/core/initialization/local_topology.pony
+++ b/lib/wallaroo/core/initialization/local_topology.pony
@@ -363,7 +363,11 @@ actor LocalTopologyInitializer is LayoutInitializer
     match _topology
     | let t: LocalTopology =>
       for c in candidates.values() do
-        if SetHelpers[String].contains[String](t.non_shrinkable, c) then
+        // A worker name is not a valid candidate if it is non shrinkable
+        // or if it's not in the current cluster.
+        if SetHelpers[String].contains[String](t.non_shrinkable, c) or
+          (not ArrayHelpers[String].contains[String](t.worker_names, c))
+        then
           return false
         end
       end


### PR DESCRIPTION
We weren't properly checking whether a requested
worker for removal was still in the cluster. This
meant that if you requested to remove the same worker
twice, then things would go wrong.