### PR TITLE
Inform joining worker to shut down on join error

### DIFF
--- a/lib/wallaroo/core/initialization/local_topology.pony
+++ b/lib/wallaroo/core/initialization/local_topology.pony
@@ -1689,8 +1689,8 @@ actor LocalTopologyInitializer is LayoutInitializer
           Fail()
         end
       else
-        _router_registry.update_joining_worker_count(worker_count)
-        _router_registry.inform_joining_worker(conn, worker_name, t)
+        _router_registry.inform_joining_worker(conn, worker_name, worker_count,
+          t)
       end
     else
       Fail()

--- a/lib/wallaroo/core/messages/channel_messages.pony
+++ b/lib/wallaroo/core/messages/channel_messages.pony
@@ -238,6 +238,14 @@ primitive ChannelMsgEncoder
       partition_blueprints, stateless_partition_blueprints,
       omni_router_blueprint), auth)?
 
+  fun inform_join_error(msg: String, auth: AmbientAuth): Array[ByteSeq] val ?
+  =>
+    """
+    This message is sent as a response to a JoinCluster message when there is
+    a join error and the joiner should shut down.
+    """
+    _encode(InformJoinErrorMsg(msg), auth)?
+
   fun inform_recover_not_join(auth: AmbientAuth): Array[ByteSeq] val ? =>
     """
     This message is sent as a response to a JoinCluster message when we
@@ -702,6 +710,12 @@ class val InformJoiningWorkerMsg is ChannelMsg
     partition_router_blueprints = p_blueprints
     stateless_partition_router_blueprints = stateless_p_blueprints
     omni_router_blueprint = omr_blueprint
+
+class val InformJoinErrorMsg is ChannelMsg
+  let message: String
+
+  new val create(m: String) =>
+    message = m
 
 primitive InformRecoverNotJoinMsg is ChannelMsg
 

--- a/lib/wallaroo/ent/network/control_channel_tcp.pony
+++ b/lib/wallaroo/ent/network/control_channel_tcp.pony
@@ -438,6 +438,9 @@ class JoiningControlSenderConnectNotifier is TCPConnectionNotify
         else
           Fail()
         end
+      | let m: InformJoinErrorMsg =>
+        @printf[I32]("Join Error: %s\n".cstring(), m.message.cstring())
+        FatalUserError("Join Error: " + m.message)
       | let m: InformRecoverNotJoinMsg =>
         @printf[I32]("Informed that we should recover.\n".cstring())
         _startup.recover_not_join()


### PR DESCRIPTION
If a joining worker supplies an invalid worker count,
then immediately inform the worker of a join error so
that it can shut down with a FatalUserError.

Closes #2084