### PR TITLE
Filter `None` values in machida compute_multi results

### DIFF
--- a/testing/correctness/topology_layouts/apps/single_stream/filtering/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/filtering/Makefile
@@ -1,0 +1,42 @@
+# include root makefile
+ifndef ROOT_MAKEFILE_MK
+include ../../../../../../Makefile
+endif
+
+# prevent rules from being evaluated/included multiple times
+ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
+$(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
+
+
+# The following are control variables that determine what logic from `rules.mk` is enabled
+
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
+
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
+
+# standard rules generation makefile
+include $(rules_mk_path)
+
+# end of prevent rules from being evaluated/included multiple times
+endif

--- a/testing/correctness/topology_layouts/apps/single_stream/filtering/python_multi_crash_dedupe/Makefile
+++ b/testing/correctness/topology_layouts/apps/single_stream/filtering/python_multi_crash_dedupe/Makefile
@@ -1,0 +1,58 @@
+# include root makefile
+ifndef ROOT_MAKEFILE_MK
+include ../../../../../../../Makefile
+endif
+
+# prevent rules from being evaluated/included multiple times
+ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
+$(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
+
+
+# The following are control variables that determine what logic from `rules.mk` is enabled
+
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
+
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := false
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := false
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := false
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := false
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := false
+
+
+TESTING_MULTICRASHDEDUPE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+# standard rules generation makefile
+include $(rules_mk_path)
+
+build-testing-correctness-topology_layouts-apps-single_stream-filtering-python_multi_crash_dedupe: build-machida
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-filtering-python_multi_crash_dedupe: build-testing-correctness-topology_layouts-apps-single_stream-filtering-python_multi_crash_dedupe
+integration-tests-testing-correctness-topology_layouts-apps-single_stream-filtering-python_multi_crash_dedupe: multi_crash_dedupe_py_test
+
+multi_crash_dedupe_py_test:
+	cd $(TESTING_MULTICRASHDEDUPE_PATH) && \
+	integration_test --sequence-sender '[0,10]' \
+		--validation-cmp \
+		--expected-csv '0,1,2,3,7,8,9,10' \
+		--log-level error \
+		--batch-size 1 \
+		--command 'machida --application-module multi_crash_dedupe' \
+		--sink-mode newlines \
+		--sink-expect 8
+
+endif

--- a/testing/correctness/topology_layouts/apps/single_stream/filtering/python_multi_crash_dedupe/multi_crash_dedupe.py
+++ b/testing/correctness/topology_layouts/apps/single_stream/filtering/python_multi_crash_dedupe/multi_crash_dedupe.py
@@ -1,0 +1,93 @@
+# Copyright 2017 The Wallaroo Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+
+import struct
+
+import wallaroo
+
+
+def application_setup(args):
+    in_host, in_port = wallaroo.tcp_parse_input_addrs(args)[0]
+    out_host, out_port = wallaroo.tcp_parse_output_addrs(args)[0]
+
+    ab = wallaroo.ApplicationBuilder("multi crash dedupe")
+    ab.new_pipeline("multi crash dedupe",
+                    wallaroo.TCPSourceConfig(in_host, in_port, decoder))
+    ab.to(multi)
+    ab.to(crash_if_none)
+    ab.to_stateful(dedupe, LastInt, "last int")
+    ab.to_sink(wallaroo.TCPSinkConfig(out_host, out_port, encoder))
+    return ab.build()
+
+
+@wallaroo.decoder(header_length=4, length_fmt=">I")
+def decoder(bs):
+    return struct.unpack(">Q", bs)[0]
+
+
+@wallaroo.computation_multi(name="Multi")
+def multi(data):
+    print("> Multi got: {}".format(data))
+    m = data % 7
+    if m == 0:
+        return [data]
+    elif m == 1:
+        return [data, data]
+    elif m == 2:
+        return [data, None]
+    elif m == 3:
+        return [None, data]
+    elif m == 4:
+        return [None]
+    elif m == 5:
+        return [None, None]
+    else:
+        return None
+
+
+@wallaroo.computation(name="Crash if None")
+def crash_if_none(data):
+    print("> Crash if None got: {}".format(data))
+    if data is None:
+        print("Got a None input value that should have been filtered. Terminating!")
+        exit(1)
+    return data
+
+
+class LastInt(object):
+    def __init__(self):
+        self.v = -1
+
+    def maybe_update(self, new):
+        if new < self.v:
+            print("Got an out of order value. Terminating!")
+            exit(1)
+        if new > self.v:
+            self.v = new
+            return True
+        return False
+
+
+@wallaroo.state_computation(name="Dedupe")
+def dedupe(data, state):
+    print("> Dedupe got: {}".format(data))
+    should_save = state.maybe_update(data)
+    return (data if should_save else None, should_save)
+
+
+@wallaroo.encoder
+def encoder(data):
+    print("> Encoder got: {}".format(data))
+    return '{}\n'.format(data)

--- a/testing/tools/integration/integration_test
+++ b/testing/tools/integration/integration_test
@@ -196,8 +196,37 @@ class FramedGenAction(argparse.Action):
 
 class CSVStringAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
-        """Split the string and store the list as expected-csv"""
-        setattr(namespace, self.dest, values.split(','))
+        """
+        Split the string and store the list as expected-csv
+        Permit 2 cases;
+        1 value: assume type is string
+        2 values: csv: {0}, type name: {1}
+
+        Types allowed are:
+        'string', 'int', 'float'
+        """
+        if not isinstance(values, list):
+            values = [values]
+        if len(values) == 1:
+            setattr(namespace, self.dest, values[0].split(','))
+        elif len(values) == 2:
+            if values[1] == 'string':
+                setattr(namespace, self.dest, values[0].split(','))
+            elif values[1] == 'int':
+                setattr(namespace, self.dest, map(int, values[0].split(',')))
+            elif values[1] == 'float':
+                setattr(namespace, self.dest, map(float, values[0].split(',')))
+            else:
+                msg = ('Argument "{f}" requires 1 or 2 arguments specifying '
+                       'a comma-delimited list of values [, type name (one of'
+                       ' "int", "float", "string").')
+                raise argparse.ArgumentTypeError(msg)
+
+        else:
+            msg = ('Argument "{f}" requires 1 or 2 arguments specifying '
+                   'a comma-delimited list of values [, type name (one of'
+                   ' "int", "float", "string").')
+            raise argparse.ArgumentTypeError(msg)
 
 
 SpikeConfig = namedtuple('SpikeConfig', ['probability', 'margin', 'seed'])
@@ -347,12 +376,13 @@ def CLI():
                       metavar=('index', 'probability', 'margin', 'seed'),
                       help=("Spike the connection on the specified worker"))
 
-    # Expected data foir validation
+    # Expected data for validation
     exp_group = parser.add_mutually_exclusive_group()
     exp_group.add_argument('--expected-file', help=("The path to a file "
                            "containing binary data to compare against the "
                            "output."))
     exp_group.add_argument('--expected-csv', dest='expected_val',
+                           nargs='+',
                            help=("A comma delimited list of"
                            " of values to compare against the output data."),
                            action=CSVStringAction)


### PR DESCRIPTION
This change makes `Machida` filter `None` values from the result set of `multi` computations.
It includes an integration test for the simple case (that relies on a "crash if None" computation to detect whether it works).