### PR TITLE
Add `--json/-j` output mode to external_sender

### DIFF
--- a/lib/wallaroo_labs/messages/external_messages.pony
+++ b/lib/wallaroo_labs/messages/external_messages.pony
@@ -323,13 +323,15 @@ class val ExternalClusterStatusQueryResponseMsg is ExternalMsg
   let worker_count: U64
   let worker_names: Array[String] val
   let processing_messages: Bool
+  let json: String
 
   new val create(worker_count': U64, worker_names': Array[String] val,
-    processing_messages': Bool)
+    processing_messages': Bool, json': String)
   =>
     worker_count = worker_count'
     worker_names = worker_names'
     processing_messages = processing_messages'
+    json = json'
 
   fun string(): String =>
     let ws = Array[String]


### PR DESCRIPTION
- fix some json formatting issues in query_json.pony
- add `json` field to ExternalClusterStatusQueryResponseMsg
- add json-only output mode to external_sender


Note: the array quoting issue that is addressed by the first bullet point is not a comprehensive fix. It's a fix to the specific instance where this is an issue.
A more comprehensive review of JSON encoding/decoding functionality is addressed in #2094 