### PR TITLE
Add `to->to_parallel` to the autoscale test apps

### DIFF
--- a/lib/wallaroo/core/initialization/application_distributor.pony
+++ b/lib/wallaroo/core/initialization/application_distributor.pony
@@ -627,6 +627,12 @@ actor ApplicationDistributor is Distributor
                 end
 
                 steps(next_id) = worker
+
+                // Since we've assigned a prestate runner, which will be
+                // placed on a non-shrinkable source or step, this worker
+                // can't be shrunk under our current requirements.
+                non_shrinkable.set(worker)
+
               //////////////////////////////////////
               // PARALLELIZED STATELESS COMPUTATIONS
               elseif next_runner_builder.is_stateless_parallel() then
@@ -736,11 +742,12 @@ actor ApplicationDistributor is Distributor
                 end
 
                 steps(next_id) = worker
-              end
 
-              // Since we've assigned at least one runner builder to this
-              // worker, it can't be shrunk under our current requirements.
-              non_shrinkable.set(worker)
+                // Since we've assigned a stateless computation runner, which
+                // will be placed on a non-shrinkable source or step, this
+                // worker can't be shrunk under our current requirements.
+                non_shrinkable.set(worker)
+              end
 
               runner_builder_idx = runner_builder_idx + 1
             end

--- a/lib/wallaroo/ent/watermarking/acker.pony
+++ b/lib/wallaroo/ent/watermarking/acker.pony
@@ -35,8 +35,14 @@ class Acker
   fun ref add_route(route: Route) =>
     _watermarker.add_route(route.id())
 
+  fun contains_route(route: Route): Bool =>
+    _watermarker.contains_route(route.id())
+
   fun ref remove_route(route: Route) =>
     _watermarker.remove_route(route.id())
+
+  fun routes_size(): USize =>
+    _watermarker.routes_size()
 
   fun ref sent(o_route_id: RouteId, o_seq_id: SeqId) =>
     _watermarker.sent(o_route_id, o_seq_id)

--- a/lib/wallaroo/ent/watermarking/watermarker.pony
+++ b/lib/wallaroo/ent/watermarking/watermarker.pony
@@ -28,6 +28,9 @@ class ref Watermarker
         _routes(id) = _AckedOnRoute
     end
 
+  fun contains_route(id: RouteId): Bool =>
+    _routes.contains(id)
+
   fun ref remove_route(id: RouteId) =>
     try
       let old_route = _routes(id)?
@@ -41,6 +44,9 @@ class ref Watermarker
     else
       Fail()
     end
+
+  fun routes_size(): USize =>
+    _routes.size()
 
   fun ref sent(o_route_id: RouteId, o_seq_id: SeqId) =>
     ifdef debug then

--- a/testing/correctness/apps/alphabet/Makefile
+++ b/testing/correctness/apps/alphabet/Makefile
@@ -41,6 +41,7 @@ TESTING_ALPHABET_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 include $(rules_mk_path)
 
 integration-tests-testing-correctness-apps-alphabet: testing_alphabet_test
+integration-tests-testing-correctness-apps-alphabet: testing_alphabet_test_toparallel
 
 testing_alphabet_test:
 	cd $(TESTING_ALPHABET_PATH) && \
@@ -54,6 +55,21 @@ testing_alphabet_test:
 		--batch-size 10 \
 		--output 'received.txt' \
 		--command './alphabet' \
+		--workers 10 \
+		--sink-expect 4000
+
+testing_alphabet_test_toparallel:
+	cd $(TESTING_ALPHABET_PATH) && \
+	integration_test \
+	  --framed-file-sender input.msg \
+	  --framed-file-sender input.msg \
+	  --framed-file-sender input.msg \
+	  --framed-file-sender input.msg \
+		--validation-cmd 'python validate.py --expected output.json --repetitions 4 --output' \
+		--log-level error \
+		--batch-size 10 \
+		--output 'received.txt' \
+		--command './alphabet --to-parallel' \
 		--workers 10 \
 		--sink-expect 4000
 

--- a/testing/correctness/apps/alphabet_python/Makefile
+++ b/testing/correctness/apps/alphabet_python/Makefile
@@ -43,6 +43,7 @@ include $(rules_mk_path)
 build-testing-correctness-apps-alphabet_python: build-machida
 integration-tests-testing-correctness-apps-alphabet_python: build-testing-correctness-apps-alphabet_python
 integration-tests-testing-correctness-apps-alphabet_python: testing_alphabet_python_test
+integration-tests-testing-correctness-apps-alphabet_python: testing_alphabet_python_test_toparallel
 
 testing_alphabet_python_test:
 	cd $(TESTING_ALPHABET_PYTHON_PATH) && \
@@ -59,4 +60,18 @@ testing_alphabet_python_test:
 		--workers 10 \
 		--sink-expect 4000
 
+testing_alphabet_python_test_toparallel:
+	cd $(TESTING_ALPHABET_PYTHON_PATH) && \
+	integration_test \
+		--framed-file-sender input.msg \
+		--framed-file-sender input.msg \
+		--framed-file-sender input.msg \
+		--framed-file-sender input.msg \
+		--validation-cmd 'python validate.py --expected output.json --repetitions 4 --output' \
+		--log-level error \
+		--batch-size 10 \
+		--output 'received.txt' \
+		--command 'machida --application-module alphabet --to-parallel' \
+		--workers 10 \
+		--sink-expect 4000
 endif

--- a/testing/correctness/apps/alphabet_python/alphabet.py
+++ b/testing/correctness/apps/alphabet_python/alphabet.py
@@ -29,8 +29,9 @@ def application_setup(args):
     ab = wallaroo.ApplicationBuilder("alphabet")
     ab.new_pipeline("alphabet",
                     wallaroo.TCPSourceConfig(in_host, in_port, decoder))
-    ab.to_parallel(double_vote)
-    ab.to(half_vote)
+    if '--to-parallel' in args:
+        ab.to_parallel(double_vote)
+        ab.to(half_vote)
     ab.to_state_partition(add_votes, TotalVotes, "letter-state",
                           partition, letter_partitions)
     ab.to_sink(wallaroo.TCPSinkConfig(out_host, out_port, encoder))

--- a/testing/correctness/tests/autoscale_tests/_autoscale_tests.py
+++ b/testing/correctness/tests/autoscale_tests/_autoscale_tests.py
@@ -43,7 +43,9 @@ from integration import (add_runner,
 from collections import Counter
 from functools import partial
 from itertools import cycle
+import json
 import logging
+import os
 import re
 from string import lowercase
 from struct import calcsize, pack, unpack
@@ -295,6 +297,10 @@ def autoscale_sequence(command, ops=[1], cycles=1, initial=None):
                 print("Some autoscale Sequence runners exited badly. "
                       "They had the following "
                       "output tails:\n===\n{}".format(outputs))
+        if hasattr(err, 'query_result') and 'PRINT_QUERY' in os.environ:
+            logging.error("The test error had the following query result"
+                          " attached:\n{}"
+                          .format(json.dumps(err.query_result)))
         raise
 
 def _autoscale_sequence(command, ops=[], cycles=1, initial=None):

--- a/testing/correctness/tests/autoscale_tests/_autoscale_tests.py
+++ b/testing/correctness/tests/autoscale_tests/_autoscale_tests.py
@@ -255,13 +255,14 @@ def test_migrated_partitions(pre_partitions, workers, partitions):
     # invert the partitions dicts
     i_pre = inverted(pre_partitions)
     i_post = inverted(partitions)
+    keys = ['state_partitions']
     for joining in workers.get('joining', {}):
-        for ptype in partitions:
+        for ptype in keys:
             for step in partitions[ptype]:
                 for pid in partitions[ptype][step][joining]:
                     assert(i_pre[ptype][step][pid] != joining)
     for leaving in workers.get('leaving', {}):
-        for ptype in pre_partitions:
+        for ptype in keys:
             for step in pre_partitions[ptype]:
                 for pid in pre_partitions[ptype][step][leaving]:
                     assert(i_post[ptype][step][pid] != leaving)

--- a/testing/correctness/tests/autoscale_tests/autoscale_tests.py
+++ b/testing/correctness/tests/autoscale_tests/autoscale_tests.py
@@ -94,9 +94,9 @@ for api, cmd in APIS.items():
 # Note that in these tests, the cluster cannot shrink any of the initial
 # workers, so the ops should never result in shrinking initial workers.
 # So test simple cases only (single op)
-for api, cmd in APIS_TO_PARALLEL.items():
-    for o in OPS:
-        if o > 0:
-            create_autoscale_test(api, cmd, [o], CYCLES)
-        else:
-            create_autoscale_test(api, cmd, [-o, o], CYCLES)
+#for api, cmd in APIS_TO_PARALLEL.items():
+#    for o in OPS:
+#        if o > 0:
+#            create_autoscale_test(api, cmd, [o], CYCLES)
+#        else:
+#            create_autoscale_test(api, cmd, [-o, o], CYCLES)

--- a/testing/correctness/tests/autoscale_tests/autoscale_tests.py
+++ b/testing/correctness/tests/autoscale_tests/autoscale_tests.py
@@ -24,11 +24,12 @@ from _autoscale_tests import autoscale_sequence
 
 CMD_PONY = 'alphabet'
 CMD_PYTHON = 'machida --application-module alphabet'
-#CMD_PONY = 'alphabet27'
-#CMD_PYTHON = 'machida --application-module alphabet27'
 
 CYCLES=1
 APIS = {'pony': CMD_PONY, 'python': CMD_PYTHON}
+# Add '--to-parallel' to the original commands:
+APIS_TO_PARALLEL = {k + '_toparallel': v + ' --to-parallel' for k, v
+                    in APIS.items()}
 
 #
 # Setup Tests
@@ -85,3 +86,17 @@ for api, cmd in APIS.items():
                 create_autoscale_test(api, cmd, [o1], CYCLES)
             else:
                 create_autoscale_test(api, cmd, [o1, o2], CYCLES)
+
+#
+# Shrink with `to_parallel` steps
+#
+
+# Note that in these tests, the cluster cannot shrink any of the initial
+# workers, so the ops should never result in shrinking initial workers.
+# So test simple cases only (single op)
+for api, cmd in APIS_TO_PARALLEL.items():
+    for o in OPS:
+        if o > 0:
+            create_autoscale_test(api, cmd, [o], CYCLES)
+        else:
+            create_autoscale_test(api, cmd, [-o, o], CYCLES)

--- a/testing/tools/integration/observability.py
+++ b/testing/tools/integration/observability.py
@@ -191,8 +191,6 @@ class ObservabilityNotifier(StoppableThread):
             # Else if any result is not True, either wait for next cycle
             # or timeout.
             if time.time() - started > self.timeout:
-                logging.error('failing query response was:\n{}'
-                    .format(json.dumps(query_result)))
                 self.error = ObservabilityTimeoutError(
                     "Observability test timed out after {} seconds with the"
                     " following tests"
@@ -203,6 +201,8 @@ class ObservabilityNotifier(StoppableThread):
                             '\n'.join((
                                 "  -> {}".format(s) for s in tb.splitlines())))
                         for t, (err, tb),in errors.items()))))
+                # Pack the query result into the error object
+                self.error.query_result = query_result
                 self.stop()
                 break
             time.sleep(self.period)


### PR DESCRIPTION
- Add `to->to_parallel -> {rest of alphabet}` to the autoscale test apps (both pony and python)

This causes the tests to fail on the error mentioned in #2157 

@jtfmumm can you take over this branch for the fix?