### PR TITLE
Update Go Linux Instructions to install Ponyc 0.24.0

### DIFF
--- a/book/go/getting-started/linux-setup.md
+++ b/book/go/getting-started/linux-setup.md
@@ -103,7 +103,7 @@ Now you need to install Pony compiler `ponyc`. Run:
 ```bash
 echo "deb https://dl.bintray.com/pony-language/ponyc-debian pony-language main" | sudo tee -a /etc/apt/sources.list
 sudo apt-get update
-sudo apt-get -V install ponyc=0.23.0
+sudo apt-get -V install ponyc=0.24.0
 ```
 
 ## Installing pony-stable


### PR DESCRIPTION
Previously, we incorrectly listed 0.23.0 as the Ponyc version to
install.

Closes #2277