### PR TITLE
Allow 'make help' target to avoid relying on GNU Awk

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -188,7 +188,6 @@ endif
 ifeq ($(shell uname -s),Linux)
   extra_xargs_arg := -r
   docker_user_arg := -u `id -u`
-  extra_awk_arg := \\
   host_ip_src = $(shell ifconfig `route -n | grep '^0.0.0.0' | awk '{print $$8}'` | egrep -o 'inet addr:[^ ]+' | awk -F: '{print $$2}')
   system_cpus := $(shell which cset > /dev/null && sudo cset set -l -r | grep '/system' | awk '{print $$2}')
   ifneq (,$(system_cpus))
@@ -544,7 +543,7 @@ help: ## this help message
 	$(QUIET)echo ''
 	$(QUIET)echo 'Options:'
 	$(QUIET)grep -h -E '^[a-zA-Z0-9_-]+ *\?=.*?## .*$$' $(MAKEFILE_LIST) | sort -u | awk \
-          'BEGIN {FS = "$(extra_awk_arg)?="}; {printf "\033[36m%-40s\033[0m ##%s\n", $$1, \
+          'BEGIN {FS = "\\?="}; {printf "\033[36m%-40s\033[0m ##%s\n", $$1, \
           $$2}' | awk 'BEGIN {FS = "## "}; {printf "%s%s \033[36m(Default:\
  %s)\033[0m\n", $$1, $$3, $$2}'
 	$(QUIET)grep -h -E 'ifeq.*filter.*\)$$' $(MAKEFILE_LIST) | sort -u | awk \


### PR DESCRIPTION
On OS X the version of Awk at `/usr/bin/awk` is, well, not quite "original" Awk (because the original was pretty primitive by 2018 standards) but definitely not GNU Awk.  Its regexp rules are a bit different than GNU Awk's.

This patch fixes a regexp problem on OS X using `/usr/bin/awk`:

    % env PATH=/usr/bin:$PATH make help
    Usage: make [option1=value] [option2=value,...] [target]

    Options:
    awk: illegal primary in regular expression ?= at =
     input record number 1, file
     source line number 1

    Targets:

The Make variable `extra_awk_arg` was only used in one place, and with removing that one use I've also removed its definition.

[skip ci]