### PR TITLE
Update gitbook-release script to properly insert MUI image path

### DIFF
--- a/.release/gitbook-release.sh
+++ b/.release/gitbook-release.sh
@@ -27,21 +27,21 @@ verify_branch() {
     ui_version=$(< VERSION)
     docker_version=$(< VERSION)
     docker_url="release\/wallaroo:$docker_version"
-    docker_metrics_ui_url="release\/wallaroo:$ui_version"
+    docker_metrics_ui_url="release\/metrics_ui:$ui_version"
   elif [[ "$BRANCH" == "release" ]]
   then
     remote_branch=release
     ui_version=$(< VERSION)
     docker_version=$(< VERSION)
     docker_url="release\/wallaroo:$docker_version"
-    docker_metrics_ui_url="release\/wallaroo:$ui_version"
+    docker_metrics_ui_url="release\/metrics_ui:$ui_version"
   elif [[ "$BRANCH" == *"release-"* ]]
   then
     remote_branch=rc
     ui_version=$(git describe --tags --always)
     docker_version=$(git describe --tags --always)
     docker_url="dev\/wallaroo:$docker_version"
-    docker_metrics_ui_url="dev\/wallaroo:$ui_version"
+    docker_metrics_ui_url="dev\/metrics_ui:$ui_version"
   else
     echo "No remote repo to push book to. Exiting"
     exit 0


### PR DESCRIPTION
The script previously inserted a path to the Wallaroo Docker image,
this fix corrects the the string replacement to insert `metrics_ui`
as opposed to `wallaroo`.

Closes #2275