### PR TITLE
Add --pic option for AA to make command for Go compiling instructions

### DIFF
--- a/book/go/getting-started/linux-setup.md
+++ b/book/go/getting-started/linux-setup.md
@@ -181,7 +181,7 @@ Due to ponyc's dependence on PIC on Artful Ubuntu, all applications must be comp
 
 
 ```bash
-make build-giles-sender-all build-utils-all
+make build-giles-sender-all build-utils-all PONYCFLAGS="--pic"
 ```
 
 ### Compiling Giles Sender, Data Receiver, and the Cluster Shutdown tool on Trusty and Xenial


### PR DESCRIPTION
Updates make command in the Go Linux Setup doc to include
`PONYCFLAGS="--pic"` for Artful Aardvark users.

Closes #2283