### PR TITLE
Only dispose of routes if we have not already unregistered

### DIFF
--- a/lib/wallaroo/core/routing/boundary_route.pony
+++ b/lib/wallaroo/core/routing/boundary_route.pony
@@ -58,10 +58,7 @@ class BoundaryRoute is Route
     _route_id
 
   fun ref dispose() =>
-    """
-    Return unused credits to downstream consumer
-    """
-    _route.dispose()
+    None
 
   fun ref run[D](metric_name: String, pipeline_time_spent: U64, data: D,
     cfp: Producer ref, msg_uid: MsgId, frac_ids: FractionalMessageId,

--- a/lib/wallaroo/core/routing/typed_route.pony
+++ b/lib/wallaroo/core/routing/typed_route.pony
@@ -57,9 +57,6 @@ class TypedRoute[In: Any val] is Route
     _route_id
 
   fun ref dispose() =>
-    """
-    Return unused credits to downstream consumer
-    """
     _route.dispose()
 
   fun ref run[D](metric_name: String, pipeline_time_spent: U64, data: D,

--- a/lib/wallaroo/core/source/tcp_source/tcp_source.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source.pony
@@ -396,14 +396,15 @@ actor TCPSource is Producer
     if not _unregistered then
       _dispose_routes()
     end
-    _unregistered = true
 
   fun ref _dispose_routes() =>
-    for r in _routes.values() do
-      r.dispose()
+    if not _unregistered then
+      for r in _routes.values() do
+        r.dispose()
+      end
+      _unregistered = true
     end
     _muted = true
-    _unregistered = true
 
   fun ref _pending_reads() =>
     """


### PR DESCRIPTION
On TCPSource, we should only be disposing our routes
once when unregistering, but the code wasn't as clear
on this point as it could have been which could easily
have led to the introduction of bugs.