### PR TITLE
Ensure that messages of len() > _max_size don't overflow buffer/cause memory explosion

### DIFF
--- a/lib/wallaroo/core/data_channel/data_channel.pony
+++ b/lib/wallaroo/core/data_channel/data_channel.pony
@@ -588,20 +588,10 @@ actor DataChannel
     """
     Resize the read buffer.
     """
-    if _expect == 0 then
-      _read_buf.undefined(_next_size)
+    if _expect != 0 then
+      _read_buf.undefined(_expect.next_pow2().max(_next_size))
     else
-      if _expect > _read_buf_offset then
-        let data = _read_buf = recover Array[U8] end
-        _read_buf.undefined(_next_size)
-        for i in Range(0, _read_buf_offset) do
-          try
-            _read_buf.update(i, data(i)?)?
-          else
-            Fail()
-          end
-        end
-      end
+      _read_buf.undefined(_next_size)
     end
 
   fun ref _queue_read() =>
@@ -692,13 +682,13 @@ actor DataChannel
               return
             end
           else
-            if _read_buf.space() > _read_buf_offset then
+            if _read_buf.size() > _read_buf_offset then
 
               // Read as much data as possible.
               let len = @pony_os_recv[USize](
                 _event,
                 _read_buf.cpointer(_read_buf_offset),
-                _read_buf.space() - _read_buf_offset) ?
+                _read_buf.size() - _read_buf_offset) ?
 
               match len
               | 0 =>
@@ -710,7 +700,7 @@ actor DataChannel
                 @pony_asio_event_resubscribe_read(_event)
                 _reading = false
                 return
-              | (_read_buf.space() - _read_buf_offset) =>
+              | (_read_buf.size() - _read_buf_offset) =>
                 // Increase the read buffer size.
                 _next_size = _max_size.min(_next_size * 2)
               end


### PR DESCRIPTION
This PR solves the problem of [the cluster locking up when individual messages are bigger than the max_size](https://github.com/WallarooLabs/wallaroo/issues/2258) parameter that DataChannel was started with.

There were 2 unwanted behaviors causing that bug, and removing one of them only exposed the second.

### Problem 1:

`_read_buf_size()` kept thinking it doesn't have a big enough buffer, because `_next_size` was smaller than `_expect`. Adding a special case for `_expect > _next_size` in this method allowed the DataChannel to handle messages bigger than `_max_size`, but eventually triggered a `Fail()` because of Problem 2. The fix involved not having a special case for when `_expect > _next_size`, but always maintaining the invariant that the buffer will be the next power of 2 above `_next_size`.

### Problem 2:

`_read_buf.space()` was being used instead of `_read_buf.size()` when deciding to consume data via `@pony_os_recv`. Space is allocated in power-of-2 blocks, and by reading `.space()` bytes off of the stream, we were effectively reading more that we could fit in our buffer, because usually `_read_buf.size() < _read_buf.space())`. So the DataChannel would end up losing data and then, at some point, passing random junk to the notifier to interpret as a header. The fix reallocates the buffer in powers-of-2 increments, (which means that .size() will equal .space()) but also calls `.size()` explicitly in `_pending_reads()`,  to remove ambiguity.

This fix includes a unit test in data_channel/_test.pony to make sure any regressions are caught, although I feel generative testing of our TCPNotify-alikes would be beneficial in flushing out other cases like this one.

