### PR TITLE
Add documentation for Wallaroo in Docker on Windows

### DIFF
--- a/book/getting-started/choosing-an-installation-option.md
+++ b/book/getting-started/choosing-an-installation-option.md
@@ -1,6 +1,8 @@
 # Choosing an Installation Option for Wallaroo
 
-We currently provide two different ways for a user to install Wallaroo: [Installing with Docker](/book/getting-started/docker-setup.md) and installing from source on [Linux](/book/getting-started/linux-setup.md). If you are unsure about which solution is right for you, we wanted to provide a breakdown of each approach.
+For MacOS and Windows users, currently the only installation option for Wallaroo is [Installing with Docker](/book/getting-started/docker-setup.md).
+
+For Linux users, we currently provide two different ways for a user to install Wallaroo: [Installing with Docker](/book/getting-started/docker-setup.md) and [Installing from Source](/book/getting-started/linux-setup.md). If you are unsure about which solution is right for you, we wanted to provide a breakdown of each approach.
 
 ## Installing with Docker
 

--- a/book/getting-started/docker-setup.md
+++ b/book/getting-started/docker-setup.md
@@ -1,6 +1,6 @@
 # Setting Up Your Environment for Wallaroo in Docker
 
-To get you up and running quickly with Wallaroo, we have provided a Docker image which includes Wallaroo and related tools needed to run and modify a few example applications. We should warn that this Docker image was created with the intent of getting users started quickly with Wallaroo and is not intended to be a fully customizable development environment or suitable for production. MacOS Sierra and High Sierra users are recommended to install via Docker to avoid a kernel panic caused by a few Wallaroo applications; this is currently under investigation.
+To get you up and running quickly with Wallaroo, we have provided a Docker image which includes Wallaroo and related tools needed to run and modify a few example applications. We should warn that this Docker image was created with the intent of getting users started quickly with Wallaroo and is not intended to be a fully customizable development environment or suitable for production. Currently, this is the only supported development environnment for MacOS and Windows.
 
 ## Installing Docker
 
@@ -9,6 +9,12 @@ To get you up and running quickly with Wallaroo, we have provided a Docker image
 There are [instructions](https://docs.docker.com/docker-for-mac/) for getting Docker up and running on MacOS on the [Docker website](https://docs.docker.com/docker-for-mac/).  We recommend the 'Standard' version of the 'Docker for Mac' package.
 
 Installing Docker will result in it running on your machine. After you reboot your machine, that will no longer be the case. In the future, you'll need to have Docker running in order to use a variety of commands in this book. We suggest that you [set up Docker to boot automatically](https://docs.docker.com/docker-for-mac/#general).
+
+### Windows
+
+There are [instructions](https://www.docker.com/docker-windows/) for getting Docker up and running on Windows on the [Docker website](https://docs.docker.com/docker-for-windows/). We recommend installing the latest stable release, as there are breaking changes to our commands on edge releases. Installing Docker will result in it running on your machine. After you reboot your machine, that will no longer be the case. In the future, you'll need to have Docker running in order to use a variety of commands in this book. We suggest that you [set up Docker to boot automatically](https://docs.docker.com/docker-for-windows/#general).
+
+Currently, development is only supported for Linux containers within Docker.
 
 ### Linux Ubuntu
 
@@ -37,6 +43,35 @@ docker pull wallaroo-labs-docker-wallaroolabs.bintray.io/{{ docker_version_url }
 * **Metrics UI**: receives and displays metrics for running Wallaroo applications.
 
 * **Wallaroo Source Code**: full Wallaroo source code is provided, including Python example applications.
+
+## Additional Windows Setup
+
+There are a few extra recommended steps that Windows users should make before continuing on to starting the Wallaroo Docker image. These steps are needed in order to persist the Wallaroo source code and Python virtual environment using [virtualenv](https://virtualenv.pypa.io/en/stable/) onto your local machine from within the Wallaroo Docker container. This will allow code changes and installed Python modules to persist beyond the lifecycle of a Docker container.
+
+These steps are optional, but will require the removal of the `-v` options when starting the Wallaroo Docker image if you choose to opt out.
+
+### Sharing your drive with Docker
+
+You can find instructions for setting up a shared drive with Docker on Windows [here](https://docs.docker.com/docker-for-windows/#shared-drives).
+
+The remainder of this tutorial assumes you shared the `C` drive, modify the commands as needed if sharing a different drive.
+
+### Creating the Wallaroo and Python Virtualenv directories
+
+We'll need to create two directories, one for the Wallaroo source code and one for the Python virtual environment.
+
+To create the Wallaroo source code directory run the following command in Powershell or Command Prompt:
+
+```bash
+mkdir c:\wallaroo-docker\wallaroo-src
+```
+To create the Wallaroo Python virtual environment directory run the following command in Powershell or Command Prompt:
+
+```bash
+mkdir c:\wallaroo-docker\python-virtualenv
+```
+
+Your Windows machine is now all set to continue!
 
 ## Register
 

--- a/book/getting-started/run-a-wallaroo-application-docker.md
+++ b/book/getting-started/run-a-wallaroo-application-docker.md
@@ -19,13 +19,25 @@ Let's get started!
 
 ## Terminal 1, Start the Wallaroo Docker container
 
-```bash
+{% codetabs name="UNIX Bash", type="bash" -%}
 docker run --rm -it --privileged -p 4000:4000 \
 -v /tmp/wallaroo-docker/wallaroo-src:/src/wallaroo \
 -v /tmp/wallaroo-docker/python-virtualenv:/src/python-virtualenv \
 --name wally \
 wallaroo-labs-docker-wallaroolabs.bintray.io/{{ docker_version_url }}
-```
+{%- language name="Windows Powershell", type="bash" -%}
+docker run --rm -it --privileged -p 4000:4000 `
+-v c:/wallaroo-docker/wallaroo-src:/src/wallaroo `
+-v c:/wallaroo-docker/python-virtualenv:/src/python-virtualenv `
+--name wally `
+wallaroo-labs-docker-wallaroolabs.bintray.io/{{ docker_version_url }}
+{%- language name="Windows Command Prompt", type="bash" -%}
+docker run --rm -it --privileged -p 4000:4000 ^
+-v c:/wallaroo-docker/wallaroo-src:/src/wallaroo ^
+-v c:/wallaroo-docker/python-virtualenv:/src/python-virtualenv ^
+--name wally ^
+wallaroo-labs-docker-wallaroolabs.bintray.io/{{ docker_version_url }}
+{%- endcodetabs %}
 
 ### Breaking down the Docker command
 


### PR DESCRIPTION
Updates "Choosing an Installation Option", "Run A Wallaroo Application
in Docker", and "Docker Setup" to add documentation for Windows support.

@SeanTAllen I'm opening this against the current release branch as there were no changes other than documentation

@strmpnk since you're the only other person with a Windows machine, can you confirm that you can start the Wallaroo docker image via the `Powershell` and `Command Prompt` commands provided and that you can successfully run

Documentation can be found here: https://wallaroo-docs-rc.netlify.com