### PR TITLE
Fix bug where ctrl-c fails to shut down cluster.

### DIFF
--- a/lib/wallaroo/ent/network/connections.pony
+++ b/lib/wallaroo/ent/network/connections.pony
@@ -200,7 +200,7 @@ actor Connections is Cluster
   =>
     _send_control_to_cluster(data, exclusions)
 
-  be _send_control_to_cluster(data: Array[ByteSeq] val,
+  fun _send_control_to_cluster(data: Array[ByteSeq] val,
     exclusions: Array[String] val = recover Array[String] end)
   =>
     for worker in _control_conns.keys() do
@@ -818,6 +818,15 @@ actor Connections is Cluster
 
   be shutdown() =>
     _shutdown()
+
+  be clean_files_shutdown(file_cleaner: RecoveryFileCleaner) =>
+    try
+      let clean_shutdown_msg = ChannelMsgEncoder.clean_shutdown(_auth)?
+      _send_control_to_cluster(clean_shutdown_msg)
+      file_cleaner.clean_recovery_files()
+    else
+      Fail()
+    end
 
   fun ref _shutdown() =>
     for (key, conn) in _control_conns.pairs() do

--- a/lib/wallaroo/startup.pony
+++ b/lib/wallaroo/startup.pony
@@ -694,9 +694,5 @@ class WallarooShutdownHandler is SignalNotify
     _auth = a
 
   fun ref apply(count: U32): Bool =>
-    try
-      let clean_shutdown_msg = ChannelMsgEncoder.clean_shutdown(_auth)?
-      _connections.send_control_to_cluster(clean_shutdown_msg)
-      _recovery_file_cleaner.clean_recovery_files()
-    end
+    _connections.clean_files_shutdown(_recovery_file_cleaner)
     false


### PR DESCRIPTION
We were shutting down before we had finished sending
shutdown messages to the rest of the cluster in response
to ctrl-c. This commit ensures we send the messages
first.