### PR TITLE
Update examples/*kafka*/README.md for Kafka server IP address consistency

### DIFF
--- a/examples/go/kafka_reverse/README.md
+++ b/examples/go/kafka_reverse/README.md
@@ -118,8 +118,10 @@ docker run --rm -it ryane/kafkacat -C -b *IP OUTPUT BY ./cluster up 1 COMMAND*:9
 
 ```bash
 ./kafka_reverse \
-  --kafka_source_topic test-in --kafka_source_brokers 127.0.0.1:9092 \
-  --kafka_sink_topic test-out --kafka_sink_brokers 127.0.0.1:9092 \
+  --kafka_source_topic test-in \
+  --kafka_source_brokers *IP OUTPUT BY ./cluster up 1 COMMAND*:9092 \
+  --kafka_sink_topic test-out \
+  --kafka_sink_brokers *IP OUTPUT BY ./cluster up 1 COMMAND*:9092 \
   --kafka_sink_max_message_size 100000 --kafka_sink_max_produce_buffer_ms 10 \
   --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
   --name worker-name --external 127.0.0.1:5050 --cluster-initializer \
@@ -139,7 +141,7 @@ Run the following and then type some characters and hit enter to send in the str
 **NOTE:** You will need to replace the IP address for the `-b` option with the one provided by `./cluster up 1` command in Shell 2.
 
 ```bash
-docker run --rm -it ryane/kafkacat -P -b 127.0.0.1:9092 -t test-in
+docker run --rm -it ryane/kafkacat -P -b *IP OUTPUT BY ./cluster up 1 COMMAND*:9092 -t test-in
 ```
 
 Note: You can use `ctrl-d` to exit `kafkacat`

--- a/examples/go/kafka_reverse/README.md
+++ b/examples/go/kafka_reverse/README.md
@@ -118,10 +118,8 @@ docker run --rm -it ryane/kafkacat -C -b *IP OUTPUT BY ./cluster up 1 COMMAND*:9
 
 ```bash
 ./kafka_reverse \
-  --kafka_source_topic test-in \
-  --kafka_source_brokers *IP OUTPUT BY ./cluster up 1 COMMAND*:9092 \
-  --kafka_sink_topic test-out \
-  --kafka_sink_brokers *IP OUTPUT BY ./cluster up 1 COMMAND*:9092 \
+  --kafka_source_topic test-in --kafka_source_brokers 127.0.0.1:9092 \
+  --kafka_sink_topic test-out --kafka_sink_brokers 127.0.0.1:9092 \
   --kafka_sink_max_message_size 100000 --kafka_sink_max_produce_buffer_ms 10 \
   --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
   --name worker-name --external 127.0.0.1:5050 --cluster-initializer \

--- a/examples/python/celsius-kafka/README.md
+++ b/examples/python/celsius-kafka/README.md
@@ -160,8 +160,10 @@ Run `machida` with `--application-module celsius`:
 
 ```bash
 machida --application-module celsius \
-  --kafka_source_topic test-in --kafka_source_brokers 127.0.0.1:9092 \
-  --kafka_sink_topic test-out --kafka_sink_brokers 127.0.0.1:9092 \
+  --kafka_source_topic test-in \
+  --kafka_source_brokers *IP OUTPUT BY ./cluster up 1 COMMAND*:9092 \
+  --kafka_sink_topic test-out \
+  --kafka_sink_brokers *IP OUTPUT BY ./cluster up 1 COMMAND*:9092 \
   --kafka_sink_max_message_size 100000 --kafka_sink_max_produce_buffer_ms 10 \
   --metrics 127.0.0.1:5001 --control 127.0.0.1:12500 --data 127.0.0.1:12501 \
   --external 127.0.0.1:5050 --cluster-initializer --ponythreads=1 \
@@ -181,7 +183,7 @@ Run the following and then type numbers (as floating point values) on each line 
 **NOTE:** You will need to replace the IP address for the `-b` option with the one provided by `./cluster up 1` command in Shell 2.
 
 ```bash
-docker run --rm -it ryane/kafkacat -P -b 127.0.0.1:9092 -t test-in
+docker run --rm -it ryane/kafkacat -P -b *IP OUTPUT BY ./cluster up 1 COMMAND*:9092 -t test-in
 ```
 
 Note: You can use `ctrl-d` to exit `kafkacat`

--- a/examples/python/celsius-kafka/README.md
+++ b/examples/python/celsius-kafka/README.md
@@ -160,10 +160,8 @@ Run `machida` with `--application-module celsius`:
 
 ```bash
 machida --application-module celsius \
-  --kafka_source_topic test-in \
-  --kafka_source_brokers *IP OUTPUT BY ./cluster up 1 COMMAND*:9092 \
-  --kafka_sink_topic test-out \
-  --kafka_sink_brokers *IP OUTPUT BY ./cluster up 1 COMMAND*:9092 \
+  --kafka_source_topic test-in --kafka_source_brokers 127.0.0.1:9092 \
+  --kafka_sink_topic test-out --kafka_sink_brokers 127.0.0.1:9092 \
   --kafka_sink_max_message_size 100000 --kafka_sink_max_produce_buffer_ms 10 \
   --metrics 127.0.0.1:5001 --control 127.0.0.1:12500 --data 127.0.0.1:12501 \
   --external 127.0.0.1:5050 --cluster-initializer --ponythreads=1 \


### PR DESCRIPTION
Use the same phraseology to refer to `./cluster up 1` output instead of `127.0.0.1`

[skip ci]