### PR TITLE
Add sleeping python pipeline for benchmarking

### DIFF
--- a/testing/performance/apps/python/sleepy_python/.gitignore
+++ b/testing/performance/apps/python/sleepy_python/.gitignore
@@ -1,0 +1,1 @@
+_nonces.bin

--- a/testing/performance/apps/python/sleepy_python/Makefile
+++ b/testing/performance/apps/python/sleepy_python/Makefile
@@ -1,0 +1,45 @@
+# include root makefile
+ifndef ROOT_MAKEFILE_MK
+include ../../../../../Makefile
+endif
+
+# prevent rules from being evaluated/included multiple times
+ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
+$(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
+
+
+# The following are control variables that determine what logic from `rules.mk` is enabled
+
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
+
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := false
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := false
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := false
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := false
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := false
+
+
+SLEEPY_PYTHON_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+# standard rules generation makefile
+include $(rules_mk_path)
+
+build-testing-performance-apps-sleepy-python: build-machida
+
+endif

--- a/testing/performance/apps/python/sleepy_python/README.md
+++ b/testing/performance/apps/python/sleepy_python/README.md
@@ -1,0 +1,71 @@
+# Sleepy Python
+
+## About The Application
+
+This is a benchmark application that is used for testing the plumbing of a cluster's horizontal scaling properties. It uses busy sleeping to force Python to hold onto the GIL while blocking.
+
+## Input
+
+The inputs for this are 1KiB "nonces" which are generated in gen.py. Most of the data is ignored but there is a 32bit value read to control partitioning. The generator uses a uniform distribution over a multiple of 60 to keep things as balanced as possible amoung many common cluster sizes.
+
+## Output
+
+The pipeline is not currently configured to write any output but there is an optional "ok" sink result can be added easily when you need to confirm that flow is reaching the sink.
+
+## Delay Configuration
+
+There is a delay parameter that is used to configure processing time of a single stateful step. This defaults to 0ms which helps give a baseline overhead for the pipeline.
+
+## Running Sleepy Python
+
+In order to run the application you will need Machida, Giles Sender, and the Cluster Shutdown tool. To build them, please see the [Linux](/book/getting-started/linux-setup.md) or [MacOS](/book/getting-started/macos-setup.md) setup instructions.
+
+### Setting up the Metrics UI
+
+We're assuming the metrics UI application is running. You may use docker or a manually started instance. We expect it to be reachable on localhost with it's default metrics collection port of 5001. Adjust the examples below as necessary
+
+### Setting up the Sink
+
+Since we don't usually care about the output here, the simplest sink would be netcat to /dev/null:
+
+```bash
+nc -l 127.0.0.1 7002 > /dev/null
+```
+
+### Setting up Machida to run the Wallaroo application
+
+Machida should have the proper PYTHON path setup to include a copy of the wallaroo module. The machida program should be in the path as well, otherwise you can use the relative build path:
+
+```bash
+machida --application-module sleepy \
+  --delay_ms 5
+  --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
+  --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
+  --worker-name worker1 --external 127.0.0.1:5050 --cluster-initializer \
+  --ponythreads=1 --ponynoblock
+```
+
+Adjust the delay (in milliseconds) as needed.
+
+### Setting up the Source
+
+There are a few ways to send data but we're expecting that the giles sender application be used to control flow rate during benchmarks in this case.
+
+```bash
+giles/sender/sender  --host 127.0.0.1:7010 \
+  --file testing/performance/apps/python/sleepy_python/_nonces.bin \
+  --batch-size 20 --interval 100_000 --messages 1024 --msg-size 1028 \
+  --binary --repeat --ponythreads=1 --ponynoblock
+```
+
+Alternatively you can use a program of your choice (`nc` for example) to send data as needed. Be advised that you'll have implement your own flow control here.
+
+## Shutdown
+
+To shutdown the cluster, use the cluster_shutdown utility with the proper cluster control port. Using the same port we provided in the example above, that would be:
+
+```bash
+cluster_shutdown 127.0.0.1:5050
+```
+
+You can shut down Giles Sender by pressing `Ctrl-c` from its shell.

--- a/testing/performance/apps/python/sleepy_python/gen.py
+++ b/testing/performance/apps/python/sleepy_python/gen.py
@@ -1,0 +1,40 @@
+# Copyright 2018 Wallaroo Labs Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+from random import randint
+from struct import pack
+
+
+# File path for our output (it will overwrite anything that's already there)
+nonce_file = "_nonces.bin"
+
+# Size in bytes, including the partition key but excluding the frame header
+nonce_size = 1024
+
+# Number of nonces to generate
+nonce_count = 1024
+
+
+def write_nonce(file):
+    partition_selector = randint(0,60000)
+    file.write(pack(">II", nonce_size, partition_selector))
+    pad = randint(0, 2**32)
+    for _ in range((nonce_size - 4) / 4):
+        file.write(pack(">I", pad))
+
+
+
+with open(nonce_file, "wb") as nonces:
+    for _ in range(nonce_count):
+        write_nonce(nonces)

--- a/testing/performance/apps/python/sleepy_python/sleepy.py
+++ b/testing/performance/apps/python/sleepy_python/sleepy.py
@@ -1,0 +1,124 @@
+# Copyright 2018 Wallaroo Labs Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+
+import argparse
+import struct
+import time
+import wallaroo
+
+
+def application_setup(args):
+    parse_delay(args)
+    in_host, in_port = wallaroo.tcp_parse_input_addrs(args)[0]
+    out_host, out_port = wallaroo.tcp_parse_output_addrs(args)[0]
+
+    nonce_source = wallaroo.TCPSourceConfig(in_host, in_port, nonce_decoder)
+    ok_sink = wallaroo.TCPSinkConfig(out_host, out_port, ok_encoder)
+    partitioner = TuplePartitioner(0)
+    ab = wallaroo.ApplicationBuilder("sleepy-python")
+    ab.new_pipeline("Counting Sheep", nonce_source)
+    ab.to(process_nonce)
+    ab.to_state_partition(
+            busy_sleep, DreamData, "dream-data",
+            partitioner, partitioner.partitions
+        )
+    ab.to_sink(ok_sink)
+    return ab.build()
+
+
+@wallaroo.decoder(header_length=4, length_fmt=">I")
+def nonce_decoder(bytes):
+    """
+    Ignore most of the data and just read a partition key off of the
+    message.
+    """
+    value = struct.unpack_from(">I", bytes)[0]
+    return (value, bytes)
+
+
+@wallaroo.encoder
+def ok_encoder(_):
+    """
+    This encoder always returns a plain-text "ok" followed but a newline.
+    It's useful for checking activity interactively during development.
+    """
+    return "ok\n"
+
+
+@wallaroo.computation(name="Forward nonce partition")
+def process_nonce(nonce):
+    """
+    We could probably do something more interesting but for now we pass
+    the entire value forward.
+    """
+    return nonce
+
+
+@wallaroo.state_computation(name="Count sheep")
+def busy_sleep(data, state):
+    delay(delay_ms)
+    state.sheep += 1
+    return (None, True)
+
+
+class DreamData(object):
+    __slots__ = ('sheep')
+
+    def __init__(self):
+        self.sheep = 0
+
+
+class TuplePartitioner(object):
+    """
+    This partitioner uses a simple modulus operator and expects the partition
+    key to be a tuple with an integer in the provided slot.
+    """
+
+    __slots__ = ('slot', 'partitions')
+
+    def __init__(self, slot, size = 60):
+        """
+        Construct a simple partitioner with a given number of partitions.
+        Defaults to 60 (a good number of integer factors for fair partition
+        assignment).
+        """
+        self.slot = slot
+        self.partitions = list(xrange(0, size))
+
+    def partition(self, tuple):
+        return self.partitions[tuple[self.slot] % len(self.partitions)]
+
+
+# Set by --delay_ms argument
+delay_ms = 0
+
+def parse_delay(args):
+    parser = argparse.ArgumentParser(prog='')
+    parser.add_argument('--delay_ms', type=int, default=0)
+    a, _ = parser.parse_known_args(args)
+    global delay_ms
+    delay_ms = a.delay_ms
+
+def delay(ms):
+    """
+    This is an intentional busy sleep which blocks execution instead of allowing
+    the GIL to be released.
+    """
+    if ms == 0:
+       return
+    target_time = time.time() + (ms / 1000.0)
+    c = 0
+    while target_time > time.time():
+        c = c + 1


### PR DESCRIPTION
This implements a busy sleep benchmark to help focus on plumbing overhead when scaling out horizontally. 