### PR TITLE
For contended APIs, only place partition steps on non-initializers

### DIFF
--- a/lib/wallaroo/application.pony
+++ b/lib/wallaroo/application.pony
@@ -38,9 +38,11 @@ class Application
   // _state_builders maps from state_name to StateSubpartition
   let _state_builders: Map[String, PartitionBuilder] = _state_builders.create()
   var sink_count: USize = 0
+  let is_contended: Bool
 
-  new create(name': String) =>
+  new create(name': String, is_contended': Bool = false) =>
     _name = name'
+    is_contended = is_contended'
 
   fun ref new_pipeline[In: Any val, Out: Any val] (pipeline_name: String,
     source_config: SourceConfig[In]): PipelineBuilder[In, Out, In]

--- a/lib/wallaroo/core/initialization/application_distributor.pony
+++ b/lib/wallaroo/core/initialization/application_distributor.pony
@@ -67,6 +67,12 @@ actor ApplicationDistributor is Distributor
       FatalUserError(err_msg)
     end
 
+    if application.is_contended then
+      ifdef debug then
+        @printf[I32]("Using Contended API.\n".cstring())
+      end
+    end
+
     try
       let all_workers_trn = recover trn Array[String] end
       all_workers_trn.push(initializer_name)

--- a/lib/wallaroo/core/initialization/local_topology.pony
+++ b/lib/wallaroo/core/initialization/local_topology.pony
@@ -1062,7 +1062,13 @@ actor LocalTopologyInitializer is LayoutInitializer
             //////////////////////
               try
                 let local_step_ids =
-                  pre_stateless_data.worker_to_step_id(_worker_name)?
+                  if pre_stateless_data.worker_to_step_id
+                    .contains(_worker_name)
+                  then
+                    pre_stateless_data.worker_to_step_id(_worker_name)?
+                  else
+                    recover val Array[StepId] end
+                  end
 
                 // Make sure all local steps for this stateless partition
                 // have already been initialized on this worker.

--- a/lib/wallaroo/core/topology/partition.pony
+++ b/lib/wallaroo/core/topology/partition.pony
@@ -55,12 +55,12 @@ primitive SingleStepPartitionFunction[In: Any val] is
   PartitionFunction[In, U8]
   fun apply(input: In): U8 => 0
 
-interface PartitionAddresses is Equatable[PartitionAddresses]
+interface val PartitionAddresses is Equatable[PartitionAddresses]
   fun apply(key: Any val): (ProxyAddress | None)
   fun update_key[Key: (Hashable val & Equatable[Key] val)](key: Key,
     pa: ProxyAddress): PartitionAddresses val ?
 
-class KeyedPartitionAddresses[Key: (Hashable val & Equatable[Key] val)]
+class val KeyedPartitionAddresses[Key: (Hashable val & Equatable[Key] val)]
   let _addresses: Map[Key, ProxyAddress] val
 
   new val create(a: Map[Key, ProxyAddress] val) =>

--- a/lib/wallaroo/core/topology/step_initializer.pony
+++ b/lib/wallaroo/core/topology/step_initializer.pony
@@ -240,16 +240,16 @@ class val PreStatelessData
   graph that have edges into it.
   """
   let _pipeline_name: String
-  let _id: U128
+  let _id: StepId
   let partition_id_to_worker: Map[U64, String] val
-  let partition_id_to_step_id: Map[U64, U128] val
-  let worker_to_step_id: Map[String, Array[U128] val] val
+  let partition_id_to_step_id: Map[U64, StepId] val
+  let worker_to_step_id: Map[String, Array[StepId] val] val
   let steps_per_worker: USize
 
-  new val create(pipeline_name': String, step_id': U128,
+  new val create(pipeline_name': String, step_id': StepId,
     partition_id_to_worker': Map[U64, String] val,
-    partition_id_to_step_id': Map[U64, U128] val,
-    worker_to_step_id': Map[String, Array[U128] val] val,
+    partition_id_to_step_id': Map[U64, StepId] val,
+    worker_to_step_id': Map[String, Array[StepId] val] val,
     steps_per_worker': USize)
   =>
     _pipeline_name = pipeline_name'
@@ -262,7 +262,7 @@ class val PreStatelessData
   fun name(): String => "PreStatelessData"
   fun state_name(): String => ""
   fun pipeline_name(): String => _pipeline_name
-  fun id(): U128 => _id
+  fun id(): StepId => _id
   fun pre_state_target_ids(): Array[StepId] val => recover Array[StepId] end
   fun is_prestate(): Bool => false
   fun is_stateful(): Bool => false

--- a/machida/machida.pony
+++ b/machida/machida.pony
@@ -528,7 +528,7 @@ primitive Machida
         let name = recover val
           String.copy_cstring(@PyString_AsString(@PyTuple_GetItem(item, 1)))
         end
-        app = Application(name)
+        app = Application(name, true)
         break
       end
     end


### PR DESCRIPTION
If you flag an API as contended, then Wallaroo will only place
state and stateless partition steps on non-initializers. The
initializer currently is the only worker that contains Sources.
This means that all message decoding will happen on the initializer
and all partition computations will happen on other workers.