### PR TITLE
Add cluster status observability queries

### DIFF
--- a/lib/wallaroo/core/initialization/local_topology.pony
+++ b/lib/wallaroo/core/initialization/local_topology.pony
@@ -1505,6 +1505,14 @@ actor LocalTopologyInitializer is LayoutInitializer
   be partition_query(conn: TCPConnection) =>
     _router_registry.partition_query(conn)
 
+  be cluster_status_query(conn: TCPConnection) =>
+    match _topology
+    | let t: LocalTopology =>
+      _router_registry.cluster_status_query(t.worker_names, conn)
+    else
+      Fail()
+    end
+
   be initialize_join_initializables() =>
     _initialize_join_initializables()
 

--- a/lib/wallaroo/ent/network/external_channel_tcp.pony
+++ b/lib/wallaroo/ent/network/external_channel_tcp.pony
@@ -153,6 +153,12 @@ class ExternalChannelConnectNotifier is TCPConnectionNotify
               "Channel\n").cstring())
           end
           _local_topology_initializer.partition_query(conn)
+        | let m: ExternalClusterStatusQueryMsg =>
+          ifdef "trace" then
+            @printf[I32](("Received ExternalClusterStatusQueryMsg on " +
+              " External Channel\n").cstring())
+          end
+          _local_topology_initializer.cluster_status_query(conn)
         else
           @printf[I32](("Incoming External Message type not handled by " +
             "external channel.\n").cstring())

--- a/lib/wallaroo/ent/router_registry/router_registry.pony
+++ b/lib/wallaroo/ent/router_registry/router_registry.pony
@@ -489,6 +489,13 @@ actor RouterRegistry
       _partition_routers, _stateless_partition_routers)
     conn.writev(msg)
 
+  be cluster_status_query(worker_names: Array[String] val,
+    conn: TCPConnection)
+  =>
+    let msg = ExternalMsgEncoder.cluster_status_query_response(
+      worker_names.size(), worker_names, _stop_the_world_in_process)
+    conn.writev(msg)
+
   //////////////
   // LOG ROTATION
   //////////////

--- a/lib/wallaroo_labs/query/_test.pony
+++ b/lib/wallaroo_labs/query/_test.pony
@@ -111,3 +111,31 @@ class iso _TestEncodeDecodeState is UnitTest
       new_map(k4)?(w2)?))
     h.assert_eq[Bool](true, ArrayHelpers[String].eq[String](map_val(k4)?(w3)?,
       new_map(k4)?(w3)?))
+
+class iso _TestEncodeDecodeClusterStatus is UnitTest
+  fun name(): String => "query_json/encode_decode_cluster_status"
+
+  fun apply(h: TestHelper) ? =>
+    var is_processing = true
+    var worker_count: U64 = 3
+    var worker_names = recover val ["w1"; "w2"; "w3"] end
+    let json1 = ClusterStatusQueryJsonEncoder.response(worker_count,
+      worker_names, is_processing)
+    let decoded1 = ClusterStatusQueryJsonDecoder.response(json1)?
+    h.assert_eq[Bool](is_processing, decoded1.processing_messages)
+    h.assert_eq[U64](worker_count, decoded1.worker_count)
+    for i in Range(0, worker_count.usize()) do
+      h.assert_eq[String](worker_names(i)?, decoded1.worker_names(i)?)
+    end
+
+    is_processing = false
+    worker_count = 5
+    worker_names = recover val ["w1"; "w2"; "w3"; "w4"; "w5"] end
+    let json2 = ClusterStatusQueryJsonEncoder.response(worker_count,
+      worker_names, is_processing)
+    let decoded2 = ClusterStatusQueryJsonDecoder.response(json2)?
+    h.assert_eq[Bool](is_processing, decoded2.processing_messages)
+    h.assert_eq[U64](worker_count, decoded2.worker_count)
+    for i in Range(0, worker_count.usize()) do
+      h.assert_eq[String](worker_names(i)?, decoded2.worker_names(i)?)
+    end

--- a/testing/tools/external_sender/external_sender.pony
+++ b/testing/tools/external_sender/external_sender.pony
@@ -53,7 +53,8 @@ actor Main
               -----------------------------------------------------------------------------------
               --external/-e [Specifies address to send message to]
               --type/-t [Specifies message type]
-                  clean-shutdown | rotate-log | partition-query | print
+                  clean-shutdown | rotate-log | partition-query |
+                  cluster-status-query | print
               --message/-m [Specifies message contents to send]
                   rotate-log
                       Node name to rotate log files
@@ -75,6 +76,9 @@ actor Main
         | "partition-query" =>
           await_response = true
           ExternalMsgEncoder.partition_query()
+        | "cluster-status-query" =>
+          await_response = true
+          ExternalMsgEncoder.cluster_status_query()
         else // default to print
           ExternalMsgEncoder.print_message(message)
         end
@@ -128,6 +132,10 @@ class ExternalSenderConnectNotifier is TCPConnectionNotify
         | let m: ExternalPartitionQueryResponseMsg =>
           _env.out.print("Partition Distribution:")
           _env.out.print(m.msg)
+          conn.dispose()
+        | let m: ExternalClusterStatusQueryResponseMsg =>
+          _env.out.print("Cluster Status:")
+          _env.out.print(m.string())
           conn.dispose()
         else
           _env.err.print("Received unhandled external message type")


### PR DESCRIPTION
Wallaroo can now be queried for the cluster status,
which includes the number of workers, worker names,
and whether it is currently processing message (i.e.
not in a stop the world phase). external_sender now
supports this type of query for testing.