### PR TITLE
Fix bug that caused Wallaroo to shut down when connecting a new source after a 3->2 shrink

### DIFF
--- a/lib/wallaroo/ent/router_registry/router_registry.pony
+++ b/lib/wallaroo/ent/router_registry/router_registry.pony
@@ -308,6 +308,7 @@ actor RouterRegistry
         Fail()
       end
       if not _outgoing_boundaries_builders.contains(worker) then
+        _outgoing_boundaries_builders(worker) = builder
         new_boundary_builders(worker) = builder
       end
     end
@@ -986,6 +987,7 @@ actor RouterRegistry
       _outgoing_boundaries.remove(worker)?
       _outgoing_boundaries_builders.remove(worker)?
     end
+
     _distribute_boundary_builders()
     if not _leaving_in_process then
       ifdef debug then


### PR DESCRIPTION
We were not correctly updating the RouterRegistry's boundary
builder map during autoscale events, leading to routing problems
in certain shrink scenarios (such as 3->2).

Closes #2071