### PR TITLE
Add support for Application validation

### DIFF
--- a/lib/wallaroo/application.pony
+++ b/lib/wallaroo/application.pony
@@ -75,6 +75,16 @@ class Application
 
   fun name(): String => _name
 
+  // Returns a String with an error message if this application fails this
+  // validation test
+  fun validate(): (String | None) =>
+    if pipelines.size() == 0 then
+      "You must provide at least 1 pipeline in an application. Did you " +
+        "forget to close out a pipeline?"
+    else
+      None
+    end
+
 trait BasicPipeline
   fun name(): String
   fun source_id(): USize

--- a/lib/wallaroo/core/initialization/application_distributor.pony
+++ b/lib/wallaroo/core/initialization/application_distributor.pony
@@ -62,6 +62,11 @@ actor ApplicationDistributor is Distributor
     @printf[I32]("---------------------------------------------------------\n".cstring())
     @printf[I32]("vvvvvv|Initializing Topologies for Workers|vvvvvv\n\n".cstring())
 
+    match application.validate()
+    | let err_msg: String =>
+      FatalUserError(err_msg)
+    end
+
     try
       let all_workers_trn = recover trn Array[String] end
       all_workers_trn.push(initializer_name)
@@ -934,6 +939,7 @@ actor ApplicationDistributor is Distributor
         "---\n").cstring())
     else
       @printf[I32]("Error initializing application!\n".cstring())
+      Fail()
     end
 
   fun ref _add_edges_to_graph(producer_ids: (U128 | Array[U128] | None),


### PR DESCRIPTION
If an Application is defined but no pipelines are added to it,
this will cause problems down the line. Applications of this kind
should not be permitted, since they don't actually do anything.
This commit adds a validate() method to Application that checks
that certain criteria are satisifed. If not, it returns an error
message that we can use to call `FatalUserError()`.

Closes #2065.