### PR TITLE
Display raw throughput value in Metrics UI if under 1k

### DIFF
--- a/monitoring_hub/apps/metrics_reporter_ui/web/static/js/util/Format.js
+++ b/monitoring_hub/apps/metrics_reporter_ui/web/static/js/util/Format.js
@@ -27,6 +27,8 @@ function formatThroughput(thr) {
         return "0k";
     } else if (thr == "-") {
         return thr;
+    } else if (thr < 1000) {
+        return thr;
     } else if (thr > 10000) {
         return cleanTrailing(thr/1000, 0) + "k";
     } else if (thr >= 1000000) {


### PR DESCRIPTION
This change is being made because using the current formatting of
`-.--k` for throughput values under 1k is not meaningful to users.
Assuming users will have computations in the ms time range, we
should provide meaningful values to those users.

closes #2112

[skip ci]

@aturley I'm adding you to review since you've already verified this works as expected