### PR TITLE
Fix errors in Python decorator API documentation

### DIFF
--- a/book/python/api.md
+++ b/book/python/api.md
@@ -6,7 +6,7 @@ The Wallaroo Python API allows developers to create Wallaroo applications in Pyt
 
 In order to create a Wallaroo application in Python, you need to create the functions and classes that provide the required interfaces for each step in your pipeline, and then connect them together in a topology structure that is returned by the entry-point function `application_setup`.
 
-The recommended way to create your topology structure is by using the [ApplicationBuilder](#wallarooapplicationbuilder) in the `wallaroo` module.
+The recommended way to create your topology structure is by using the [ApplicationBuilder](#applicationbuilder) in the `wallaroo` module.
 
 ## Table of Contents
 

--- a/book/python/api.md
+++ b/book/python/api.md
@@ -69,7 +69,7 @@ Create a new pipeline.
 
 `name` must be a string.
 
-`source_config` must be [SourceConfig](#sourceconfig).
+`source_config` must be one of the [SourceConfig](#source) classes.
 
 If you're adding more than one pipeline, make sure to call `done()` before creating another pipeline.
 
@@ -134,13 +134,13 @@ Add a partitioned state computation to the current pipeline.
 
 Add a sink to the end of a pipeline.
 
-`sink_config` must be a [SinkConfig](#sinkconfig).
+`sink_config` must be one of the [SinkConfig](#sink) classes.
 
 ##### `to_sinks(sink_configs)`
 
 Add multiple sinks to the end of a pipeline.
 
-`sink_configs` must be a list of [SinkConfig](#sinkconfig).
+`sink_config` must be a list of [SinkConfig](#sink) classes.
 
 At the moment, the same pipeline output is sent via all sinks. The ability to determine what output should be sent to which sinks will be added in a future version of Wallaroo.
 

--- a/book/python/api.md
+++ b/book/python/api.md
@@ -303,7 +303,7 @@ def decode(self, bs):
 
 ### State
 
-State is an object that is passed to the [StateComputation's](#statecomputation) `compute` method. It is a plain Python object and can be as simple or as complex as you would like. The class definition must be wrapped in the `@state` decorator.
+State is an object that is passed to the [StateComputation's](#statecomputation) `compute` method. It is a plain Python object and can be as simple or as complex as you would like.
 
 A common issue that arises with asynchronous execution is that when references to mutable objects are passed to the next step, if another update to the state precedes the execution of the next step, it will then execute with the latest state (that is, it will execute with the "wrong" state). Therefore, anything returned by a [Computation](#computation) or [StateComputation](#statecomputation) ought to be either unique, or immutable.
 
@@ -316,7 +316,6 @@ An `AlphabetCounts` keeps a count for how many times each letter in the English 
 ```python
 import copy
 
-@state
 AlphabetCounts(objects):
     def __init__(self, initial_counts):
         self.data = dict(initial_counts)

--- a/machida/wallaroo.py
+++ b/machida/wallaroo.py
@@ -215,7 +215,7 @@ class KafkaSourceConfig(object):
     def __init__(self, topic, brokers, log_level, decoder):
         """
         topic: string
-        brokers: list of (string, int) tuples with values (HOST, PORT)
+        brokers: list of (string, string) tuples with values (HOST, PORT)
         log_level: string of "Fine", "Info", "Warn", or "Error"
         decoder: decoder
         """


### PR DESCRIPTION
It doesn't exist and using it causes a syntax error.

[skip ci]