### PR TITLE
Ensure that parallel stateless computations always run independently

### DIFF
--- a/lib/wallaroo/core/initialization/application_distributor.pony
+++ b/lib/wallaroo/core/initialization/application_distributor.pony
@@ -238,6 +238,17 @@ actor ApplicationDistributor is Distributor
             // We're done putting runners on the source since
             // the stateless partition will not be on the source
             handled_source_runners = true
+
+            // We don't want the parallelized stateless partitions to be
+            // coalesced onto the preceding producer if they are preceded
+            // by another stateless computation (since it's the output of
+            // that computation that should be routed to one of many).
+            if latest_runner_builders.size() > 0 then
+              let seq_builder = RunnerSequenceBuilder(
+                latest_runner_builders = recover Array[RunnerBuilder] end,
+                parallel_stateless)
+              step_runner_builders.push(seq_builder)
+            end
           end
 
           if r_builder.is_stateful() then

--- a/lib/wallaroo/core/topology/router.pony
+++ b/lib/wallaroo/core/topology/router.pony
@@ -993,8 +993,6 @@ class val DataRouter is Equatable[DataRouter]
     let id = try
       _keyed_step_ids(state_name, key)?
     else
-      @printf[I32]("!@ `remove_keyed_route('%s', '%s')` FAILED\n".cstring(),
-        state_name.cstring(), key.cstring())
       Fail()
       0
     end

--- a/lib/wallaroo/core/topology/stateless_partitions.pony
+++ b/lib/wallaroo/core/topology/stateless_partitions.pony
@@ -2,7 +2,6 @@ use "collections"
 use "wallaroo/core/common"
 
 
-// !@ StatelessPartition -> StatelessPartitions
 primitive StatelessPartitions
   fun pre_stateless_data(pipeline_name: String, partition_id: StepId,
     workers: Array[String] val, threads_per_worker: USize): PreStatelessData ?


### PR DESCRIPTION
In certain scenarios (such as stateful->stateless->to_parallel), we
were coalescing the parallelized stateless computation back on the
preceding stateless computation's Producer. This meant all results
from the preceding computation went to the same place, defeating the
purpose of parallelization.

Closes #2320