### PR TITLE
Add VirtualBox install intsructions to Vagrant docs

### DIFF
--- a/book/getting-started/vagrant-setup.md
+++ b/book/getting-started/vagrant-setup.md
@@ -52,6 +52,16 @@ cd wallaroo
 git checkout {{ book.wallaroo_version }}
 ```
 
+## Installing VirtualBox
+
+The Wallaroo Vagrant environment is dependent on the default provider,[VirtualBox](https://www.vagrantup.com/docs/virtualbox/). To install VirtualBox, download a installer or package for your OS [here](https://www.virtualbox.org/wiki/Downloads). Linux users can also use `apt-get` as documented below.
+
+### Linux
+
+```bash
+sudo apt-get install virtualbox
+```
+
 ## Installing Vagrant
 
 ### Linux Ubuntu, MacOS, and Windows


### PR DESCRIPTION
Adds installation instructions for VirtualBox to Vagrant docs to
avoid users running into errors if attempting a vagrant command.

Closes #2272