### PR TITLE
Recoverable kafka related changes

### DIFF
--- a/demos/go_word_count/bundle.json
+++ b/demos/go_word_count/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "0.3.4"
+      "tag": "ee70576"
     }
   ]
 }

--- a/examples/go/alphabet/bundle.json
+++ b/examples/go/alphabet/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "0.3.4"
+      "tag": "ee70576"
     }
   ]
 }

--- a/examples/go/celsius/bundle.json
+++ b/examples/go/celsius/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "0.3.4"
+      "tag": "ee70576"
     }
   ]
 }

--- a/examples/go/kafka_reverse/.gitignore
+++ b/examples/go/kafka_reverse/.gitignore
@@ -1,0 +1,3 @@
+/kafka_reverse
+*.dSYM
+lib

--- a/examples/go/kafka_reverse/Makefile
+++ b/examples/go/kafka_reverse/Makefile
@@ -1,0 +1,62 @@
+# include root makefile
+ifndef ROOT_MAKEFILE_MK
+include ../../../Makefile
+endif
+
+# prevent rules from being evaluated/included multiple times
+ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
+$(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
+
+
+# The following are control variables that determine what logic from `rules.mk` is enabled
+
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
+
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := false
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := false
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := false
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := false
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := false
+
+KAFKA_REVERSE_GO_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+GO_PONY_LIB := $(wallaroo_path)/go_api/go
+KAFKA_REVERSE_GOPATH := $(KAFKA_REVERSE_GO_PATH)/go:$(GO_PONY_LIB)
+
+# standard rules generation makefile
+include $(rules_mk_path)
+
+build-examples-go-kafka_reverse: kafka_reverse_go_build
+unit-tests-examples-go-kafka_reverse: build-examples-go-kafka_reverse
+integration-tests-examples-go-kafka_reverse: build-examples-go-kafka_reverse
+clean-examples-go-kafka_reverse: kafka_reverse_go_clean
+
+kafka_reverse_go_build: $(KAFKA_REVERSE_GO_PATH)/kafka_reverse
+
+kafka_reverse_go_clean:
+	$(QUIET)rm -rf $(KAFKA_REVERSE_GO_PATH)/lib $(KAFKA_REVERSE_GO_PATH)/.deps $(KAFKA_REVERSE_GO_PATH)/kafka_reverse $(KAFKA_REVERSE_GO_PATH)/kafka_reverse.d
+
+-include $(KAFKA_REVERSE_GO_PATH)/kafka_reverse.d
+$(KAFKA_REVERSE_GO_PATH)/kafka_reverse: $(KAFKA_REVERSE_GO_PATH)/lib/libwallaroo.a
+	$(call PONYC,$(abspath $(KAFKA_REVERSE_GO_PATH:%/=%)))
+
+$(KAFKA_REVERSE_GO_PATH)/lib/libwallaroo.a: $(KAFKA_REVERSE_GO_PATH)/go/src/kafka_reverse/kafka_reverse.go
+	$(QUIET)export GOPATH=$(KAFKA_REVERSE_GOPATH) && go build -buildmode=c-archive -o $(KAFKA_REVERSE_GO_PATH)lib/libwallaroo.a kafka_reverse
+
+# end of prevent rules from being evaluated/included multiple times
+endif

--- a/examples/go/kafka_reverse/application.pony
+++ b/examples/go/kafka_reverse/application.pony
@@ -1,0 +1,37 @@
+use "go_api"
+use "wallaroo"
+use "wallaroo/core/source"
+use "wallaroo/core/source/tcp_source"
+use "wallaroo/core/sink/tcp_sink"
+use wct = "wallaroo/core/topology"
+use "wallaroo_labs/options"
+
+use @WallarooApiSetArgs[None](argv: Pointer[Pointer[U8] tag] tag, argc: U64)
+
+primitive ArgsToCArgs
+  fun apply(args: Array[String] val): Array[Pointer[U8] tag] val =>
+    let c_args = recover trn Array[Pointer[U8] tag] end
+    for a in args.values() do
+      c_args.push(a.cstring())
+    end
+    consume c_args
+
+actor Main
+  new create(env: Env) =>
+    try
+      let options = Options(WallarooConfig.application_args(env.args)?, false)
+
+      let c_args = ArgsToCArgs(options.remaining())
+      @WallarooApiSetArgs(c_args.cpointer(), c_args.size().u64())
+      let application_json_string = ApplicationSetup()
+
+      try
+        (let application, let application_name) = recover val
+          BuildApplication.from_json(application_json_string, env)?
+        end
+
+        Startup(env, application, application_name)
+      else
+        @printf[I32]("Couldn't build topology\n".cstring())
+      end
+    end

--- a/examples/go/kafka_reverse/bundle.json
+++ b/examples/go/kafka_reverse/bundle.json
@@ -1,0 +1,21 @@
+{
+  "deps": [
+    {
+      "type": "local",
+      "local-path": "../../../lib"
+    },
+    {
+      "type": "local",
+      "local-path": "lib"
+    },
+    {
+      "type": "local",
+      "local-path": "../../../go_api/pony"
+    },
+    {
+      "type": "github",
+      "repo": "WallarooLabs/pony-kafka",
+      "tag": "ee70576"
+    }
+  ]
+}

--- a/examples/go/kafka_reverse/go/src/kafka_reverse/kafka_reverse.go
+++ b/examples/go/kafka_reverse/go/src/kafka_reverse/kafka_reverse.go
@@ -1,0 +1,166 @@
+// Copyright 2017 The Wallaroo Authors.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+//  implied. See the License for the specific language governing
+//  permissions and limitations under the License.
+
+package main
+
+import (
+  "bytes"
+  "C"
+  "encoding/binary"
+  "encoding/gob"
+  "fmt"
+  "reflect"
+  wa "wallarooapi"
+  app "wallarooapi/application"
+)
+
+//export ApplicationSetup
+func ApplicationSetup() *C.char {
+  wa.Serialize = Serialize
+  wa.Deserialize = Deserialize
+
+  application := app.MakeApplication("Reverse Word")
+  application.NewPipeline("Reverse", app.MakeKafkaSourceConfig("kafka_source", &Decoder{})).
+    To(&ReverseBuilder{}).
+    ToSink(app.MakeKafkaSinkConfig("kafka_sink", &Encoder{}))
+
+  return C.CString(application.ToJson())
+}
+
+type ReverseBuilder struct {}
+
+func (rb *ReverseBuilder) Build() interface{} {
+  return &Reverse{}
+}
+
+type Reverse struct {}
+
+func (r *Reverse) Name() string {
+  return "reverse"
+}
+
+func (r *Reverse) Compute(data interface{}) interface{} {
+  input := *(data.(*string))
+
+  // string reversal taken from
+  // https://groups.google.com/forum/#!topic/golang-nuts/oPuBaYJ17t4
+
+  n := 0
+  rune := make([]rune, len(input))
+  for _, r := range input {
+    rune[n] = r
+    n++
+  }
+  rune = rune[0:n]
+  // Reverse
+  for i := 0; i < n/2; i++ {
+    rune[i], rune[n-1-i] = rune[n-1-i], rune[i]
+  }
+  // Convert back to UTF-8.
+  output := string(rune)
+
+  return output
+}
+
+type Decoder struct {}
+
+func (d *Decoder) HeaderLength() uint64 {
+  return 4
+}
+
+func (d *Decoder) PayloadLength(b []byte) uint64 {
+  return uint64(binary.BigEndian.Uint32(b[0:4]))
+}
+
+func (d* Decoder) Decode(b []byte) interface{} {
+  x := string(b[:])
+  return &x
+}
+
+type Encoder struct {}
+
+func (e *Encoder) Encode(data interface{}) ([]byte, []byte, int32) {
+  msg := data.(string)
+  return []byte(msg + "\n"), nil, -1
+}
+
+const (
+  stringType = iota
+  reverseType
+  reverseBuilderType
+  decoderType
+  encoderType
+)
+
+func Serialize(c interface{}) []byte {
+  switch t := c.(type) {
+  case *string:
+    buff := make([]byte, 4)
+    binary.BigEndian.PutUint32(buff, stringType)
+    var b bytes.Buffer
+    enc := gob.NewEncoder(&b)
+    enc.Encode(c)
+    return append(buff, b.Bytes()...)
+  case *Reverse:
+     buff := make([]byte, 4)
+    binary.BigEndian.PutUint32(buff, reverseType)
+    return buff
+  case *ReverseBuilder:
+    buff := make([]byte, 4)
+    binary.BigEndian.PutUint32(buff, reverseBuilderType)
+    return buff
+  case *Decoder:
+    buff := make([]byte, 4)
+    binary.BigEndian.PutUint32(buff, decoderType)
+    return buff
+  case *Encoder:
+    buff := make([]byte, 4)
+    binary.BigEndian.PutUint32(buff, encoderType)
+    return buff
+  default:
+    fmt.Println("SERIALIZE MISSED A CASE")
+    fmt.Println(reflect.TypeOf(t))
+  }
+
+  return nil
+}
+
+func Deserialize(buff []byte) interface{} {
+  componentType := binary.BigEndian.Uint32(buff[:4])
+  payload := buff[4:]
+
+  switch componentType {
+  case stringType:
+    b := bytes.NewBuffer(payload)
+    dec := gob.NewDecoder(b)
+    var s string
+    dec.Decode(&s)
+    return &s
+  case reverseType:
+    return &Reverse{}
+  case reverseBuilderType:
+    return &ReverseBuilder{}
+  case decoderType:
+    return &Decoder{}
+  case encoderType:
+    return &Encoder{}
+  default:
+    fmt.Println("DESERIALIZE MISSED A CASE")
+  }
+
+  return nil
+}
+
+func main() {
+}

--- a/examples/go/reverse/bundle.json
+++ b/examples/go/reverse/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "0.3.4"
+      "tag": "ee70576"
     }
   ]
 }

--- a/examples/go/word_count/bundle.json
+++ b/examples/go/word_count/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "0.3.4"
+      "tag": "ee70576"
     }
   ]
 }

--- a/examples/pony/celsius-kafka/bundle.json
+++ b/examples/pony/celsius-kafka/bundle.json
@@ -5,7 +5,7 @@
       },
       { "type": "github",
         "repo": "WallarooLabs/pony-kafka",
-        "tag": "0.3.4"
+        "tag": "ee70576"
       }
   ]
 }

--- a/examples/pony/celsius-kafka/celsius.pony
+++ b/examples/pony/celsius-kafka/celsius.pony
@@ -70,9 +70,9 @@ primitive Add is Computation[F32, F32]
   fun name(): String => "Add 32"
 
 primitive FahrenheitEncoder
-  fun apply(f: F32, wb: Writer): (Array[ByteSeq] val, None) =>
+  fun apply(f: F32, wb: Writer): (Array[ByteSeq] val, None, None) =>
     wb.f32_be(f)
-    (wb.done(), None)
+    (wb.done(), None, None)
 
 primitive CelsiusKafkaDecoder is SourceHandler[F32]
   fun decode(a: Array[U8] val): F32 ? =>

--- a/examples/python/celsius-kafka/celsius.py
+++ b/examples/python/celsius-kafka/celsius.py
@@ -60,4 +60,4 @@ def add(data):
 @wallaroo.encoder
 def encoder(data):
     # data is a float
-    return (struct.pack(">f", data), None)
+    return (struct.pack(">f", data), None, None)

--- a/examples/python/celsius-kafka/celsius.py
+++ b/examples/python/celsius-kafka/celsius.py
@@ -19,25 +19,15 @@ import wallaroo
 
 
 def application_setup(args):
-    (in_topic, in_brokers,
-     in_log_level) = wallaroo.kafka_parse_source_options(args)
-
-    (out_topic, out_brokers, out_log_level, out_max_produce_buffer_ms,
-     out_max_message_size) = wallaroo.kafka_parse_sink_options(args)
-
     ab = wallaroo.ApplicationBuilder("Celsius to Fahrenheit with Kafka")
 
     ab.new_pipeline("convert",
-                    wallaroo.KafkaSourceConfig(in_topic, in_brokers, in_log_level,
-                                               decoder))
+                    wallaroo.DefaultKafkaSourceCLIParser(decoder))
 
     ab.to(multiply)
     ab.to(add)
 
-    ab.to_sink(wallaroo.KafkaSinkConfig(out_topic, out_brokers, out_log_level,
-                                        out_max_produce_buffer_ms,
-                                        out_max_message_size,
-                                        encoder))
+    ab.to_sink(wallaroo.DefaultKafkaSinkCLIParser(encoder))
     return ab.build()
 
 

--- a/go_api/examples/kafka_reverse/bundle.json
+++ b/go_api/examples/kafka_reverse/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "0.3.4"
+      "tag": "ee70576"
     }
   ]
 }

--- a/go_api/go/src/wallarooapi/application/kafkaconfig.go
+++ b/go_api/go/src/wallarooapi/application/kafkaconfig.go
@@ -5,41 +5,18 @@ import (
 	"wallarooapi/application/repr"
 )
 
-func brokersRepr(brokers []*KafkaHostPort) []*repr.KafkaHostPort {
-	brokers_repr := make([]*repr.KafkaHostPort, 0)
-	for _, b := range brokers {
-		brokers_repr = append(brokers_repr, b.Repr())
-	}
-	return brokers_repr
-}
-
-func MakeKafkaHostPort(host string, port uint64) *KafkaHostPort {
-	return &KafkaHostPort{host, port}
-}
-
-type KafkaHostPort struct {
-	host string
-	port uint64
-}
-
-func (khp *KafkaHostPort) Repr() *repr.KafkaHostPort {
-	return &repr.KafkaHostPort{khp.host, khp.port}
-}
-
-func MakeKafkaSourceConfig(topic string, brokers []*KafkaHostPort, logLevel string, decoder wa.Decoder) *KafkaSourceConfig {
-	return &KafkaSourceConfig{topic, brokers, logLevel, decoder, 0}
+func MakeKafkaSourceConfig(name string, decoder wa.Decoder) *KafkaSourceConfig {
+	return &KafkaSourceConfig{name, decoder, 0}
 }
 
 type KafkaSourceConfig struct {
-	topic string
-	brokers []*KafkaHostPort
-	logLevel string
+	name string
 	decoder wa.Decoder
 	decoderId uint64
 }
 
 func (ksc *KafkaSourceConfig) SourceConfigRepr() interface{} {
-	return repr.MakeKafkaSourceConfig(ksc.topic, brokersRepr(ksc.brokers), ksc.logLevel, ksc.decoderId)
+	return repr.MakeKafkaSourceConfig(ksc.name, ksc.decoderId)
 }
 
 func (ksc *KafkaSourceConfig) MakeDecoder() repr.ComponentRepresentable {
@@ -51,23 +28,18 @@ func (ksc *KafkaSourceConfig) addDecoder() uint64 {
 	return ksc.decoderId
 }
 
-func MakeKafkaSinkConfig(topic string, brokers []*KafkaHostPort, logLevel string,
-	maxProduceBufferMs uint64, maxMessageSize uint64, encoder wa.KafkaEncoder) *KafkaSinkConfig {
-	return &KafkaSinkConfig{topic, brokers, logLevel, maxProduceBufferMs, maxMessageSize, encoder, 0}
+func MakeKafkaSinkConfig(name string, encoder wa.KafkaEncoder) *KafkaSinkConfig {
+	return &KafkaSinkConfig{name, encoder, 0}
 }
 
 type KafkaSinkConfig struct {
-	topic string
-	brokers []*KafkaHostPort
-	logLevel string
-	maxProduceBufferMs uint64
-	maxMessageSize uint64
+	name string
 	encoder wa.KafkaEncoder
 	encoderId uint64
 }
 
 func (ksc *KafkaSinkConfig) SinkConfigRepr() interface{} {
-	return repr.MakeKafkaSinkConfig(ksc.topic, brokersRepr(ksc.brokers), ksc.logLevel, ksc.maxProduceBufferMs, ksc.maxMessageSize, ksc.encoderId)
+	return repr.MakeKafkaSinkConfig(ksc.name, ksc.encoderId)
 }
 
 func (ksc *KafkaSinkConfig) MakeEncoder() repr.ComponentRepresentable {

--- a/go_api/go/src/wallarooapi/application/repr/kafkaconfig.go
+++ b/go_api/go/src/wallarooapi/application/repr/kafkaconfig.go
@@ -1,37 +1,21 @@
 package repr
 
-func MakeKafkaHostPort(host string, port uint64) *KafkaHostPort {
-	return &KafkaHostPort{host, port}
-}
-
-type KafkaHostPort struct {
-	Host string
-	Port uint64
-}
-
-func MakeKafkaSourceConfig(topic string, brokers []*KafkaHostPort, logLevel string, decoderId uint64) *KafkaSourceConfig {
-	return &KafkaSourceConfig{"KafkaSource", topic, brokers, logLevel, decoderId}
+func MakeKafkaSourceConfig(name string, decoderId uint64) *KafkaSourceConfig {
+	return &KafkaSourceConfig{"KafkaSource", name, decoderId}
 }
 
 type KafkaSourceConfig struct {
 	Class string
-	Topic string
-	Brokers []*KafkaHostPort
-	LogLevel string
+	Name string
 	DecoderId uint64
 }
 
-func MakeKafkaSinkConfig(topic string, brokers []*KafkaHostPort, logLevel string,
-	maxProduceBufferMs uint64, maxMessageSize uint64, encoderId uint64) *KafkaSinkConfig {
-	return &KafkaSinkConfig{"KafkaSink", topic, brokers, logLevel, maxProduceBufferMs, maxMessageSize, encoderId}
+func MakeKafkaSinkConfig(name string, encoderId uint64) *KafkaSinkConfig {
+	return &KafkaSinkConfig{"KafkaSink", name, encoderId}
 }
 
 type KafkaSinkConfig struct {
 	Class string
-	Topic string
-	Brokers []*KafkaHostPort
-	LogLevel string
-	MaxProduceBufferMs uint64
-	MaxMessageSize uint64
+	Name string
 	EncoderId uint64
 }

--- a/go_api/go/src/wallarooapi/encoder.go
+++ b/go_api/go/src/wallarooapi/encoder.go
@@ -19,14 +19,15 @@ func EncoderEncode(encoderId uint64, dataId uint64, size *uint64) unsafe.Pointer
 }
 
 type KafkaEncoder interface {
-	Encode(d interface{}) ([]byte, []byte)
+	Encode(d interface{}) ([]byte, []byte, int32)
 }
 
 //export KafkaEncoderEncode
-func KafkaEncoderEncode(encoderId uint64, dataId uint64, value *unsafe.Pointer, valueSize *uint64, key *unsafe.Pointer, keySize *uint64) {
+func KafkaEncoderEncode(encoderId uint64, dataId uint64, value *unsafe.Pointer, valueSize *uint64, key *unsafe.Pointer, keySize *uint64, partitionId *int32) {
 	encoder := GetComponent(encoderId, EncoderTypeId).(KafkaEncoder)
 	data := GetComponent(dataId, DataTypeId)
-	valueRes, keyRes := encoder.Encode(data)
+	valueRes, keyRes, partId := encoder.Encode(data)
+        *partitionId = partId
 	*valueSize = uint64(len(valueRes))
 	*keySize = uint64(len(keyRes))
 	if *valueSize > 0 {

--- a/go_api/pony/go_api/build_application.pony
+++ b/go_api/pony/go_api/build_application.pony
@@ -273,20 +273,13 @@ primitive _SourceConfig
       let decoder_id = source("DecoderId")?.int()?.u64()
       TCPSourceConfig[GoData](GoFramedSourceHandler(decoder_id), host, port)
     | "KafkaSource" =>
-      let topic = source("Topic")?.string()?
+      let kafka_source_name = source("Name")?.string()?
 
-      let brokers = recover trn Array[(String, I32)] end
-      for b in source("Brokers")?.array()?.values() do
-        let host = b("Host")?.string()?
-        let port = b("Port")?.int()?.i32()
-        brokers.push((host, port))
-      end
+      let ksclip = KafkaSourceConfigCLIParser(env.out, kafka_source_name)
+      let ksco = ksclip.parse_options(env.args)?
 
-      let log_level = source("LogLevel")?.string()?
       let decoder_id = source("DecoderId")?.int()?.u64()
-      let brokers_val: Array[(String, I32)] val = consume brokers
-      let ksco = KafkaConfigOptions("Wallaroo Kakfa Source", KafkaConsumeOnly,
-        topic, brokers_val, log_level)
+
       KafkaSourceConfig[GoData](consume ksco, env.root as TCPConnectionAuth,
         GoSourceHandler(decoder_id))
     else
@@ -302,22 +295,13 @@ primitive _SinkConfig
       let encoderId = sink("EncoderId")?.int()?.u64()
       TCPSinkConfig[GoData](GoEncoder(encoderId), host, port)
     | "KafkaSink" =>
-      let topic = sink("Topic")?.string()?
+      let kafka_sink_name = sink("Name")?.string()?
 
-      let brokers = recover trn Array[(String, I32)] end
-      for b in sink("Brokers")?.array()?.values() do
-        let host = b("Host")?.string()?
-        let port = b("Port")?.int()?.i32()
-        brokers.push((host, port))
-      end
-
-      let log_level = sink("LogLevel")?.string()?
-      let max_produce_buffer_ms = sink("MaxProduceBufferMs")?.int()?.u64()
-      let max_message_size = sink("MaxMessageSize")?.int()?.i32()
       let encoder_id = sink("EncoderId")?.int()?.u64()
-      let brokers_val: Array[(String, I32)] val = consume brokers
-      let ksco = KafkaConfigOptions("Wallaroo Kakfa Sink", KafkaProduceOnly,
-        topic, brokers_val, log_level, max_produce_buffer_ms, max_message_size)
+
+      let ksclip = KafkaSinkConfigCLIParser(env.out, kafka_sink_name)
+      let ksco = ksclip.parse_options(env.args)?
+
       KafkaSinkConfig[GoData](GoKafkaEncoder(encoder_id), consume ksco,
         env.root as TCPConnectionAuth)
     else

--- a/go_api/pony/go_api/encoder.pony
+++ b/go_api/pony/go_api/encoder.pony
@@ -4,7 +4,8 @@ use "pony-kafka"
 
 use @EncoderEncode[Pointer[U8] ref](eid: U64, did: U64, size: Pointer[U64])
 use @KafkaEncoderEncode[None](eid: U64, did: U64, value: Pointer[Pointer[U8]],
-  value_size: Pointer[U64], key: Pointer[Pointer[U8]], key_size: Pointer[U64])
+  value_size: Pointer[U64], key: Pointer[Pointer[U8]], key_size: Pointer[U64],
+  part_id: Pointer[I32])
 
 class val GoEncoder
   var _encoder_id: U64
@@ -41,15 +42,19 @@ class val GoKafkaEncoder
   new val create(encoder_id: U64) =>
     _encoder_id = encoder_id
 
-  fun apply(data: GoData, wb: Writer): (Array[ByteSeq] val, (Array[ByteSeq] val | None), (None | KafkaPartitionId)) =>
-    let k_v: (Array[U8] val, (Array[U8] val | None)) = recover val
+  fun apply(data: GoData, wb: Writer):
+    (Array[ByteSeq] val, (Array[ByteSeq] val | None), (None | KafkaPartitionId))
+  =>
+    let k_v_p: (Array[U8] val, (Array[U8] val | None), I32) = recover val
       var value_res: Pointer[U8] = Pointer[U8]
       var value_size: U64 = 0
       var key_res: Pointer[U8] = Pointer[U8]
       var key_size: U64 = 0
+      var part_id: I32 = 0
 
       @KafkaEncoderEncode(_encoder_id, data.id(), addressof value_res,
-        addressof value_size, addressof key_res, addressof key_size)
+        addressof value_size, addressof key_res, addressof key_size,
+        addressof part_id)
 
       let value'' = Array[U8].from_cpointer(value_res, value_size.usize()).clone()
 
@@ -60,10 +65,10 @@ class val GoKafkaEncoder
       end
       @free(value_res)
       @free(key_res)
-      (value'', key'')
+      (value'', key'', part_id)
     end
 
-    (let value', let key') = k_v
+    (let value', let key', let part_id') = k_v_p
 
     wb.write(value')
     let value = wb.done()
@@ -76,7 +81,9 @@ class val GoKafkaEncoder
       None
     end
 
-    (consume value, consume key, None)
+    let part_id = if part_id' == -1 then None else part_id' end
+
+    (consume value, consume key, part_id)
 
     // var s: U64 = 0
     // let r = recover val

--- a/go_api/pony/go_api/encoder.pony
+++ b/go_api/pony/go_api/encoder.pony
@@ -1,5 +1,6 @@
 use "buffered"
 use "wallaroo/core/sink"
+use "pony-kafka"
 
 use @EncoderEncode[Pointer[U8] ref](eid: U64, did: U64, size: Pointer[U64])
 use @KafkaEncoderEncode[None](eid: U64, did: U64, value: Pointer[Pointer[U8]],
@@ -40,7 +41,7 @@ class val GoKafkaEncoder
   new val create(encoder_id: U64) =>
     _encoder_id = encoder_id
 
-  fun apply(data: GoData, wb: Writer): (Array[ByteSeq] val, (Array[ByteSeq] val | None)) =>
+  fun apply(data: GoData, wb: Writer): (Array[ByteSeq] val, (Array[ByteSeq] val | None), (None | KafkaPartitionId)) =>
     let k_v: (Array[U8] val, (Array[U8] val | None)) = recover val
       var value_res: Pointer[U8] = Pointer[U8]
       var value_size: U64 = 0
@@ -75,7 +76,7 @@ class val GoKafkaEncoder
       None
     end
 
-    (consume value, consume key)
+    (consume value, consume key, None)
 
     // var s: U64 = 0
     // let r = recover val

--- a/lib/wallaroo/core/initialization/local_topology.pony
+++ b/lib/wallaroo/core/initialization/local_topology.pony
@@ -1061,8 +1061,9 @@ actor LocalTopologyInitializer is LayoutInitializer
                 // egress_builder finds it from _outgoing_boundaries
                 let sink =
                   try
-                    egress_builder(_worker_name, consume sink_reporter, _env,
-                      _auth, _outgoing_boundaries)?
+                    egress_builder(_worker_name, consume sink_reporter,
+                      _event_log, _recovering, _env, _auth,
+                      _outgoing_boundaries)?
                   else
                     @printf[I32]("Failed to build sink from egress_builder\n"
                       .cstring())
@@ -1265,7 +1266,8 @@ actor LocalTopologyInitializer is LayoutInitializer
                 out_router, _router_registry,
                 source_data.route_builder(),
                 _outgoing_boundary_builders,
-                _event_log, _auth, this,  consume source_reporter))
+                _event_log, _auth, pipeline_name,
+                this,  consume source_reporter, _recovering))
 
               // Nothing connects to a source via an in edge locally,
               // so this just marks that we've built this one
@@ -1453,7 +1455,8 @@ actor LocalTopologyInitializer is LayoutInitializer
               // Create a sink or OutgoingBoundary. If the latter,
               // egress_builder finds it from _outgoing_boundaries
               let sink = egress_builder(_worker_name,
-                consume sink_reporter, _env, _auth, _outgoing_boundaries)?
+                consume sink_reporter, _event_log, _recovering, _env, _auth,
+                _outgoing_boundaries)?
 
               _initializables.set(sink)
 

--- a/lib/wallaroo/core/sink/kafka_sink/kafka_sink_encoder.pony
+++ b/lib/wallaroo/core/sink/kafka_sink/kafka_sink_encoder.pony
@@ -17,16 +17,19 @@ Copyright 2017 The Wallaroo Authors.
 */
 
 use "buffered"
+use "pony-kafka"
 
 interface val KafkaSinkEncoder[In: Any val]
-  // Returns a tuple (encoded_value, encoded_key) where you can pass None
-  // for the encoded_key if there is none
+  // Returns a tuple (encoded_value, encoded_key, partition_id) where you
+  // can pass None for the encoded_key and partition_id if there is none
   fun apply(input: In, wb: Writer):
-    (Array[ByteSeq] val, (Array[ByteSeq] val | None))
+    ((ByteSeq | Array[ByteSeq] val), (None | ByteSeq | Array[ByteSeq] val),
+    (None | KafkaPartitionId))
 
 trait val KafkaEncoderWrapper
   fun encode[D: Any val](d: D, wb: Writer):
-    (Array[ByteSeq] val, (Array[ByteSeq] val | None)) ?
+    ((ByteSeq | Array[ByteSeq] val), (None | ByteSeq | Array[ByteSeq] val),
+    (None | KafkaPartitionId)) ?
 
 class val TypedKafkaEncoderWrapper[In: Any val] is KafkaEncoderWrapper
   let _encoder: KafkaSinkEncoder[In] val
@@ -35,7 +38,8 @@ class val TypedKafkaEncoderWrapper[In: Any val] is KafkaEncoderWrapper
     _encoder = e
 
   fun encode[D: Any val](data: D, wb: Writer):
-    (Array[ByteSeq] val, (Array[ByteSeq] val | None)) ?
+    ((ByteSeq | Array[ByteSeq] val), (None | ByteSeq | Array[ByteSeq] val),
+    (None | KafkaPartitionId)) ?
   =>
     match data
     | let i: In =>

--- a/lib/wallaroo/core/sink/sink.pony
+++ b/lib/wallaroo/core/sink/sink.pony
@@ -20,6 +20,7 @@ use "wallaroo/core/common"
 use "wallaroo/core/metrics"
 use "wallaroo/core/routing"
 use "wallaroo/core/topology"
+use "wallaroo/ent/recovery"
 
 type Sink is (Consumer & DisposableActor)
 
@@ -27,4 +28,5 @@ interface val SinkConfig[Out: Any val]
   fun apply(): SinkBuilder
 
 interface val SinkBuilder
-  fun apply(reporter: MetricsReporter iso, env: Env): Sink
+  fun apply(sink_name: String, event_log: EventLog,
+    reporter: MetricsReporter iso, env: Env, recovering: Bool): Sink

--- a/lib/wallaroo/core/sink/tcp_sink/tcp_sink.pony
+++ b/lib/wallaroo/core/sink/tcp_sink/tcp_sink.pony
@@ -35,6 +35,7 @@ use "wallaroo/core/boundary"
 use "wallaroo/core/common"
 use "wallaroo/ent/data_receiver"
 use "wallaroo/ent/network"
+use "wallaroo/ent/recovery"
 use "wallaroo/ent/watermarking"
 use "wallaroo_labs/mort"
 use "wallaroo/core/initialization"
@@ -79,6 +80,10 @@ actor TCPSink is Consumer
   """
   let _env: Env
   // Steplike
+  let _sink_id: StepId
+  let _event_log: EventLog
+  let _recovering: Bool
+  let _name: String
   let _encoder: TCPEncoderWrapper
   let _wb: Writer = Writer
   let _metrics_reporter: MetricsReporter
@@ -126,7 +131,8 @@ actor TCPSink is Consumer
 
   let _terminus_route: TerminusRoute = TerminusRoute
 
-  new create(env: Env, encoder_wrapper: TCPEncoderWrapper,
+  new create(sink_id: StepId, sink_name: String, event_log: EventLog,
+    recovering: Bool, env: Env, encoder_wrapper: TCPEncoderWrapper,
     metrics_reporter: MetricsReporter iso, host: String, service: String,
     initial_msgs: Array[Array[ByteSeq] val] val,
     from: String = "", init_size: USize = 64, max_size: USize = 16384,
@@ -137,6 +143,10 @@ actor TCPSink is Consumer
     will be made from the specified interface.
     """
     _env = env
+    _sink_id = sink_id
+    _name = sink_name
+    _event_log = event_log
+    _recovering = recovering
     _encoder = encoder_wrapper
     _metrics_reporter = consume metrics_reporter
     _read_buf = recover Array[U8].>undefined(init_size) end

--- a/lib/wallaroo/core/sink/tcp_sink/tcp_sink_builder.pony
+++ b/lib/wallaroo/core/sink/tcp_sink/tcp_sink_builder.pony
@@ -18,9 +18,11 @@ Copyright 2017 The Wallaroo Authors.
 
 use "options"
 use "wallaroo"
+use "wallaroo/core/common"
 use "wallaroo/core/messages"
 use "wallaroo/core/metrics"
 use "wallaroo/core/sink"
+use "wallaroo/ent/recovery"
 
 primitive TCPSinkConfigCLIParser
   fun apply(args: Array[String] val): Array[TCPSinkConfigOptions] val ? =>
@@ -104,9 +106,13 @@ class val TCPSinkBuilder
     _service = service
     _initial_msgs = initial_msgs
 
-  fun apply(reporter: MetricsReporter iso, env: Env): Sink =>
+  fun apply(sink_name: String, event_log: EventLog,
+    reporter: MetricsReporter iso, env: Env, recovering: Bool): Sink
+  =>
     @printf[I32](("Connecting to sink at " + _host + ":" + _service + "\n")
       .cstring())
 
-    TCPSink(env, _encoder_wrapper, consume reporter, _host, _service,
-      _initial_msgs)
+    let id: StepId = StepIdGenerator()
+
+    TCPSink(id, sink_name, event_log, recovering, env, _encoder_wrapper,
+      consume reporter, _host, _service, _initial_msgs)

--- a/lib/wallaroo/core/source/kafka_source/kafka_source_notify.pony
+++ b/lib/wallaroo/core/source/kafka_source/kafka_source_notify.pony
@@ -97,7 +97,6 @@ class KafkaSourceNotify[In: Any val]
 
     (let is_finished, let last_ts) =
       try
-        source.next_sequence_id()
         let decoded =
           try
             _handler.decode(consume data)?

--- a/lib/wallaroo/core/source/source_listener.pony
+++ b/lib/wallaroo/core/source/source_listener.pony
@@ -36,7 +36,7 @@ interface val SourceListenerBuilderBuilder
   fun apply(source_builder: SourceBuilder, router: Router,
     router_registry: RouterRegistry, route_builder: RouteBuilder,
     outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val,
-    event_log: EventLog, auth: AmbientAuth,
+    event_log: EventLog, auth: AmbientAuth, pipeline_name: String,
     layout_initializer: LayoutInitializer,
-    metrics_reporter: MetricsReporter iso,
+    metrics_reporter: MetricsReporter iso, recovering: Bool,
     target_router: Router = EmptyRouter): SourceListenerBuilder

--- a/lib/wallaroo/core/source/tcp_source/tcp_source_listener_builder.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source_listener_builder.pony
@@ -28,6 +28,7 @@ use "wallaroo/core/topology"
 
 class val TCPSourceListenerBuilder
   let _source_builder: SourceBuilder
+  let _pipeline_name: String
   let _router: Router
   let _router_registry: RouterRegistry
   let _route_builder: RouteBuilder
@@ -43,13 +44,14 @@ class val TCPSourceListenerBuilder
   new val create(source_builder: SourceBuilder, router: Router,
     router_registry: RouterRegistry, route_builder: RouteBuilder,
     outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val,
-    event_log: EventLog, auth: AmbientAuth,
+    event_log: EventLog, auth: AmbientAuth, pipeline_name: String,
     layout_initializer: LayoutInitializer,
     metrics_reporter: MetricsReporter iso,
     target_router: Router = EmptyRouter,
     host: String = "", service: String = "0")
   =>
     _source_builder = source_builder
+    _pipeline_name = pipeline_name
     _router = router
     _router_registry = router_registry
     _route_builder = route_builder
@@ -64,8 +66,8 @@ class val TCPSourceListenerBuilder
 
   fun apply(env: Env): SourceListener =>
     TCPSourceListener(env, _source_builder, _router, _router_registry,
-      _route_builder, _outgoing_boundary_builders,
-      _event_log, _auth, _layout_initializer, _metrics_reporter.clone(),
+      _route_builder, _outgoing_boundary_builders, _event_log, _auth,
+      _pipeline_name, _layout_initializer, _metrics_reporter.clone(),
       _target_router, _host, _service)
 
 class val TCPSourceListenerBuilderBuilder
@@ -79,14 +81,14 @@ class val TCPSourceListenerBuilderBuilder
   fun apply(source_builder: SourceBuilder, router: Router,
     router_registry: RouterRegistry, route_builder: RouteBuilder,
     outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val,
-    event_log: EventLog, auth: AmbientAuth,
+    event_log: EventLog, auth: AmbientAuth, pipeline_name: String,
     layout_initializer: LayoutInitializer,
-    metrics_reporter: MetricsReporter iso,
+    metrics_reporter: MetricsReporter iso, recovering: Bool,
     target_router: Router = EmptyRouter): TCPSourceListenerBuilder
   =>
     TCPSourceListenerBuilder(source_builder, router, router_registry,
       route_builder,
-      outgoing_boundary_builders, event_log, auth,
+      outgoing_boundary_builders, event_log, auth, pipeline_name,
       layout_initializer, consume metrics_reporter, target_router, _host,
       _service)
 

--- a/lib/wallaroo/core/topology/step_initializer.pony
+++ b/lib/wallaroo/core/topology/step_initializer.pony
@@ -185,7 +185,7 @@ class val EgressBuilder
     _proxy_addr
 
   fun apply(worker_name: String, reporter: MetricsReporter ref,
-    env: Env, auth: AmbientAuth,
+    event_log: EventLog, recovering: Bool, env: Env, auth: AmbientAuth,
     proxies: Map[String, OutgoingBoundary] val =
       recover Map[String, OutgoingBoundary] end): Consumer ?
   =>
@@ -200,7 +200,7 @@ class val EgressBuilder
     | None =>
       match _sink_builder
       | let sb: SinkBuilder =>
-        sb(reporter.clone(), env)
+        sb(_name, event_log, reporter.clone(), env, recovering)
       else
         EmptySink
       end

--- a/lib/wallaroo/core/topology/steps.pony
+++ b/lib/wallaroo/core/topology/steps.pony
@@ -96,7 +96,7 @@ actor Step is (Producer & Consumer)
     for (worker, boundary) in outgoing_boundaries.pairs() do
       _outgoing_boundaries(worker) = boundary
     end
-    _event_log.register_producer(this, id)
+    _event_log.register_resilient(this, id)
 
     let initial_router = _runner.clone_router_and_set_input_type(router)
     _update_router(initial_router)
@@ -439,6 +439,8 @@ actor Step is (Producer & Consumer)
       @printf[I32]("flushing at and below: %llu\n".cstring(), low_watermark)
     end
     _event_log.flush_buffer(_id, low_watermark)
+
+  be log_replay_finished() => None
 
   be replay_log_entry(uid: U128, frac_ids: FractionalMessageId,
     statechange_id: U64, payload: ByteSeq val)

--- a/lib/wallaroo/ent/router_registry/router_registry.pony
+++ b/lib/wallaroo/ent/router_registry/router_registry.pony
@@ -684,15 +684,9 @@ actor RouterRegistry is InFlightAckRequester
     """
     Start the log rotation and initiate snapshots.
     """
-    let steps: Map[U128, Step] iso = recover steps.create() end
-    for pr in _partition_routers.values() do
-      for (i, v) in pr.local_map().pairs() do
-        steps(i) = v
-      end
-    end
     match _event_log
     | let e: EventLog =>
-      e.rotate_file(consume steps)
+      e.rotate_file()
     else
       Fail()
     end

--- a/machida/bundle.json
+++ b/machida/bundle.json
@@ -5,7 +5,7 @@
       },
       { "type": "github",
         "repo": "WallarooLabs/pony-kafka",
-        "tag": "0.3.4"
+        "tag": "ee70576"
       }
   ]
 }

--- a/machida/wallaroo.py
+++ b/machida/wallaroo.py
@@ -211,37 +211,50 @@ class TCPSinkConfig(object):
         return ("tcp", self._host, self._port, self._encoder)
 
 
-class KafkaSourceConfig(object):
-    def __init__(self, topic, brokers, log_level, decoder):
-        """
-        topic: string
-        brokers: list of (string, string) tuples with values (HOST, PORT)
-        log_level: string of "Fine", "Info", "Warn", or "Error"
-        decoder: decoder
-        """
-        self.topic = topic
-        self.brokers = brokers
-        self.log_level = log_level
+class CustomKafkaSourceCLIParser(object):
+    def __init__(self, args, decoder):
+        (in_topic, in_brokers,
+        in_log_level) = kafka_parse_source_options(args)
+
+        self.topic = in_topic
+        self.brokers = in_brokers
+        self.log_level = in_log_level
         self.decoder = decoder
 
     def to_tuple(self):
         return ("kafka", self.topic, self.brokers, self.log_level, self.decoder)
 
+class CustomKafkaSinkCLIParser(object):
+    def __init__(self, args, encoder):
+        (out_topic, out_brokers, out_log_level, out_max_produce_buffer_ms,
+         out_max_message_size) = kafka_parse_sink_options(args)
 
-class KafkaSinkConfig(object):
-    def __init__(self, topic, brokers, log_level, max_produce_buffer_ms,
-                 max_message_size, encoder):
-        self.topic = topic
-        self.brokers = brokers
-        self.log_level = log_level
-        self.max_produce_buffer_ms = max_produce_buffer_ms
-        self.max_message_size = max_message_size
+        self.topic = out_topic
+        self.brokers = out_brokers
+        self.log_level = out_log_level
+        self.max_produce_buffer_ms = out_max_produce_buffer_ms
+        self.max_message_size = out_max_message_size
         self.encoder = encoder
 
     def to_tuple(self):
         return ("kafka", self.topic, self.brokers, self.log_level,
                 self.max_produce_buffer_ms, self.max_message_size, self.encoder)
 
+class DefaultKafkaSourceCLIParser(object):
+    def __init__(self, decoder, name="kafka_source"):
+        self.decoder = decoder
+        self.name = name
+
+    def to_tuple(self):
+        return ("kafka-internal", self.name, self.decoder)
+
+class DefaultKafkaSinkCLIParser(object):
+    def __init__(self, encoder, name="kafka_sink"):
+        self.encoder = encoder
+        self.name = name
+
+    def to_tuple(self):
+        return ("kafka-internal", self.name, self.encoder)
 
 def tcp_parse_input_addrs(args):
     parser = argparse.ArgumentParser(prog="wallaroo")

--- a/testing/performance/apps/go/market_spread/bundle.json
+++ b/testing/performance/apps/go/market_spread/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "0.3.4"
+      "tag": "ee70576"
     }
   ]
 }


### PR DESCRIPTION
* Add support for recoverable sources/sinks
  Prior to this commit, sources and sinks did not support recovery.
  This commit makes it so that the plumbing is in place for any
  source or sink to be recoverable. The KafkaSource has been modified
  to be recoverable. The KafkaSink has been wired to be recoverable
  but does not actually implement writing to/recovering from the
  event log as of right now (and it will not be idempotent until
  the kafka client supports transactions regardless).
* Update machida to use pony kafka cli parser
  Prior to this commit, machida only supported a custom python
  cli parser. This commit changes it so that machida can take
  advantage of the built in pony kafka cli parser that comes
  from the kafka client (just like the pony wallaroo examples).
* Update go api to use pony kafka cli parser and add example app
  Prior to this commit, the go api did not support a kafka
  cli parser. This commit changes it so that the go api can take
  advantage of the built in pony kafka cli parser that comes
  from the kafka client (just like the pony wallaroo examples).

  This commit also add an example go app using the kafka source
  and sink called kafka_reverse.