### PR TITLE
Add Python3 class compatibility to Wallaroo Python API (wallaroo.py)

### DIFF
--- a/.ci-dockerfiles/ci-standard/Dockerfile
+++ b/.ci-dockerfiles/ci-standard/Dockerfile
@@ -22,6 +22,9 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "D401AB61 
     python \
     python-dev \
     python-pip \
+    python3 \
+    python3-dev \
+    python3-pip \
     wget
 
 # install MonHub dependencies
@@ -41,9 +44,13 @@ RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 
-# python testing dependencies
+# python2 testing dependencies
 RUN python2 -m pip install --upgrade pip enum34 \
   && python2 -m pip install pytest==3.2.2
+
+# python3 testing dependencies
+RUN python3 -m pip install --upgrade pip enum34 \
+  && python3 -m pip install pytest==3.7.1
 
 # install go
 RUN wget https://dl.google.com/go/go1.9.2.linux-amd64.tar.gz \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: wallaroolabs/wallaroo-ci:2018.07.30.1
+      - image: wallaroolabs/wallaroo-ci:2018.08.13.1
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -16,21 +16,21 @@ jobs:
       - run: changelog-tool verify CHANGELOG.md
   integration-tests:
     docker:
-      - image: wallaroolabs/wallaroo-ci:2018.07.30.1
+      - image: wallaroolabs/wallaroo-ci:2018.08.13.1
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
       - run: make integration-tests debug=true
   integration-tests-with-resilience:
     docker:
-      - image: wallaroolabs/wallaroo-ci:2018.07.30.1
+      - image: wallaroolabs/wallaroo-ci:2018.08.13.1
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
       - run: make integration-tests-testing-correctness-tests-all resilience=on debug=true
   unit-tests:
     docker:
-      - image: wallaroolabs/wallaroo-ci:2018.07.30.1
+      - image: wallaroolabs/wallaroo-ci:2018.08.13.1
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 .deps/
 .cache/
 .cache/*
+.pytest_cache/
+.pytest_cache/*
 __pycache__/
 __pycache__/*
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,12 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys "D401AB61 
     numactl \
     python-dev \
     python-pip && \
-    pip install virtualenv virtualenvwrapper && \
-    pip install --upgrade pip && \
+    python3-dev \
+    python3-pip && \
+    pip2 install virtualenv virtualenvwrapper && \
+    pip2 install --upgrade pip && \
+    pip3 install virtualenv virtualenvwrapper && \
+    pip3 install --upgrade pip && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get -y autoremove --purge && \
     apt-get -y clean

--- a/machida/Makefile
+++ b/machida/Makefile
@@ -65,7 +65,8 @@ machida_clean:
 
 wallaroo_unit_tests:
 	cd $(MACHIDA_PATH) && \
-		python2 -m pytest --color=yes --tb=native --verbose wallaroo_test.py
+		python2 -m pytest --color=yes --tb=native --verbose --exitfirst wallaroo_test.py && \
+		python3 -m pytest --color=yes --tb=native --verbose --exitfirst wallaroo_test.py
 
 machida_build: $(MACHIDA_BUILD)/machida
 

--- a/machida/wallaroo.py
+++ b/machida/wallaroo.py
@@ -14,10 +14,11 @@
 
 
 import argparse
-from functools import wraps
 import pickle
 import struct
 import inspect
+import sys
+
 
 def serialize(o):
     return pickle.dumps(o)
@@ -197,62 +198,141 @@ def _validate_arity_compatability(obj, arity):
             ).format(arity))
 
 
-def computation(name):
-    def wrapped(computation_function):
-        _validate_arity_compatability(computation_function, 1)
-        @wraps(computation_function)
-        class C:
+def attach_to_module(cls, cls_name, func):
+    # Do some scope mangling to create a uniquely named class based on
+    # the decorated function's name and place it in the wallaroo module's
+    # namespace so that pickle can find it.
+
+    name = cls_name + '__' + func.__name__
+
+    # Python2: use __name__
+    if sys.version_info.major == 2:
+        cls.__name__ = name
+    # Python3: use __qualname__
+    else:
+        cls.__qualname__ = name
+
+    globals()[name] = cls
+    return globals()[name]
+
+
+
+def _wallaroo_wrap(name, func, base_cls, **kwargs):
+    # Case 1: Computations
+    if issubclass(base_cls, Computation):
+        # Create the appropriate computation signature
+        if base_cls._is_state:
+            def comp(self, data, state):
+                return func(data, state)
+        else:
+            def comp(self, data):
+                return func(data)
+
+        # Create a custom class type for the computation
+        class C(base_cls):
+            __doc__ = func.__doc__
+            __module__ = __module__
             def name(self):
                 return name
-            def compute(self, data):
-                return computation_function(data)
-            def __call__(self, *args):
-                return self
+
+        # Attach the computation to the class
+        # TODO: maybe move this to machida, using PyObject_IsInstance
+        # instead of PyObject_HasAttrString
+        if base_cls._is_multi:
+            C.compute_multi = comp
+        else:
+            C.compute = comp
+
+    # Case 2: Partition
+    elif base_cls is Partition:
+        class C(base_cls):
+            def partition(self, data):
+                return func(data)
+
+    # Case 3: Encoder
+    elif base_cls is Encoder:
+        class C(base_cls):
+            def encode(self, data):
+                return func(data)
+
+    # Case 4: Decoder
+    elif base_cls is Decoder:
+        header_length = kwargs['header_length']
+        length_fmt = kwargs['length_fmt']
+        class C(base_cls):
+            def header_length(self):
+                return header_length
+            def payload_length(self, bs):
+                return struct.unpack(length_fmt, bs)[0]
+            def decode(self, bs):
+                return func(bs)
+
+    # Attach the new class to the module's global namespace and return it
+    return attach_to_module(C, base_cls.__name__, func)
+
+
+class BaseWrapped(object):
+    def __call__(self, *args):
+        return self
+
+
+class Computation(BaseWrapped):
+    _is_multi = False
+    _is_state = False
+
+
+class ComputationMulti(Computation):
+    _is_multi = True
+
+
+class StateComputation(Computation):
+    _is_state = True
+
+
+class StateComputationMulti(StateComputation):
+    _is_multi = True
+
+
+class Partition(BaseWrapped):
+    pass
+
+
+class Decoder(BaseWrapped):
+    pass
+
+
+class Encoder(BaseWrapped):
+    pass
+
+
+def computation(name):
+    def wrapped(func):
+        _validate_arity_compatability(func, 1)
+        C = _wallaroo_wrap(name, func, Computation)
         return C()
     return wrapped
 
 
 def state_computation(name):
-    def wrapped(computation_function):
-        _validate_arity_compatability(computation_function, 2)
-        @wraps(computation_function)
-        class C:
-            def name(self):
-                return name
-            def compute(self, data, state):
-                return computation_function(data, state)
-            def __call__(self, *args):
-                return self
+    def wrapped(func):
+        _validate_arity_compatability(func, 2)
+        C = _wallaroo_wrap(name, func, StateComputation)
         return C()
     return wrapped
 
 
 def computation_multi(name):
-    def wrapped(computation_function):
-        _validate_arity_compatability(computation_function, 1)
-        @wraps(computation_function)
-        class C:
-            def name(self):
-                return name
-            def compute_multi(self, data):
-                return computation_function(data)
-            def __call__(self, *args):
-                return self
+    def wrapped(func):
+        _validate_arity_compatability(func, 1)
+        C = _wallaroo_wrap(name, func, ComputationMulti)
         return C()
     return wrapped
 
 
 def state_computation_multi(name):
-    def wrapped(computation_function):
-        _validate_arity_compatability(computation_function, 2)
-        @wraps(computation_function)
-        class C:
-            def name(self):
-                return name
-            def compute_multi(self, data, state):
-                return computation_function(data, state)
-            def __call__(self, *args):
-                return self
+    def wrapped(func):
+        _validate_arity_compatability(func, 2)
+        C = _wallaroo_wrap(name, func, StateComputationMulti)
         return C()
     return wrapped
 
@@ -269,42 +349,25 @@ class StateBuilder(object):
         return self.name
 
 
-def partition(fn):
-    _validate_arity_compatability(fn, 1)
-    @wraps(fn)
-    class C:
-        def partition(self, data):
-            return fn(data)
-        def __call__(self, *args):
-            return self
+def partition(func):
+    _validate_arity_compatability(func, 1)
+    C = _wallaroo_wrap(func.__name__, func, Partition)
     return C()
 
 
 def decoder(header_length, length_fmt):
-    def wrapped(decoder_function):
-        _validate_arity_compatability(decoder_function, 1)
-        @wraps(decoder_function)
-        class C:
-            def header_length(self):
-                return header_length
-            def payload_length(self, bs):
-                return struct.unpack(length_fmt, bs)[0]
-            def decode(self, bs):
-                return decoder_function(bs)
-            def __call__(self, *args):
-                return self
+    def wrapped(func):
+        _validate_arity_compatability(func, 1)
+        C = _wallaroo_wrap(func.__name__, func, Decoder,
+                           header_length = header_length,
+                           length_fmt = length_fmt)
         return C()
     return wrapped
 
 
-def encoder(encoder_function):
-    _validate_arity_compatability(encoder_function, 1)
-    @wraps(encoder_function)
-    class C:
-        def encode(self, data):
-            return encoder_function(data)
-        def __call__(self, *args):
-            return self
+def encoder(func):
+    _validate_arity_compatability(func, 1)
+    C = _wallaroo_wrap(func.__name__, func, Encoder)
     return C()
 
 

--- a/machida/wallaroo_test.py
+++ b/machida/wallaroo_test.py
@@ -7,22 +7,41 @@ import wallaroo
 # Test computation
 #
 
-
 @wallaroo.computation(name="My Computation")
 def my_computation(data):
     return data
 
 
+
+@wallaroo.computation("My Computation 2")
+def my_computation2(data):
+    return data*2
+
+
 def test_my_computation():
     assert(my_computation.name() == "My Computation")
     assert(my_computation.compute("abcd") == "abcd")
+    assert(my_computation2.name() == "My Computation 2")
+    assert(my_computation2.compute("abcd") == "abcdabcd")
+    assert(isinstance(my_computation, wallaroo.Computation))
+    assert(isinstance(my_computation, wallaroo.Computation__my_computation))
+    assert(isinstance(my_computation2, wallaroo.Computation))
+    assert(isinstance(my_computation2, wallaroo.Computation__my_computation2))
+    assert(not isinstance(my_computation, wallaroo.StateComputation))
 
 
-def test_serialization():
+def test_my_computation_serialization():
     serialized = pickle.dumps(my_computation)
     deserialized = pickle.loads(serialized)
     assert(deserialized.name() == "My Computation")
     assert(deserialized.compute("abcd") == "abcd")
+    assert(isinstance(deserialized, wallaroo.Computation__my_computation))
+
+    serialized2 = pickle.dumps(my_computation2)
+    deserialized2 = pickle.loads(serialized2)
+    assert(deserialized2.name() == "My Computation 2")
+    assert(deserialized2.compute("abcd") == "abcdabcd")
+    assert(isinstance(deserialized2, wallaroo.Computation__my_computation2))
 
 
 #


### PR DESCRIPTION
- Can now pickle new style classes (deriving object in py2)
- Can now pickle python3 classes
- Refactored Wallaroo step wrappers (Computations, partition, decoder,
  encoder)
- Added Python3 tests for `machida/wallaroo.py`
- Add python3 dependencies to dockerfiles


This is an incremental change towards a Python3 version of Machida. It does not introduce any API changes. What's changed is the decorator mechanism, such that it can now create new style classes that are pickleable.