### PR TITLE
Revert "Stop using untyped InputWrapper at partition router"

### DIFF
--- a/lib/wallaroo/core/topology/computations.pony
+++ b/lib/wallaroo/core/topology/computations.pony
@@ -59,11 +59,11 @@ trait val StateProcessor[S: State ref] is BasicComputation
     (Bool, (StateChange[S] ref | DirectStateChange | None), U64,
       U64, U64)
 
-trait InputWrapper[In: Any val]
-  fun input(): In
+trait InputWrapper
+  fun input(): Any val
 
 class val StateComputationWrapper[In: Any val, Out: Any val, S: State ref]
-  is (StateProcessor[S] & InputWrapper[In])
+  is (StateProcessor[S] & InputWrapper)
   let _state_comp: StateComputation[In, Out, S] val
   let _input: In
   let _target_ids: Array[StepId] val
@@ -74,7 +74,7 @@ class val StateComputationWrapper[In: Any val, Out: Any val, S: State ref]
     _input = input'
     _target_ids = target_ids
 
-  fun input(): In => _input
+  fun input(): Any val => _input
 
   fun apply(state: S, sc_repo: StateChangeRepository[S],
     omni_router: OmniRouter, metric_name: String, pipeline_time_spent: U64,

--- a/lib/wallaroo/core/topology/router.pony
+++ b/lib/wallaroo/core/topology/router.pony
@@ -1109,51 +1109,58 @@ class val LocalPartitionRouter[In: Any val,
       @printf[I32]("Rcvd msg at PartitionRouter\n".cstring())
     end
     match data
-    | let iw: InputWrapper[In] val =>
-      let input = iw.input()
-      let key = _partition_function(input)
-      try
-        match _partition_routes(key)?
-        | let s: Step =>
-          let might_be_route = producer.route_to(s)
-          match might_be_route
-          | let r: Route =>
-            ifdef "trace" then
-              @printf[I32]("PartitionRouter found Route\n".cstring())
+    // TODO: Using an untyped input wrapper that returns an Any val might
+    // cause perf slowdowns and should be reevaluated.
+    | let iw: InputWrapper val =>
+      match iw.input()
+      | let input: In =>
+        let key = _partition_function(input)
+        try
+          match _partition_routes(key)?
+          | let s: Step =>
+            let might_be_route = producer.route_to(s)
+            match might_be_route
+            | let r: Route =>
+              ifdef "trace" then
+                @printf[I32]("PartitionRouter found Route\n".cstring())
+              end
+              r.run[D](metric_name, pipeline_time_spent,
+                data, producer_id, producer, i_msg_uid, frac_ids,
+                latest_ts, metrics_id, worker_ingress_ts)
+              (false, latest_ts)
+            else
+              // TODO: What do we do if we get None?
+              Fail()
+              (true, latest_ts)
             end
-            r.run[D](metric_name, pipeline_time_spent,
-              data, producer_id, producer, i_msg_uid, frac_ids,
-              latest_ts, metrics_id, worker_ingress_ts)
-            (false, latest_ts)
-          else
-            // TODO: What do we do if we get None?
-            Fail()
-            (true, latest_ts)
+          | let p: ProxyRouter =>
+            p.route[D](metric_name, pipeline_time_spent, data, producer_id,
+              producer, i_msg_uid, frac_ids, latest_ts, metrics_id,
+              worker_ingress_ts)
           end
-        | let p: ProxyRouter =>
-          p.route[D](metric_name, pipeline_time_spent, data, producer_id,
-            producer, i_msg_uid, frac_ids, latest_ts, metrics_id,
-            worker_ingress_ts)
+        else
+          ifdef debug then
+            match key
+            | let k: Stringable val =>
+              @printf[I32](("LocalPartitionRouter.route: No entry for " +
+              "key %s\n\n").cstring(), k.string().cstring())
+            else
+              @printf[I32](("LocalPartitionRouter.route: No entry for " +
+              "this key\n\n").cstring())
+            end
+          end
+          (true, latest_ts)
         end
       else
+        // InputWrapper doesn't wrap In
         ifdef debug then
-          match key
-          | let k: Stringable val =>
-            @printf[I32](("LocalPartitionRouter.route: No entry for " +
-            "key %s\n\n").cstring(), k.string().cstring())
-          else
-            @printf[I32](("LocalPartitionRouter.route: No entry for " +
-            "this key\n\n").cstring())
-          end
+          @printf[I32](("LocalPartitionRouter.route: InputWrapper doesn't " +
+            "contain data of type In\n").cstring())
         end
+        Fail()
         (true, latest_ts)
       end
     else
-      // InputWrapper doesn't wrap In
-      ifdef debug then
-        @printf[I32](("LocalPartitionRouter.route: InputWrapper doesn't " +
-          "contain data of type In\n").cstring())
-      end
       Fail()
       (true, latest_ts)
     end


### PR DESCRIPTION
We've run into a problem with type matching and we've decided to revert this commit for the time being so we can investigate later.  See #2109 for more details.