### PR TITLE
Expand HashPartitions class to support arbitrary weights, add & remove, Ponycheck

### DIFF
--- a/lib/wallaroo/core/Makefile
+++ b/lib/wallaroo/core/Makefile
@@ -1,0 +1,41 @@
+# include root makefile
+ifndef ROOT_MAKEFILE_MK
+include ../../../Makefile
+endif
+
+# prevent rules from being evaluated/included multiple times
+ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
+$(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
+
+
+# The following are control variables that determine what logic from `rules.mk` is enabled
+
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
+
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
+# standard rules generation makefile
+include $(rules_mk_path)
+
+# end of prevent rules from being evaluated/included multiple times
+endif

--- a/lib/wallaroo/core/routing/hash_partitions.pony
+++ b/lib/wallaroo/core/routing/hash_partitions.pony
@@ -1,0 +1,657 @@
+use "collections"
+use "crypto"
+use "wallaroo_labs/mort"
+
+class val HashPartitions is (Equatable[HashPartitions] & Stringable)
+  let _lower_bounds: Array[U128] = _lower_bounds.create()
+  let _interval_sizes: Array[U128] = _interval_sizes.create()
+  let _lb_to_c: Map[U128, String] = _lb_to_c.create()  // lower bound -> claimant
+
+  new val create(cs: Array[String] val) =>
+    """
+    Given an array of claimant name strings that are non-zero length,
+    create a HashPartitions that assigns equal weight to all claimants.
+    """
+    let sizes: Array[(String, U128)] iso = recover sizes.create() end
+    let interval: U128 = if cs.size() == 0 then
+      U128.max_value()
+    else
+      U128.max_value() / cs.size().u128()
+    end
+
+    for c in cs.values() do
+      if c != "" then
+        sizes.push((c, interval))
+      end
+    end
+    create2(consume sizes)
+
+  new val create_with_weights(weights: Array[(String, F64)] val,
+    decimal_digits: USize = 2)
+  =>
+    """
+    Given an array of 2-tuples (claimant name strings that are
+    non-zero length plus floating point weighting factor for the claimant),
+    create a HashPartitions that assigns equal weight to all claimants.
+    """
+    let weights': Array[(String, F64)] trn = recover weights'.create() end
+    var sum: F64 = 0.0
+    let sizes: Array[(String, U128)] trn = recover sizes.create() end
+
+    for (c, w) in weights.values() do
+      let w' = RoundF64(w, decimal_digits)
+      if (c != "") and (w' > 0.0) then
+        weights'.push((c, w'))
+      end
+    end
+
+    for (_, w) in weights'.values() do
+      sum = sum + w
+    end
+    for (c, w) in weights'.values() do
+      if w == sum then
+        sizes.push((c, U128.max_value()))
+      else
+        let fraction: F64 = w / sum
+        let sz': F64 = U128.max_value().f64() * fraction
+        let sz: U128 = U128.from[F64](sz')
+        sizes.push((c, sz))
+      end
+    end
+    create2(consume sizes)
+
+  new val create_with_sizes(sizes: Array[(String, U128)] val) =>
+    create2(sizes)
+
+  fun adjust_weights(new_weights: Array[(String, F64)] val,
+    decimal_digits: USize = 2): HashPartitions
+   =>
+    """
+    Given a previously-built HashPartitions object, make some adjustments
+    simultaneously to any/all of the following dimensions for one or more
+    claimants and return a new HashPartitions object:
+
+    1. Change weight of the existing claimant.
+    2. Add a new claimant by dividing all existing interval assignments
+       proportionally by weight.
+    3. Remove an existing claimant by reassigning all interval assignments
+       for that client to remaining clients proportionally by weight.
+
+    It is possible to use weight assignment less than 1.0 but is not
+    recommended.  Future use of adjust_weights() and related functions
+    will re-normalize total weight assignments based on the smallest
+    claim interval sum and will assign a weight of 1.0 to that sum.
+    """
+    _adjust_weights(new_weights, decimal_digits)
+
+fun add_claimants(cs: Array[String] val, decimal_digits: USize = 2):
+  HashPartitions ?
+=>
+  """
+  A wrapper around adjust_weights() where we wish only to add new
+  claimants with weight 1.0 to this HashPartitions and return a new
+  HashPartitions object.
+
+  This function is partial: it is an error if we try to add a claimant
+  name that already exists in this HashPartitions.
+  """
+  let current_weights = get_weights_normalized(decimal_digits)
+  let new_weights: Array[(String, F64)] iso = recover new_weights.create() end
+
+  for c in cs.values() do
+    if current_weights.contains(c) then
+      error
+    end
+  end
+  for (c, w) in current_weights.pairs() do
+    new_weights.push((c, w))
+  end
+  for c in cs.values() do
+    new_weights.push((c, 1.0))
+  end
+  let new_weights' = recover val consume new_weights end
+  if get_weights_normalized().size() == 0 then
+    create_with_weights(new_weights', decimal_digits)
+  else
+    adjust_weights(new_weights', decimal_digits)
+  end
+
+fun remove_claimants(cs: Array[String] val, decimal_digits: USize = 2):
+  HashPartitions ?
+=>
+  """
+  A wrapper around adjust_weights() where we wish only to remove
+  existing claimants from this HashPartitions and return a new
+  HashPartitions object.
+
+  This function is partial: it is an error if we try to remove a claimant
+  name that does not exist in this HashPartitions.
+  """
+  let current_weights = get_weights_normalized(decimal_digits)
+  let new_weights: Array[(String, F64)] trn = recover new_weights.create() end
+  var rs: Set[String] = rs.create()
+
+  for c in cs.values() do
+    if not current_weights.contains(c) then
+      error
+    end
+    rs = rs.add(c)
+  end
+  for (c, w) in current_weights.pairs() do
+    if not rs.contains(c) then
+      new_weights.push((c, w))
+    end
+  end
+  adjust_weights(consume new_weights, decimal_digits)
+
+fun ref create2(sizes: Array[(String, U128)] val) =>
+    """
+    Create a HashPartitions using U128-sized intervals.
+    """
+    let count = sizes.size()
+    var next_lower_bound: U128 = 0
+
+    if sizes.size() == 0 then
+      return
+    end
+    try
+      for i in Range[USize](0, count) do
+        let c = sizes(i)?._1
+        let interval = sizes(i)?._2
+        _lower_bounds.push(next_lower_bound)
+        _interval_sizes.push(interval)
+        _lb_to_c(next_lower_bound) = c
+        next_lower_bound = next_lower_bound + interval
+      end
+    else
+      Fail()
+    end
+
+    var sum: U128 = 0
+    for interval in _interval_sizes.values() do
+      sum = sum + interval
+    end
+    let idx = _lower_bounds.size() - 1
+    let i_adjust = (U128.max_value() - sum)
+    try _interval_sizes(idx)? = _interval_sizes(idx)? + i_adjust
+      else Fail() end
+
+  fun box eq(y: HashPartitions box): Bool =>
+    """
+    Implement eq for Equatable trait.
+    """
+    try
+      if (_lower_bounds.size() == y._lower_bounds.size()) and
+         (_interval_sizes.size() == y._interval_sizes.size()) and
+         (_lb_to_c.size() == y._lb_to_c.size())
+      then
+        for i in _lower_bounds.keys() do
+          if (_lower_bounds(i)? != y._lower_bounds(i)?) or
+             (_interval_sizes(i)? != y._interval_sizes(i)?) or
+             (_lb_to_c(_lower_bounds(i)?)? != y._lb_to_c(y._lower_bounds(i)?)?)
+          then
+            return false
+          end
+        end
+        return true
+      else
+        return false
+      end
+    else
+      false
+    end
+
+  fun box ne(y: HashPartitions box): Bool =>
+    """
+    Implement eq for Equatable trait.
+    """
+    not eq(y)
+
+  fun box string(): String iso^ =>
+    """
+    Implement string for Stringable trait.
+    """
+    let s: String iso = "".clone()
+
+    try
+      for i in _lower_bounds.keys() do
+        s.append(_lb_to_c(_lower_bounds(i)?)? + "@" +
+          _interval_sizes(i)?.string() + ",")
+      end
+    else
+      Fail()
+    end
+    consume s
+
+  fun get_claimant(hash: U128): String ? =>
+    var next_to_last_idx: USize = _lower_bounds.size() - 1
+    var last_idx: USize = 0
+
+    if hash > _lower_bounds(next_to_last_idx)? then
+      return _lb_to_c(_lower_bounds(next_to_last_idx)?)?
+    end
+
+    // Binary search
+    while true do
+      let next_lower_bound = _lower_bounds(last_idx)?
+
+      if hash >= next_lower_bound then
+        if hash < _lower_bounds(last_idx + 1)? then
+          return _lb_to_c(next_lower_bound)?
+        else
+          var step =
+            (next_to_last_idx.isize() - last_idx.isize()).abs().usize() / 2
+          if step == 0 then step = 1 end
+          next_to_last_idx = last_idx
+          last_idx = last_idx + step
+        end
+      else
+        var step =
+          (next_to_last_idx.isize() - last_idx.isize()).abs().usize() / 2
+        if step == 0 then step = 1 end
+        next_to_last_idx = last_idx
+        last_idx = last_idx - step
+      end
+    end
+    Unreachable()
+    ""
+
+  fun get_claimant_by_key(key: ByteSeq): String ? =>
+    var hashed_key: U128 = 0
+    for v in MD5(key).values() do
+      hashed_key = (hashed_key << 8) + v.u128()
+    end
+    get_claimant(hashed_key)?
+
+  fun claimants(): Iterator[String] ref =>
+    _lb_to_c.values()
+
+  fun _get_interval_size_sums(): Map[String,U128] =>
+    let interval_sums: Map[String,U128] = interval_sums.create()
+
+    try
+      for c in _lb_to_c.values() do
+        interval_sums(c) = 0
+      end
+
+      for i in Range[USize](0, _lower_bounds.size()) do
+        let c = _lb_to_c(_lower_bounds(i)?)?
+        interval_sums(c) = interval_sums(c)? + _interval_sizes(i)?
+      end
+    else
+      Fail()
+    end
+    interval_sums
+
+  fun get_sizes(): Array[(String, U128)] =>
+    let s: Array[(String, U128)] = s.create()
+
+    try 
+      for i in Range[USize](0, _lower_bounds.size()) do
+        let c = _lb_to_c(_lower_bounds(i)?)?
+        s.push((c, _interval_sizes(i)?))
+      end
+    else
+      Fail()
+    end
+    s
+
+  fun get_weights_unit_interval(): Map[String,F64] =>
+    let ws: Map[String, F64] = ws.create()
+
+    for (c, sum) in _get_interval_size_sums().pairs() do
+      ws(c) = sum.f64() / U128.max_value().f64()
+    end
+    ws
+
+  fun get_weights_normalized(decimal_digits: USize = 2): Map[String,F64] =>
+    let ws: Map[String, F64] = ws.create()
+    var min_weight = F64.max_value()
+    let weights = get_weights_unit_interval()
+
+    for (_, weight) in weights.pairs() do
+      min_weight = min_weight.min(weight)
+    end
+    if min_weight == 0 then
+      Fail()
+    end
+    for (node, weight) in weights.pairs() do
+      ws(node) = RoundF64(weight.f64() / min_weight, decimal_digits)
+    end
+    ws
+
+  fun pretty_print() =>
+    for (n, w) in _normalize_for_pp().values() do
+      @printf[I32]("node %10s relative-size %.4f\n".cstring(), n.cstring(), w)
+    end
+
+  fun _normalize_for_pp(decimal_digits: USize = 2): Array[(String, F64)] =>
+    var min_size: U128 = U128.max_value()
+    let ns: Array[(String, F64)] = ns.create()
+
+    try
+      for i in Range[USize](0, _interval_sizes.size()) do
+        min_size = min_size.min(_interval_sizes(i)?)
+      end
+      if min_size == 0 then
+        Fail()
+      end
+
+      for i in Range[USize](0, _interval_sizes.size()) do
+        let w = RoundF64(_interval_sizes(i)?.f64() / min_size.f64(), decimal_digits)
+        ns.push((_lb_to_c(_lower_bounds(i)?)?, w))
+      end
+    else
+      Fail()
+    end
+    ns
+
+  fun _adjust_weights(new_weights: Array[(String, F64)] val,
+    decimal_digits: USize = 2): HashPartitions
+   =>
+    //// Figure out what claimants have been removed.
+
+    let current_weights = get_weights_normalized(decimal_digits)
+    var current_cs: Set[String] = current_cs.create()
+    let current_sizes_m = _get_interval_size_sums()
+    var new_cs: Set[String] = new_cs.create()
+    let new_weights_m: Map[String, F64] = new_weights_m.create()
+    let new_sizes_m: Map[String, U128] = new_sizes_m.create()
+    var sum_new_weights: F64 = 0.0
+
+    for (c, w) in get_weights_normalized().pairs() do
+      current_cs = current_cs.add(c)
+    end
+    for (c, w) in new_weights.values() do
+      new_cs = new_cs.add(c)
+      let w' = RoundF64(w, decimal_digits)
+      sum_new_weights = sum_new_weights + w'
+      new_weights_m(c) = w'
+      if not current_sizes_m.contains(c) then
+        current_sizes_m(c) = 0
+      end
+    end
+    let removed_cs = current_cs.without(new_cs)
+
+    //// Assign weights of zero to claimants not in the new list
+    for c in removed_cs.values() do
+      new_weights_m(c) = 0.0
+    end
+
+    //// Calculate the interval slices that need to be redistributed
+    let size_add: Map[String,U128] = size_add.create()
+    let size_sub: Map[String,U128] = size_sub.create()
+
+    try
+      for (c, w) in new_weights_m.pairs() do
+        let new_size = if (sum_new_weights == 1.0) and (w == sum_new_weights) then
+            U128.max_value() // Avoid overflow to 0!
+          else
+            U128.from[F64]((w / sum_new_weights) * U128.max_value().f64())
+          end
+        if new_size > current_sizes_m(c)? then
+          size_add(c) = (new_size - current_sizes_m(c)?)
+        elseif new_size < current_sizes_m(c)? then
+          size_sub(c) = (current_sizes_m(c)? - new_size)
+        else
+          None
+        end
+      end
+    else
+      Fail()
+    end
+
+    //// Get the current map in Array[(Claimant,Size)] format, which
+    //// is what create2() requires.
+
+    let sizes1 = get_sizes()
+    //// Process subtractions first: use the claimant name ""
+    //// for unclaimed intervals.
+    let sizes2 = _process_subtractions(sizes1, size_sub)
+
+    let sizes2b = _coalesce_adjacent_intervals(sizes2)
+    //// Process additions next.
+    let sizes3 = _process_additions(consume sizes2b, size_add, decimal_digits)
+
+    //// Coalesce adjacent intervals to reduce the size of the map
+    let sizes4 = _coalesce_adjacent_intervals(sizes3)
+
+    //// Deal with a couple of edge cases
+    let sizes5 = if sizes4.size() == 0 then
+      Fail(); consume sizes4
+    elseif sizes4.size() == 1 then
+      // Either it's all unclaimed or all claimed or we have an error
+      try
+        (let c, let s) = sizes4(0)?
+        let frac = (s.f64() / U128.max_value().f64())
+        if RoundF64(frac, decimal_digits) != 1.0 then
+          Fail()
+        end
+        if c == "" then
+          // Entire interval is unclaimed, so return empty list instead.
+          let empty: Array[(String, U128)] trn = recover empty.create() end
+          consume empty
+        else
+          // Entire interval claimed by s, so leave it alone
+          consume sizes4
+        end
+      else
+        Fail()
+        let empty: Array[(String, U128)] trn = recover empty.create() end
+        consume empty
+      end
+    else
+      consume sizes4
+    end
+
+    //// Done!
+    HashPartitions.create_with_sizes(consume sizes5)
+
+  fun _process_subtractions(old_sizes: Array[(String, U128)],
+    size_sub: Map[String, U128]): Array[(String, U128)]
+  =>
+    let new_sizes: Array[(String, U128)] iso = recover new_sizes.create() end
+
+    try
+      for (c, s) in old_sizes.values() do
+        if size_sub.contains(c) then
+          let to_sub = size_sub(c)?
+
+          if to_sub > 0 then
+            if to_sub >= s then
+              new_sizes.push(("", s))     // Unassign all of s
+              size_sub(c) = to_sub - s
+            else
+              let remainder = s - to_sub  // Unassign some of s, keep remainder
+              new_sizes.push((c, remainder))
+              new_sizes.push(("", to_sub))
+              size_sub(c) = 0
+            end
+          else
+            // c has had enough subtracted from its overall total, keep this
+            new_sizes.push((c, s)) // Assignment of s is unchanged
+          end
+        else
+          new_sizes.push((c, s)) // Assignment of s is unchanged
+        end
+      end
+    else
+      Fail()
+    end
+    new_sizes
+    
+  fun _process_additions(old_sizes: Array[(String, U128)],
+    size_add: Map[String, U128], decimal_digits: USize):
+    Array[(String, U128)]
+  =>
+    let new_sizes: Array[(String, U128)] = new_sizes.create()
+    let total_length = old_sizes.size()
+
+    try
+      for i in Range[USize](0, total_length) do
+        (let c, let s) = old_sizes(i)?
+
+        if c != "" then
+          new_sizes.push((c, s)) // Assignment of s is unchanged
+        else
+          // Bind neighbors (or dummy values) on the left & right.
+          (let left_c, let left_s) = if i > 0 then
+            old_sizes(i - 1)?
+          else
+            ("", 0)
+          end
+          (let right_c, let right_s) = if i < (total_length - 1) then
+            old_sizes(i + 1)?
+          else
+            ("", 0)
+          end
+
+          // Is there a neighbor on the left that needs extra?
+          if (i > 0)
+            and (left_c != "") and (size_add.contains(left_c))
+            and (size_add(left_c)? > 0)
+          then
+            let to_add = size_add(left_c)?
+
+            if to_add >= s then
+              // Assign all of s to left. 
+              new_sizes.push((left_c, s))
+              size_add(left_c) = to_add - s
+            else
+              // Assign some of s, keep remainder unassigned.
+              // Split s into 2, copy remaining old_sizes -> new_sizes,
+              // then recurse.
+              let remainder = s - to_add
+              new_sizes.push((left_c, to_add)) // Keep on left side
+              new_sizes.push(("", remainder))
+              new_sizes.reserve(total_length + 1)
+              old_sizes.copy_to(new_sizes, i + 1, i + 2,
+                total_length - (i + 1))
+              size_add(left_c) = 0
+              return _process_additions(new_sizes, size_add, decimal_digits)
+            end
+          // Is there a neighbor on the right that needs extra?
+          elseif (i < (total_length - 1))
+            and(right_c != "") and (size_add.contains(right_c))
+            and (size_add(right_c)? > 0)
+          then
+            let to_add = size_add(right_c)?
+
+            if to_add >= s then
+              // Assign all of s to right.
+              new_sizes.push((right_c, s))
+              size_add(right_c) = to_add - s
+            else
+              // Assign some of s, keep remainding unassigned.
+              // Split s into 2, copy remaining old_sizes -> new_sizes,
+              // then recurse.
+              let remainder = s - to_add
+              new_sizes.push(("", remainder))
+              new_sizes.push((right_c, to_add)) // Keep on right side
+              new_sizes.reserve(total_length + 1)
+              old_sizes.copy_to(new_sizes, i + 1, i + 2,
+                total_length - (i + 1))
+              size_add(right_c) = 0
+              return _process_additions(new_sizes, size_add, decimal_digits)
+            end
+          // Neither neighbor is suitable, so choose another claimant
+          else
+            let smallest_c = _find_smallest_nonzero_size_to_add(size_add,
+              decimal_digits, s)
+            if (smallest_c == "") then
+              None // Don't add anything to new_sizes
+            else
+              new_sizes.push((c, s)) // This is the unassigned size
+              // Zero size is illegal in the final result, but it will be
+              // removed when we recurse, or it will be removed by final
+              // neighbor coalescing.
+              new_sizes.push((smallest_c, 0))
+              new_sizes.reserve(total_length + 1)
+              old_sizes.copy_to(new_sizes, i + 1, i + 2,
+                total_length - (i + 1))
+              return _process_additions(new_sizes, size_add, decimal_digits)
+            end
+          end
+        end // if c != ...
+      end //for i ...
+    else
+      Fail()
+    end
+    new_sizes
+
+  fun _find_smallest_nonzero_size_to_add(size_add: Map[String,U128],
+    decimal_digits: USize, vestige_size: U128): String
+  =>
+    var smallest_c = ""
+    var smallest_s = U128.max_value()
+
+    for (c, s) in size_add.pairs() do
+      if (s > 0) and (s < smallest_s) then
+        smallest_c = c
+        smallest_s = s
+      end
+    end
+    if smallest_c != "" then
+      smallest_c
+    else
+      let vestige_perc = (vestige_size.f64() / U128.max_value().f64()) * 100.0
+      let vestige_rounded = RoundF64(vestige_perc, decimal_digits + 2)
+      if not ((vestige_rounded == 0.0) or (vestige_rounded == 100.0)) then
+        Fail()
+      end
+      ""
+    end
+
+
+  fun _coalesce_adjacent_intervals(old_sizes: Array[(String, U128)]):
+    Array[(String, U128)] trn^
+  =>
+    let new_sizes: Array[(String, U128)] trn = recover new_sizes.create() end
+
+    if old_sizes.size() == 0 then
+      return recover [("", U128.max_value())] end
+    end
+    try
+      (let first_c, let first_s) = old_sizes.shift()?
+      if old_sizes.size() == 0 then
+        new_sizes.push((first_c, first_s))
+        consume new_sizes
+      else
+        (let next_c, let next_s) = old_sizes.shift()?
+        _coalesce(first_c, first_s, next_c, next_s, old_sizes, consume new_sizes)
+      end
+    else
+      recover Array[(String, U128)]() end
+    end
+
+  fun _coalesce(last_c: String, last_s: U128, head_c: String, head_s: U128,
+    tail: Array[(String, U128)], new_sizes: Array[(String, U128)] trn):
+    Array[(String, U128)] trn^
+  =>
+    if tail.size() == 0 then
+      if last_c == head_c then
+        new_sizes.push((last_c, last_s + head_s))
+      else
+        new_sizes.push((last_c, last_s))
+        new_sizes.push((head_c, head_s))
+      end
+      return consume new_sizes
+    end
+    try
+      (let next_c, let next_s) = tail.shift()?
+      if last_c == head_c then
+        _coalesce(head_c, last_s + head_s, next_c, next_s, tail, consume new_sizes)
+      else
+        new_sizes.push((last_c, last_s))
+        _coalesce(head_c, head_s, next_c, next_s, tail, consume new_sizes)
+      end
+    else
+      Fail()
+      recover Array[(String, U128)]() end
+    end
+
+primitive RoundF64
+  fun apply(f: F64, decimal_digits: USize = 2): F64 =>
+    let factor = F64(10).pow(decimal_digits.f64())
+
+    ((f * factor) + 0.5).trunc() / factor

--- a/lib/wallaroo/core/routing_test/.gitignore
+++ b/lib/wallaroo/core/routing_test/.gitignore
@@ -1,0 +1,1 @@
+routing_test

--- a/lib/wallaroo/core/routing_test/Makefile
+++ b/lib/wallaroo/core/routing_test/Makefile
@@ -1,0 +1,41 @@
+# include root makefile
+ifndef ROOT_MAKEFILE_MK
+include ../../../../Makefile
+endif
+
+# prevent rules from being evaluated/included multiple times
+ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
+$(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
+
+
+# The following are control variables that determine what logic from `rules.mk` is enabled
+
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
+
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
+# standard rules generation makefile
+include $(rules_mk_path)
+
+# end of prevent rules from being evaluated/included multiple times
+endif

--- a/lib/wallaroo/core/routing_test/_test.pony
+++ b/lib/wallaroo/core/routing_test/_test.pony
@@ -1,0 +1,508 @@
+/*
+
+Copyright 2017 The Wallaroo Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing
+ permissions and limitations under the License.
+
+*/
+
+use "collections"
+use "ponycheck"
+use "ponytest"
+use "wallaroo/core/routing"
+use "wallaroo_labs/mort"
+
+actor Main is TestList
+  new make() =>
+    None
+
+  new create(env: Env) =>
+    PonyTest(env, this)
+
+  fun tag tests(test: PonyTest) =>
+    test(_TestMakeHashPartitions)
+    test(_TestMakeHashPartitions2)
+    test(_TestMakeHashPartitions3)
+    test(_TestAdjustHashPartitions)
+    test(_Regression2to1)
+    test(_Regression0to1)
+    test(Property1UnitTest[(Array[TestOp])](_TestPonycheckStateful))
+
+
+class iso _TestMakeHashPartitions is UnitTest
+  """
+  Basic test of making a simple HashPartition with 3 claimants.
+  """
+  fun name(): String =>
+    "hash_partitions/line-" + __loc.line().string()
+
+  fun ref apply(h: TestHelper) ? =>
+    let n3: Array[String] val = recover ["n1"; "n2"; "n3"] end
+    let hp = HashPartitions(n3)
+    // hp.pretty_print()
+
+    // There's no guarantee the following is true, but it probably is true.
+
+    let got: Map[String,Bool] = got.create()
+    for i in Range[USize](0,255) do
+      let s = "key" + i.string()
+      let m = hp.get_claimant_by_key(s)? // TODO make this fun not-partial
+      got(m) = true
+    end
+    h.assert_eq[USize](got.size(), n3.size())
+    for (c, res) in got.pairs() do
+      h.assert_eq[Bool](n3.contains(c), true)
+      h.assert_eq[Bool](res, true)
+    end
+
+class iso _TestMakeHashPartitions2 is UnitTest
+  """
+  Make several HashPartitions that should be equivalent
+  """
+  fun name(): String =>
+    "hash_partitions/line-" + __loc.line().string()
+
+  fun ref apply(h: TestHelper) /**?**/ =>
+    let weights1: Array[(String,F64)] val = recover
+      [("n1", 1*1); ("n2", 2*1); ("n3", 3*1); ("n4", 1*1)] end
+    let weights2: Array[(String,F64)] val = recover
+      [("n1", 1*3); ("n2", 2*3); ("n3", 3*3); ("n4", 1*3)] end
+    let weights3: Array[(String,F64)] val = recover
+     [("n1", 48611766702991206367701239421883908096)
+      ("n2", 97223533405982412735402478843767816192)
+      ("n3", 145835300108973619103103718265651724288)
+      ("n4", 48611766702991225257167170900464762879)] end
+    let weights4: Array[(String,F64)] val = recover
+     [("n1", 48611766702991206367701239421883908096/15)
+      ("n2", 97223533405982412735402478843767816192/15)
+      ("n3", 145835300108973619103103718265651724288/15)
+      ("n4", 48611766702991225257167170900464762879/15)] end
+    let hp1 = HashPartitions.create_with_weights(weights1)
+    let hp2 = HashPartitions.create_with_weights(weights2)
+    let hp3 = HashPartitions.create_with_weights(weights3)
+    let hp4 = HashPartitions.create_with_weights(weights4)
+
+    // hp1.pretty_print()
+    // All 4 HashPartitions should be exactly equal
+    h.assert_eq[HashPartitions](hp1, hp2)
+    h.assert_eq[HashPartitions](hp1, hp3)
+    h.assert_eq[HashPartitions](hp1, hp4)
+
+class iso _TestMakeHashPartitions3 is UnitTest
+  """
+  Basic test of making HashPartitions with weights
+  """
+  fun name(): String =>
+    "hash_partitions/line-" + __loc.line().string()
+
+  fun ref apply(h: TestHelper) /**?**/ =>
+    // This is an intentionally choppy way of making a map for 4 nodes
+    // Total ratio should be 1 : 12 : 3 : 1.
+    let weights1: Array[(String,F64)] val = recover
+      [("n1", 1*1); ("n2", 2*7); ("n3", 3*1); ("n4", 1*1)
+       ("n1", 1*1); ("n2", 2*6); ("n3", 3*1); ("n4", 1*1)
+       ("n1", 1*1); ("n2", 2*5); ("n3", 3*1); ("n4", 1*1)] end
+
+    let hp1 = HashPartitions.create_with_weights(weights1)
+    // hp1.pretty_print() ; @printf[I32]("\n".cstring())
+
+    for (c, w) in hp1.get_weights_normalized().pairs() do
+      match c
+      | "n1" => h.assert_eq[F64](w, 1.0)
+      | "n2" => h.assert_eq[F64](w, 12.0)
+      | "n3" => h.assert_eq[F64](w, 3.0)
+      | "n4" => h.assert_eq[F64](w, 1.0)
+      else
+        h.assert_eq[String](c, "no other claimant is possible")
+      end
+    end
+
+class iso _Regression2to1 is UnitTest
+  """
+  Regression test for failure found by Ponycheck: remove claimants
+  so that only a single claimant remains.
+  """
+  fun name(): String =>
+    "hash_partitions/_TestAdjustHashPartitions2to1"
+
+  fun ref apply(h: TestHelper) ? =>
+    let weights1: Array[(String,F64)] val = recover
+      [("n1", 1.0); ("n2", 1.0)] end
+    let hp1 = HashPartitions.create_with_weights(weights1)
+    let hp2 = hp1.remove_claimants(recover ["n1"] end)?
+
+    h.assert_eq[USize](hp2.get_weights_normalized().size(), 1)
+    for (c, w) in hp2.get_weights_normalized().pairs() do
+      match c
+      | "n2" => h.assert_eq[F64](w, 1.0)
+      else
+        h.assert_eq[String](c, "no other claimant is possible")
+      end
+    end
+
+class iso _Regression0to1 is UnitTest
+  """
+  Regression test for overflow when adding a single claimant to
+  empty map.  Funny that I hadn't created a unit test that tested
+  this very simple scenario.  However, I'm half-confident that most
+  or all of the sanity checking by CompareWeights() wouldn't catch
+  the NaN problem in the map caused by overflow in
+  create_with_weights()....
+  """
+  fun name(): String =>
+    "hash_partitions/regression-0-to-1"
+
+  fun ref apply(h: TestHelper) ? =>
+    var sut = HashPartitions.create(recover [] end)
+    let c = "n27"
+
+    sut = sut.add_claimants(recover [c] end)?
+    let w = sut.get_weights_normalized()(c)?
+    // NOTE: This will not fail if w is NaN: h.assert_eq[F64](1.0, w)
+    h.assert_eq[Bool](false, w.nan())
+    h.assert_eq[Bool](true, (w == 1))
+
+class iso _TestAdjustHashPartitions is UnitTest
+  """
+  Basic test of adjusting a HashPartitions with added & removed nodes
+  """
+  fun name(): String =>
+    "hash_partitions/line-" + __loc.line().string()
+
+  fun ref apply(h: TestHelper) ? =>
+    let weights1: Array[(String,F64)] val = recover
+      [("n1", 1); ("n2", 2); ("n3", 3); ("n4", 4)] end
+    let hp1 = HashPartitions.create_with_weights(weights1)
+
+    let weights2: Array[(String,F64)] val = recover
+      [("n1", 1); ("n2", 2);            ("n4", 4)] end
+    let hp2a = HashPartitions.create_with_weights(weights2)
+    let hp2b = hp1.adjust_weights(weights2)
+    let hp2c = try hp1.remove_claimants(recover ["n3"] end)?
+      else /* super-bogus value */ HashPartitions.create([]) end
+
+    // 4 -> 3: weights of direct path = weights of adjusted HashPartitions
+    let norm_w_hp2a = hp2a.get_weights_normalized()
+    let norm_w_hp2b = hp2b.get_weights_normalized()
+    let norm_w_hp2c = hp2c.get_weights_normalized()
+    CompareWeights(norm_w_hp2a, norm_w_hp2b, "", __loc.line())?
+    CompareWeights(norm_w_hp2a, norm_w_hp2c, "", __loc.line())?
+
+    // n -> n+1: weights of direct path = weights of adjusted HashPartitions
+    let weights = weights2.clone()
+    var more: Array[String] val = recover ["n5"; "n6"; "n7"; "n8"] end
+    var hpb = hp2b
+    for c in more.values() do
+      weights.push((c, 1))
+      let ws: Array[(String, F64)] val = copyit(weights)
+      let hpa = HashPartitions.create_with_weights(ws)
+      hpb = hpb.adjust_weights(ws)
+
+      let norm_w_hpa = hpa.get_weights_normalized()
+      let norm_w_hpb = hpb.get_weights_normalized()
+      CompareWeights(norm_w_hpa, norm_w_hpb, c, __loc.line())?
+    end
+
+    // n -> n+8: weights of direct path = weights of adjusted HashPartitions
+    for c in ["n9"; "n10"; "n11"; "n12"; "n13"; "n14"; "n15"; "n16"].values() do
+      weights.push((c,1))
+    end
+    let ws16: Array[(String, F64)] val = copyit(weights)
+    let hpa16 = HashPartitions.create_with_weights(ws16)
+    hpb = hpb.adjust_weights(ws16)
+    let norm_w_hpa16 = hpa16.get_weights_normalized()
+    let norm_w_hpb16 = hpb.get_weights_normalized()
+    CompareWeights(norm_w_hpa16, norm_w_hpb16, "up to n16", __loc.line())?
+
+    // n -> n+1: weights of direct path = weights of adjusted HashPartitions
+    more = recover 
+      ["n17"; "n18"; "n19"; "n20"; "n21"; "n22"; "n24"; "n25"; "n26"; "n27"]end
+    for c in more.values() do
+      weights.push((c, 1))
+      let ws: Array[(String, F64)] val = copyit(weights)
+      let hpa = HashPartitions.create_with_weights(ws)
+      hpb = hpb.adjust_weights(ws)
+
+      let norm_w_hpa = hpa.get_weights_normalized()
+      let norm_w_hpb = hpb.get_weights_normalized()
+      CompareWeights(norm_w_hpa, norm_w_hpb, c, __loc.line())?
+    end
+
+    // n -> n-2: weights of direct path = weights of adjusted HashPartitions
+    while weights.size() > 3 do
+      try
+        (let c_r1, _) = weights(weights.size()-2)?
+        (let c_r2, _) = weights(1)?
+        weights.remove(weights.size()-2, 1)
+        weights.remove(1, 1)
+        let ws: Array[(String, F64)] val = copyit(weights)
+        let hpa = HashPartitions.create_with_weights(ws)
+        // Test both adjust_weights() and remove_claimants() API
+        hpb = if weights.size() > 16 then
+            hpb.adjust_weights(ws)
+          else
+            hpb.remove_claimants(recover [c_r1; c_r2] end)?
+          end
+
+        let norm_w_hpa = hpa.get_weights_normalized()
+        let norm_w_hpb = hpb.get_weights_normalized()
+        CompareWeights(norm_w_hpa, norm_w_hpb, "foo", __loc.line())?
+      end
+    else
+      Fail()
+    end
+
+    fun copyit(src: Array[(String, F64)]): Array[(String, F64)] iso^ =>
+      let dst: Array[(String, F64)] iso = recover dst.create() end
+
+      for x in src.values() do
+        dst.push(x)
+      end
+      consume dst
+
+primitive CompareWeights
+  fun apply(a: Map[String, F64], b: Map[String, F64],
+    extra: String, test_line: USize) ?
+   =>
+    if a.size() != b.size() then
+      @printf[I32]("Map size error: %d != %d at test_line %d extra %s\n".cstring(),
+       a.size(), b.size(), test_line, extra.cstring())
+      @printf[I32]("Map a\n".cstring())
+      for k in a.keys() do
+        try @printf[I32]("-> c %s weight %.2f\n".cstring(), k.cstring(), a(k)?) end
+      end
+      @printf[I32]("Map b\n".cstring())
+      for k in b.keys() do
+        try @printf[I32]("-> c %s weight %.2f\n".cstring(), k.cstring(), b(k)?) end
+      end
+
+      error
+    end
+    for (c, s) in a.pairs() do
+      try
+        if s != b(c)? then
+          @printf[I32]("Map error: claimant %s, a interval size %.20f b interval size %.20f test_line %d extra %s\n".cstring(), c.cstring(), s, b(c)?, test_line, extra.cstring())
+          error
+        end
+      else
+          @printf[I32]("Map error: claimant %s does not exist in map b test_line %d extra %s\n".cstring(), c.cstring(), test_line, extra.cstring())
+          error
+      end
+    end
+
+/*
+** Let's try to make a stateful Ponycheck test case.  Unfortunately,
+** Ponycheck doesn't support stateful properties.  So we need to fake it.
+**
+** 1. Our generator will create a sequence of TestOp objects, one TestOp
+**    for each state change we wish to make to the system.  ("system" is
+**    the HashPartitions class.)
+**    With Erlang QuickCheck or PropEr, each op would be a 2-tuple like
+**    {'add', Names::List(String)} or {'remove', Names::List(String)}
+**
+** 2. We "apply" the TestOp's method to the SUT (system under test) and to
+**    our model.
+**    With Erlang QuickCheck or PropEr, there's framework support for
+**    doing this in a 1-step-at-a-time manner.  Ponycheck has no such
+**    framework yet, so we have to implement it ourselves.
+**
+** 3. After each apply, check that the SUT and our model are equivalent.
+**    We also check for other desirable properties, e.g., the sum of all
+**    intervals is equal to 2^128.
+*/
+
+primitive HashOpAdd is Stringable
+  fun string(): String iso^ => "add_claimants".clone()
+
+primitive HashOpRemove is Stringable
+  fun string(): String iso^ => "remove_claimants".clone()
+
+type HashOp is (HashOpAdd | HashOpRemove)
+
+class TestOp is Stringable
+  let op: HashOp
+  let cs: Array[String] val
+
+  new create(op': HashOp, n_set: Set[USize]) =>
+    let cs': Array[String] trn = recover cs.create() end
+
+    op = op'
+    for n in n_set.values() do
+      cs'.push("n" + n.string())
+    end
+    cs = consume cs'
+
+  fun string(): String iso^ =>
+    let s: String ref = recover s.create() end
+
+    s.append("op=" + op.string() + ",cs=[")
+    for c in cs.values() do
+      s.append("\"" + c + "\";")
+    end
+    if cs.size() > 0 then try s.pop()? /* remove trailing comma */ end end
+    s.append("]")
+    s.clone()
+
+
+class _TestPonycheckStateful is Property1[(Array[TestOp])]
+  fun name(): String => "hash_partitions/ponycheck"
+
+  fun gen(): Generator[Array[TestOp]] =>
+    // If max_claimant_name=100, then this test should run in under 20 seconds.
+    let max_claimant_name: USize = 75
+
+    let gen_hash_op = try Generators.one_of[HashOp]([
+        HashOpAdd; HashOpRemove ])?
+      else
+        Fail()
+        Generators.unit[HashOp](HashOpAdd)
+      end
+
+    // We are going to generate Array[USize] and rely on TestOp.create()
+    // to convert the integers into claimant name strings.
+    // create() will also remove any duplicate integers that this
+    // generator creates.
+    let gen_ns = Generators.set_of[USize](
+      Generators.usize(where min=0, max=max_claimant_name)
+      where max=(max_claimant_name*3))
+
+    let gen_testop = Generators.map2[HashOp, Set[USize], TestOp](
+      gen_hash_op, gen_ns,
+      {(hash_op, n_seq) => TestOp(hash_op, n_seq)}
+    )
+    Generators.seq_of[TestOp, Array[TestOp]](gen_testop where min=1)
+
+
+  fun property(arg1: Array[TestOp], ph: PropertyHelper) /**?**/ =>
+    @printf[I32](".".cstring())
+
+    // Create our initial state-keeping vars
+    var sut = HashPartitions.create([])
+    let bogus = HashPartitions.create(recover ["error-case-bogus"] end)
+    var who: Set[String] = who.create()
+
+    // Apply each TestOp to state, check for sanity, etc.
+    for op in arg1.values() do
+      match op.op
+      | let o: HashOpAdd =>
+        let to_add: Array[String] iso = recover to_add.create() end
+        for c in op.cs.values() do
+          if not who.contains(c) then
+            to_add.push(c)
+          end
+        end
+        let to_add' = recover val consume to_add end
+
+        // update model
+        for c in to_add'.values() do
+          if not who.contains(c) then who = who.add(c) end
+        end
+        // update SUT
+        sut = try sut.add_claimants(to_add')?
+          else
+            ph.fail("add_claimants error")
+            @printf[I32]("add_claimants error\n".cstring())
+            sut.pretty_print()
+            for c in to_add'.values() do @printf[I32]("    to_add' %s\n".cstring(), c.cstring())
+            end
+            Fail(); bogus
+          end
+
+      | let o: HashOpRemove =>
+        let to_remove: Array[String] iso = recover to_remove.create() end
+        for c in op.cs.values() do
+          if who.contains(c) then
+            to_remove.push(c)
+          end
+        end
+        let to_remove' = recover val consume to_remove end
+
+        // update model
+        for c in to_remove'.values() do who = who.sub(c) end
+        // update SUT
+        sut = try sut.remove_claimants(to_remove')?
+          else
+            ph.fail("remove_claimants error")
+            @printf[I32]("remove_claimants error\n".cstring())
+            sut.pretty_print()
+            for c in to_remove'.values() do @printf[I32]("    to_remove' %s\n".cstring(), c.cstring())
+            end
+            Fail(); bogus
+          end
+      end
+
+      // Step-wise sanity checks & model properties
+
+      _sanity_checks(who, sut, ph)
+    end
+    
+    // Final sanity checks & model properties
+    _sanity_checks(who, sut, ph)
+
+  fun _sanity_checks(who: Set[String], sut: HashPartitions,
+    ph: PropertyHelper): Bool
+  =>
+    // Weights from HashPartitions created stepwise should be equal to
+    // a single step; build single-step HashPartitions with 'who' set.
+    let who_a: Array[String] trn = recover who_a.create() end
+    for c in who.values() do who_a.push(c) end
+           // Bug trigger: try who_a.pop()? ; who_a.push("bad worker") end
+    let hp_single = HashPartitions.create(consume who_a)
+
+    let norm_w_single  = hp_single.get_weights_normalized()
+    let norm_w_sut = sut.get_weights_normalized()
+    try
+      CompareWeights(norm_w_single, norm_w_sut, "stepwise", __loc.line())?
+    else
+      ph.fail("CompareWeights failed")
+      return false
+    end
+
+    // Check for overflow errors: the entire map could "add up"
+    // to U128.max_value() (which is correct) but have an integer
+    // overflow error along the way (which is not correct)
+    var sum: U128 = 0
+    for i in Range[USize](0, sut.get_sizes().size()) do
+      try
+        (let c, let s) = sut.get_sizes()(i)?
+        if s == 0 then
+          sut.pretty_print()
+          ph.fail("size is zero for claimant " + c + ", " +
+            "sut.get_sizes().size() = " + sut.get_sizes().size().string())
+        end
+        let last_sum = sum = sum + s
+        if sum < last_sum then
+          if i == (sut.get_sizes().size() - 1) then
+            // Our iteration has reached the end.  An overflow here
+            // means we're off by exactly one.  Define this as ok.
+            None
+          else
+            ph.fail("size overflow error by " + c + " size " + s.string() + " sum is " + sum.string())
+          end
+        end
+
+        // Claimant name "" is invalid if visible here
+        if c == "" then
+          ph.fail("Claimant name \"\" found with size " + s.string())
+        end
+      end
+    end
+
+    if (sut.get_sizes().size() > 0) then
+      // The sum for a non-empty map ought to be max_value.
+      if sum != U128.max_value() then
+        ph.fail("final sum error at " + sum.string() + ", sut.get_sizes().size() = " + sut.get_sizes().size().string())
+      end
+    end
+
+    true

--- a/lib/wallaroo/core/routing_test/bundle.json
+++ b/lib/wallaroo/core/routing_test/bundle.json
@@ -1,0 +1,12 @@
+{
+  "deps": [
+    { "type": "local",
+      "local-path": "../../../../lib/"
+    },
+    {
+      "type": "github",
+      "repo": "mfelsche/ponycheck",
+      "tag": "62a27532773ed63749151abce8e9d20690ce73a5"
+    }
+  ]
+}


### PR DESCRIPTION
(Dummy(?) PR to see how the unit tests work with CircleCi)

Squash of slf-consistent-hashing branch at commit c12f3bb7ec26

New: add_claimants() and remove_clamants() functions were added
to assist grow- and shrink-to-fit procedures.

The unit tests for the HashPartitions class have been moved to a
separate subdirectory, lib/wallaroo/core/routing_test.  I took
this step to avoid having the `use "wallaroo/core/routing"`
statement to use (eventaully!) the `_test.pony` source file
that contains `use "ponycheck"`.  *That* style of `use` created
the need to edit 75 different `bundle.json` files in order to
permit the rest of Wallaroo to compile without error.  {sigh}
