### PR TITLE
Remove unused return type in Runners and Routers

### DIFF
--- a/lib/wallaroo/core/routing/boundary_route.pony
+++ b/lib/wallaroo/core/routing/boundary_route.pony
@@ -65,16 +65,15 @@ class BoundaryRoute is Route
 
   fun ref run[D](metric_name: String, pipeline_time_spent: U64, data: D,
     cfp: Producer ref, msg_uid: MsgId, frac_ids: FractionalMessageId,
-    latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64): Bool
+    latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64)
   =>
     // Run should never be called on a BoundaryRoute
     Fail()
-    true
 
   fun ref forward(delivery_msg: ReplayableDeliveryMsg,
     pipeline_time_spent: U64, cfp: Producer ref,
     latest_ts: U64, metrics_id: U16,
-    metric_name: String, worker_ingress_ts: U64): Bool
+    metric_name: String, worker_ingress_ts: U64)
   =>
     ifdef debug then
       match _step
@@ -93,7 +92,6 @@ class BoundaryRoute is Route
       metrics_id,
       metric_name,
       worker_ingress_ts)
-    true
 
   fun ref _send_message_on_route(delivery_msg: ReplayableDeliveryMsg,
     pipeline_time_spent: U64, cfp: Producer ref,

--- a/lib/wallaroo/core/routing/route.pony
+++ b/lib/wallaroo/core/routing/route.pony
@@ -33,12 +33,12 @@ trait Route
   // should mute
   fun ref run[D](metric_name: String, pipeline_time_spent: U64, data: D,
     cfp: Producer ref, msg_uid: MsgId, frac_ids: FractionalMessageId,
-    latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64): Bool
+    latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64)
 
   fun ref forward(delivery_msg: ReplayableDeliveryMsg,
     pipeline_time_spent: U64, cfp: Producer ref,
     latest_ts: U64, metrics_id: U16,
-    metric_name: String, worker_ingress_ts: U64): Bool
+    metric_name: String, worker_ingress_ts: U64)
 
   fun ref request_ack()
 
@@ -97,7 +97,7 @@ class EmptyRoute is Route
 
   fun ref run[D](metric_name: String, pipeline_time_spent: U64, data: D,
     cfp: Producer ref, msg_uid: MsgId, frac_ids: FractionalMessageId,
-    latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64): Bool
+    latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64)
   =>
     Fail()
     true
@@ -105,7 +105,7 @@ class EmptyRoute is Route
   fun ref forward(delivery_msg: ReplayableDeliveryMsg,
     pipeline_time_spent: U64, cfp: Producer ref,
     latest_ts: U64, metrics_id: U16,
-    metric_name: String, worker_ingress_ts: U64): Bool
+    metric_name: String, worker_ingress_ts: U64)
   =>
     Fail()
     true

--- a/lib/wallaroo/core/routing/typed_route.pony
+++ b/lib/wallaroo/core/routing/typed_route.pony
@@ -64,7 +64,7 @@ class TypedRoute[In: Any val] is Route
 
   fun ref run[D](metric_name: String, pipeline_time_spent: U64, data: D,
     cfp: Producer ref, msg_uid: MsgId, frac_ids: FractionalMessageId,
-    latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64): Bool
+    latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64)
   =>
     ifdef "trace" then
       @printf[I32]("--Rcvd msg at Route (%s)\n".cstring(),
@@ -90,7 +90,7 @@ class TypedRoute[In: Any val] is Route
   fun ref forward(delivery_msg: ReplayableDeliveryMsg,
     pipeline_time_spent: U64, cfp: Producer ref,
     latest_ts: U64, metrics_id: U16, metric_name: String,
-    worker_ingress_ts: U64): Bool
+    worker_ingress_ts: U64)
   =>
     // Forward should never be called on a TypedRoute
     Fail()

--- a/lib/wallaroo/core/source/kafka_source/kafka_source_notify.pony
+++ b/lib/wallaroo/core/source/kafka_source/kafka_source_notify.pony
@@ -91,7 +91,7 @@ class KafkaSourceNotify[In: Any val]
       @printf[I32](("Rcvd msg at " + _pipeline_name + " source\n").cstring())
     end
 
-    (let is_finished, let keep_sending, let last_ts) =
+    (let is_finished, let last_ts) =
       try
         src.next_sequence_id()
         let decoded =
@@ -122,7 +122,7 @@ class KafkaSourceNotify[In: Any val]
         ifdef debug then
           Fail()
         end
-        (true, true, ingest_ts)
+        (true, ingest_ts)
       end
 
     if is_finished then

--- a/lib/wallaroo/core/source/tcp_source/framed_source_notify.pony
+++ b/lib/wallaroo/core/source/tcp_source/framed_source_notify.pony
@@ -96,7 +96,7 @@ class TCPFramedSourceNotify[In: Any val] is TCPSourceNotify
         @printf[I32](("Rcvd msg at " + _pipeline_name + " source\n").cstring())
       end
 
-      (let is_finished, let keep_sending, let last_ts) =
+      (let is_finished, let last_ts) =
         try
           let decoded =
             try
@@ -126,7 +126,7 @@ class TCPFramedSourceNotify[In: Any val] is TCPSourceNotify
           ifdef debug then
             Fail()
           end
-          (true, true, ingest_ts)
+          (true, ingest_ts)
         end
 
       if is_finished then

--- a/lib/wallaroo/core/topology/steps.pony
+++ b/lib/wallaroo/core/topology/steps.pony
@@ -270,7 +270,7 @@ actor Step is (Producer & Consumer)
       @printf[I32](("Rcvd msg at " + _runner.name() + " step\n").cstring())
     end
 
-    (let is_finished, _, let last_ts) = _runner.run[D](metric_name,
+    (let is_finished, let last_ts) = _runner.run[D](metric_name,
       pipeline_time_spent, data, this, _router, _omni_router,
       msg_uid, frac_ids, my_latest_ts, my_metrics_id, worker_ingress_ts,
       _metrics_reporter)


### PR DESCRIPTION
Routers and Runners were returning a triple
(Bool, Bool, U64) where the second element
indicated whether to keep sending. This is a
vestige from when we kept explicit queues in
Steps and needed to indicate they were full.
Since we no longer do this, this return type
is updated in this commit to (Bool, U64).

Closes #1010