### PR TITLE
Add missing .cstring() to @printf() format

### DIFF
--- a/lib/wallaroo/ent/barrier/barrier_handler.pony
+++ b/lib/wallaroo/ent/barrier/barrier_handler.pony
@@ -248,7 +248,7 @@ class InProgressSecondaryBarrierHandler is BarrierHandler
     if not _sinks.contains(s) then Fail() end
 
     _acked_sinks.set(s)
-    @printf[I32]("!@ InProgressSecondaryBarrierHandler: Ack received.")
+    @printf[I32]("!@ InProgressSecondaryBarrierHandler: Ack received.".cstring())
 
     check_for_completion()
 


### PR DESCRIPTION
This is the only `printf()` with a bad format string that I've noticed from the recent `sept-2018-prerelease` branch merge.

[skip-ci]
[ci-skip]
