### PR TITLE
Fix makefiles

### DIFF
--- a/testing/correctness/tests/autoscale_tests/Makefile
+++ b/testing/correctness/tests/autoscale_tests/Makefile
@@ -38,14 +38,14 @@ autoscale_tests : CUSTOM_PATH = :$(EXTERNAL_SENDER_PATH):$(TESTING_ALPHABET_PATH
 autoscale_tests : CUSTOM_PYTHONPATH = :$(TESTING_ALPHABET_PYTHON_PATH):$(TESTING_ALPHABET_PYTHON27_PATH)
 
 build-testing-correctness-tests-autoscale_tests: build-testing-correctness-apps-alphabet
+# standard rules generation makefile
+include $(rules_mk_path)
+
 build-testing-correctness-tests-autoscale_tests: build-machida
 build-testing-correctness-tests-autoscale_tests: build-testing-tools-external_sender
 build-testing-correctness-tests-autoscale_tests: build-utils-cluster_shrinker
 # integration-tests-testing-correctness-tests-autoscale_tests: build-testing-correctness-tests-autoscale_tests
 # integration-tests-testing-correctness-tests-autoscale_tests: autoscale_tests
-
-# standard rules generation makefile
-include $(rules_mk_path)
 
 ifeq ($(autoscale),on)
 autoscale_tests:

--- a/testing/correctness/tests/resilience/Makefile
+++ b/testing/correctness/tests/resilience/Makefile
@@ -36,14 +36,13 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := false
 RESILIENCE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 resilience_tests : CUSTOM_PATH = $(MULTI_PARTITION_DETECTOR_PATH):$(MULTI_PART_VALIDATOR_PATH):$(CLUSTER_SHRINKER_PATH)
 
-build-testing-correctness-tests-resilience: build-testing-correctness-apps-multi_partition_detector
-build-testing-correctness-tests-resilience: build-utils-cluster_shrinker
-build-testing-correctness-tests-resilience: build-testing-tools-external_sender
-integration-tests-testing-correctness-tests-resilience: build-testing-correctness-tests-resilience
-integration-tests-testing-correctness-tests-resilience: resilience_tests
-
 # standard rules generation makefile
 include $(rules_mk_path)
+
+build-testing-correctness-tests-resilience: build-testing-correctness-apps-multi_partition_detector
+build-testing-correctness-tests-resilience: build-utils-cluster_shrinker
+integration-tests-testing-correctness-tests-resilience: build-testing-correctness-tests-resilience
+integration-tests-testing-correctness-tests-resilience: resilience_tests
 
 ifeq ($(resilience),on)
 resilience_tests:

--- a/testing/correctness/tests/restart_without_resilience/Makefile
+++ b/testing/correctness/tests/restart_without_resilience/Makefile
@@ -37,16 +37,17 @@ RESTART_WITHOUT_RESILIENCE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST)))
 restart_without_resilience_tests : CUSTOM_PATH = $(SEQUENCE_WINDOW_PATH):$(VALIDATOR_PATH):$(EXTERNAL_SENDER_PATH)
 restart_without_resilience_tests : CUSTOM_PYTHONPATH = $(SEQUENCE_WINDOW_PYTHON_PATH)
 
+# standard rules generation makefile
+include $(rules_mk_path)
+
+ifeq ($(resilience),on)
+
 build-testing-correctness-tests-restart_without_resilience: build-testing-correctness-apps-sequence_window
 build-testing-correctness-tests-restart_without_resilience: build-testing-tools-external_sender
 build-testing-correctness-tests-restart_without_resilience: build-machida
 integration-tests-testing-correctness-tests-restart_without_resilience: build-testing-correctness-tests-restart_without_resilience
 integration-tests-testing-correctness-tests-restart_without_resilience: restart_without_resilience_tests
 
-# standard rules generation makefile
-include $(rules_mk_path)
-
-ifeq ($(resilience),on)
 restart_without_resilience_tests:
 	$(QUIET)printf "restart_without_resilience_tests not run.\nRun make with 'resilience=off' to run this test.\n"
 else


### PR DESCRIPTION
Fix makefile issues causing dependencies to not be available during tests.

Namely, `CUSTOM_PATH` and `CUSTOM_PYTHONPATH` need to be defined _before_ 
```
# standard rules generation makefile
include $(rules_mk_path)
```

And any `build-`, `clean-`, `integration-tests-` and `unit-tests-` command need to be defined _after_ it.