### PR TITLE
Improve Python exception handling in user provided functions

### DIFF
--- a/machida/cpp/python-wallaroo.c
+++ b/machida/cpp/python-wallaroo.c
@@ -157,10 +157,7 @@ extern PyObject *computation_compute(PyObject *computation, PyObject *data,
   pValue = PyObject_CallFunctionObjArgs(pFunc, data, NULL);
   Py_DECREF(pFunc);
 
-  if (pValue != Py_None)
-    return pValue;
-  else
-    return NULL;
+  return pValue;
 }
 
 extern PyObject *sink_encoder_encode(PyObject *sink_encoder, PyObject *data)
@@ -238,7 +235,9 @@ extern long partition_function_partition_u64(PyObject *partition_function, PyObj
   Py_DECREF(pFunc);
 
   long rtn = PyInt_AsLong(pValue);
-  Py_DECREF(pValue);
+  if (pValue != NULL) {
+    Py_DECREF(pValue);
+  }
   return rtn;
 }
 

--- a/machida/machida.pony
+++ b/machida/machida.pony
@@ -154,7 +154,10 @@ class PyStateBuilder
     _state_builder = state_builder
 
   fun apply(): PyState =>
-    PyState(@state_builder_build_state(_state_builder))
+    let py_state = @state_builder_build_state(_state_builder)
+    Machida.print_errors()
+    if py_state.is_null() then Fail() end
+    PyState(py_state)
 
   fun _serialise_space(): USize =>
     Machida.user_serialization_get_size(_state_builder)
@@ -326,7 +329,7 @@ class PyComputation is Computation[PyData val, PyData val]
     let r: Pointer[U8] val =
       Machida.computation_compute(_computation, input.obj(), _is_multi)
 
-    if not r.is_null() then
+    if not Machida.is_py_none(r) then
       Machida.process_computation_results(r, _is_multi)
     else
       None
@@ -406,14 +409,21 @@ class PyTCPEncoder is TCPSinkEncoder[PyData val]
 
   fun apply(data: PyData val, wb: Writer): Array[ByteSeq] val =>
     let byte_buffer = Machida.sink_encoder_encode(_sink_encoder, data.obj())
-    if not byte_buffer.is_null() and not Machida.is_py_none(byte_buffer) then
-      let arr = recover val
-        // create a temporary Array[U8] wrapper for the C array, then clone it
-        Array[U8].from_cpointer(@PyString_AsString(byte_buffer),
-          @PyString_Size(byte_buffer)).clone()
+    if not Machida.is_py_none(byte_buffer) then
+      let byte_string = @PyString_AsString(byte_buffer)
+
+      if not byte_string.is_null() then
+        let arr = recover val
+          // create a temporary Array[U8] wrapper for the C array, then clone it
+          Array[U8].from_cpointer(@PyString_AsString(byte_buffer),
+            @PyString_Size(byte_buffer)).clone()
+        end
+        Machida.dec_ref(byte_buffer)
+        wb.write(arr)
+      else
+        Machida.print_errors()
+        Fail()
       end
-      Machida.dec_ref(byte_buffer)
-      wb.write(arr)
     end
     wb.done()
 
@@ -714,6 +724,7 @@ primitive Machida
   =>
     let r = @source_decoder_decode(source_decoder, data, size)
     print_errors()
+    if r.is_null() then Fail() end
     r
 
   fun sink_encoder_encode(sink_encoder: Pointer[U8] val, data: Pointer[U8] val):
@@ -721,6 +732,7 @@ primitive Machida
   =>
     let r = @sink_encoder_encode(sink_encoder, data)
     print_errors()
+    if r.is_null() then Fail() end
     r
 
   fun computation_compute(computation: Pointer[U8] val, data: Pointer[U8] val,
@@ -729,6 +741,7 @@ primitive Machida
     let method = if multi then "compute_multi" else "compute" end
     let r = @computation_compute(computation, data, method.cstring())
     print_errors()
+    if r.is_null() then Fail() end
     r
 
   fun stateful_computation_compute(computation: Pointer[U8] val,
@@ -738,7 +751,10 @@ primitive Machida
     let method = if multi then "compute_multi" else "compute" end
     let r =
       @stateful_computation_compute(computation, data, state, method.cstring())
+
     print_errors()
+    if r.is_null() then Fail() end
+
     let msg = @PyTuple_GetItem(r, 0)
     let persist = @PyTuple_GetItem(r, 1)
 
@@ -755,7 +771,10 @@ primitive Machida
     data: Pointer[U8] val): U64
   =>
     let r = @partition_function_partition_u64(partition_function, data)
-    print_errors()
+    if err_occurred() and (r == -1) then
+      print_errors()
+      Fail()
+    end
     r
 
   fun py_list_int_to_pony_array_u64(py_array: Pointer[U8] val):
@@ -787,6 +806,7 @@ primitive Machida
   =>
     let r = @partition_function_partition(partition_function, data)
     print_errors()
+    if r.is_null() then Fail() end
     r
 
   fun py_list_int_to_pony_array_pykey(py_array: Pointer[U8] val):


### PR DESCRIPTION
Adds null checks around the returned object of user provided functions
and fails if the returned object is `NULL`. This stops us from
segfaulting and provides an immediate error as opposed to the error
propagating up further down the pipeline when we attempt to use the
`NULL` object.

Addresses: #2180 #2184 
I'm pretty sure I got all cases, but if I missed something, let me know.

To test, apply this diff and comment in the exception you want to test:

```diff --git a/examples/python/market_spread/market_spread.py b/examples/python/market_spread/market_spread.py
index 796de72..029813c 100644
--- a/examples/python/market_spread/market_spread.py
+++ b/examples/python/market_spread/market_spread.py
@@ -94,6 +94,7 @@ class SymbolData(object):
 
 @wallaroo.partition
 def symbol_partition_function(data):
+    # raise Exception("Exception on partition U64!\n")
     return str_to_partition(data.symbol)
 
 
diff --git a/examples/python/word_count/word_count.py b/examples/python/word_count/word_count.py
index 140d71e..42d7534 100644
--- a/examples/python/word_count/word_count.py
+++ b/examples/python/word_count/word_count.py
@@ -41,6 +41,7 @@ def application_setup(args):
 
 @wallaroo.computation_multi(name="split into words")
 def split(data):
+    # raise Exception("Exception in Split!\n")
     punctuation = " !\"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~"
 
     words = []
@@ -56,12 +57,14 @@ def split(data):
 
 @wallaroo.state_computation(name="Count Word")
 def count_word(word, word_totals):
+    # raise Exception("Exception in state computation!\n")
     word_totals.update(word)
     return (word_totals.get_count(word), True)
 
 
 class WordTotals(object):
     def __init__(self):
+        # raise Exception("Exception in State init!\n")
         self.word_totals = {}
 
     def update(self, word):
@@ -76,12 +79,14 @@ class WordTotals(object):
 
 class WordCount(object):
     def __init__(self, word, count):
+        # raise Exception("Exception in State init!\n")
         self.word = word
         self.count = count
 
 
 @wallaroo.partition
 def partition(data):
+    # raise Exception("Exception in partition!\n")
     if data[0] >= "a" and data[0] <= "z":
         return data[0]
     else:
@@ -90,9 +95,11 @@ def partition(data):
 
 @wallaroo.decoder(header_length=4, length_fmt=">I")
 def decoder(bs):
+    # raise Exception("Exception in decoder!\n")
     return bs.decode("utf-8")
 
 
 @wallaroo.encoder
 def encoder(data):
+    # raise Exception("Exception in encoder!\n")
     return data.word + " => " + str(data.count) + "\n"
```