### PR TITLE
Release 0.5.2 bug fixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to Wallaroo will be documented in this file.
 
 ### Added
 
+- Added Wallaroo Up to automate development environment setup on multiple Linux distributions
+- Added support for Fedora 28, CentOS 7, and Debian Stretch Linux distributions via Wallaroo Up
+- Added Vagrant as an option for trying out the Wallaroo Go
+- Added Docker as an option for trying out the Wallaroo Go
 
 ### Changed
 

--- a/book/getting-started/linux-setup.md
+++ b/book/getting-started/linux-setup.md
@@ -37,7 +37,7 @@ cd ~/wallaroo-tutorial
 This will be our base directory in what follows. Download the Wallaroo sources (this will create a subdirectory called `wallaroo-{{ book.wallaroo_version }}`):
 
 ```bash
-wget -q -O wallaroo-{{ book.wallaroo_version }}.tar.gz '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/wallaroo-{{ book.wallaroo_version }}.tar.gz'
+wget -O wallaroo-{{ book.wallaroo_version }}.tar.gz '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/wallaroo-{{ book.wallaroo_version }}.tar.gz'
 mkdir wallaroo-{{ book.wallaroo_version }}
 tar -C wallaroo-{{ book.wallaroo_version }} --strip-components=1 -xzf wallaroo-{{ book.wallaroo_version }}.tar.gz
 rm wallaroo-{{ book.wallaroo_version }}.tar.gz
@@ -164,7 +164,7 @@ sudo apt-get install -y python-dev
 ```bash
 cd ~/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/
 mkdir bin
-wget -q -O Wallaroo_Metrics_UI-{{ book.wallaroo_version }}-x86_64.AppImage '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/Wallaroo_Metrics_UI-{{ book.wallaroo_version }}-x86_64.AppImage'
+wget -O Wallaroo_Metrics_UI-{{ book.wallaroo_version }}-x86_64.AppImage '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/Wallaroo_Metrics_UI-{{ book.wallaroo_version }}-x86_64.AppImage'
 chmod +x Wallaroo_Metrics_UI-{{ book.wallaroo_version }}-x86_64.AppImage
 ./Wallaroo_Metrics_UI-{{ book.wallaroo_version }}-x86_64.AppImage --appimage-extract
 mv squashfs-root bin/metrics_ui

--- a/book/getting-started/linux-setup.md
+++ b/book/getting-started/linux-setup.md
@@ -37,7 +37,7 @@ cd ~/wallaroo-tutorial
 This will be our base directory in what follows. Download the Wallaroo sources (this will create a subdirectory called `wallaroo-{{ book.wallaroo_version }}`):
 
 ```bash
-wget -q -O wallaroo-{{ book.wallaroo_version }}.tar.gz '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/{{ book.wallaroo_version }}.tar.gz'
+wget -q -O wallaroo-{{ book.wallaroo_version }}.tar.gz '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/wallaroo-{{ book.wallaroo_version }}.tar.gz'
 mkdir wallaroo-{{ book.wallaroo_version }}
 tar -C wallaroo-{{ book.wallaroo_version }} --strip-components=1 -xzf wallaroo-{{ book.wallaroo_version }}.tar.gz
 rm wallaroo-{{ book.wallaroo_version }}.tar.gz
@@ -90,7 +90,7 @@ sudo update-alternatives --install /usr/bin/gcc gcc \
 In order to install `ponyc` and `pony-stable` via `apt-get` the following keyserver must be added to the APT key management utility.
 
 ```bash
-sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "E04F0923 B3B48BDA"
+sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys E04F0923 B3B48BDA
 ```
 
 The following packages need to be installed to allow `apt` to use a repository over HTTPS:

--- a/book/getting-started/linux-setup.md
+++ b/book/getting-started/linux-setup.md
@@ -37,7 +37,7 @@ cd ~/wallaroo-tutorial
 This will be our base directory in what follows. Download the Wallaroo sources (this will create a subdirectory called `wallaroo-{{ book.wallaroo_version }}`):
 
 ```bash
-wget -O wallaroo-{{ book.wallaroo_version }}.tar.gz '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/wallaroo-{{ book.wallaroo_version }}.tar.gz'
+curl -L -o wallaroo-{{ book.wallaroo_version }}.tar.gz '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/wallaroo-{{ book.wallaroo_version }}.tar.gz'
 mkdir wallaroo-{{ book.wallaroo_version }}
 tar -C wallaroo-{{ book.wallaroo_version }} --strip-components=1 -xzf wallaroo-{{ book.wallaroo_version }}.tar.gz
 rm wallaroo-{{ book.wallaroo_version }}.tar.gz
@@ -146,7 +146,7 @@ Trusty Ubuntu has an outdated `liblz4` package. You will need to install from so
 
 ```bash
 cd ~/
-wget -O liblz4-1.7.5.tar.gz https://github.com/lz4/lz4/archive/v1.7.5.tar.gz
+curl -L -o liblz4-1.7.5.tar.gz https://github.com/lz4/lz4/archive/v1.7.5.tar.gz
 tar zxvf liblz4-1.7.5.tar.gz
 cd lz4-1.7.5
 make
@@ -164,7 +164,7 @@ sudo apt-get install -y python-dev
 ```bash
 cd ~/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/
 mkdir bin
-wget -O Wallaroo_Metrics_UI-{{ book.wallaroo_version }}-x86_64.AppImage '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/Wallaroo_Metrics_UI-{{ book.wallaroo_version }}-x86_64.AppImage'
+curl -L -o Wallaroo_Metrics_UI-{{ book.wallaroo_version }}-x86_64.AppImage '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/Wallaroo_Metrics_UI-{{ book.wallaroo_version }}-x86_64.AppImage'
 chmod +x Wallaroo_Metrics_UI-{{ book.wallaroo_version }}-x86_64.AppImage
 ./Wallaroo_Metrics_UI-{{ book.wallaroo_version }}-x86_64.AppImage --appimage-extract
 mv squashfs-root bin/metrics_ui

--- a/book/getting-started/vagrant-setup.md
+++ b/book/getting-started/vagrant-setup.md
@@ -19,7 +19,7 @@ cd ~/wallaroo-tutorial
 This will be our base directory in what follows. Download the Wallaroo sources (this will create a subdirectory called `wallaroo-{{ book.wallaroo_version }}`):
 
 ```bash
-curl -L -o wallaroo-{{ book.wallaroo_version }}.tar.gz '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/{{ book.wallaroo_version }}.tar.gz'
+curl -L -o wallaroo-{{ book.wallaroo_version }}.tar.gz '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/wallaroo-{{ book.wallaroo_version }}.tar.gz'
 mkdir wallaroo-{{ book.wallaroo_version }}
 tar -C wallaroo-{{ book.wallaroo_version }} --strip-components=1 -xzf wallaroo-{{ book.wallaroo_version }}.tar.gz
 rm wallaroo-{{ book.wallaroo_version }}.tar.gz

--- a/book/getting-started/vagrant-setup.md
+++ b/book/getting-started/vagrant-setup.md
@@ -19,7 +19,7 @@ cd ~/wallaroo-tutorial
 This will be our base directory in what follows. Download the Wallaroo sources (this will create a subdirectory called `wallaroo-{{ book.wallaroo_version }}`):
 
 ```bash
-wget -q -O wallaroo-{{ book.wallaroo_version }}.tar.gz '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/{{ book.wallaroo_version }}.tar.gz'
+curl -L -o wallaroo-{{ book.wallaroo_version }}.tar.gz '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/{{ book.wallaroo_version }}.tar.gz'
 mkdir wallaroo-{{ book.wallaroo_version }}
 tar -C wallaroo-{{ book.wallaroo_version }} --strip-components=1 -xzf wallaroo-{{ book.wallaroo_version }}.tar.gz
 rm wallaroo-{{ book.wallaroo_version }}.tar.gz

--- a/book/go/getting-started/linux-setup.md
+++ b/book/go/getting-started/linux-setup.md
@@ -30,7 +30,7 @@ cd ~/wallaroo-tutorial
 This will be our base directory in what follows. Download the Wallaroo sources (this will create a subdirectory called `wallaroo-{{ book.wallaroo_version }}`):
 
 ```bash
-wget -O wallaroo-{{ book.wallaroo_version }}.tar.gz '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/wallaroo-{{ book.wallaroo_version }}.tar.gz'
+curl -L -o wallaroo-{{ book.wallaroo_version }}.tar.gz '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/wallaroo-{{ book.wallaroo_version }}.tar.gz'
 mkdir wallaroo-{{ book.wallaroo_version }}
 tar -C wallaroo-{{ book.wallaroo_version }} --strip-components=1 -xzf wallaroo-{{ book.wallaroo_version }}.tar.gz
 rm wallaroo-{{ book.wallaroo_version }}.tar.gz
@@ -43,7 +43,7 @@ You'll need a Go 1.9.x compiler. The following instructions will download a priv
 
 ```bash
 mkdir bin
-wget https://dl.google.com/go/go{{ book.golang_version }}.linux-amd64.tar.gz -O /tmp/go.tar.gz
+curl -L -o /tmp/go.tar.gz https://dl.google.com/go/go{{ book.golang_version }}.linux-amd64.tar.gz
 tar -C bin -xzf /tmp/go.tar.gz
 mv bin/go bin/go{{ book.golang_version }}
 rm /tmp/go.tar.gz
@@ -159,7 +159,7 @@ Trusty Ubuntu has an outdated `liblz4` package. You will need to install from so
 
 ```bash
 cd ~/
-wget -O liblz4-1.7.5.tar.gz https://github.com/lz4/lz4/archive/v1.7.5.tar.gz
+curl -L -o liblz4-1.7.5.tar.gz https://github.com/lz4/lz4/archive/v1.7.5.tar.gz
 tar zxvf liblz4-1.7.5.tar.gz
 cd lz4-1.7.5
 make
@@ -171,7 +171,7 @@ sudo make install
 ```bash
 cd ~/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/
 mkdir bin
-wget -O Wallaroo_Metrics_UI-{{ book.wallaroo_version }}-x86_64.AppImage '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/Wallaroo_Metrics_UI-{{ book.wallaroo_version }}-x86_64.AppImage'
+curl -L -o Wallaroo_Metrics_UI-{{ book.wallaroo_version }}-x86_64.AppImage '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/Wallaroo_Metrics_UI-{{ book.wallaroo_version }}-x86_64.AppImage'
 chmod +x Wallaroo_Metrics_UI-{{ book.wallaroo_version }}-x86_64.AppImage
 ./Wallaroo_Metrics_UI-{{ book.wallaroo_version }}-x86_64.AppImage --appimage-extract
 mv squashfs-root bin/metrics_ui

--- a/book/go/getting-started/linux-setup.md
+++ b/book/go/getting-started/linux-setup.md
@@ -30,7 +30,7 @@ cd ~/wallaroo-tutorial
 This will be our base directory in what follows. Download the Wallaroo sources (this will create a subdirectory called `wallaroo-{{ book.wallaroo_version }}`):
 
 ```bash
-wget -q -O wallaroo-{{ book.wallaroo_version }}.tar.gz '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/{{ book.wallaroo_version }}.tar.gz'
+wget -q -O wallaroo-{{ book.wallaroo_version }}.tar.gz '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/wallaroo-{{ book.wallaroo_version }}.tar.gz'
 mkdir wallaroo-{{ book.wallaroo_version }}
 tar -C wallaroo-{{ book.wallaroo_version }} --strip-components=1 -xzf wallaroo-{{ book.wallaroo_version }}.tar.gz
 rm wallaroo-{{ book.wallaroo_version }}.tar.gz
@@ -103,7 +103,7 @@ sudo update-alternatives --install /usr/bin/gcc gcc \
 In order to install `ponyc` and `pony-stable` via `apt-get` the following keyserver must be added to the APT key management utility.
 
 ```bash
-sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "E04F0923 B3B48BDA"
+sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys E04F0923 B3B48BDA
 ```
 
 The following packages need to be installed to allow `apt` to use a repository over HTTPS:

--- a/book/go/getting-started/linux-setup.md
+++ b/book/go/getting-started/linux-setup.md
@@ -30,7 +30,7 @@ cd ~/wallaroo-tutorial
 This will be our base directory in what follows. Download the Wallaroo sources (this will create a subdirectory called `wallaroo-{{ book.wallaroo_version }}`):
 
 ```bash
-wget -q -O wallaroo-{{ book.wallaroo_version }}.tar.gz '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/wallaroo-{{ book.wallaroo_version }}.tar.gz'
+wget -O wallaroo-{{ book.wallaroo_version }}.tar.gz '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/wallaroo-{{ book.wallaroo_version }}.tar.gz'
 mkdir wallaroo-{{ book.wallaroo_version }}
 tar -C wallaroo-{{ book.wallaroo_version }} --strip-components=1 -xzf wallaroo-{{ book.wallaroo_version }}.tar.gz
 rm wallaroo-{{ book.wallaroo_version }}.tar.gz
@@ -43,7 +43,7 @@ You'll need a Go 1.9.x compiler. The following instructions will download a priv
 
 ```bash
 mkdir bin
-wget -q https://dl.google.com/go/go{{ book.golang_version }}.linux-amd64.tar.gz -O /tmp/go.tar.gz
+wget https://dl.google.com/go/go{{ book.golang_version }}.linux-amd64.tar.gz -O /tmp/go.tar.gz
 tar -C bin -xzf /tmp/go.tar.gz
 mv bin/go bin/go{{ book.golang_version }}
 rm /tmp/go.tar.gz
@@ -171,7 +171,7 @@ sudo make install
 ```bash
 cd ~/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/
 mkdir bin
-wget -q -O Wallaroo_Metrics_UI-{{ book.wallaroo_version }}-x86_64.AppImage '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/Wallaroo_Metrics_UI-{{ book.wallaroo_version }}-x86_64.AppImage'
+wget -O Wallaroo_Metrics_UI-{{ book.wallaroo_version }}-x86_64.AppImage '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/Wallaroo_Metrics_UI-{{ book.wallaroo_version }}-x86_64.AppImage'
 chmod +x Wallaroo_Metrics_UI-{{ book.wallaroo_version }}-x86_64.AppImage
 ./Wallaroo_Metrics_UI-{{ book.wallaroo_version }}-x86_64.AppImage --appimage-extract
 mv squashfs-root bin/metrics_ui

--- a/book/go/getting-started/vagrant-setup.md
+++ b/book/go/getting-started/vagrant-setup.md
@@ -19,7 +19,7 @@ cd ~/wallaroo-tutorial
 This will be our base directory in what follows. Download the Wallaroo sources (this will create a subdirectory called `wallaroo-{{ book.wallaroo_version }}`):
 
 ```bash
-curl -L -o wallaroo-{{ book.wallaroo_version }}.tar.gz '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/{{ book.wallaroo_version }}.tar.gz'
+curl -L -o wallaroo-{{ book.wallaroo_version }}.tar.gz '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/wallaroo-{{ book.wallaroo_version }}.tar.gz'
 mkdir wallaroo-{{ book.wallaroo_version }}
 tar -C wallaroo-{{ book.wallaroo_version }} --strip-components=1 -xzf wallaroo-{{ book.wallaroo_version }}.tar.gz
 rm wallaroo-{{ book.wallaroo_version }}.tar.gz

--- a/book/go/getting-started/vagrant-setup.md
+++ b/book/go/getting-started/vagrant-setup.md
@@ -19,7 +19,7 @@ cd ~/wallaroo-tutorial
 This will be our base directory in what follows. Download the Wallaroo sources (this will create a subdirectory called `wallaroo-{{ book.wallaroo_version }}`):
 
 ```bash
-wget -q -O wallaroo-{{ book.wallaroo_version }}.tar.gz '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/{{ book.wallaroo_version }}.tar.gz'
+curl -L -o wallaroo-{{ book.wallaroo_version }}.tar.gz '{{ book.bintray_repo_url }}/wallaroo/{{ book.wallaroo_version }}/{{ book.wallaroo_version }}.tar.gz'
 mkdir wallaroo-{{ book.wallaroo_version }}
 tar -C wallaroo-{{ book.wallaroo_version }} --strip-components=1 -xzf wallaroo-{{ book.wallaroo_version }}.tar.gz
 rm wallaroo-{{ book.wallaroo_version }}.tar.gz

--- a/examples/go/kafka_reverse/README.md
+++ b/examples/go/kafka_reverse/README.md
@@ -100,7 +100,7 @@ docker exec -it local_kafka_1_1 /kafka/bin/kafka-topics.sh --zookeeper \
 
 **Note:** The `./cluster up 1` command outputs `Host IP used for Kafka Brokers is <YOUR_HOST_IP>`.
 
-#### Set up a listener to monitor the Kafka topic to which you would the application to publish results. We usually use `kafkacat`.
+#### Set up a listener to monitor the Kafka topic the application will publish results to. We usually use `kafkacat`.
 
 `kafkacat` can be installed via:
 

--- a/examples/python/celsius-kafka/README.md
+++ b/examples/python/celsius-kafka/README.md
@@ -95,7 +95,7 @@ docker exec -it local_kafka_1_1 /kafka/bin/kafka-topics.sh --zookeeper \
 
 **Note:** The `./cluster up 1` command outputs `Host IP used for Kafka Brokers is <YOUR_HOST_IP>`. You will need to use this IP address for the `kafka_source_brokers` and `kafka_sink_brokers` arguments when starting `machida` within Docker in order to communicate with the cluster running on your host machine.
 
-#### Set up a listener to monitor the Kafka topic to which you would the application to publish results. We usually use `kafkacat`.
+#### Set up a listener to monitor the Kafka topic the application will publish results to. We usually use `kafkacat`.
 
 `kafkacat` can be installed via:
 

--- a/misc/.gitignore
+++ b/misc/.gitignore
@@ -1,0 +1,2 @@
+.vagrant
+Vagrantfile

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -10,16 +10,41 @@ ifeq ($(wallaroo_path),)
 else
   WALLAROO_UP_PATH := $(wallaroo_path)/misc
 endif
-WALLAROO_UP_DISTROS:=debian-jessie debian-stretch debian-buster ubuntu-trusty ubuntu-xenial ubuntu-bionic ubuntu-artful centos-7 fedora-26 fedora-27 fedora-28
-TEST_WALLAROO_UP_SUPPORTED_DISTROS:=$(addprefix test-wallaroo-up-,$(WALLAROO_UP_DISTROS))
+WALLAROO_UP_DISTROS_DOCKER:=debian-jessie debian-stretch ubuntu-trusty ubuntu-xenial ubuntu-bionic ubuntu-artful centos-7 fedora-26 fedora-27 fedora-28 debian-buster amazonlinux-2 oraclelinux-7
+WALLAROO_UP_DISTROS_VAGRANT:=debian-jessie64 debian-stretch64 ubuntu-trusty64 ubuntu-xenial64 ubuntu-bionic64 ubuntu-artful64 centos-7 fedora-26-cloud-base fedora-27-cloud-base fedora-28-cloud-base gbailey-amzn2 generic-oracle7 debian-testing64
+TEST_WALLAROO_UP_SUPPORTED_DISTROS_DOCKER:=$(addprefix test-wallaroo-up-docker-,$(WALLAROO_UP_DISTROS_DOCKER))
+TEST_WALLAROO_UP_SUPPORTED_DISTROS_VAGRANT:=$(addprefix test-wallaroo-up-vagrant-,$(WALLAROO_UP_DISTROS_VAGRANT))
 
-.PHONY: test-wallaroo-up clean-wallaroo-up
-test-wallaroo-up: $(TEST_WALLAROO_UP_SUPPORTED_DISTROS)
+ifeq ($(shell uname -s),Linux)
+  WALLAROO_UP_SED_ARGS=-i
+else
+  WALLAROO_UP_SED_ARGS=-i ""
+endif
 
-test-wallaroo-up-%:
+.PHONY: test-wallaroo-up-docker test-wallaroo-up-vagrant
+# TODO: Add ability to run all and then produce a report after of which ones failed... maybe this is already possible via make?
+test-wallaroo-up-docker: $(TEST_WALLAROO_UP_SUPPORTED_DISTROS_DOCKER)
+test-wallaroo-up-vagrant: $(TEST_WALLAROO_UP_SUPPORTED_DISTROS_VAGRANT)
+
+test-wallaroo-up: test-wallaroo-up-docker test-wallaroo-up-vagrant
+
+test-wallaroo-up-docker-%:
 	$(QUIET)docker run \
 		--rm \
-		-v $(WALLAROO_UP_PATH):/v \
+		-v $(WALLAROO_UP_PATH)/..:/v \
 		-w /v \
-		$(subst -,:,$*) \
-		sh -c '(echo y | /v/wallaroo-up.sh -t all || (tail -n 100 /v/wallaroo-up.log && exit 1)) && ~/wallaroo-tutorial/wallaroo*/misc/example-tester.bash python && ~/wallaroo-tutorial/wallaroo*/misc/example-tester.bash go' && docker rmi $(subst -,:,$*)
+		--name wally-tester \
+		$(subst -,:,$*) sh -c \
+		'(export CUSTOM_WALLAROO_SOURCE_TGZ_URL=$(CUSTOM_WALLAROO_SOURCE_TGZ_URL) && export CUSTOM_WALLAROO_METRICS_UI_APPIMAGE_URL=$(CUSTOM_WALLAROO_METRICS_UI_APPIMAGE_URL) && echo y | /v/misc/wallaroo-up.sh -t all || (tail -n 100 wallaroo-up.log && exit 1)) && ~/wallaroo-tutorial/wallaroo*/misc/example-tester.bash python && ~/wallaroo-tutorial/wallaroo*/misc/example-tester.bash go'
+	$(QUIET)docker rmi $(subst -,:,$*)
+
+test-wallaroo-up-vagrant-%:
+	$(QUIET)cd $(WALLAROO_UP_PATH) && vagrant destroy -f
+	$(QUIET)cd $(WALLAROO_UP_PATH) && rm -f Vagrantfile
+	$(QUIET)cd $(WALLAROO_UP_PATH) && vagrant init $(shell echo $* | sed 's#-#/#')
+	$(QUIET)cd $(WALLAROO_UP_PATH) && sed $(WALLAROO_UP_SED_ARGS) -e 's@^end@  config.vm.synced_folder "../", "/v";  config.vm.provider "virtualbox" do |vb|    vb.memory = 4084  end  end@' Vagrantfile
+	$(QUIET)cd $(WALLAROO_UP_PATH) && vagrant up
+	$(QUIET)cd $(WALLAROO_UP_PATH) && vagrant ssh -c \
+		'(export CUSTOM_WALLAROO_SOURCE_TGZ_URL=$(CUSTOM_WALLAROO_SOURCE_TGZ_URL) && export CUSTOM_WALLAROO_METRICS_UI_APPIMAGE_URL=$(CUSTOM_WALLAROO_METRICS_UI_APPIMAGE_URL) && echo y | /v/misc/wallaroo-up.sh -t all || (tail -n 100 wallaroo-up.log && exit 1)) && ~/wallaroo-tutorial/wallaroo*/misc/example-tester.bash python && ~/wallaroo-tutorial/wallaroo*/misc/example-tester.bash go'
+	$(QUIET)cd $(WALLAROO_UP_PATH) && vagrant destroy -f
+	$(QUIET)cd $(WALLAROO_UP_PATH) && rm -f Vagrantfile

--- a/misc/activate
+++ b/misc/activate
@@ -1,5 +1,8 @@
 ## stolen from python virtualenv
-WALLAROO_ROOT="${HOME}/wallaroo-tutorial/wallaroo-release-0.5.2"
+WALLAROO_ACTIVATE="${BASH_SOURCE}"
+HERE=$(dirname "$(readlink -e "${WALLAROO_ACTIVATE}")")
+
+WALLAROO_ROOT="$(readlink -e "${HERE}/..")"
 export WALLAROO_ROOT
 
 export GOROOT=$WALLAROO_ROOT/bin/go1.9.4
@@ -13,6 +16,8 @@ export PYTHONPATH
 export LANG=en_US.UTF-8
 export LANGUAGE=en_US:en
 export LC_ALL=en_US.UTF-8
+
+export RELEASE_MUTABLE_DIR="${WALLAROO_ROOT}/tmp"
 
 # This should detect bash and zsh, which have a hash command that must
 # be called to get it to forget past commands.  Without forgetting

--- a/rules.mk
+++ b/rules.mk
@@ -512,6 +512,172 @@ print-%:
 	$(QUIET)echo '   value = $(value  $*)'
 
 
+# rule to build wallaroo source archive
+.PHONY: build-wallaroo-source-archive
+build-wallaroo-source-archive:
+	$(QUIET)cd $(wallaroo_path) && \
+          tar --transform "flags=r;s|^|wallaroo/|" -czf "wallaroo.tgz" ./*
+
+
+define METRICS_UI_DESKTOP_HEREDOC
+[Desktop Entry]
+Name=Wallaroo Metrics UI
+Icon=metrics_ui
+Type=Application
+NoDisplay=true
+Exec=metrics_reporter_ui
+Terminal=true
+Categories=Development;
+endef
+
+
+define APPRUN_HEREDOC
+#!/bin/sh
+HERE=$$(dirname "$$(readlink -f "$${0}")")
+"$${HERE}"/usr/bin/metrics_reporter_ui $$@
+if [ "$$1" = "start" ]; then
+  sleep 4
+fi
+if [ "$$1" = "stop" ]; then
+  PID_TO_KILL=$$(ps aux | grep '/usr/erts-9.1/bin/epmd' | grep -v grep | awk '{print $$2}')
+  if [ "$$PID_TO_KILL" != "" ]; then
+    kill $$PID_TO_KILL
+  fi
+fi
+endef
+
+
+export APPRUN_HEREDOC
+export METRICS_UI_DESKTOP_HEREDOC
+
+# rule to build metrics_ui appimage
+.PHONY: build-metrics-ui-appimage
+build-metrics-ui-appimage:
+## Build Metrics UI if not already built
+	$(QUIET)cd $(wallaroo_path) && \
+          mkdir -p metrics_ui.AppDir/usr/
+
+	$(QUIET)cd $(wallaroo_path) && \
+	  echo "$$METRICS_UI_DESKTOP_HEREDOC" >> ./metrics_ui.desktop
+
+	$(QUIET)cd $(wallaroo_path) && \
+	  echo "$$APPRUN_HEREDOC" >> ./AppRun
+
+	$(QUIET)cd $(wallaroo_path) && \
+          chmod a+x ./AppRun
+
+	$(QUIET)cd $(wallaroo_path) && \
+          curl https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage -o linuxdeploy-x86_64.AppImage -J -L
+	$(QUIET)cd $(wallaroo_path) && \
+          chmod +x linuxdeploy-x86_64.AppImage
+
+# set up icon/logo for appimage
+	$(QUIET)cd $(wallaroo_path) && \
+          cp .release/metrics_ui_appimage_icon.png metrics_ui.png
+
+# can't run appimages in docker; need to extract and then run
+	$(QUIET)docker run --rm -i -v \
+          $(abs_wallaroo_dir):$(abs_wallaroo_dir) \
+          $(if $(wildcard -v $(HOME)/.gitconfig),-v $(HOME)/.gitconfig:/.gitconfig,) \
+          $(if $(wildcard -v $(HOME)/.gitconfig),-v $(HOME)/.gitconfig:/root/.gitconfig,) \
+          $(if $(wildcard -v $(HOME)/.git-credential-cache),-v $(HOME)/.git-credential-cache:/.git-credential-cache,) \
+          $(if $(wildcard -v $(HOME)/.git-credential-cache),-v $(HOME)/.git-credential-cache:/root/.git-credential-cache,) \
+          -w $(abs_wallaroo_dir) \
+          wallaroolabs/metrics_ui-centos-builder:2018.08.03.1 \
+          sh -c "./linuxdeploy-x86_64.AppImage --appimage-extract"
+
+# need to run in CentOS 7 docker image
+	$(QUIET)docker run --rm -i -v \
+          $(abs_wallaroo_dir):$(abs_wallaroo_dir) \
+          $(if $(wildcard -v $(HOME)/.gitconfig),-v $(HOME)/.gitconfig:/.gitconfig,) \
+          $(if $(wildcard -v $(HOME)/.gitconfig),-v $(HOME)/.gitconfig:/root/.gitconfig,) \
+          $(if $(wildcard -v $(HOME)/.git-credential-cache),-v $(HOME)/.git-credential-cache:/.git-credential-cache,) \
+          $(if $(wildcard -v $(HOME)/.git-credential-cache),-v $(HOME)/.git-credential-cache:/root/.git-credential-cache,) \
+          -w $(abs_wallaroo_dir) \
+          wallaroolabs/metrics_ui-centos-builder:2018.08.03.1 \
+          sh -c "make release-monitoring_hub-apps-metrics_reporter_ui"
+
+# put files into AppDir
+	$(QUIET)docker run --rm -i -v \
+          $(abs_wallaroo_dir):$(abs_wallaroo_dir) \
+          $(if $(wildcard -v $(HOME)/.gitconfig),-v $(HOME)/.gitconfig:/.gitconfig,) \
+          $(if $(wildcard -v $(HOME)/.gitconfig),-v $(HOME)/.gitconfig:/root/.gitconfig,) \
+          $(if $(wildcard -v $(HOME)/.git-credential-cache),-v $(HOME)/.git-credential-cache:/.git-credential-cache,) \
+          $(if $(wildcard -v $(HOME)/.git-credential-cache),-v $(HOME)/.git-credential-cache:/root/.git-credential-cache,) \
+          -w $(abs_wallaroo_dir) \
+          wallaroolabs/metrics_ui-centos-builder:2018.08.03.1 \
+          sh -c "cd metrics_ui.AppDir/usr && tar -xvzf ../../monitoring_hub/apps/metrics_reporter_ui/_build/prod/rel/metrics_reporter_ui/releases/0.0.1/metrics_reporter_ui.tar.gz"
+
+# build appimage
+	$(QUIET)docker run --rm -i -v \
+          $(abs_wallaroo_dir):$(abs_wallaroo_dir) \
+          $(if $(wildcard -v $(HOME)/.gitconfig),-v $(HOME)/.gitconfig:/.gitconfig,) \
+          $(if $(wildcard -v $(HOME)/.gitconfig),-v $(HOME)/.gitconfig:/root/.gitconfig,) \
+          $(if $(wildcard -v $(HOME)/.git-credential-cache),-v $(HOME)/.git-credential-cache:/.git-credential-cache,) \
+          $(if $(wildcard -v $(HOME)/.git-credential-cache),-v $(HOME)/.git-credential-cache:/root/.git-credential-cache,) \
+          -w $(abs_wallaroo_dir) \
+          wallaroolabs/metrics_ui-centos-builder:2018.08.03.1 \
+          sh -c "ARCH=x86_64 ./squashfs-root/AppRun --appdir metrics_ui.AppDir --custom-apprun=AppRun --desktop-file=metrics_ui.desktop --icon-file=metrics_ui.png -l /usr/lib64/libtinfo.so.5"
+
+## temporary hack; remove once linuxdeploy works correctly
+	$(QUIET)docker run --rm -i -v \
+          $(abs_wallaroo_dir):$(abs_wallaroo_dir) \
+          $(if $(wildcard -v $(HOME)/.gitconfig),-v $(HOME)/.gitconfig:/.gitconfig,) \
+          $(if $(wildcard -v $(HOME)/.gitconfig),-v $(HOME)/.gitconfig:/root/.gitconfig,) \
+          $(if $(wildcard -v $(HOME)/.git-credential-cache),-v $(HOME)/.git-credential-cache:/.git-credential-cache,) \
+          $(if $(wildcard -v $(HOME)/.git-credential-cache),-v $(HOME)/.git-credential-cache:/root/.git-credential-cache,) \
+          -w $(abs_wallaroo_dir) \
+          wallaroolabs/metrics_ui-centos-builder:2018.08.03.1 \
+          sh -c "yum install patchelf -y && patchelf --set-rpath '\$$ORIGIN/../../lib' metrics_ui.AppDir/usr/erts-9.1/bin/beam.smp"
+
+## temporary hack; remove once linuxdeploy works correctly
+	$(QUIET)docker run --rm -i -v \
+          $(abs_wallaroo_dir):$(abs_wallaroo_dir) \
+          $(if $(wildcard -v $(HOME)/.gitconfig),-v $(HOME)/.gitconfig:/.gitconfig,) \
+          $(if $(wildcard -v $(HOME)/.gitconfig),-v $(HOME)/.gitconfig:/root/.gitconfig,) \
+          $(if $(wildcard -v $(HOME)/.git-credential-cache),-v $(HOME)/.git-credential-cache:/.git-credential-cache,) \
+          $(if $(wildcard -v $(HOME)/.git-credential-cache),-v $(HOME)/.git-credential-cache:/root/.git-credential-cache,) \
+          -w $(abs_wallaroo_dir) \
+          wallaroolabs/metrics_ui-centos-builder:2018.08.03.1 \
+          sh -c "mv metrics_ui.AppDir/usr/lib/libcrypto.so.10 metrics_ui.AppDir/usr/lib/crypto-4.1/priv/lib/"
+
+	$(QUIET)docker run --rm -i -v \
+          $(abs_wallaroo_dir):$(abs_wallaroo_dir) \
+          $(if $(wildcard -v $(HOME)/.gitconfig),-v $(HOME)/.gitconfig:/.gitconfig,) \
+          $(if $(wildcard -v $(HOME)/.gitconfig),-v $(HOME)/.gitconfig:/root/.gitconfig,) \
+          $(if $(wildcard -v $(HOME)/.git-credential-cache),-v $(HOME)/.git-credential-cache:/.git-credential-cache,) \
+          $(if $(wildcard -v $(HOME)/.git-credential-cache),-v $(HOME)/.git-credential-cache:/root/.git-credential-cache,) \
+          -w $(abs_wallaroo_dir) \
+          wallaroolabs/metrics_ui-centos-builder:2018.08.03.1 \
+          sh -c "ARCH=x86_64 ./squashfs-root/AppRun --appdir metrics_ui.AppDir --custom-apprun=AppRun --desktop-file=metrics_ui.desktop --icon-file=metrics_ui.png --output appimage"
+
+	$(QUIET)cd $(wallaroo_path) && \
+          rm linuxdeploy-x86_64.AppImage
+	$(QUIET)docker run --rm -i -v \
+          $(abs_wallaroo_dir):$(abs_wallaroo_dir) \
+          $(if $(wildcard -v $(HOME)/.gitconfig),-v $(HOME)/.gitconfig:/.gitconfig,) \
+          $(if $(wildcard -v $(HOME)/.gitconfig),-v $(HOME)/.gitconfig:/root/.gitconfig,) \
+          $(if $(wildcard -v $(HOME)/.git-credential-cache),-v $(HOME)/.git-credential-cache:/.git-credential-cache,) \
+          $(if $(wildcard -v $(HOME)/.git-credential-cache),-v $(HOME)/.git-credential-cache:/root/.git-credential-cache,) \
+          -w $(abs_wallaroo_dir) \
+          wallaroolabs/metrics_ui-centos-builder:2018.08.03.1 \
+          sh -c "rm -rf squashfs-root"
+	$(QUIET)docker run --rm -i -v \
+          $(abs_wallaroo_dir):$(abs_wallaroo_dir) \
+          $(if $(wildcard -v $(HOME)/.gitconfig),-v $(HOME)/.gitconfig:/.gitconfig,) \
+          $(if $(wildcard -v $(HOME)/.gitconfig),-v $(HOME)/.gitconfig:/root/.gitconfig,) \
+          $(if $(wildcard -v $(HOME)/.git-credential-cache),-v $(HOME)/.git-credential-cache:/.git-credential-cache,) \
+          $(if $(wildcard -v $(HOME)/.git-credential-cache),-v $(HOME)/.git-credential-cache:/root/.git-credential-cache,) \
+          -w $(abs_wallaroo_dir) \
+          wallaroolabs/metrics_ui-centos-builder:2018.08.03.1 \
+          sh -c "rm -rf metrics_ui.AppDir"
+	$(QUIET)cd $(wallaroo_path) && \
+          rm AppRun
+	$(QUIET)cd $(wallaroo_path) && \
+          rm metrics_ui.desktop
+	$(QUIET)cd $(wallaroo_path) && \
+          rm metrics_ui.png
+
 # rule to confirm we are building for a real docker architecture we support
 docker-arch-check:
 	$(if $(filter $(arch),native),$(error Arch cannot be 'native' \


### PR DESCRIPTION
* Add make commands for wallaroo source tgz and metrics appimage
  to make testing of wallaroo-up easier.
* Add changelog entries for release
* Fix book wallaroo source url issue (resolves #2360)
* Fix book apt-key issue for ubuntu bionic (resolves #2366)
* Switch from wget to curl for vagrant setup due to no wget on OSX
  (resolves #2367)
* Fix phrasing based on item 2 from issue #2365
* enhancements to the example-tester script
* enhancements to wallaroo-up to add support for oracle linux 7 and
  amazon linux 2
* enhancements to wallaroo-up to make it easier to test
* Fix metrics ui appimage issue on fedora 28 (resolves #2364)