### PR TITLE
Fix Make always-build bug when no bundle.json

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -258,14 +258,14 @@ define PONYC
   $(QUIET)cd $(1) && $(ponyc_docker_args) $(PONYSTABLE) env $(PONYCC) $(ponyc_arch_args) \
     $(debug_arg) $(spike_arg) $(autoscale_arg) $(clustering_arg) $(resilience_arg) \
     $(PONYCFLAGS) $(EXTRA_PONYCFLAGS) $(target_cpu_arg) --features=-avx512f . $(if $(filter $(ponyc_docker_args),docker),$(quote))
-  $(QUIET)cd $(1) && echo "$@: $(abspath $(1))/bundle.json" | tr '\n' ' ' > $(notdir $(abspath $(1:%/=%))).d
+  $(QUIET)cd $(1) && echo "$@: $(wildcard $(abspath $(1))/bundle.json)" | tr '\n' ' ' > $(notdir $(abspath $(1:%/=%))).d
   $(QUIET)cd $(1) && $(ponyc_docker_args) $(PONYSTABLE) env $(PONYCC) $(ponyc_arch_args) \
     $(debug_arg) $(spike_arg) $(autoscale_arg) $(clustering_arg) $(resilience_arg) \
     $(PONYCFLAGS) $(EXTRA_PONYCFLAGS) $(target_cpu_arg) --features=-avx512f . --pass import --files $(if $(filter \
     $(ponyc_docker_args),docker),$(quote)) 2>/dev/null | grep -o "$(abs_wallaroo_dir).*.pony" \
     | awk 'BEGIN { a="" } {a=a$$1":\n"; printf "%s ",$$1} END {print "\n"a}' \
     >> $(notdir $(abspath $(1:%/=%))).d
-  $(QUIET)cd $(1) && echo "$(abspath $(1))/bundle.json:" >> $(notdir $(abspath $(1:%/=%))).d
+  $(QUIET)cd $(1) && echo $(if $(wildcard $(abspath $(1))/bundle.json),"$(abspath $(1))/bundle.json:",) >> $(notdir $(abspath $(1:%/=%))).d
 endef
 
 # function call for compiling monhub projects

--- a/testing/correctness/apps/sequence_window/ring/bundle.json
+++ b/testing/correctness/apps/sequence_window/ring/bundle.json
@@ -1,7 +1,0 @@
-{
-  "deps": [
-    { "type": "local",
-      "local-path": "../../../../../lib/"
-    }
-  ]
-}


### PR DESCRIPTION
Before this change, Make would always build submodules that didn't have
a bundle.json, regardless of whether the resource was already built.
After this change, it only bulds if code changes.

closes #2226