### PR TITLE
Automagic clone tracking via Chuck's Zapier endpoint

### DIFF
--- a/.circleci/clone_tracker.sh
+++ b/.circleci/clone_tracker.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# ping chuck's clone tracking endpoint
+wget -S --header="Accept: application/json" \
+  --header="Content-Type: application/json" \
+  --post-data="{\"date\":\"$(date)\",\"source\":\"circle-ci\",\"count\":1}" \
+  -O - https://hooks.zapier.com/hooks/catch/175929/f4hnh4/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,30 +5,35 @@ jobs:
       - image: wallaroolabs/wallaroo-ci:2018.06.11.1
     steps:
       - checkout
+      - run: .circleci/clone_tracker.sh
       - run: make build debug=true
   verify-changelog:
     docker:
       - image: ponylang/changelog-tool:release
     steps:
       - checkout
+      - run: .circleci/clone_tracker.sh
       - run: changelog-tool verify CHANGELOG.md
   integration-tests:
     docker:
       - image: wallaroolabs/wallaroo-ci:2018.06.11.1
     steps:
       - checkout
+      - run: .circleci/clone_tracker.sh
       - run: make integration-tests debug=true
   integration-tests-with-resilience:
     docker:
       - image: wallaroolabs/wallaroo-ci:2018.06.11.1
     steps:
       - checkout
+      - run: .circleci/clone_tracker.sh
       - run: make integration-tests-testing-correctness-tests-all resilience=on debug=true
   unit-tests:
     docker:
       - image: wallaroolabs/wallaroo-ci:2018.06.11.1
     steps:
       - checkout
+      - run: .circleci/clone_tracker.sh
       - run: make unit-tests debug=true
 workflows:
   version: 2

--- a/.release/bootstrap.sh
+++ b/.release/bootstrap.sh
@@ -158,7 +158,7 @@ clone_and_report() {
   curl -v -H "Accept: application/json" \
         -H "Content-Type: application/json" \
         -X POST \
-        -d "{\"date\":\"$(date)\",\"source\":\"vagrant\",\"count\":1}" \
+        -d "{\"date\":\"$(date)\",\"source\":\"vagrant-release\",\"count\":1}" \
         https://hooks.zapier.com/hooks/catch/175929/f4hnh4/
 
   echo "** Wallaroo repo cloned"

--- a/demos/bootstrap.sh
+++ b/demos/bootstrap.sh
@@ -48,6 +48,14 @@ mkdir wallaroo-tutorial
 pushd wallaroo-tutorial || exit
 
 git clone https://github.com/WallarooLabs/wallaroo
+
+# ping chuck's clone tracking endpoint
+curl -v -H "Accept: application/json" \
+  -H "Content-Type: application/json" \
+  -X POST \
+  -d "{\"date\":\"$(date)\",\"source\":\"vagrant-demo\",\"count\":1}" \
+  https://hooks.zapier.com/hooks/catch/175929/f4hnh4/
+
 pushd wallaroo || exit
 git checkout $wallaroo_version
 

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -144,6 +144,9 @@ install_gitbook_dependencies() {
   sudo python2 -m pip install ghp-import
 }
 
+# ping chuck's clone tracking endpoint
+wget -S --header="Accept: application/json" --header="Content-Type: application/json" --post-data="{\"date\":\"$(date)\",\"source\":\"travis-ci\",\"count\":1}" -O - https://hooks.zapier.com/hooks/catch/175929/f4hnh4/
+
 echo "----- Installing dependencies"
 
 install_cpuset


### PR DESCRIPTION
NOTE: I manually tested the `wget` command in a Vagrant environment. I did not specifically test all of these changes. The `.release/bootstrap.sh` change seems harmless. The `demos/bootstrap.sh` change should work as it is a direct copy from `.release/bootstrap.sh`. The `circle-ci` changes should get tested when this PR's CI tests run. The `travis-ci` changes would be tested the next time there's a release branch CI run.

-------------------

This commit ensures circle-ci and travis-ci jobs will
automagically ping Chuck's Zaiper endpoint for tracking
Wallaroo clones when CI jobs are run.

It also ensure the Vagrant Demo environment will also
ping the same endpoint when a Demo environment is spun up.

Lastly, it renames the name reported by the release
environment when it pings the same endpoint to help
differentiate it from the Demo environment pings.