### PR TITLE
Updates Wallaroo Vagrant bootstrap script to use Ponyc 0.24.0

### DIFF
--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -5,7 +5,7 @@ set -o nounset
 export DEBIAN_FRONTEND=noninteractive
 
 export WALLAROO_VERSION="release-0.5.0"
-export PONYC_VERSION="0.21.3"
+export PONYC_VERSION="0.24.0"
 export OTP_VERSION="1:20.1-1"
 export ELIXIR_VERSION="1.5.2-1"
 export GO_VERSION="1.9.4"


### PR DESCRIPTION
This is so the latest release can properly compile now that it is
based off `master` and depends on Ponyc 0.24.0.

Closes #2274