### PR TITLE
Update Python example READMEs to have instructions for both Metric UIs

### DIFF
--- a/examples/python/alphabet/README.md
+++ b/examples/python/alphabet/README.md
@@ -32,30 +32,62 @@ You will need five separate shells to run this application. Open each shell and 
 
 ### Shell 1: Metrics
 
-Start up the Metrics UI if you don't already have it running:
+Start up the Metrics UI if you don't already have it running.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker start mui
 ```
 
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui start
+```
+
 You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000).
 
-If you need to restart the UI, run:
+If you need to restart the UI, run the following.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker restart mui
 ```
 
-When it's time to stop the UI, run:
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui restart
+```
+
+When it's time to stop the UI, run the following.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker stop mui
 ```
 
-If you need to start the UI after stopping it, run:
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui stop
+```
+
+If you need to start the UI after stopping it, run the following.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker start mui
+```
+
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui start
 ```
 
 ### Shell 2: Data Receiver
@@ -131,8 +163,16 @@ cluster_shutdown 127.0.0.1:5050
 
 You can shut down Giles Sender and Data Receiver by pressing `Ctrl-c` from their respective shells.
 
-You can shut down the Metrics UI with the following command:
+You can shut down the Metrics UI with the following command.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker stop mui
+```
+
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui stop
 ```

--- a/examples/python/alphabet_partitioned/README.md
+++ b/examples/python/alphabet_partitioned/README.md
@@ -40,30 +40,62 @@ You will need six separate shells to run this application. Open each shell and g
 
 ### Shell 1: Metrics
 
-Start up the Metrics UI if you don't already have it running:
+Start up the Metrics UI if you don't already have it running.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker start mui
 ```
 
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui start
+```
+
 You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000).
 
-If you need to restart the UI, run:
+If you need to restart the UI, run the following.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker restart mui
 ```
 
-When it's time to stop the UI, run:
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui restart
+```
+
+When it's time to stop the UI, run the following.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker stop mui
 ```
 
-If you need to start the UI after stopping it, run:
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui stop
+```
+
+If you need to start the UI after stopping it, run the following.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker start mui
+```
+
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui start
 ```
 
 ### Shell 2: Data Receiver
@@ -159,8 +191,16 @@ cluster_shutdown 127.0.0.1:5050
 
 You can shut down Giles Sender and Data Receiver by pressing `Ctrl-c` from their respective shells.
 
-You can shut down the Metrics UI with the following command:
+You can shut down the Metrics UI with the following command.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker stop mui
+```
+
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui stop
 ```

--- a/examples/python/celsius-kafka/README.md
+++ b/examples/python/celsius-kafka/README.md
@@ -32,30 +32,62 @@ You will need five separate shells to run this application. Open each shell and 
 
 ### Shell 1: Metrics
 
-Start up the Metrics UI if you don't already have it running:
+Start up the Metrics UI if you don't already have it running.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker start mui
 ```
 
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui start
+```
+
 You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000).
 
-If you need to restart the UI, run:
+If you need to restart the UI, run the following.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker restart mui
 ```
 
-When it's time to stop the UI, run:
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui restart
+```
+
+When it's time to stop the UI, run the following.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker stop mui
 ```
 
-If you need to start the UI after stopping it, run:
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui stop
+```
+
+If you need to start the UI after stopping it, run the following.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker start mui
+```
+
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui start
 ```
 
 ### Shell 2: Kafka setup and listener
@@ -184,8 +216,16 @@ cd /tmp/local-kafka-cluster
 ./cluster down # shut down cluster
 ```
 
-You can shut down the Metrics UI with the following command:
+You can shut down the Metrics UI with the following command.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker stop mui
+```
+
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui stop
 ```

--- a/examples/python/celsius/README.md
+++ b/examples/python/celsius/README.md
@@ -32,30 +32,62 @@ You will need five separate shells to run this application. Open each shell and 
 
 ### Shell 1: Metrics
 
-Start up the Metrics UI if you don't already have it running:
+Start up the Metrics UI if you don't already have it running.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker start mui
 ```
 
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui start
+```
+
 You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000).
 
-If you need to restart the UI, run:
+If you need to restart the UI, run the following.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker restart mui
 ```
 
-When it's time to stop the UI, run:
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui restart
+```
+
+When it's time to stop the UI, run the following.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker stop mui
 ```
 
-If you need to start the UI after stopping it, run:
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui stop
+```
+
+If you need to start the UI after stopping it, run the following.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker start mui
+```
+
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui start
 ```
 
 ### Shell 2: Data Receiver
@@ -132,8 +164,16 @@ cluster_shutdown 127.0.0.1:5050
 
 You can shut down Giles Sender and Data Receiver by pressing `Ctrl-c` from their respective shells.
 
-You can shut down the Metrics UI with the following command:
+You can shut down the Metrics UI with the following command.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker stop mui
+```
+
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui stop
 ```

--- a/examples/python/market_spread/README.md
+++ b/examples/python/market_spread/README.md
@@ -66,30 +66,62 @@ You will need six separate shells to run this application. Open each shell and g
 
 ### Shell 1: Metrics
 
-Start up the Metrics UI if you don't already have it running:
+Start up the Metrics UI if you don't already have it running.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker start mui
 ```
 
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui start
+```
+
 You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000).
 
-If you need to restart the UI, run:
+If you need to restart the UI, run the following.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker restart mui
 ```
 
-When it's time to stop the UI, run:
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui restart
+```
+
+When it's time to stop the UI, run the following.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker stop mui
 ```
 
-If you need to start the UI after stopping it, run:
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui stop
+```
+
+If you need to start the UI after stopping it, run the following.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker start mui
+```
+
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui start
 ```
 
 ### Shell 2: Data Receiver
@@ -201,10 +233,16 @@ The sender commands will send data for a long time, so processing never really f
 cluster_shutdown 127.0.0.1:5050
 ```
 
-You can shut down the Giles Senders and Data Receiver by pressing `Ctrl-c` from their shells.
+You can shut down the Metrics UI with the following command.
 
-You can shut down the Metrics UI with the following command:
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker stop mui
+```
+
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui stop
 ```

--- a/examples/python/reverse/README.md
+++ b/examples/python/reverse/README.md
@@ -34,30 +34,62 @@ You will need five separate shells to run this application. Open each shell and 
 
 ### Shell 1: Metrics
 
-Start up the Metrics UI if you don't already have it running:
+Start up the Metrics UI if you don't already have it running.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker start mui
 ```
 
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui start
+```
+
 You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000).
 
-If you need to restart the UI, run:
+If you need to restart the UI, run the following.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker restart mui
 ```
 
-When it's time to stop the UI, run:
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui restart
+```
+
+When it's time to stop the UI, run the following.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker stop mui
 ```
 
-If you need to start the UI after stopping it, run:
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui stop
+```
+
+If you need to start the UI after stopping it, run the following.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker start mui
+```
+
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui start
 ```
 
 ### Shell 2: Data Receiver
@@ -137,8 +169,16 @@ cluster_shutdown 127.0.0.1:5050
 
 You can shut down Giles Sender and Data Receiver by pressing `Ctrl-c` from their respective shells.
 
-You can shut down the Metrics UI with the following command:
+You can shut down the Metrics UI with the following command.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker stop mui
+```
+
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui stop
 ```

--- a/examples/python/word_count/README.md
+++ b/examples/python/word_count/README.md
@@ -32,30 +32,62 @@ You will need three separate shells to run this application. Open each shell and
 
 ### Shell 1: Metrics
 
-Start up the Metrics UI if you don't already have it running:
+Start up the Metrics UI if you don't already have it running.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker start mui
 ```
 
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui start
+```
+
 You can verify it started up correctly by visiting [http://localhost:4000](http://localhost:4000).
 
-If you need to restart the UI, run:
+If you need to restart the UI, run the following.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker restart mui
 ```
 
-When it's time to stop the UI, run:
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui restart
+```
+
+When it's time to stop the UI, run the following.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker stop mui
 ```
 
-If you need to start the UI after stopping it, run:
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui stop
+```
+
+If you need to start the UI after stopping it, run the following.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker start mui
+```
+
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui start
 ```
 
 ### Shell 2: Data Receiver
@@ -134,8 +166,16 @@ cluster_shutdown 127.0.0.1:5050
 
 You can shut down Giles Sender and Data Receiver by pressing `Ctrl-c` from their respective shells.
 
-You can shut down the Metrics UI with the following command:
+You can shut down the Metrics UI with the following command.
+
+Ubuntu users who are using the Metrics UI Docker image:
 
 ```bash
 docker stop mui
+```
+
+Wallaroo in Docker and Wallaroo in Vagrant users:
+
+```bash
+metrics_reporter_ui stop
 ```


### PR DESCRIPTION
Includes instructions for starting the Metrics UI if running the Docker
container or if using the prebuilt binary in the Wallaroo Docker image
or Wallaroo Vagrant box.

Closes #2282