### PR TITLE
Delay writev calls if we don't have enough data

### DIFF
--- a/lib/wallaroo/core/boundary/boundary.pony
+++ b/lib/wallaroo/core/boundary/boundary.pony
@@ -710,6 +710,10 @@ actor OutgoingBoundary is Consumer
     Perform a graceful shutdown. Don't accept new writes, but don't finish
     closing until we get a zero length read.
     """
+    if _delayed_writes then
+      _pending_writes()
+      _delayed_writes = false
+    end
     _closed = true
     _try_shutdown()
 

--- a/lib/wallaroo/core/boundary/boundary.pony
+++ b/lib/wallaroo/core/boundary/boundary.pony
@@ -129,6 +129,8 @@ actor OutgoingBoundary is Consumer
   var _muted: Bool = false
   var _no_more_reconnect: Bool = false
   var _expect_read_buf: Reader = Reader
+  var _delayed_writes: Bool = false
+  let _delayed_flush_threshold: USize = 4000
 
   // Connection, Acking and Replay
   var _connection_initialized: Bool = false
@@ -360,6 +362,10 @@ actor OutgoingBoundary is Consumer
 
   be writev(data: Array[ByteSeq] val) =>
     _writev(data)
+
+  be flush_pending_writes() =>
+    _pending_writes()
+    _delayed_writes = false
 
   be receive_state(state: ByteSeq val) => Fail()
 
@@ -664,7 +670,14 @@ actor OutgoingBoundary is Consumer
       data_size = data_size + bytes.size()
     end
 
-    _pending_writes()
+    if _pending_writev_total > _delayed_flush_threshold then
+      _pending_writes()
+    elseif _delayed_writes == false then
+      // Allow the mailbox to drain a bit before calling writev
+      // to reduce system call overhead.
+      _delayed_writes = true
+      this.flush_pending_writes()
+    end
 
     _in_sent = false
 


### PR DESCRIPTION

Since we don't know how deep our boundary actor queue is, we attempt to do immediate writev calls. Unfortunately, with fast networks and proportionally high system call overhead, this can lead to underwhelming throughput. Instead of "nagling", which does the buffering and waiting on the wrong side of the system call, we want to encourage the message queue to run through more messages as quickly as possible. This change simulates hitting the end of the queue at a given point in time (serializing on message mailbox order). 

The drawback here is that we incur a scheduling cycle's worth of latency on some applications depending on load and overall computation time. A more ideal runtime would allow us to flush pending writes when the actor is at the end of it's scheduled allotment of message processing. This would allow us to replace the asynchronous callback to flush_pending_writes with a scheduler notification that we've finished our scheduled work and will be rescheduled, giving us a more ideal moment to trigger the send.

The original intention was to pace writes in such a way that we produce smoother and more consistent throughput by using a timer, avoiding then magic threshold number of bytes for immediate writev calls but I found the scheduling to be too inconsistent (timers introduce a round-trip interaction with the timer wheel actor). Again it becomes a very workload dependent issue. The worker's step, core count, and how CPU bound certain code paths may be start playing into the variance you might get making it hard to guarantee that we're free of anomalous timing. The workaround is to avoid pacing and instead focus on getting more data into the buffer at once to ensure we can waste less time doing context switches and end us with packets closer to our MTU.

I need to rerun tests with the new delay mechanism to find a threshold that works best for our applications (minimizing latency lost without throughput gains). I may also allow the threshold to be changed dynamically to turn this effect off for certain applications (using a threshold of 0 should cause us to do immediate writes again).
