### PR TITLE
Correctly remove boundary references when worker leaves

### DIFF
--- a/lib/wallaroo/core/common/producer_consumer.pony
+++ b/lib/wallaroo/core/common/producer_consumer.pony
@@ -31,6 +31,9 @@ trait tag Producer is (Muteable & Ackable & AckRequester)
 interface tag RouterUpdateable
   be update_router(r: Router)
 
+interface tag BoundaryUpdateable
+  be remove_boundary(worker: String)
+
 trait tag Consumer is (Runnable & StateReceiver & AckRequester & Initializable)
   be register_producer(producer: Producer)
   be unregister_producer(producer: Producer)

--- a/lib/wallaroo/core/source/kafka_source/kafka_source.pony
+++ b/lib/wallaroo/core/source/kafka_source/kafka_source.pony
@@ -147,6 +147,19 @@ actor KafkaSource[In: Any val] is (Producer & KafkaConsumer)
     end
     _notify.update_boundaries(_outgoing_boundaries)
 
+  be remove_boundary(worker: String) =>
+    if _outgoing_boundaries.contains(worker) then
+      try
+        let boundary = _outgoing_boundaries(worker)?
+        _routes(boundary)?.dispose()
+        _routes.remove(boundary)?
+        _outgoing_boundaries.remove(worker)?
+      else
+        Fail()
+      end
+    end
+    _notify.update_boundaries(_outgoing_boundaries)
+
   be reconnect_boundary(target_worker_name: String) =>
     try
       _outgoing_boundaries(target_worker_name)?.reconnect()

--- a/lib/wallaroo/core/source/kafka_source/kafka_source_listener.pony
+++ b/lib/wallaroo/core/source/kafka_source/kafka_source_listener.pony
@@ -283,5 +283,14 @@ actor KafkaSourceListener[In: Any val] is (SourceListener & KafkaClientManager)
   =>
     _outgoing_boundary_builders = boundary_builders
 
+  be remove_boundary(worker: String) =>
+    let new_boundary_builders =
+      recover iso Map[String, OutgoingBoundaryBuilder] end
+    for (w, b) in _outgoing_boundary_builders.pairs() do
+      if w != worker then new_boundary_builders(w) = b end
+    end
+
+    _outgoing_boundary_builders = consume new_boundary_builders
+
   be dispose() =>
     None

--- a/lib/wallaroo/core/source/source.pony
+++ b/lib/wallaroo/core/source/source.pony
@@ -92,7 +92,7 @@ interface val SourceConfig[In: Any val]
   fun source_builder(app_name: String, name: String):
     SourceBuilderBuilder
 
-interface tag Source is DisposableActor
+interface tag Source is (DisposableActor & BoundaryUpdateable)
   be update_router(router: PartitionRouter)
   be add_boundary_builders(
     boundary_builders: Map[String, OutgoingBoundaryBuilder] val)
@@ -100,7 +100,7 @@ interface tag Source is DisposableActor
   be mute(c: Consumer)
   be unmute(c: Consumer)
 
-interface tag SourceListener is DisposableActor
+interface tag SourceListener is (DisposableActor & BoundaryUpdateable)
   be update_router(router: PartitionRouter)
   be add_boundary_builders(
     boundary_builders: Map[String, OutgoingBoundaryBuilder] val)

--- a/lib/wallaroo/core/source/tcp_source/tcp_source.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source.pony
@@ -201,6 +201,19 @@ actor TCPSource is Producer
     end
     _notify.update_boundaries(_outgoing_boundaries)
 
+  be remove_boundary(worker: String) =>
+    if _outgoing_boundaries.contains(worker) then
+      try
+        let boundary = _outgoing_boundaries(worker)?
+        _routes(boundary)?.dispose()
+        _routes.remove(boundary)?
+        _outgoing_boundaries.remove(worker)?
+      else
+        Fail()
+      end
+    end
+    _notify.update_boundaries(_outgoing_boundaries)
+
   be reconnect_boundary(target_worker_name: String) =>
     try
       _outgoing_boundaries(target_worker_name)?.reconnect()

--- a/lib/wallaroo/core/source/tcp_source/tcp_source_listener.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source_listener.pony
@@ -137,6 +137,15 @@ actor TCPSourceListener is SourceListener
   =>
     _outgoing_boundary_builders = boundary_builders
 
+  be remove_boundary(worker: String) =>
+    let new_boundary_builders =
+      recover iso Map[String, OutgoingBoundaryBuilder] end
+    for (w, b) in _outgoing_boundary_builders.pairs() do
+      if w != worker then new_boundary_builders(w) = b end
+    end
+
+    _outgoing_boundary_builders = consume new_boundary_builders
+
   be dispose() =>
     @printf[I32]("Shutting down TCPSourceListener\n".cstring())
     _close()


### PR DESCRIPTION
We were not removing all routes to a boundary to a worker
that left the cluster. This led to problems in in-flight
message acking, since we would try to request acks to
boundaries that were no longer connected.

Closes #2074