### PR TITLE
Clarify use of separate shells in docs & examples

### DIFF
--- a/book/getting-started/run-a-wallaroo-application-docker.md
+++ b/book/getting-started/run-a-wallaroo-application-docker.md
@@ -17,7 +17,9 @@ NOTE: If you haven't set up Docker to run without root, you will need to use `su
 
 Let's get started!
 
-## Terminal 1, Start the Wallaroo Docker container
+Since Wallaroo is a distributed application, its components need to run separately, and concurrently, so that they may connect to one another to form the application cluster. For this example, you will need 6 separate terminal shells to start the docker container, run the metrics UI, run a source, run a sink, run the Celsius application, and eventually, to send a cluster shutdown command.
+
+## Shell 1: Start the Wallaroo Docker container
 
 ```bash
 docker run --rm -it --privileged -p 4000:4000 \
@@ -45,7 +47,7 @@ wallaroo-labs-docker-wallaroolabs.bintray.io/{{ docker_version_url }}
 
 * `--name wally`: The name for the container. This setting is optional but makes it easier to reference the container in later commands.
 
-## Terminal 2, Start the Metrics UI
+## Shell 2: Metrics UI
 
 Enter the Wallaroo Docker container:
 
@@ -81,7 +83,7 @@ If you need to start the UI after stopping it, run:
 metrics_reporter_ui start
 ```
 
-## Terminal 3, Run Giles Receiver
+## Shell 3: Giles Receiver
 
 Enter the Wallaroo Docker container:
 
@@ -97,7 +99,7 @@ receiver --listen 127.0.0.1:5555 --no-write --ponythreads=1 --ponynoblock
 
 You should see the line `Listening for data` that indicates that Giles receiver is running.
 
-## Terminal 4, Run the "Celsius to Fahrenheit" Application
+## Shell 4: Run the "Celsius to Fahrenheit" Application
 
 Enter the Wallaroo Docker container:
 
@@ -122,7 +124,7 @@ machida --application-module celsius --in 127.0.0.1:7000 \
 
 This tells the "Celsius to Fahrenheit" application that it should listen on port `7000` for incoming data, write outgoing data to port `5555`, and send metrics data to port `5001`.
 
-## Terminal 5, Sending Data
+## Shell 5: Sending Data
 
 Enter the Wallaroo Docker container:
 
@@ -171,7 +173,7 @@ Feel free to click around and get a feel for how the Metrics UI is set up and ho
 
 ## Shutdown
 
-### Terminal 6, Cluster Shutdown
+### Shell 6: Cluster Shutdown
 
 Enter the Wallaroo Docker container:
 

--- a/book/getting-started/run-a-wallaroo-application.md
+++ b/book/getting-started/run-a-wallaroo-application.md
@@ -15,7 +15,9 @@ The Metrics UI process will be run in the background via Docker.  The other thre
 
 Let's get started!
 
-## Terminal 1, Start the Metrics UI
+Since Wallaroo is a distributed application, its components need to run separately, and concurrently, so that they may connect to one another to form the application cluster. For this example, you will need 5 separate terminal shells to run the metrics UI, run a source, run a sink, run the Celsius application, and eventually, to send a cluster shutdown command.
+
+## Shell 1: Start the Metrics UI
 
 NOTE: You might need to run with sudo depending on how you set up Docker.
 
@@ -46,7 +48,7 @@ If you need to start the UI after stopping it, run:
 docker start mui
 ```
 
-## Terminal 2, Run Giles Receiver
+## Shell 2: Run Giles Receiver
 
 We'll use Giles Receiver to listen for data from our Wallaroo application.
 
@@ -57,7 +59,7 @@ cd ~/wallaroo-tutorial/wallaroo/giles/receiver
 
 You should see the `Listening for data` that indicates that Giles receiver is running.
 
-## Terminal 3, Run the "Celsius to Fahrenheit" Application
+## Shell 3: Run the "Celsius to Fahrenheit" Application
 
 First, we will need to set up the `PYTHONPATH` environment variable. Machida needs to be able to find the `wallaroo` Python module, which is in a file called `wallaroo.py` in the `machida` directory. It also needs to be able to find the module that defines the application. In order to do that, set and export the `PYTHONPATH` environment variable like this:
 
@@ -77,9 +79,7 @@ cd ~/wallaroo-tutorial/wallaroo/machida
 
 This tells the "Celsius to Fahrenheit" application that it should listen on port `7000` for incoming data, write outgoing data to port `5555`, and send metrics data to port `5001`.
 
-## Terminal 4
-
-### Sending Data with Giles Sender
+## Shell 4: Sending Data with Giles Sender
 
 We will be sending in 25,000,000 messages using a pre-generated data file. The data file will be repeatedly sent via Giles Sender until we reach 25,000,000 messages.
 
@@ -122,7 +122,7 @@ Feel free to click around and get a feel for how the Metrics UI is setup and how
 
 ## Shutdown
 
-### Terminal 5, Cluster Shutdown
+### Shell 5: Cluster Shutdown
 
 You can shut down the cluster with this command at any time:
 

--- a/book/go/getting-started/run-a-wallaroo-go-application.md
+++ b/book/go/getting-started/run-a-wallaroo-go-application.md
@@ -14,7 +14,9 @@ The Metrics UI process will be run in the background via Docker.  The other thre
 
 Let's get started!
 
-## Terminal 1, Start the Metrics UI
+Since Wallaroo is a distributed application, its components need to run separately, and concurrently, so that they may connect to one another to form the application cluster. For this example, you will need 5 separate terminal shells to run the metrics UI, run a source, run a sink, run the Celsius application, and eventually, to send a cluster shutdown command.
+
+## Shell 1: Start the Metrics UI
 
 NOTE: You might need to run with sudo depending on how you set up Docker.
 
@@ -45,7 +47,7 @@ If you need to start the UI after stopping it, run:
 docker start mui
 ```
 
-## Terminal 2, Run Data Receiver
+## Shell 2: Run the Data Receiver
 
 We'll use Data Receiver to listen for data from our Wallaroo application.
 
@@ -56,7 +58,7 @@ cd ~/wallaroo-tutorial/wallaroo/utils/data_receiver
 
 Data Receiver will start up and receive data without creating any output. By default, it prints received data to standard out, but we are giving it the `--no-write` flag which results in no output.
 
-## Terminal 3, Run the "Celsius to Fahrenheit" Application
+## Shell 3: Run the "Celsius to Fahrenheit" Application
 
 First, we need to build the application.
 
@@ -77,9 +79,7 @@ cd ~/wallaroo-tutorial/wallaroo/examples/go/celsius
 
 This tells the "Celsius to Fahrenheit" application that it should listen on port `7000` for incoming data, write outgoing data to port `5555`, and send metrics data to port `5001`.
 
-## Terminal 4
-
-### Sending Data with Giles Sender
+## Shell 4: Sending Data with Giles Sender
 
 We will be sending in 25,000,000 messages using a pre-generated data file. The data file will be repeatedly sent via Giles Sender until we reach 25,000,000 messages.
 
@@ -122,7 +122,7 @@ Feel free to click around and get a feel for how the Metrics UI is setup and how
 
 ## Shutdown
 
-### Terminal 5, Cluster Shutdown
+### Shell 5: Cluster Shutdown
 
 You can shut down the cluster with this command at any time:
 

--- a/examples/cpp/alphabet-cpp/README.md
+++ b/examples/cpp/alphabet-cpp/README.md
@@ -34,28 +34,83 @@ ponyc --linker c++ --debug --export --output=build \
 
 ## Running
 
+You will need five separate shells to run this application. Open each shell and go to the `examples/cpp/alphabet-cpp` directory.
+
+### Shell 1: Metrics UI
+
 Start the Metrics UI if it isn't already running:
-    ```bash
-    docker start mui
-    ```
 
-In a separate shell each:
+```bash
+docker start mui
+```
 
-1. Start a listener with Giles Receiver
-    ```bash
-    ../../../../giles/receiver/receiver --ponythreads=1 --ponynoblock \
-      --ponypinasio -l 127.0.0.1:7002 --no-write
-    ```
-2. Start the application
-    ```bash
-    ./build/alphabet-app --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
-      --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
-      --worker-name worker-name --cluster-initializer --ponythreads=1 \
-      --ponynoblock
-    ```
-3. Start sending data
-    ```bash
-     ../../../../giles/sender/sender --host 127.0.0.1:7010 --file votes.msg \
-       --batch-size 50 --interval 10_000_000 --binary --msg-size 9 --repeat \
-       --ponythreads=1 --ponynoblock --messages 1000000 --no-write
-    ```
+You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000).
+
+If you need to restart the UI, run:
+
+```bash
+docker restart mui
+```
+
+When it's time to stop the UI, run:
+
+```bash
+docker stop mui
+```
+
+If you need to start the UI after stopping it, run:
+
+```bash
+docker start mui
+```
+
+### Shell 2: Data Receiver
+
+Start a listener with Giles Receiver
+
+```bash
+../../../../giles/receiver/receiver --ponythreads=1 --ponynoblock \
+  --ponypinasio -l 127.0.0.1:7002 --no-write
+```
+
+### Shell 3: Alphabet-app
+
+Start the application
+
+```bash
+./build/alphabet-app --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
+  --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
+  --worker-name worker-name --cluster-initializer --ponythreads=1 \
+  --ponynoblock
+```
+
+### Shell 4: Sender
+
+Start sending data
+
+```bash
+../../../../giles/sender/sender --host 127.0.0.1:7010 --file votes.msg \
+  --batch-size 50 --interval 10_000_000 --binary --msg-size 9 --repeat \
+  --ponythreads=1 --ponynoblock --messages 1000000 --no-write
+```
+
+If the sender is working correctly, you should see `Connected` printed to the screen. If you see that, you can be assured that we are now sending data into our example application.
+
+## Shutdown
+
+### Shell 5: Shutdown
+
+You can shut down the cluster with this command at any time:
+
+```bash
+cd ~/wallaroo-tutorial/wallaroo/utils/cluster_shutdown
+./cluster_shutdown 127.0.0.1:5050
+```
+
+You can shut down Giles Sender and Giles Receiver by pressing Ctrl-c from their respective shells.
+
+You can shut down the Metrics UI with the following command:
+
+```bash
+docker stop mui
+```

--- a/examples/cpp/counter-app/README.md
+++ b/examples/cpp/counter-app/README.md
@@ -48,31 +48,79 @@ python data_gen.py 10000
 
 Will generate 10,000 messages with 10 32-bit uints each.
 
-Return to the `counter-app` app directory for the [running](#running) instructions.
-
 ## Running
 
-Start the Metrics UI if it isn't already running:
+You will need five separate shells to run this application. Open each shell and go to the `examples/cpp/counter-app` directory.
+
+### Shell 1: Metrics UI
     ```bash
     docker start mui
     ```
 
-In a separate shell each:
+You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000).
 
-1. Start a listener with using `nc`
-    ```bash
-    nc -l 127.0.0.1 7002 > counter.out
-    ```
-2. Start the application
-    ```bash
-    ./build/counter-app --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
-      --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
-      --worker-name worker-name --cluster-initializer --ponythreads=1 \
-      --ponynoblock
-    ```
-3. Start sending data
-    ```bash
-     ../../../../giles/sender/sender --host 127.0.0.1:7010 --file data_gen/numbers.msg \
-       --batch-size 50 --interval 10_000_000 --binary --msg-size 44 --repeat \
-       --ponythreads=1 --ponynoblock --messages 1000000 --no-write
-    ```
+If you need to restart the UI, run:
+
+```bash
+docker restart mui
+```
+
+When it's time to stop the UI, run:
+
+```bash
+docker stop mui
+```
+
+If you need to start the UI after stopping it, run:
+
+```bash
+docker start mui
+```
+
+### Shell 2: Data Receiver
+
+Start a listener with using `nc`
+
+```bash
+nc -l 127.0.0.1 7002 > counter.out
+```
+
+### Shell 3: Counter-app
+
+Start the application
+
+```bash
+./build/counter-app --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
+  --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
+  --worker-name worker-name --cluster-initializer --ponythreads=1 \
+  --ponynoblock
+```
+
+### Shell 4: Sender
+
+Start sending data
+
+```bash
+../../../../giles/sender/sender --host 127.0.0.1:7010 --file data_gen/numbers.msg \
+  --batch-size 50 --interval 10_000_000 --binary --msg-size 44 --repeat \
+  --ponythreads=1 --ponynoblock --messages 1000000 --no-write
+```
+
+## Shutdown
+
+### Shell 5: Shutdown
+
+You can shut down the cluster with this command at any time:
+
+```bash
+cd ~/wallaroo-tutorial/wallaroo/utils/cluster_shutdown
+./cluster_shutdown 127.0.0.1:5050
+```
+
+You can shut down Giles Sender and Giles Receiver by pressing Ctrl-c from their respective shells.
+
+You can shut down the Metrics UI with the following command:
+
+```bash
+docker stop mui
+```

--- a/examples/go/alphabet/README.md
+++ b/examples/go/alphabet/README.md
@@ -33,9 +33,37 @@ In the alphabet directory, run `make`.
 
 In order to run the application you will need Giles Sender, Data Receiver, and the Cluster Shutdown tool. To build them, please see the [Linux](/book/go/getting-started/linux-setup.md) or [MacOS](/book/go/getting-started/macos-setup.md) setup instructions.
 
-You will need four separate shells to run this application. Open each shell and go to the `examples/go/alphabet` directory.
+You will need five separate shells to run this application. Open each shell and go to the `examples/go/alphabet` directory.
 
-### Shell 1
+### Shell 1: Metrics
+
+Start up the Metrics UI if you don't already have it running:
+
+```bash
+docker start mui
+```
+
+You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000).
+
+If you need to restart the UI, run:
+
+```bash
+docker restart mui
+```
+
+When it's time to stop the UI, run:
+
+```bash
+docker stop mui
+```
+
+If you need to start the UI after stopping it, run:
+
+```bash
+docker start mui
+```
+
+### Shell 2: Data Receiver
 
 Run `data_receiver` to listen for TCP output on `127.0.0.1` port `7002`:
 
@@ -43,7 +71,7 @@ Run `data_receiver` to listen for TCP output on `127.0.0.1` port `7002`:
 ../../../utils/data_receiver/data_receiver --listen 127.0.0.1:7002
 ```
 
-### Shell 2
+### Shell 3: Alphabet
 
 ```bash
 ./alphabet --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
@@ -52,7 +80,7 @@ Run `data_receiver` to listen for TCP output on `127.0.0.1` port `7002`:
   --external 127.0.0.1:6002 --ponythreads=1 --ponynoblock
 ```
 
-### Shell 3
+### Shell 4: Sender
 
 Send messages:
 
@@ -63,7 +91,7 @@ Send messages:
   --ponynoblock --no-write
 ```
 
-## Shutdown
+## Shell 5: Shutdown
 
 You can shut down the cluster with this command at any time:
 
@@ -72,3 +100,9 @@ You can shut down the cluster with this command at any time:
 ```
 
 You can shut down Giles Sender and Data Receiver by pressing `Ctrl-c` from their respective shells.
+
+You can shut down the Metrics UI with the following command:
+
+```bash
+docker stop mui
+```

--- a/examples/go/celsius/README.md
+++ b/examples/go/celsius/README.md
@@ -26,9 +26,37 @@ In the celsius directory, run `make`.
 
 In order to run the application you will need Giles Sender, Data Receiver, and the Cluster Shutdown tool. To build them, please see the [Linux](/book/go/getting-started/linux-setup.md) or [MacOS](/book/go/getting-started/macos-setup.md) setup instructions.
 
-You will need three separate shells to run this application. Open each shell and go to the `examples/go/celsius` directory.
+You will need five separate shells to run this application. Open each shell and go to the `examples/go/celsius` directory.
 
-### Shell 1
+### Shell 1: Metrics
+
+Start up the Metrics UI if you don't already have it running:
+
+```bash
+docker start mui
+```
+
+You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000).
+
+If you need to restart the UI, run:
+
+```bash
+docker restart mui
+```
+
+When it's time to stop the UI, run:
+
+```bash
+docker stop mui
+```
+
+If you need to start the UI after stopping it, run:
+
+```bash
+docker start mui
+```
+
+### Shell 2: Data Receiver
 
 Run `data_receiver` to listen for TCP output on `127.0.0.1` port `7002`:
 
@@ -36,7 +64,7 @@ Run `data_receiver` to listen for TCP output on `127.0.0.1` port `7002`:
 ../../../utils/data_receiver/data_receiver --listen 127.0.0.1:7002
 ```
 
-### Shell 2
+### Shell 3: Celsius
 
 Run `celsius`.
 
@@ -47,7 +75,7 @@ Run `celsius`.
   --ponythreads=1 --ponynoblock
 ```
 
-### Shell 3
+### Shell 4: Sender
 
 Send messages:
 
@@ -55,14 +83,14 @@ Send messages:
 ../../../giles/sender/sender --host 127.0.0.1:7010 \
   --file celsius.msg --batch-size 50 --interval 10_000_000 \
   --messages 500 --repeat --binary --msg-size 8 --no-write \
-  --ponythreads=1 --ponynoblock 
+  --ponythreads=1 --ponynoblock
 ```
 
 ## Reading the Output
 
 There will be a stream of output messages in the first shell (where you ran `data_receiver`).
 
-## Shutdown
+## Shell 5: Shutdown
 
 You can shut down the cluster with this command at any time:
 
@@ -71,3 +99,9 @@ You can shut down the cluster with this command at any time:
 ```
 
 You can shut down Giles Sender and Data Receiver by pressing `Ctrl-c` from their respective shells.
+
+You can shut down the Metrics UI with the following command:
+
+```bash
+docker stop mui
+```

--- a/examples/go/reverse/README.md
+++ b/examples/go/reverse/README.md
@@ -34,9 +34,37 @@ In the reverse directory, run `make`.
 
 In order to run the application you will need Giles Sender, Data Receiver, and the Cluster Shutdown tool. To build them, please see the [Linux](/book/go/getting-started/linux-setup.md) or [MacOS](/book/go/getting-started/macos-setup.md) setup instructions.
 
-You will need three separate shells to run this application. Open each shell and go to the `examples/go/reverse` directory.
+You will need five separate shells to run this application. Open each shell and go to the `examples/go/reverse` directory.
 
-### Shell 1
+### Shell 1: Metrics
+
+Start up the Metrics UI if you don't already have it running:
+
+```bash
+docker start mui
+```
+
+You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000).
+
+If you need to restart the UI, run:
+
+```bash
+docker restart mui
+```
+
+When it's time to stop the UI, run:
+
+```bash
+docker stop mui
+```
+
+If you need to start the UI after stopping it, run:
+
+```bash
+docker start mui
+```
+
+### Shell 2: Data Receiver
 
 Run `data_receiver` to listen for TCP output on `127.0.0.1` port `7002`:
 
@@ -44,16 +72,16 @@ Run `data_receiver` to listen for TCP output on `127.0.0.1` port `7002`:
 ../../../utils/data_receiver/data_receiver --listen 127.0.0.1:7002
 ```
 
-### Shell 2
+### Shell 3: Reverse
 
 ```bash
  ./reverse --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
   --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
   --name worker-name --external 127.0.0.1:5050 --cluster-initializer \
-  --ponythreads=1 --ponynoblock 
+  --ponythreads=1 --ponynoblock
 ```
 
-### Shell 3
+### Shell 4: Sender
 
 Send some messages:
 
@@ -67,7 +95,7 @@ Send some messages:
 
 The output will be printed to the console in the first shell. Each line should be the reverse of a word found in the `words.txt` file.
 
-## Shutdown
+## Shell 5: Shutdown
 
 You can shut down the cluster with this command at any time:
 
@@ -76,3 +104,9 @@ You can shut down the cluster with this command at any time:
 ```
 
 You can shut down Giles Sender and Data Receiver by pressing `Ctrl-c` from their respective shells.
+
+You can shut down the Metrics UI with the following command:
+
+```bash
+docker stop mui
+```

--- a/examples/go/word_count/README.md
+++ b/examples/go/word_count/README.md
@@ -30,9 +30,37 @@ In the word_count directory, run `make`.
 
 In order to run the application you will need Giles Sender, Data Receiver, and the Cluster Shutdown tool. To build them, please see the [Linux](/book/go/getting-started/linux-setup.md) or [MacOS](/book/go/getting-started/macos-setup.md) setup instructions.
 
-You will need three separate shells to run this application. Open each shell and go to the `examples/go/word_count` directory.
+You will need five separate shells to run this application. Open each shell and go to the `examples/go/word_count` directory.
 
-### Shell 1
+### Shell 1: Metrics
+
+Start up the Metrics UI if you don't already have it running:
+
+```bash
+docker start mui
+```
+
+You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000).
+
+If you need to restart the UI, run:
+
+```bash
+docker restart mui
+```
+
+When it's time to stop the UI, run:
+
+```bash
+docker stop mui
+```
+
+If you need to start the UI after stopping it, run:
+
+```bash
+docker start mui
+```
+
+### Shell 2: Data Receiver
 
 Run `data_receiver` to listen for TCP output on `127.0.0.1` port `7002`:
 
@@ -40,7 +68,7 @@ Run `data_receiver` to listen for TCP output on `127.0.0.1` port `7002`:
 ../../../utils/data_receiver/data_receiver --listen 127.0.0.1:7002
 ```
 
-### Shell 2
+### Shell 3: Word Count
 
 Run `word_count`.
 
@@ -51,7 +79,7 @@ Run `word_count`.
   --ponythreads=1 --ponynoblock
 ```
 
-### Shell 3
+### Shell 4: Sender
 
 In a third shell, send some messages:
 
@@ -65,7 +93,7 @@ In a third shell, send some messages:
 
 There will be a stream of output messages in the first shell (where you ran `data_receiver`).
 
-## Shutdown
+## Shell 5: Shutdown
 
 You can shut down the cluster with this command at any time:
 
@@ -74,3 +102,9 @@ You can shut down the cluster with this command at any time:
 ```
 
 You can shut down Giles Sender and Data Receiver by pressing `Ctrl-c` from their respective shells.
+
+You can shut down the Metrics UI with the following command:
+
+```bash
+docker stop mui
+```

--- a/examples/pony/alphabet/README.md
+++ b/examples/pony/alphabet/README.md
@@ -32,22 +32,47 @@ This will create a `votes.msg` file in your current working directory.
 
 ## Running Alphabet
 
-In a separate shell, each:
+You will need five separate shells to run this application. Open each shell and go to the `examples/pony/alphabet` directory.
 
-0. In a shell, start up the Metrics UI if you don't already have it running:
+### Shell 1: Metrics
+
+Start up the Metrics UI if you don't already have it running:
 
 ```bash
 docker start mui
 ```
 
-1. Start a listener
+You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000).
+
+If you need to restart the UI, run:
+
+```bash
+docker restart mui
+```
+
+When it's time to stop the UI, run:
+
+```bash
+docker stop mui
+```
+
+If you need to start the UI after stopping it, run:
+
+```bash
+docker start mui
+```
+
+### Shell 2: Data Receiver
+
+Start a listener
 
 ```bash
 ../../../../giles/receiver/receiver --listen 127.0.0.1:7002 --no-write \
   --ponythreads=1 --ponynoblock
 ```
 
-2. Start the application
+### Shell 3: Alphabet
+Start the application
 
 ```bash
 ./alphabet --in 127.0.0.1:7010 --out 127.0.0.1:7002 --metrics 127.0.0.1:5001 \
@@ -55,7 +80,9 @@ docker start mui
   --cluster-initializer --ponynoblock --ponythreads=1
 ```
 
-3. Start a sender
+### Shell 4: Sender
+
+Start a sender
 
 ```bash
 ../../../../giles/sender/sender --host 127.0.0.1:7010 \
@@ -64,8 +91,21 @@ docker start mui
   --ponynoblock --no-write
 ```
 
-4. Shut down cluster once finished processing
+## Shutdown
+
+### Shell 5: Shutdown
+
+You can shut down the cluster with this command at any time:
 
 ```bash
-../../../../utils/cluster_shutdown/cluster_shutdown 127.0.0.1:5050
+cd ~/wallaroo-tutorial/wallaroo/utils/cluster_shutdown
+./cluster_shutdown 127.0.0.1:5050
+```
+
+You can shut down Giles Sender and Giles Receiver by pressing Ctrl-c from their respective shells.
+
+You can shut down the Metrics UI with the following command:
+
+```bash
+docker stop mui
 ```

--- a/examples/python/alphabet/README.md
+++ b/examples/python/alphabet/README.md
@@ -36,10 +36,37 @@ The `decoder` function creates a `Votes` object with the letter being voted on a
 
 In order to run the application you will need Machida, Giles Sender, and the Cluster Shutdown tool. We provide instructions for building these tools yourself and we provide prebuilt binaries within a Docker container. Please visit our [setup](https://docs.wallaroolabs.com/book/getting-started/choosing-an-installation-option.html) instructions to choose one of these options if you have not already done so.
 
-You will need three separate shells to run this application. Open each shell and go to the `examples/python/alphabet` directory.
+You will need five separate shells to run this application. Open each shell and go to the `examples/python/alphabet` directory.
 
+### Shell 1: Metrics
 
-### Shell 1
+Start up the Metrics UI if you don't already have it running:
+
+```bash
+docker start mui
+```
+
+You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000).
+
+If you need to restart the UI, run:
+
+```bash
+docker restart mui
+```
+
+When it's time to stop the UI, run:
+
+```bash
+docker stop mui
+```
+
+If you need to start the UI after stopping it, run:
+
+```bash
+docker start mui
+```
+
+### Shell 2: Data Receiver
 
 Run `nc` to listen for TCP output on `127.0.0.1` port `7002`:
 
@@ -47,7 +74,7 @@ Run `nc` to listen for TCP output on `127.0.0.1` port `7002`:
 nc -l 127.0.0.1 7002 > alphabet.out
 ```
 
-### Shell 2
+### Shell 3: Alphabet
 
 Set `PATH` to refer to the directory that contains the `machida` executable. Set `PYTHONPATH` to refer to the current directory (where `alphabet.py` is) and the `machida` directory (where `wallaroo.py` is). Assuming you installed Wallaroo according to the tutorial instructions you would do:
 
@@ -67,7 +94,7 @@ machida --application-module alphabet --in 127.0.0.1:7010 \
   --name worker-name --ponythreads=1 --ponynoblock
 ```
 
-### Shell 3
+### Shell 4: Sender
 
 Set `PATH` to refer to the directory that contains the `sender`  executable. Assuming you installed Wallaroo according to the tutorial instructions you would do:
 
@@ -100,7 +127,7 @@ with open('alphabet.out', 'rb') as f:
             break
 ```
 
-## Shutdown
+## Shell 5: Shutdown
 
 Set `PATH` to refer to the directory that contains the `cluster_shutdown` executable. Assuming you installed Wallaroo  according to the tutorial instructions you would do:
 
@@ -117,3 +144,9 @@ cluster_shutdown 127.0.0.1:5050
 ```
 
 You can shut down Giles Sender by pressing `Ctrl-c` from its shell.
+
+You can shut down the Metrics UI with the following command:
+
+```bash
+docker stop mui
+```

--- a/examples/python/alphabet_partitioned/README.md
+++ b/examples/python/alphabet_partitioned/README.md
@@ -36,9 +36,37 @@ The `decoder` creates a `Votes` object with the letter being voted on and the nu
 
 In order to run the application you will need Machida, Giles Sender, Giles Receiver, and the Cluster Shutdown tool. We provide instructions for building these tools yourself and we provide prebuilt binaries within a Docker container. Please visit our [setup](https://docs.wallaroolabs.com/book/getting-started/choosing-an-installation-option.html) instructions to choose one of these options if you have not already done so.
 
-You will need four separate shells to run this application. Open each shell and go to the `examples/python/alphabet_partitioned` directory.
+You will need six separate shells to run this application. Open each shell and go to the `examples/python/alphabet_partitioned` directory.
 
-### Shell 1
+### Shell 1: Metrics
+
+Start up the Metrics UI if you don't already have it running:
+
+```bash
+docker start mui
+```
+
+You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000).
+
+If you need to restart the UI, run:
+
+```bash
+docker restart mui
+```
+
+When it's time to stop the UI, run:
+
+```bash
+docker stop mui
+```
+
+If you need to start the UI after stopping it, run:
+
+```bash
+docker start mui
+```
+
+### Shell 2: Data Receiver
 
 Set `PATH` to refer to the directory that contains the `receiver` executable. Assuming you installed Wallaroo according to the tutorial instructions you would do:
 
@@ -55,7 +83,7 @@ receiver --ponythreads=1 --ponynoblock \
   --listen 127.0.0.1:7002 --no-write
 ```
 
-### Shell 2
+### Shell 3: Alphabet (initializer)
 
 Set `PATH` to refer to the directory that contains the `machida` executable. Set `PYTHONPATH` to refer to the current directory (where `alphabet_partitioned.py` is) and the `machida` directory (where `wallaroo.py` is). Assuming you installed Machida according to the tutorial instructions you would do:
 
@@ -75,7 +103,7 @@ machida --application-module alphabet_partitioned --in 127.0.0.1:7010 \
   --external 127.0.0.1:5050 --ponythreads=1 --ponynoblock
 ```
 
-### Shell 3
+### Shell 4: Alphabet (worker-2)
 
 Set `PATH` to refer to the directory that contains the `machida` executable. Set `PYTHONPATH` to refer to the current directory (where `alphabet_partitioned.py` is) and the `machida` directory (where `wallaroo.py` is). Assuming you installed Machida according to the tutorial instructions you would do:
 
@@ -94,7 +122,7 @@ machida --application-module alphabet_partitioned --in 127.0.0.1:7010 \
   --name worker-2 --external 127.0.0.1:6010 --ponythreads=1 --ponynoblock
 ```
 
-### Shell 4
+### Shell 5: Sender
 
 Set `PATH` to refer to the directory that contains the `sender`  executable. Assuming you installed Wallaroo according to the tutorial instructions you would do:
 
@@ -113,7 +141,7 @@ sender --host 127.0.0.1:7010 \
   --ponynoblock --no-write
 ```
 
-## Shutdown
+## Shell 6: Shutdown
 
 Set `PATH` to refer to the directory that contains the `cluster_shutdown` executable. Assuming you installed Wallaroo  according to the tutorial instructions you would do:
 
@@ -130,3 +158,9 @@ cluster_shutdown 127.0.0.1:5050
 ```
 
 You can shut down Giles Sender and Giles Receiver by pressing `Ctrl-c` from their respective shells.
+
+You can shut down the Metrics UI with the following command:
+
+```bash
+docker stop mui
+```

--- a/examples/python/celsius-kafka/README.md
+++ b/examples/python/celsius-kafka/README.md
@@ -27,9 +27,37 @@ You will also need access to a Kafka cluster. This example assumes that there is
 
 **NOTE:** If running in Docker, the kafkfa cluster and kafkacat should be run from your host and not within the Docker container.
 
-You will need three separate shells to run this application. Open each shell and go to the `examples/python/celsius-kafka` directory.
+You will need five separate shells to run this application. Open each shell and go to the `examples/python/celsius-kafka` directory.
 
-### Shell 1
+### Shell 1: Metrics
+
+Start up the Metrics UI if you don't already have it running:
+
+```bash
+docker start mui
+```
+
+You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000).
+
+If you need to restart the UI, run:
+
+```bash
+docker restart mui
+```
+
+When it's time to stop the UI, run:
+
+```bash
+docker stop mui
+```
+
+If you need to start the UI after stopping it, run:
+
+```bash
+docker start mui
+```
+
+### Shell 2: Kafka setup and listener
 
 #### Start kafka and create the `test-in` and `test-out` topics
 
@@ -84,7 +112,7 @@ To run `kafkacat` to listen to the `test-out` topic via Docker:
 docker run --rm -it ryane/kafkacat -C -b 127.0.0.1:9092 -t test-out -q > celsius.out
 ```
 
-### Shell 2
+### Shell 3: Celsius-kafka
 
 Set `PATH` to refer to the directory that contains the `machida` executable. Set `PYTHONPATH` to refer to the current directory (where `celsius.py` is) and the `machida` directory (where `wallaroo.py` is). Assuming you installed Wallaroo according to the tutorial instructions you would do:
 
@@ -111,7 +139,7 @@ machida --application-module celsius \
 
 `kafka_sink_max_produce_buffer_ms` controls maximum time (in ms) to buffer messages before sending to kafka. Either don't specify it or set it to `0` to disable batching on produce.
 
-### Shell 3
+### Shell 4: Sender
 
 Send data into Kafka. Again, we use `kafakcat`.
 
@@ -141,7 +169,7 @@ with open('celsius.out', 'rb') as f:
             break
 ```
 
-## Shutdown
+## Shell 5: Shutdown
 
 Set `PATH` to refer to the directory that contains the `cluster_shutdown` executable. Assuming you installed Wallaroo  according to the tutorial instructions you would do:
 
@@ -169,4 +197,10 @@ If you followed the commands earlier to start kafka you can stop it by running:
 ```bash
 cd /tmp/local-kafka-cluster
 ./cluster down # shut down cluster
+```
+
+You can shut down the Metrics UI with the following command:
+
+```bash
+docker stop mui
 ```

--- a/examples/python/celsius/README.md
+++ b/examples/python/celsius/README.md
@@ -24,9 +24,37 @@ The `decoder` function creates a float from the value represented by the payload
 
 In order to run the application you will need Machida, Giles Sender, and the Cluster Shutdown tool. We provide instructions for building these tools yourself and we provide prebuilt binaries within a Docker container. Please visit our [setup](https://docs.wallaroolabs.com/book/getting-started/choosing-an-installation-option.html) instructions to choose one of these options if you have not already done so.
 
-You will need three separate shells to run this application. Open each shell and go to the `examples/python/celsius` directory.
+You will need five separate shells to run this application. Open each shell and go to the `examples/python/celsius` directory.
 
-### Shell 1
+### Shell 1: Metrics
+
+Start up the Metrics UI if you don't already have it running:
+
+```bash
+docker start mui
+```
+
+You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000).
+
+If you need to restart the UI, run:
+
+```bash
+docker restart mui
+```
+
+When it's time to stop the UI, run:
+
+```bash
+docker stop mui
+```
+
+If you need to start the UI after stopping it, run:
+
+```bash
+docker start mui
+```
+
+### Shell 2: Data Receiver
 
 Run `nc` to listen for TCP output on `127.0.0.1` port `7002`:
 
@@ -34,7 +62,7 @@ Run `nc` to listen for TCP output on `127.0.0.1` port `7002`:
 nc -l 127.0.0.1 7002 > celsius.out
 ```
 
-### Shell 2
+### Shell 3: Celsius
 
 Set `PATH` to refer to the directory that contains the `machida` executable. Set `PYTHONPATH` to refer to the current directory (where `alphabet.py` is) and the `machida` directory (where `celsius.py` is). Assuming you installed Wallaroo according to the tutorial instructions you would do:
 
@@ -54,7 +82,7 @@ machida --application-module celsius --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
   --ponythreads=1 --ponynoblock
 ```
 
-### Shell 3
+### Shell 4: Sender
 
 Set `PATH` to refer to the directory that contains the `sender`  executable. Assuming you installed Wallaroo according to the tutorial instructions you would do:
 
@@ -89,7 +117,7 @@ with open('celsius.out', 'rb') as f:
             break
 ```
 
-## Shutdown
+## Shell 5: Shutdown
 
 Set `PATH` to refer to the directory that contains the `cluster_shutdown` executable. Assuming you installed Wallaroo  according to the tutorial instructions you would do:
 
@@ -106,3 +134,9 @@ cluster_shutdown 127.0.0.1:5050
 ```
 
 You can shut down Giles Sender by pressing `Ctrl-c` from its shell.
+
+You can shut down the Metrics UI with the following command:
+
+```bash
+docker stop mui
+```

--- a/examples/python/market_spread/README.md
+++ b/examples/python/market_spread/README.md
@@ -61,9 +61,37 @@ The Order messages are handled by the `order_decoder` function, which takes the 
 
 In order to run the application you will need Machida, Giles Sender, and the Cluster Shutdown tool. We provide instructions for building these tools yourself and we provide prebuilt binaries within a Docker container. Please visit our [setup](https://docs.wallaroolabs.com/book/getting-started/choosing-an-installation-option.html) instructions to choose one of these options if you have not already done so.
 
-You will need five separate shells to run this application. Open each shell and go to the `examples/python/market_spread` directory.
+You will need six separate shells to run this application. Open each shell and go to the `examples/python/market_spread` directory.
 
-### Shell 1
+### Shell 1: Metrics
+
+Start up the Metrics UI if you don't already have it running:
+
+```bash
+docker start mui
+```
+
+You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000).
+
+If you need to restart the UI, run:
+
+```bash
+docker restart mui
+```
+
+When it's time to stop the UI, run:
+
+```bash
+docker stop mui
+```
+
+If you need to start the UI after stopping it, run:
+
+```bash
+docker start mui
+```
+
+### Shell 2: Data Receiver
 
 Run `nc` to listen for TCP output on `127.0.0.1` port `7002`:
 
@@ -71,7 +99,7 @@ Run `nc` to listen for TCP output on `127.0.0.1` port `7002`:
 nc -l 127.0.0.1 7002 > marketspread.out
 ```
 
-### Shell 2
+### Shell 3: Market Spread
 
 Set `PATH` to refer to the directory that contains the `machida` executable. Set `PYTHONPATH` to refer to the current directory (where `market_spread.py` is) and the `machida` directory (where `wallaroo.py` is). Assuming you installed Wallaroo according to the tutorial instructions you would do:
 
@@ -92,7 +120,7 @@ machida --application-module market_spread \
   --ponythreads=1 --ponynoblock
 ```
 
-### Shell 3
+### Shell 4: Sender (NBBO)
 
 Set `PATH` to refer to the directory that contains the `sender`  executable. Assuming you installed Wallaroo according to the tutorial instructions you would do:
 
@@ -113,17 +141,7 @@ sender --host 127.0.0.1:7011 --file \
 
 This will run for a few seconds and then terminate.
 
-### Shell 4
-
-Set `PATH` to refer to the directory that contains the `sender`  executable. Assuming you installed Wallaroo according to the tutorial instructions you would do:
-
-**Note:** If running in Docker, the `PATH` variable is pre-set for you to include the necessary directories to run this example.
-
-```bash
-export PATH="$PATH:$HOME/wallaroo-tutorial/wallaroo/machida/build:$HOME/wallaroo-tutorial/wallaroo/giles/sender:$HOME/wallaroo-tutorial/wallaroo/utils/cluster_shutdown"
-```
-
-To send market messages, run this command:
+To begin send market messages, run this command:
 
 ```bash
 sender --host 127.0.0.1:7011 --file \
@@ -136,7 +154,7 @@ This will run until all 1,000,000 messages are processed; it can be stopped by `
 
 Once you've started sending Market messages, go to the next section to start sending order messages.
 
-### Shell 5
+### Shell 5: Sender (Orders)
 
 Set `PATH` to refer to the directory that contains the `sender`  executable. Assuming you installed Wallaroo according to the tutorial instructions you would do:
 
@@ -157,7 +175,7 @@ sender --host 127.0.0.1:7010 --file \
 
 This will run until all 1,000,000 messages are processed; it can be stopped by `ctrl-c`.
 
-## Shutdown
+## Shell 6: Shutdown
 
 Set `PATH` to refer to the directory that contains the `cluster_shutdown` executable. Assuming you installed Wallaroo  according to the tutorial instructions you would do:
 
@@ -174,3 +192,9 @@ cluster_shutdown 127.0.0.1:5050
 ```
 
 You can shut down the Giles Senders by pressing `Ctrl-c` from their shells.
+
+You can shut down the Metrics UI with the following command:
+
+```bash
+docker stop mui
+```

--- a/examples/python/market_spread/README.md
+++ b/examples/python/market_spread/README.md
@@ -141,7 +141,7 @@ sender --host 127.0.0.1:7011 --file \
 
 This will run for a few seconds and then terminate.
 
-To begin send market messages, run this command:
+To begin sending market messages, run this command:
 
 ```bash
 sender --host 127.0.0.1:7011 --file \

--- a/examples/python/reverse/README.md
+++ b/examples/python/reverse/README.md
@@ -30,9 +30,37 @@ The `decoder` function creates a string from the value represented by the payloa
 
 In order to run the application you will need Machida, Giles Sender, and the Cluster Shutdown tool. We provide instructions for building these tools yourself and we provide prebuilt binaries within a Docker container. Please visit our [setup](https://docs.wallaroolabs.com/book/getting-started/choosing-an-installation-option.html) instructions to choose one of these options if you have not already done so.
 
-You will need three separate shells to run this application. Open each shell and go to the `examples/python/reverse` directory.
+You will need five separate shells to run this application. Open each shell and go to the `examples/python/reverse` directory.
 
-### Shell 1
+### Shell 1: Metrics
+
+Start up the Metrics UI if you don't already have it running:
+
+```bash
+docker start mui
+```
+
+You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000).
+
+If you need to restart the UI, run:
+
+```bash
+docker restart mui
+```
+
+When it's time to stop the UI, run:
+
+```bash
+docker stop mui
+```
+
+If you need to start the UI after stopping it, run:
+
+```bash
+docker start mui
+```
+
+### Shell 2: Data Receiver
 
 Run `nc` to listen for the output messages:
 
@@ -40,7 +68,7 @@ Run `nc` to listen for the output messages:
 nc -l 127.0.0.1 7002
 ```
 
-### Shell 2
+### Shell 3: Reverse
 
 Set `PATH` to refer to the directory that contains the `machida` executable. Set `PYTHONPATH` to refer to the current directory (where `reverse.py` is) and the `machida` directory (where `wallaroo.py` is). Assuming you installed Wallaroo according to the tutorial instructions you would do:
 
@@ -60,7 +88,7 @@ machida --application-module reverse --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
   --ponythreads=1 --ponynoblock
 ```
 
-### Shell 3
+### Shell 4: Sender
 
 Set `PATH` to refer to the directory that contains the `sender`  executable. Assuming you installed Wallaroo according to the tutorial instructions you would do:
 
@@ -82,7 +110,7 @@ sender --host 127.0.0.1:7010 --file words.txt \
 
 The output will be printed to the console in the first shell. Each line should be the reverse of a word found in the `words.txt` file.
 
-## Shutdown
+## Shell 5: Shutdown
 
 Set `PATH` to refer to the directory that contains the `cluster_shutdown` executable. Assuming you installed Wallaroo  according to the tutorial instructions you would do:
 
@@ -99,3 +127,9 @@ cluster_shutdown 127.0.0.1:5050
 ```
 
 You can shut down Giles Sender by pressing `Ctrl-c` from its shell.
+
+You can shut down the Metrics UI with the following command:
+
+```bash
+docker stop mui
+```

--- a/examples/python/word_count/README.md
+++ b/examples/python/word_count/README.md
@@ -30,7 +30,35 @@ In order to run the application you will need Machida, Giles Sender, and the Clu
 
 You will need three separate shells to run this application. Open each shell and go to the `examples/python/word_count` directory.
 
-### Shell 1
+### Shell 1: Metrics
+
+Start up the Metrics UI if you don't already have it running:
+
+```bash
+docker start mui
+```
+
+You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000).
+
+If you need to restart the UI, run:
+
+```bash
+docker restart mui
+```
+
+When it's time to stop the UI, run:
+
+```bash
+docker stop mui
+```
+
+If you need to start the UI after stopping it, run:
+
+```bash
+docker start mui
+```
+
+### Shell 2: Data Receiver
 
 Run `nc` to listen for TCP output on `127.0.0.1` port `7002`:
 
@@ -38,7 +66,7 @@ Run `nc` to listen for TCP output on `127.0.0.1` port `7002`:
 nc -l 127.0.0.1 7002
 ```
 
-### Shell 2
+### Shell 3: Word Count
 
 Set `PATH` to refer to the directory that contains the `machida` executable. Set `PYTHONPATH` to refer to the current directory (where `word_count.py` is) and the `machida` directory (where `wallaroo.py` is). Assuming you installed Wallaroo according to the tutorial instructions you would do:
 
@@ -58,7 +86,7 @@ machida --application-module word_count --in 127.0.0.1:7010 --out 127.0.0.1:7002
   --ponythreads=1 --ponynoblock
 ```
 
-### Shell 3
+### Shell 4: Sender
 
 Set `PATH` to refer to the directory that contains the `sender`  executable. Assuming you installed Wallaroo according to the tutorial instructions you would do:
 
@@ -79,7 +107,7 @@ sender --host 127.0.0.1:7010 --file count_this.txt \
 
 There will be a stream of output messages in the first shell (where you ran `nc`).
 
-## Shutdown
+## Shell 5: Shutdown
 
 Set `PATH` to refer to the directory that contains the `cluster_shutdown` executable. Assuming you installed Wallaroo  according to the tutorial instructions you would do:
 
@@ -96,3 +124,9 @@ cluster_shutdown 127.0.0.1:5050
 ```
 
 You can shut down Giles Sender by pressing `Ctrl-c` from its shell.
+
+You can shut down the Metrics UI with the following command:
+
+```bash
+docker stop mui
+```


### PR DESCRIPTION
This PR attempts to clarify the use of multiple shells in the examples. It does this by:

1. standardizing the format across all examples with a `Shell <num>: <Type/purpose>` header
2. including a shell for Metrics UI in all examples
3. including complete shutdown instructions in a separate shell (including instructions for the metrics UI)
4. Replacing uses of "Terminal" with "Shell" to keep things uniform.

[skip ci]
closes #2051 