### PR TITLE
Simplify machida makefile for extra ponyc arguments

### DIFF
--- a/machida/Makefile
+++ b/machida/Makefile
@@ -70,11 +70,9 @@ wallaroo_unit_tests:
 machida_build: $(MACHIDA_BUILD)/machida
 
 -include $(MACHIDA_PATH)/machida.d
+$(MACHIDA_BUILD)/machida: EXTRA_PONYCFLAGS= --output=$(MACHIDA_BUILD) --path=$(MACHIDA_BUILD)
 $(MACHIDA_BUILD)/machida: $(MACHIDA_BUILD)/libpython-wallaroo.a
-	$(eval original_PONYCFLAGS := $(PONYCFLAGS))
-	$(eval PONYCFLAGS := $(original_PONYCFLAGS) --output=$(MACHIDA_BUILD) --path=$(MACHIDA_BUILD))
 	$(call PONYC,$(abspath $(MACHIDA_PATH:%/=%)))
-	$(eval PONYCFLAGS := $(original_PONYCFLAGS))
 
 $(MACHIDA_BUILD)/libpython-wallaroo.a: $(MACHIDA_BUILD)/python-wallaroo.o
 	$(QUIET)ar rvs $(MACHIDA_BUILD)/libpython-wallaroo.a $(MACHIDA_BUILD)/python-wallaroo.o

--- a/rules.mk
+++ b/rules.mk
@@ -256,11 +256,11 @@ define PONYC
     $(if $(filter $(ponyc_docker_args),docker),$(quote))
   $(QUIET)cd $(1) && $(ponyc_docker_args) $(PONYSTABLE) env $(PONYCC) $(ponyc_arch_args) \
     $(debug_arg) $(spike_arg) $(autoscale_arg) $(clustering_arg) $(resilience_arg) \
-    $(PONYCFLAGS) $(target_cpu_arg) --features=-avx512f . $(if $(filter $(ponyc_docker_args),docker),$(quote))
+    $(PONYCFLAGS) $(EXTRA_PONYCFLAGS) $(target_cpu_arg) --features=-avx512f . $(if $(filter $(ponyc_docker_args),docker),$(quote))
   $(QUIET)cd $(1) && echo "$@: $(abspath $(1))/bundle.json" | tr '\n' ' ' > $(notdir $(abspath $(1:%/=%))).d
   $(QUIET)cd $(1) && $(ponyc_docker_args) $(PONYSTABLE) env $(PONYCC) $(ponyc_arch_args) \
     $(debug_arg) $(spike_arg) $(autoscale_arg) $(clustering_arg) $(resilience_arg) \
-    $(PONYCFLAGS) $(target_cpu_arg) --features=-avx512f . --pass import --files $(if $(filter \
+    $(PONYCFLAGS) $(EXTRA_PONYCFLAGS) $(target_cpu_arg) --features=-avx512f . --pass import --files $(if $(filter \
     $(ponyc_docker_args),docker),$(quote)) 2>/dev/null | grep -o "$(abs_wallaroo_dir).*.pony" \
     | awk 'BEGIN { a="" } {a=a$$1":\n"; printf "%s ",$$1} END {print "\n"a}' \
     >> $(notdir $(abspath $(1:%/=%))).d


### PR DESCRIPTION
Adds a new variable called `EXTRA_PONYCFLAGS` for internal use
in the Makefiles to add additional ponyc arguments when needed.
Updates machida Makefile to use the new variable and cleaner
approach.