### PR TITLE
Add partition count observability query

### DIFF
--- a/lib/wallaroo/core/initialization/local_topology.pony
+++ b/lib/wallaroo/core/initialization/local_topology.pony
@@ -1522,6 +1522,9 @@ actor LocalTopologyInitializer is LayoutInitializer
   be partition_query(conn: TCPConnection) =>
     _router_registry.partition_query(conn)
 
+  be partition_count_query(conn: TCPConnection) =>
+    _router_registry.partition_count_query(conn)
+
   be cluster_status_query(conn: TCPConnection) =>
     match _topology
     | let t: LocalTopology =>

--- a/lib/wallaroo/ent/network/external_channel_tcp.pony
+++ b/lib/wallaroo/ent/network/external_channel_tcp.pony
@@ -153,6 +153,12 @@ class ExternalChannelConnectNotifier is TCPConnectionNotify
               "Channel\n").cstring())
           end
           _local_topology_initializer.partition_query(conn)
+        | let m: ExternalPartitionCountQueryMsg =>
+          ifdef "trace" then
+            @printf[I32](("Received ExternalPartitionCountQueryMsg on " +
+              "External Channel\n").cstring())
+          end
+          _local_topology_initializer.partition_count_query(conn)
         | let m: ExternalClusterStatusQueryMsg =>
           ifdef "trace" then
             @printf[I32](("Received ExternalClusterStatusQueryMsg on " +

--- a/lib/wallaroo/ent/router_registry/router_registry.pony
+++ b/lib/wallaroo/ent/router_registry/router_registry.pony
@@ -517,6 +517,11 @@ actor RouterRegistry
       _partition_routers, _stateless_partition_routers)
     conn.writev(msg)
 
+  be partition_count_query(conn: TCPConnection) =>
+    let msg = ExternalMsgEncoder.partition_count_query_response(
+      _partition_routers, _stateless_partition_routers)
+    conn.writev(msg)
+
   be cluster_status_query(worker_names: Array[String] val,
     conn: TCPConnection)
   =>

--- a/lib/wallaroo_labs/query/query_json.pony
+++ b/lib/wallaroo_labs/query/query_json.pony
@@ -71,6 +71,20 @@ primitive PartitionQueryEncoder
     end
     _JsonEncoder(consume entries, _JsonMap)
 
+  fun partition_counts_by_worker(se: _StepIdsByWorker): String =>
+    let entries = recover iso Array[String] end
+    for (k, v) in se.pairs() do
+      entries.push(_Quoted(k) + ":" + v.size().string())
+    end
+    _JsonEncoder(consume entries, _JsonMap)
+
+  fun partition_counts(qm: _PartitionQueryMap): String =>
+    let entries = recover iso Array[String] end
+    for (k, v) in qm.pairs() do
+      entries.push(_Quoted(k) + ":" + partition_counts_by_worker(v))
+    end
+    _JsonEncoder(consume entries, _JsonMap)
+
   fun state_and_stateless(m: Map[String, _PartitionQueryMap]): String =>
     let entries = recover iso Array[String] end
     try
@@ -78,6 +92,20 @@ primitive PartitionQueryEncoder
         partitions(m("state_partitions")?))
       entries.push(_Quoted("stateless_partitions") + ":" +
         partitions(m("stateless_partitions")?))
+    else
+      Fail()
+    end
+    _JsonEncoder(consume entries, _JsonMap)
+
+  fun state_and_stateless_by_count(m: Map[String, _PartitionQueryMap]):
+    String
+  =>
+    let entries = recover iso Array[String] end
+    try
+      entries.push(_Quoted("state_partitions") + ":" +
+        partition_counts(m("state_partitions")?))
+      entries.push(_Quoted("stateless_partitions") + ":" +
+        partition_counts(m("stateless_partitions")?))
     else
       Fail()
     end

--- a/testing/tools/external_sender/external_sender.pony
+++ b/testing/tools/external_sender/external_sender.pony
@@ -76,6 +76,9 @@ actor Main
         | "partition-query" =>
           await_response = true
           ExternalMsgEncoder.partition_query()
+        | "partition-count-query" =>
+          await_response = true
+          ExternalMsgEncoder.partition_count_query()
         | "cluster-status-query" =>
           await_response = true
           ExternalMsgEncoder.cluster_status_query()
@@ -136,6 +139,10 @@ class ExternalSenderConnectNotifier is TCPConnectionNotify
         | let m: ExternalClusterStatusQueryResponseMsg =>
           _env.out.print("Cluster Status:")
           _env.out.print(m.string())
+          conn.dispose()
+        | let m: ExternalPartitionCountQueryResponseMsg =>
+          _env.out.print("Partition Distribution (counts):")
+          _env.out.print(m.msg)
           conn.dispose()
         else
           _env.err.print("Received unhandled external message type")


### PR DESCRIPTION
We currently have an observability query called that gets you
the distribution of particular step ids across the
cluster, but this can be unwieldy and is most useful
in the context of automated tests. This new query
returns just the number of steps on each worker broken
down by partition type.