### PR TITLE
Update Linux instructions to require GCC5 + up

### DIFF
--- a/book/getting-started/linux-setup.md
+++ b/book/getting-started/linux-setup.md
@@ -55,15 +55,15 @@ sudo apt-get install -y build-essential
 sudo apt-get install -y libssl-dev
 ```
 
-### Install GCC 4.7 or Higher
+### Install GCC 5 or Higher
 
- If you have at least GCC 4.7 installed on your machine, you don't need to do anything. If you have gcc 4.6 or lower, you'll need to upgrade. You can check your `gcc` version by running:
+ If you have at least GCC 5 installed on your machine, you don't need to do anything. If you have gcc 4.9 or lower, you'll need to upgrade. You can check your `gcc` version by running:
 
 ```bash
 gcc --version
 ```
 
-To upgrade to GCC 5 if you don't have at least GCC 4.7:
+To upgrade to GCC 5:
 
 ```bash
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test

--- a/book/go/getting-started/linux-setup.md
+++ b/book/go/getting-started/linux-setup.md
@@ -60,15 +60,15 @@ sudo apt-get install -y build-essential
 sudo apt-get install -y libssl-dev
 ```
 
-### Install GCC 4.7 or Higher
+### Install GCC 5 or Higher
 
- If you have at least GCC 4.7 installed on your machine, you don't need to do anything. If you have gcc 4.6 or lower, you'll need to upgrade. You can check your `gcc` version by running:
+ If you have at least GCC 5 installed on your machine, you don't need to do anything. If you have gcc 4.9 or lower, you'll need to upgrade. You can check your `gcc` version by running:
 
 ```bash
 gcc --version
 ```
 
-To upgrade to GCC 5 if you don't have at least GCC 4.7:
+To upgrade to GCC 5:
 
 ```bash
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test


### PR DESCRIPTION
New packaging of Ponyc caused the dependency of GCC to be bumped up
to 5 instead of 4.7.

Closes #2273