### PR TITLE
Add LatencyStatsCalculator tests for MonHub

### DIFF
--- a/monitoring_hub/README.md
+++ b/monitoring_hub/README.md
@@ -3,8 +3,8 @@ An umbrella application containing shared utils and different UI components
 
 ## Shared Dependency Installation Guide
 ### Depends on:
-	1. Erlang 18.x
-	2. Elixir 1.2.x
+	1. Erlang 20.x
+	2. Elixir 1.5.2
 	3. Node 4.2.2
 		- Node-Sass
 		- Browserify
@@ -15,7 +15,7 @@ An umbrella application containing shared utils and different UI components
 [Installing Node](https://github.com/creationix/nvm): NVM makes it easiest to install proper version
 
 Installing Hex: run `mix local.hex`
-Installing Node de: run `npm install -g node-sass browserify`
+Installing Node dependencies: run `npm install -g node-sass browserify`
 
 ## Monitoring Hub Dependency Installation Guide
 * run `mix deps.get`

--- a/monitoring_hub/apps/metrics_reporter/lib/metrics_reporter/latency_stats_calculator.ex
+++ b/monitoring_hub/apps/metrics_reporter/lib/metrics_reporter/latency_stats_calculator.ex
@@ -30,7 +30,7 @@ defmodule MetricsReporter.LatencyStatsCalculator do
     0..64 |> Enum.reduce(%{}, fn(pow, map) -> Map.put(map, to_string(pow), 0) end)
   end
 
-  def get_empty_latency_percentage_bins_data(expected_latency_bins) do
+  defp get_empty_latency_percentage_bins_data(expected_latency_bins) do
     Map.new(expected_latency_bins, & {&1, 0})
   end
 

--- a/monitoring_hub/apps/metrics_reporter/lib/metrics_reporter/latency_stats_calculator.ex
+++ b/monitoring_hub/apps/metrics_reporter/lib/metrics_reporter/latency_stats_calculator.ex
@@ -7,18 +7,18 @@ defmodule MetricsReporter.LatencyStatsCalculator do
     do_calculate_latency_percentage_bins_data(aggregated_latency_bins_data, expected_latency_bins, total_count)
   end
 
-  def calculate_cumalative_latency_percentage_bins_data(latency_percentage_bins_data) do
+  def calculate_cumulative_latency_percentage_bins_data(latency_percentage_bins_data) do
       sorted_keys = Map.keys(latency_percentage_bins_data)
         |> Enum.sort(&(String.to_integer(&1)< String.to_integer(&2)))
 
-    {_, cumalative_latency_percentage_bins_data} = sorted_keys
-      |> Enum.reduce({0, %{}}, fn key, {cumalative_percentage, cumalative_latency_percentage_bins_data} ->
+    {_, cumulative_latency_percentage_bins_data} = sorted_keys
+      |> Enum.reduce({0, %{}}, fn key, {cumulative_percentage, cumulative_latency_percentage_bins_data} ->
         val = Map.get(latency_percentage_bins_data, key)
-        cumalative_percentage = calculate_cumalative_percentage(val, cumalative_percentage)
-        cumalative_latency_percentage_bins_data = Map.put(cumalative_latency_percentage_bins_data, key, cumalative_percentage)
-        {cumalative_percentage, cumalative_latency_percentage_bins_data}
+        cumulative_percentage = calculate_cumulative_percentage(val, cumulative_percentage)
+        cumulative_latency_percentage_bins_data = Map.put(cumulative_latency_percentage_bins_data, key, cumulative_percentage)
+        {cumulative_percentage, cumulative_latency_percentage_bins_data}
       end)
-      cumalative_latency_percentage_bins_data
+      cumulative_latency_percentage_bins_data
   end
 
   defp aggregate_latency_bins_data(latency_bins_list) do
@@ -38,13 +38,13 @@ defmodule MetricsReporter.LatencyStatsCalculator do
     ["50.0", "95.0", "99.0", "99.9", "99.99"]
   end
 
-  def calculate_latency_percentile_bin_stats(cumalative_latency_percentage_bins_msg) do
-    sorted_bin_keys = Map.keys(cumalative_latency_percentage_bins_msg)
+  def calculate_latency_percentile_bin_stats(cumulative_latency_percentage_bins_msg) do
+    sorted_bin_keys = Map.keys(cumulative_latency_percentage_bins_msg)
       |> Enum.sort(&(String.to_integer(&1)< String.to_integer(&2)))
     _latency_percent_bin_stats = get_percentiles()
       |> Enum.reduce(%{}, fn percentile, percentile_map ->
         bin = Enum.reduce_while(sorted_bin_keys, 0, fn bin, _acc ->
-          percentage_at_bin = cumalative_latency_percentage_bins_msg[bin]
+          percentage_at_bin = cumulative_latency_percentage_bins_msg[bin]
           if String.to_float(percentile) > percentage_at_bin do
             {:cont, Enum.max_by(sorted_bin_keys, fn bin ->
               String.to_integer(bin)
@@ -111,14 +111,14 @@ defmodule MetricsReporter.LatencyStatsCalculator do
     end
   end
 
-  defp calculate_cumalative_percentage(value, cumalative_percentage) do
+  defp calculate_cumulative_percentage(value, cumulative_percentage) do
     cond do
-      (value + cumalative_percentage >= 100) ->
+      (value + cumulative_percentage >= 100) ->
         100
-      (value + cumalative_percentage == 0) ->
+      (value + cumulative_percentage == 0) ->
         0
       true ->
-        Float.round(value + cumalative_percentage, 4)
+        Float.round(value + cumulative_percentage, 4)
     end
   end
 

--- a/monitoring_hub/apps/metrics_reporter/test/metrics_reporter/latency_stats_calculator_test.exs
+++ b/monitoring_hub/apps/metrics_reporter/test/metrics_reporter/latency_stats_calculator_test.exs
@@ -1,0 +1,99 @@
+defmodule MetricsReporter.LatencyStatsCalculatorTest do
+	use ExUnit.Case
+	require Logger
+
+	alias MetricsReporter.LatencyStatsCalculator
+
+	setup do
+		latency_bins_msg_1 = %{"time" => 1523977525,
+		"pipeline_key" => "test",
+		"latency_bins" => %{"1" => 100, "10" => 50}
+		}
+		latency_bins_msg_2 = %{"time" => 1523977526,
+		"pipeline_key" => "test",
+		"latency_bins" => %{"1" => 50, "10" => 100}
+		}
+		expected_latency_bins = get_all_bins()
+		latency_bins_list = [latency_bins_msg_1, latency_bins_msg_2]
+		empty_stats = %{
+			"50.0" => "0",
+			"95.0" => "0",
+			"99.0" => "0",
+			"99.9" => "0",
+			"99.99" => "0"
+			}
+		%{expected_latency_bins: expected_latency_bins, latency_bins_list: latency_bins_list, empty_stats: empty_stats}
+	end
+
+	defp get_all_bins do
+    Enum.reduce(0..64, [], fn bin, list ->
+      List.insert_at(list, -1, bin |> to_string)
+    end)
+  end
+
+	test "it calculates the percentage of the values that fall within each bin for a set of latency bin messages, where the key becomes the previous key to the power of 2", %{latency_bins_list: latency_bins_list, expected_latency_bins: expected_latency_bins} do
+		latency_bins_data = LatencyStatsCalculator.calculate_latency_percentage_bins_data(latency_bins_list, expected_latency_bins)
+		Enum.each latency_bins_data, fn {bin, percentage} ->
+			cond do
+				bin == "2" ->
+					# verifying that 50% of the total count of messages fall under the "1"/2^1 bin
+					percentage == 50.0
+				bin == "1024" ->
+					# verifying that 50% of the total count of messages fall under the "10"/2^10 bin
+					percentage == 50.00
+				true ->
+					# verifying that 0% of the total count of messages fall under the remaining bins
+					percentage == 0.0
+			end
+		end
+	end
+
+	test "it calculates the cumulative percentage for each bin in a map of bin to percentage data", %{latency_bins_list: latency_bins_list, expected_latency_bins: expected_latency_bins} do
+		latency_bins_data = LatencyStatsCalculator.calculate_latency_percentage_bins_data(latency_bins_list, expected_latency_bins)
+		cumulative_latency_percentage_bins_data = LatencyStatsCalculator.calculate_cumulative_latency_percentage_bins_data(latency_bins_data)
+		Enum.each cumulative_latency_percentage_bins_data, fn {bin, cumulative_percentage} ->
+			cond do
+				String.to_integer(bin) < 2 ->
+					# verifying that 0% of the total cumulative count of messages fall under the "0"/2^0 bin
+					cumulative_percentage == 0.0
+				bin == "2" ->
+					# verifying that 50% of the total cumulative count of messages fall in the "1"/2^1 bin
+					cumulative_percentage == 50.0
+				(String.to_integer(bin) > 2) && (String.to_integer(bin) < 1024) ->
+					# verifying that 50% of the total cumulative count of messages fall below the "10"/2^10 bin
+					cumulative_percentage == 50.00
+				bin == "1024" ->
+					# verifying that 100% of the total cumulative count of messages fall in the "10"/2^10 bin
+					cumulative_percentage == 100.00
+				String.to_integer(bin) > 1024 ->
+					# verifying that 100% of the total cumulative count of messages fall above the "10"/2^10 bin
+					cumulative_percentage == 0.0
+			end
+		end
+	end
+
+	test "it calculates the latency percentile bin stats based off the cumulative latency percentage bins", %{expected_latency_bins: expected_latency_bins, latency_bins_list: latency_bins_list} do
+		latency_bins_data = LatencyStatsCalculator.calculate_latency_percentage_bins_data(latency_bins_list, expected_latency_bins)
+		cumulative_latency_percentage_bins_data = LatencyStatsCalculator.calculate_cumulative_latency_percentage_bins_data(latency_bins_data)
+		latency_percentile_bin_stats = LatencyStatsCalculator.calculate_latency_percentile_bin_stats(cumulative_latency_percentage_bins_data)
+		Enum.each latency_percentile_bin_stats, fn {percentile, bin} ->
+			cond do
+				percentile == "50.0" ->
+					assert bin == "2"
+				true ->
+					assert bin == "1024"
+			end
+		end
+	end
+
+	test "it generates empty stats for the expected percentiles", %{empty_stats: empty_stats} do
+		assert LatencyStatsCalculator.generate_empty_latency_percentile_bin_stats == empty_stats
+	end
+
+	test "it generates an empty map with the keys 0..64 as strings and the values as 0" do
+		empty_percentage_bins_data = LatencyStatsCalculator.get_empty_latency_percentage_bins_data
+		for n <- 0..64 do
+			assert empty_percentage_bins_data[to_string(n)] == 0
+		end
+	end
+end

--- a/monitoring_hub/apps/metrics_reporter_ui/lib/metrics_reporter_ui/latency_stats_broadcaster/worker.ex
+++ b/monitoring_hub/apps/metrics_reporter_ui/lib/metrics_reporter_ui/latency_stats_broadcaster/worker.ex
@@ -50,8 +50,8 @@ defmodule MetricsReporterUI.LatencyStatsBroadcaster.Worker do
           {[], LatencyStatsCalculator.generate_empty_latency_percentile_bin_stats()}
         throughputs_list ->
           all_latency_percentage_bins_data = LatencyStatsCalculator.calculate_latency_percentage_bins_data(throughputs_list, all_bins)
-          cumalative_latency_percentage_bins_data = LatencyStatsCalculator.calculate_cumalative_latency_percentage_bins_data(all_latency_percentage_bins_data)
-          {throughputs_list, LatencyStatsCalculator.calculate_latency_percentile_bin_stats(cumalative_latency_percentage_bins_data)}
+          cumulative_latency_percentage_bins_data = LatencyStatsCalculator.calculate_cumulative_latency_percentage_bins_data(all_latency_percentage_bins_data)
+          {throughputs_list, LatencyStatsCalculator.calculate_latency_percentile_bin_stats(cumulative_latency_percentage_bins_data)}
       end
 
     latency_percentage_bins_data = LatencyStatsCalculator.calculate_latency_percentage_bins_data(latency_bins_list, bins)


### PR DESCRIPTION
Updates MonHub README to include latest dependencies and adds minimal test cases for the LatencyStatsCalculator