### PR TITLE
Uncomment `to_parallel` autoscale tests

### DIFF
--- a/testing/correctness/tests/autoscale_tests/autoscale_tests.py
+++ b/testing/correctness/tests/autoscale_tests/autoscale_tests.py
@@ -94,9 +94,9 @@ for api, cmd in APIS.items():
 # Note that in these tests, the cluster cannot shrink any of the initial
 # workers, so the ops should never result in shrinking initial workers.
 # So test simple cases only (single op)
-#for api, cmd in APIS_TO_PARALLEL.items():
-#    for o in OPS:
-#        if o > 0:
-#            create_autoscale_test(api, cmd, [o], CYCLES)
-#        else:
-#            create_autoscale_test(api, cmd, [-o, o], CYCLES)
+for api, cmd in APIS_TO_PARALLEL.items():
+    for o in OPS:
+        if o > 0:
+            create_autoscale_test(api, cmd, [o], CYCLES)
+        else:
+            create_autoscale_test(api, cmd, [-o, o], CYCLES)


### PR DESCRIPTION
Issue #2164 

These tests should fail and allow me and @jtfmumm to continue working on the bug encountered in #2158.

**NOTE**: This PR is on hold until after the consistent hashing work is merged.
It remains open, however, because so far we have only been able to reproduce this error on CI.
Please refer to #2164 for the related issue details.