### PR TITLE
Only complete autoscale early if no steps to migrate

### DIFF
--- a/lib/wallaroo/ent/autoscale/autoscale.pony
+++ b/lib/wallaroo/ent/autoscale/autoscale.pony
@@ -62,8 +62,6 @@ class Autoscale
     2) _WaitingForAutoscale: Autoscale is complete and we are back to our
       initial waiting state.
 
-
-
     SHRINK (coordinator):
     1) _InitiatingShrink: RouterRegistry currently handles the details. We're
       waiting until all steps have been migrated from leaving workers.


### PR DESCRIPTION
There was a mechanism for ending autoscale early if
it was determined that there were no steps to migrate.
However, this was handled on a per-state-partition-router basis, 
which meant that if one happened to have
no steps to migrate but another had some, then we
might end early based on a trigger from the former.
This change ensures that we first check all routers
to ensure that there are actually no steps to migrate
before we end early.

Closes #2225