### PR TITLE
Switch Go WallarooAPI SerializedDicts to use ConcurrentMap

### DIFF
--- a/go_api/go/src/wallarooapi/component_mapping.go
+++ b/go_api/go/src/wallarooapi/component_mapping.go
@@ -2,7 +2,6 @@ package wallarooapi
 
 import (
 	"C"
-	"sync"
 	"sync/atomic"
 )
 
@@ -72,47 +71,4 @@ func AddComponent(component interface{}, componentType uint64) uint64 {
 func RemoveComponent(id uint64, componentType uint64) {
 	componentDicts[componentType].remove(id)
 	RemoveSerialized(id, componentType)
-}
-
-var SHARD_COUNT = uint64(16384)
-
-type ConcurrentMap []*ConcurrentMapShared
-
-type ConcurrentMapShared struct {
-	items map[uint64]interface{}
-	sync.RWMutex
-}
-
-func NewConcurrentMap() ConcurrentMap {
-	m := make(ConcurrentMap, SHARD_COUNT)
-	for i := uint64(0); i < SHARD_COUNT; i++ {
-		m[i] = &ConcurrentMapShared{items: make(map[uint64]interface{})}
-	}
-	return m
-}
-
-func (m ConcurrentMap) GetShard(key uint64) *ConcurrentMapShared {
-	return m[key%SHARD_COUNT]
-}
-
-func (m ConcurrentMap) Store(key uint64, value interface{}) {
-	shard := m.GetShard(key)
-	shard.Lock()
-	shard.items[key] = value
-	shard.Unlock()
-}
-
-func (m ConcurrentMap) Load(key uint64) (interface{}, bool) {
-	shard := m.GetShard(key)
-	shard.RLock()
-	val, ok := shard.items[key]
-	shard.RUnlock()
-	return val, ok
-}
-
-func (m ConcurrentMap) Delete(key uint64) {
-	shard := m.GetShard(key)
-	shard.Lock()
-	delete(shard.items, key)
-	shard.Unlock()
 }

--- a/go_api/go/src/wallarooapi/concurrent_map.go
+++ b/go_api/go/src/wallarooapi/concurrent_map.go
@@ -1,0 +1,49 @@
+package wallarooapi
+
+import (
+	"C"
+	"sync"
+)
+
+var SHARD_COUNT = uint64(16384)
+
+type ConcurrentMap []*ConcurrentMapShared
+
+type ConcurrentMapShared struct {
+	items map[uint64]interface{}
+	sync.RWMutex
+}
+
+func NewConcurrentMap() ConcurrentMap {
+	m := make(ConcurrentMap, SHARD_COUNT)
+	for i := uint64(0); i < SHARD_COUNT; i++ {
+		m[i] = &ConcurrentMapShared{items: make(map[uint64]interface{})}
+	}
+	return m
+}
+
+func (m ConcurrentMap) GetShard(key uint64) *ConcurrentMapShared {
+	return m[key%SHARD_COUNT]
+}
+
+func (m ConcurrentMap) Store(key uint64, value interface{}) {
+	shard := m.GetShard(key)
+	shard.Lock()
+	shard.items[key] = value
+	shard.Unlock()
+}
+
+func (m ConcurrentMap) Load(key uint64) (interface{}, bool) {
+	shard := m.GetShard(key)
+	shard.RLock()
+	val, ok := shard.items[key]
+	shard.RUnlock()
+	return val, ok
+}
+
+func (m ConcurrentMap) Delete(key uint64) {
+	shard := m.GetShard(key)
+	shard.Lock()
+	delete(shard.items, key)
+	shard.Unlock()
+}


### PR DESCRIPTION
This change improves the both the single worker performance of a Go Wallaroo application due to the usage of `RemoveSerialized` inside of `RemoveComponent` and multi-worker performance.  