### PR TITLE
Remove self from encoder, decoder, computation code in Python docs

### DIFF
--- a/book/python/writing-your-own-application.md
+++ b/book/python/writing-your-own-application.md
@@ -16,7 +16,7 @@ Let's start with the computation, because that's the purpose of the application:
 
 ```python
 @wallaroo.computation(name='reverse'):
-def reverse(self, data):
+def reverse(data):
     print "compute", data
     return data[::-1]
 ```
@@ -31,7 +31,7 @@ Next, we are going to define how the output gets constructed for the sink. It is
 
 ```python
 @wallaroo.encoder
-def encode(self, data):
+def encode(data):
     # data is a string
     print "encode", data
     return data + "\n"
@@ -43,7 +43,7 @@ Now, we also need to decode the incoming bytes of the source.
 
 ```python
 @wallaroo.decoder(header_length=4, length_fmt=">I")
-def decode(self, bs):
+def decode(bs):
     print "decode", bs
     return bs.decode("utf-8")
 ```

--- a/book/python/writing-your-own-partitioned-stateful-application.md
+++ b/book/python/writing-your-own-partitioned-stateful-application.md
@@ -9,7 +9,7 @@ Partitioning is a key aspect of how work is distributed in Wallaroo. From the ap
 * a partitioning function
 * partition-compatible states - the state should be defined in such a way that each partition can have its own distinct state instance
 
-A list of partition keys is optional. If included, your application will use these keys to set up the initial state partitions in the system. As we encounter new keys derived from messages using the user-defined partition function, we will dynamically create new state partitions. There is a slight performance penalty to dynamically creating state partitions in this way, so if you know all your keys ahead of time, it can be a good idea to provide them here. 
+A list of partition keys is optional. If included, your application will use these keys to set up the initial state partitions in the system. As we encounter new keys derived from messages using the user-defined partition function, we will dynamically create new state partitions. There is a slight performance penalty to dynamically creating state partitions in this way, so if you know all your keys ahead of time, it can be a good idea to provide them here.
 
 ## A Partitioned Stateful Application - Alphabet (partitioned)
 
@@ -29,7 +29,7 @@ And then we define a partitioning function which returns a key from the above li
 
 ```python
 @wallaroo.partition
-def partition(self, data):
+def partition(data):
     return data.letter[0]
 ```
 

--- a/book/python/writing-your-own-stateful-application.md
+++ b/book/python/writing-your-own-stateful-application.md
@@ -20,7 +20,7 @@ The state computation here is fairly straightforward: given a data object and a 
 
 ```python
 @wallaroo.state_computation(name='add votes')
-def add_votes(self, data, state):
+def add_votes(data, state):
     state.update(data)
     return (state.get_votes(data.letter), True)
 ```
@@ -75,7 +75,7 @@ The encoder is going to receive a `Votes` instance and encode into a string with
 
 ```python
 @wallaroo.encoder
-def encode(self, data):
+def encode(data):
     # data is a Votes
     return struct.pack(">IsQ", 9, data.letter, data.votes)
 ```
@@ -86,7 +86,7 @@ The decoder, like the one in Reverse Word, is going to use a `header_length` of 
 
 ```python
 @wallaroo.decoder(header_length=4, length_fmt=">I")
-def decode(self, bs):
+def decode(bs):
     (letter, vote_count) = struct.unpack(">sI", bs)
     return Votes(letter, vote_count)
 ```


### PR DESCRIPTION
The documentation did not reflect the updated code which no longer
requires passing self to the encdoer, decoder, or computation methods.
Updates documentation to reflect existing method structure,

closes #2328