### PR TITLE
Update Python Word Count demos to properly encode output

### DIFF
--- a/demos/python_word_count/word_count.py
+++ b/demos/python_word_count/word_count.py
@@ -78,4 +78,4 @@ def decoder(bs):
 def encoder(data):
     output = data.word + " => " + str(data.count) + "\n"
     print output
-    return output
+    return output.encode("utf-8")

--- a/examples/python/word_count/word_count.py
+++ b/examples/python/word_count/word_count.py
@@ -95,4 +95,5 @@ def decoder(bs):
 
 @wallaroo.encoder
 def encoder(data):
-    return data.word + " => " + str(data.count) + "\n"
+    output = data.word + " => " + str(data.count) + "\n"
+    return output.encode("utf-8")


### PR DESCRIPTION
Use `encode("utf-8")` for the encoders so we don't raise an exception
if we encounter a string that can't properly be encoded without utf-8

Partially addresses #2182, the segfault issue is handled by PR #2194 