### PR TITLE
Improve Go component lookup/storage performance

### DIFF
--- a/go_api/go/src/wallarooapi/component_mapping.go
+++ b/go_api/go/src/wallarooapi/component_mapping.go
@@ -3,6 +3,7 @@ package wallarooapi
 import (
 	"C"
 	"sync"
+	"sync/atomic"
 )
 
 const (
@@ -34,34 +35,27 @@ func makeComponentDicts() []*ComponentDict {
 var componentDicts = makeComponentDicts()
 
 type ComponentDict struct {
-	mu sync.RWMutex
-	components map[uint64]interface{}
-	nextId uint64
+	id uint64
+	components ConcurrentMap
 }
 
 func NewComponentDict() *ComponentDict {
-	return &ComponentDict {sync.RWMutex{}, make(map[uint64]interface{}), 1}
+	return &ComponentDict{0, NewConcurrentMap()}
 }
 
 func (cd *ComponentDict) add(component interface{}) uint64 {
-	cd.mu.Lock()
-	defer cd.mu.Unlock()
-	cd.components[cd.nextId] = component
-	lastId := cd.nextId
-	cd.nextId++
-	return lastId
+	var id = atomic.AddUint64(&cd.id, 1)
+	cd.components.Store(id, component)
+	return id
 }
 
 func (cd *ComponentDict) get(id uint64) interface{} {
-	cd.mu.RLock()
-	defer cd.mu.RUnlock()
-	return cd.components[id]
+	result, _ := cd.components.Load(id)
+	return result
 }
 
 func (cd *ComponentDict) remove(id uint64) {
-	cd.mu.Lock()
-	defer cd.mu.Unlock()
-	delete(cd.components, id)
+	cd.components.Delete(id)
 }
 
 //export GetComponent
@@ -78,4 +72,47 @@ func AddComponent(component interface{}, componentType uint64) uint64 {
 func RemoveComponent(id uint64, componentType uint64) {
 	componentDicts[componentType].remove(id)
 	RemoveSerialized(id, componentType)
+}
+
+var SHARD_COUNT = uint64(16384)
+
+type ConcurrentMap []*ConcurrentMapShared
+
+type ConcurrentMapShared struct {
+	items map[uint64]interface{}
+	sync.RWMutex
+}
+
+func NewConcurrentMap() ConcurrentMap {
+	m := make(ConcurrentMap, SHARD_COUNT)
+	for i := uint64(0); i < SHARD_COUNT; i++ {
+		m[i] = &ConcurrentMapShared{items: make(map[uint64]interface{})}
+	}
+	return m
+}
+
+func (m ConcurrentMap) GetShard(key uint64) *ConcurrentMapShared {
+	return m[key%SHARD_COUNT]
+}
+
+func (m ConcurrentMap) Store(key uint64, value interface{}) {
+	shard := m.GetShard(key)
+	shard.Lock()
+	shard.items[key] = value
+	shard.Unlock()
+}
+
+func (m ConcurrentMap) Load(key uint64) (interface{}, bool) {
+	shard := m.GetShard(key)
+	shard.RLock()
+	val, ok := shard.items[key]
+	shard.RUnlock()
+	return val, ok
+}
+
+func (m ConcurrentMap) Delete(key uint64) {
+	shard := m.GetShard(key)
+	shard.Lock()
+	delete(shard.items, key)
+	shard.Unlock()
 }


### PR DESCRIPTION
Previously, our Go components had a single map and lock per component
type. This leads to scalability issues as we are bound by getting the
lock for each component type. This change switches us from having a
single map per component type to many shards per component type.

Locks are grabbed on a per shard rather than per component basis.