### PR TITLE
Add "No applications connected" message to Apps page in Metrics UI

### DIFF
--- a/monitoring_hub/apps/metrics_reporter_ui/web/static/js/buffy-ui/components/applications/ApplicationsTable.js
+++ b/monitoring_hub/apps/metrics_reporter_ui/web/static/js/buffy-ui/components/applications/ApplicationsTable.js
@@ -1,15 +1,22 @@
 import React from "react"
 import { Table, Alert } from "react-bootstrap"
 import ApplicationsTableRow from "./ApplicationsTableRow"
+import EmptyAppsRow from "./EmptyAppsRow"
 import VersionAlert from "./VersionAlert"
+import { List } from "immutable"
 
 export default class ApplicationsTable extends React.Component {
 	render() {
+		let rows;
 		const { appConfigs } = this.props;
-		const rows =  appConfigs.map(function(appConfig) {
-			const appName = appConfig.get("app_name");
-			return <ApplicationsTableRow appName={appName} key={appName} />;
-		});
+		if (appConfigs.isEmpty()) {
+			rows = List([<EmptyAppsRow />])
+		} else {
+			rows =  appConfigs.map(function(appConfig) {
+				const appName = appConfig.get("app_name");
+				return <ApplicationsTableRow appName={appName} key={appName} />;
+			});
+		}
 		return (
 			<div>
 			<VersionAlert />

--- a/monitoring_hub/apps/metrics_reporter_ui/web/static/js/buffy-ui/components/applications/EmptyAppsRow.js
+++ b/monitoring_hub/apps/metrics_reporter_ui/web/static/js/buffy-ui/components/applications/EmptyAppsRow.js
@@ -1,0 +1,16 @@
+import React from "react"
+import { Link } from "react-router"
+import ApplicationTitle from "./ApplicationTitle"
+
+export default class EmptyAppsRow extends React.Component {
+	render() {
+		const noApps = "No applications connected"
+		return (
+			<tr>
+				<td>
+					<ApplicationTitle appName={noApps}/>
+				</td>
+			</tr>
+		)
+	}
+}


### PR DESCRIPTION
From a users experience perspective, visiting the Apps page for the
first time should notify the user that no apps are connected instead
of being an empty page. This commit adds a "No applications connected"
message and is removed once an application connects to the MonHub.

closes #2048 

**Testing:**

Start the Metrics UI with the following command:

```bash
docker run -d --name mui -p 0.0.0.0:4000:4000 -p 0.0.0.0:5001:5001 \
  wallaroolabs/metrics-reporter-ui:gcf5da20
```

You should see "No application connected" on the Applications page. After an application does connect, this notice should disappear and the standard links to app names should replace it.