### PR TITLE
Update to pony-kafka that requires ponyc master

### DIFF
--- a/demos/go_word_count/bundle.json
+++ b/demos/go_word_count/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "ee70576"
+      "tag": "db252ef"
     }
   ]
 }

--- a/examples/go/alphabet/bundle.json
+++ b/examples/go/alphabet/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "ee70576"
+      "tag": "db252ef"
     }
   ]
 }

--- a/examples/go/celsius/bundle.json
+++ b/examples/go/celsius/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "ee70576"
+      "tag": "db252ef"
     }
   ]
 }

--- a/examples/go/kafka_reverse/bundle.json
+++ b/examples/go/kafka_reverse/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "ee70576"
+      "tag": "db252ef"
     }
   ]
 }

--- a/examples/go/reverse/bundle.json
+++ b/examples/go/reverse/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "ee70576"
+      "tag": "db252ef"
     }
   ]
 }

--- a/examples/go/word_count/bundle.json
+++ b/examples/go/word_count/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "ee70576"
+      "tag": "db252ef"
     }
   ]
 }

--- a/examples/pony/celsius-kafka/bundle.json
+++ b/examples/pony/celsius-kafka/bundle.json
@@ -5,7 +5,7 @@
       },
       { "type": "github",
         "repo": "WallarooLabs/pony-kafka",
-        "tag": "ee70576"
+        "tag": "db252ef"
       }
   ]
 }

--- a/go_api/examples/kafka_reverse/bundle.json
+++ b/go_api/examples/kafka_reverse/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "ee70576"
+      "tag": "db252ef"
     }
   ]
 }

--- a/machida/bundle.json
+++ b/machida/bundle.json
@@ -5,7 +5,7 @@
       },
       { "type": "github",
         "repo": "WallarooLabs/pony-kafka",
-        "tag": "ee70576"
+        "tag": "db252ef"
       }
   ]
 }

--- a/testing/performance/apps/go/market_spread/bundle.json
+++ b/testing/performance/apps/go/market_spread/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "ee70576"
+      "tag": "db252ef"
     }
   ]
 }


### PR DESCRIPTION
NOTE: There are no other functional changes but merging this PR will mean that `ponyc` `master` will be required to compile Wallaroo going forward.