### PR TITLE
Add 64-bit and 32-bit notes to languages supported, Python, & Go docs

### DIFF
--- a/book/getting-started/choosing-an-installation-option.md
+++ b/book/getting-started/choosing-an-installation-option.md
@@ -1,12 +1,12 @@
 # Choosing an Installation Option for Wallaroo
 
-For MacOS and Windows users, we provide two different ways for you to install Wallaroo:
+For 64-bit MacOS and Windows users, we provide two different ways for you to install Wallaroo:
 - [Wallaroo in Docker](/book/getting-started/docker-setup.md)
 - [Wallaroo in Vagrant](/book/getting-started-vagrant-setup.md)
 
-If you are unsure about which solution is right for you, a breakdown of each is provided below.
+If you are unsure about which solution is right for you, a breakdown of each is provided below. (NOTE: Wallaroo does not support 32-bit platforms.)
 
-For Linux users, we provide three different ways for you to install Wallaroo:
+For 64-bit Linux users, we provide three different ways for you to install Wallaroo:
 - [Wallaroo in Docker](/book/getting-started/docker-setup.md)
 - [Wallaroo in Vagrant](/book/getting-started-vagrant-setup.md)
 - [Installing from Source](/book/getting-started/linux-setup.md)

--- a/book/go/getting-started/setup.md
+++ b/book/go/getting-started/setup.md
@@ -1,5 +1,5 @@
 # Setting Up Your Environment for Wallaroo
 
-It is currently possible to develop Wallaroo Go applications on Linux. This guide currently has installation instructions for Ubuntu Linux. It's assumed that if you are using a different Linux distribution then you are able to translate the Ubuntu instructions to your distribution of choice.
+It is currently possible to develop Wallaroo Go applications on 64-bit Linux. (NOTE: Wallaroo does not support 32-bit platforms.) This guide currently has installation instructions for Ubuntu Linux. It's assumed that if you are using a different Linux distribution then you are able to translate the Ubuntu instructions to your distribution of choice.
 
 - [Ubuntu setup](linux-setup.md)

--- a/book/go/intro.md
+++ b/book/go/intro.md
@@ -1,6 +1,6 @@
 # Go API Introduction
 
-The Wallaroo Go API can be used to write Wallaroo applications using Go. 
+The Wallaroo Go API can be used to write Wallaroo applications using Go on 64-bit platforms.
 
 In order to write a Wallaroo application in Go, the developer creates a series of functions and types that provide methods expected by Wallaroo (see [Wallaroo Go API Classes](api/api.md) for more detail). Additionally, the developer writes an entry point function that Wallaroo uses to lay out the application.
 

--- a/book/language_support.md
+++ b/book/language_support.md
@@ -1,6 +1,6 @@
 # Wallaroo Languages Supported
 
-Wallaroo currently supports the Python and Go programming languages.
+Wallaroo currently supports the Python and Go programming languages on 64-bit platforms.
 
 * Learn more about how to use [Wallaroo with Python](python/intro.md).
 * Learn more about how to use [Wallaroo with Go](go/intro.md).

--- a/book/python/intro.md
+++ b/book/python/intro.md
@@ -1,6 +1,6 @@
 # Python API Introduction
 
-The Wallaroo Python API can be used to write Wallaroo applications entirely in Python without needing Java or a JVM. This lets developers quickly get started with Wallaroo by leveraging their existing Python knowledge. It currently supports Python 2.7. Support for Python 3.X is in the works and we encourage you to contact us if that is a requirement.
+The Wallaroo Python API can be used to write Wallaroo applications entirely in Python without needing Java or a JVM. This lets developers quickly get started with Wallaroo by leveraging their existing Python knowledge. It currently supports Python 2.7 on 64-bit platforms. Support for Python 3.X is in the works and we encourage you to contact us if that is a requirement.
 
 In order to write a Wallaroo application in Python, the developer creates the functions (decorated with [the Wallaroo API](api.md)) to be run at each step of their application, along with an entry point function that uses the Wallaroo `ApplicationBuilder` that defines the layout of their application.
 


### PR DESCRIPTION
I've added 64-bit and 32-bit notes about platform support:

- To the "Wallaroo Languages Supported" doc
- The first two sections for the Python & Go docs, respectively

Fixes #2309
[skip ci]