### PR TITLE
Remove unused struct import in reverse.py

### DIFF
--- a/book/python/writing-your-own-application.md
+++ b/book/python/writing-your-own-application.md
@@ -126,7 +126,6 @@ Wallaroo provides the convenience functions `tcp_parse_input_addrs` and `tcp_par
 Of course, no Python module is complete without its imports. In this case, only two imports are required:
 
 ```python
-import struct
 import wallaroo
 ```
 

--- a/examples/python/reverse/reverse.py
+++ b/examples/python/reverse/reverse.py
@@ -17,8 +17,6 @@ This is an example application that receives strings as input and outputs the
 reversed strings.
 """
 
-import struct
-
 import wallaroo
 
 


### PR DESCRIPTION
Also removes documentation which stated users should import struct.

closes #2330