### PR TITLE
Remove Check Order print in Go Market Spread

### DIFF
--- a/testing/performance/apps/go/market_spread/go/src/market_spread/market_spread/check_order.go
+++ b/testing/performance/apps/go/market_spread/go/src/market_spread/market_spread/check_order.go
@@ -1,11 +1,10 @@
 package market_spread
 
 import (
-	"fmt"
 	"time"
 )
 
-type CheckOrder struct {}
+type CheckOrder struct{}
 
 func (co *CheckOrder) Name() string {
 	return "Check Order"
@@ -16,7 +15,6 @@ func (co *CheckOrder) Compute(data interface{}, state interface{}) (interface{},
 	symbolData := state.(*SymbolData)
 
 	if symbolData.ShouldRejectTrades {
-		fmt.Println("Rejected trade")
 		var orderCopy Order = *order
 		ts := uint64(time.Now().UnixNano())
 		return NewOrderResult(&orderCopy, symbolData.LastBid, symbolData.LastOffer, ts), false


### PR DESCRIPTION
The print statement for rejected orders is not needed and is a debugging
artifact that was left behind.

closes #2097