### PR TITLE
Update regex lookup for shrink test

### DIFF
--- a/testing/correctness/tests/autoscale_tests/_autoscale_tests.py
+++ b/testing/correctness/tests/autoscale_tests/_autoscale_tests.py
@@ -424,9 +424,9 @@ def _autoscale_sequence(command, ops=[1], cycles=1, initial=None):
                              re.escape(r'Shutting down Startup...'),
                              re.escape(r'Shutting down DataChannel'),
                              re.escape(r'metrics connection closed'),
-                             re.escape(r'TCPSink connection closed')])
-                        patterns_l_per = [
-                            r'ControlChannelConnectNotifier:{}: server closed']
+                             re.escape(r'TCPSink connection closed'),
+                             re.escape(r'ControlChannelConnectNotifier: server closed')])
+                        patterns_l_per = []
 
                         left_checkers = []
 

--- a/testing/correctness/tests/autoscale_tests/autoscale_tests.py
+++ b/testing/correctness/tests/autoscale_tests/autoscale_tests.py
@@ -66,10 +66,10 @@ def test_autoscale_pony_grow_by_many():
 #
 #def test_autoscale_pony_shrink_by_1_grow_by_many():
 #    autoscale_sequence(CMD_PONY, ops=[-1,4], cycles=CYCLES)
-#
-#
-# def test_autoscale_pony_shrink_by_1():
-#     autoscale_sequence(CMD_PONY, ops=[-1], cycles=CYCLES)
+
+
+def test_autoscale_pony_shrink_by_1():
+     autoscale_sequence(CMD_PONY, ops=[-1], cycles=CYCLES)
 #
 #
 #def test_autoscale_pony_shrink_by_1_shrink_by_many():

--- a/testing/tools/integration/integration.py
+++ b/testing/tools/integration/integration.py
@@ -773,7 +773,7 @@ class RunnerReadyChecker(StoppableThread):
                         self.stop()
                         break
                 if time.time() - started > self.timeout:
-                    outputs = runners_output_format(runners)
+                    outputs = runners_output_format(self.runners)
                     self.error = TimeoutError(
                         'Application did not report as ready after {} '
                         'seconds. It had the following outputs:\n===\n{}'


### PR DESCRIPTION
Update the regex lookup term that was failing in shrink tests.
This also enables the pony shrink by 1 test which was erroneously commented out.

closes #2063 
