### PR TITLE
Add Issue and PR github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+<!--
+Before submitting an issue, please make sure the issue hasn't already been reported.
+-->
+
+### Is this a bug, feature request, or feedback?
+
+### What is the current behavior?
+
+### What is the expected behavior?
+
+### What OS and version of Wallaroo are you using? If you have a stacktrace and/or steps to reproduce the issue, that also helps a lot.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,3 @@
-<!--
-Before submitting an issue, please make sure the issue hasn't already been reported.
--->
-
 ### Is this a bug, feature request, or feedback?
 
 ### What is the current behavior?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+Make sure you've read the [Contributors Guide](https://github.com/WallarooLabs/wallaroo/blob/master/CONTRIBUTING.md). You'll need to sign our CLA before your issue can be accepted.
+
+<!--
+Reference the issue your code change relates to if possible
+-->
+ref #
+
+<!--
+Include any other necessary information below. If you have any questions don't hesitate to reach out on the mailing list or on IRC.
+-->


### PR DESCRIPTION
Closes #2342 

The idea here is to make it easier for contributors to add issues or PRs without maintainers needing to comment on an issue for something like "Can you include a stacktrace?" or "Which operating system are you using?"