### PR TITLE
Update to pony-kafka version 0.5.0 and cleanup kafka example apps a bit

### DIFF
--- a/book/go/api/start-a-project.md
+++ b/book/go/api/start-a-project.md
@@ -29,7 +29,7 @@ Once you've done that, you can run the following commands to create the `bundle.
 ```bash
 stable add local $WALLAROO_HOME/lib
 stable add local $WALLAROO_HOME/go_api/pony
-stable add github WallarooLabs/pony-kafka --tag=0.3.4
+stable add github WallarooLabs/pony-kafka --tag=0.5.0
 stable add local lib
 ```
 
@@ -49,7 +49,7 @@ The contents of the `bundle.json` file will look something like this:
         {
             "type": "github",
             "repo": "WallarooLabs/pony-kafka",
-            "tag": "0.3.4"
+            "tag": "0.5.0"
         },
         {
             "type": "local",

--- a/demos/go_word_count/bundle.json
+++ b/demos/go_word_count/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "a10e66b"
+      "tag": "0.5.0"
     }
   ]
 }

--- a/examples/go/alphabet/bundle.json
+++ b/examples/go/alphabet/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "a10e66b"
+      "tag": "0.5.0"
     }
   ]
 }

--- a/examples/go/celsius/bundle.json
+++ b/examples/go/celsius/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "a10e66b"
+      "tag": "0.5.0"
     }
   ]
 }

--- a/examples/go/kafka_reverse/README.md
+++ b/examples/go/kafka_reverse/README.md
@@ -111,7 +111,7 @@ To run `kafkacat` to listen to the `test-out` topic via Docker:
 **NOTE:** You will need to replace the IP address for the `-b` option with the one provided by `./cluster up 1` command in Shell 2.
 
 ```bash
-docker run --rm -it ryane/kafkacat -C -b 127.0.0.1:9092 -t test-out -q
+docker run --rm -it ryane/kafkacat -C -b *IP OUTPUT BY ./cluster up 1 COMMAND*:9092 -t test-out -q
 ```
 
 ### Shell 3: Kafka Reverse

--- a/examples/go/kafka_reverse/README.md
+++ b/examples/go/kafka_reverse/README.md
@@ -14,9 +14,9 @@ The inputs of the "Kafka Reverse" application are strings. Here's an example inp
 
 ### Output
 
-The outputs of the application are strings followed by newlines. Here's an example output message, written as a Go string:
+The outputs of the application are strings. Here's an example output message, written as a Go string:
 
-`olleh\n` -- the string `"olleh"` (`"hello"` reversed)
+`olleh` -- the string `"olleh"` (`"hello"` reversed)
 
 ### Processing
 

--- a/examples/go/kafka_reverse/bundle.json
+++ b/examples/go/kafka_reverse/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "a10e66b"
+      "tag": "0.5.0"
     }
   ]
 }

--- a/examples/go/kafka_reverse/go/src/kafka_reverse/kafka_reverse.go
+++ b/examples/go/kafka_reverse/go/src/kafka_reverse/kafka_reverse.go
@@ -75,14 +75,6 @@ func (r *Reverse) Compute(data interface{}) interface{} {
 
 type Decoder struct{}
 
-func (d *Decoder) HeaderLength() uint64 {
-	return 4
-}
-
-func (d *Decoder) PayloadLength(b []byte) uint64 {
-	return uint64(binary.BigEndian.Uint32(b[0:4]))
-}
-
 func (d *Decoder) Decode(b []byte) interface{} {
 	x := string(b[:])
 	return &x
@@ -92,7 +84,7 @@ type Encoder struct{}
 
 func (e *Encoder) Encode(data interface{}) ([]byte, []byte, int32) {
 	msg := data.(string)
-	return []byte(msg + "\n"), nil, -1
+	return []byte(msg), nil, -1
 }
 
 const (

--- a/examples/go/reverse/bundle.json
+++ b/examples/go/reverse/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "a10e66b"
+      "tag": "0.5.0"
     }
   ]
 }

--- a/examples/go/word_count/bundle.json
+++ b/examples/go/word_count/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "a10e66b"
+      "tag": "0.5.0"
     }
   ]
 }

--- a/examples/pony/celsius-kafka/bundle.json
+++ b/examples/pony/celsius-kafka/bundle.json
@@ -5,7 +5,7 @@
       },
       { "type": "github",
         "repo": "WallarooLabs/pony-kafka",
-        "tag": "a10e66b"
+        "tag": "0.5.0"
       }
   ]
 }

--- a/examples/python/celsius-kafka/README.md
+++ b/examples/python/celsius-kafka/README.md
@@ -144,7 +144,7 @@ machida --application-module celsius \
 
 Send data into Kafka. Again, we use `kafakcat`.
 
-Run the following and then type at least 4 characters on each line and hit enter to send in data (only first 4 characters are used/interpreted as a float; the application will throw an error and possibly segfault if less than 4 characters are sent in):
+Run the following and then type numbers (as floating point values) on each line and hit enter to send in celsius temperatures:
 
 **NOTE:** You will need to replace the IP address for the `-b` option with the one provided by `./cluster up 1` command in Shell 2.
 

--- a/examples/python/celsius-kafka/README.md
+++ b/examples/python/celsius-kafka/README.md
@@ -110,7 +110,7 @@ To run `kafkacat` to listen to the `test-out` topic via Docker:
 **NOTE:** You will need to replace the IP address for the `-b` option with the one provided by `./cluster up 1` command in Shell 2.
 
 ```bash
-docker run --rm -it ryane/kafkacat -C -b 127.0.0.1:9092 -t test-out -q
+docker run --rm -it ryane/kafkacat -C -b *IP OUTPUT BY ./cluster up 1 COMMAND*:9092 -t test-out -q
 ```
 
 ### Shell 3: Celsius-kafka

--- a/machida/bundle.json
+++ b/machida/bundle.json
@@ -5,7 +5,7 @@
       },
       { "type": "github",
         "repo": "WallarooLabs/pony-kafka",
-        "tag": "a10e66b"
+        "tag": "0.5.0"
       }
   ]
 }

--- a/testing/performance/apps/go/market_spread/bundle.json
+++ b/testing/performance/apps/go/market_spread/bundle.json
@@ -15,7 +15,7 @@
     {
       "type": "github",
       "repo": "WallarooLabs/pony-kafka",
-      "tag": "a10e66b"
+      "tag": "0.5.0"
     }
   ]
 }


### PR DESCRIPTION
This commit updates all bundle.json files to use pony-kafka tag
version 0.5.0.

It also includes some minor updates/clarifications to the go
kafka_reverse and the python celsius-kafka examples.