### PR TITLE
Ci artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,14 +20,22 @@ jobs:
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
-      - run: make integration-tests debug=true
+      - run: |
+          ulimit -c unlimited
+          make integration-tests debug=true
+      - store_artifacts:
+          path: /tmp/wallaroo_test_errors
   integration-tests-with-resilience:
     docker:
       - image: wallaroolabs/wallaroo-ci:2018.08.13.1
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
-      - run: make integration-tests-testing-correctness-tests-all resilience=on debug=true
+      - run: |
+          ulimit -c unlimited
+          make integration-tests-testing-correctness-tests-all resilience=on debug=true
+      - store_artifacts:
+          path: /tmp/wallaroo_test_errors
   unit-tests:
     docker:
       - image: wallaroolabs/wallaroo-ci:2018.08.13.1

--- a/lib/wallaroo/core/boundary/boundary.pony
+++ b/lib/wallaroo/core/boundary/boundary.pony
@@ -152,7 +152,11 @@ actor OutgoingBoundary is Consumer
   var _host: String
   var _service: String
   let _from: String
+  // Queuing all messages in case we need to resend them
   let _queue: Array[Array[ByteSeq] val] = _queue.create()
+  // Queuing messages we haven't sent yet (these will also be queued in _queue,
+  // so _unsent is a subset of _queue).
+  let _unsent: Array[Array[ByteSeq] val] = _unsent.create()
   var _lowest_queue_id: SeqId = 0
   // TODO: this should go away and TerminusRoute entirely takes
   // over seq_id generation whether there is resilience or not.
@@ -320,6 +324,7 @@ actor OutgoingBoundary is Consumer
 
   // TODO: open question: how do we reconnect if our external system goes away?
   be forward(delivery_msg: ReplayableDeliveryMsg, pipeline_time_spent: U64,
+    i_producer_id: RoutingId,
     i_producer: Producer, i_seq_id: SeqId, i_route_id: RouteId, latest_ts: U64,
     metrics_id: U16, worker_ingress_ts: U64)
   =>
@@ -349,6 +354,7 @@ actor OutgoingBoundary is Consumer
       _seq_id = _seq_id + 1
 
       let outgoing_msg = ChannelMsgEncoder.data_channel(delivery_msg,
+        i_producer_id,
         pipeline_time_spent + (Time.nanos() - worker_ingress_ts),
         _seq_id, _wb, _auth, WallClock.nanoseconds(),
         new_metrics_id, metric_name)?
@@ -356,6 +362,8 @@ actor OutgoingBoundary is Consumer
 
       if _connection_initialized then
         _writev(outgoing_msg)
+      else
+        _unsent.push(outgoing_msg)
       end
 
       let end_ts = Time.nanos()
@@ -406,6 +414,10 @@ actor OutgoingBoundary is Consumer
     end
     _connection_initialized = true
     _replaying = false
+    for msg in _unsent.values() do
+      _writev(msg)
+    end
+    _unsent.clear()
     _maybe_mute_or_unmute_upstreams()
 
   fun ref _replay_from(idx: SeqId) =>
@@ -421,7 +433,9 @@ actor OutgoingBoundary is Consumer
         end
         cur_id = cur_id + 1
       end
-      _writev(ChannelMsgEncoder.replay_complete(_worker_name, _step_id, _auth)?)
+      _unsent.clear()
+      _writev(ChannelMsgEncoder.replay_complete(_worker_name, _step_id,
+        _auth)?)
     else
       Fail()
     end
@@ -525,6 +539,7 @@ actor OutgoingBoundary is Consumer
     match barrier_token
     | let srt: CheckpointRollbackBarrierToken =>
       _queue.clear()
+      _unsent.clear()
     end
 
     try
@@ -536,6 +551,8 @@ actor OutgoingBoundary is Consumer
         origin_step_id, barrier_token, _seq_id, _auth)?
       if _connection_initialized then
         _writev(msg)
+      else
+        _unsent.push(msg)
       end
       _add_to_upstream_backup(msg)
     else
@@ -566,6 +583,7 @@ actor OutgoingBoundary is Consumer
   be prepare_for_rollback() =>
     _lowest_queue_id = _lowest_queue_id + _queue.size().u64()
     _queue.clear()
+    _unsent.clear()
 
   be rollback(payload: ByteSeq val, event_log: EventLog,
     checkpoint_id: CheckpointId)

--- a/lib/wallaroo/core/common/step_message_processor.pony
+++ b/lib/wallaroo/core/common/step_message_processor.pony
@@ -105,6 +105,7 @@ class BarrierStepMessageProcessor is StepMessageProcessor
         i_route_id, latest_ts, metrics_id, worker_ingress_ts)
       _queued.push(msg)
     else
+      @printf[I32]("!@ Input not blocking so processing waiting for barrier\n".cstring())
       step.process_message[D](metric_name, pipeline_time_spent, data,
         i_producer_id, i_producer, msg_uid, frac_ids, i_seq_id, i_route_id,
         latest_ts, metrics_id, worker_ingress_ts)

--- a/lib/wallaroo/core/data_channel/data_channel_tcp.pony
+++ b/lib/wallaroo/core/data_channel/data_channel_tcp.pony
@@ -310,7 +310,7 @@ class _DataReceiver is _DataReceiverWrapper
       _metrics_reporter.step_metric(data_msg.metric_name,
         "Before receive on data channel (network time)", data_msg.metrics_id,
         data_msg.latest_ts, ingest_ts)
-      _data_receiver.received(data_msg.delivery_msg,
+      _data_receiver.received(data_msg.delivery_msg, data_msg.producer_id,
           data_msg.pipeline_time_spent + (ingest_ts - data_msg.latest_ts),
           data_msg.seq_id, my_latest_ts, data_msg.metrics_id + 1,
           my_latest_ts)

--- a/lib/wallaroo/core/messages/channel_messages.pony
+++ b/lib/wallaroo/core/messages/channel_messages.pony
@@ -46,11 +46,12 @@ primitive ChannelMsgEncoder
     wb.done()
 
   fun data_channel(delivery_msg: ReplayableDeliveryMsg,
-    pipeline_time_spent: U64, seq_id: SeqId, wb: Writer, auth: AmbientAuth,
+    producer_id: RoutingId, pipeline_time_spent: U64, seq_id: SeqId,
+    wb: Writer, auth: AmbientAuth,
     latest_ts: U64, metrics_id: U16, metric_name: String): Array[ByteSeq] val ?
   =>
-    _encode(DataMsg(delivery_msg, pipeline_time_spent, seq_id, latest_ts,
-      metrics_id, metric_name), auth, wb)?
+    _encode(DataMsg(delivery_msg, producer_id, pipeline_time_spent, seq_id,
+      latest_ts, metrics_id, metric_name), auth, wb)?
 
   fun migrate_key(state_name: String, key: Key, checkpoint_id: CheckpointId,
     state: ByteSeq val, worker: String, auth: AmbientAuth):
@@ -832,22 +833,24 @@ class val AckDataReceivedMsg is ChannelMsg
 
 class val DataMsg is ChannelMsg
   let pipeline_time_spent: U64
+  let producer_id: RoutingId
   let seq_id: SeqId
   let delivery_msg: ReplayableDeliveryMsg
   let latest_ts: U64
   let metrics_id: U16
   let metric_name: String
 
-  new val create(msg: ReplayableDeliveryMsg, pipeline_time_spent': U64,
-    seq_id': SeqId, latest_ts': U64, metrics_id': U16, metric_name': String)
+  new val create(msg: ReplayableDeliveryMsg, producer_id': RoutingId,
+    pipeline_time_spent': U64, seq_id': SeqId, latest_ts': U64,
+    metrics_id': U16, metric_name': String)
   =>
+    producer_id = producer_id'
     seq_id = seq_id'
     pipeline_time_spent = pipeline_time_spent'
     delivery_msg = msg
     latest_ts = latest_ts'
     metrics_id = metrics_id'
     metric_name = metric_name'
-
 
 class val ReplayMsg is ChannelMsg
   let data_bytes: Array[ByteSeq] val

--- a/lib/wallaroo/core/routing/boundary_route.pony
+++ b/lib/wallaroo/core/routing/boundary_route.pony
@@ -72,9 +72,9 @@ class BoundaryRoute is Route
     Fail()
 
   fun ref forward(delivery_msg: ReplayableDeliveryMsg,
-    pipeline_time_spent: U64, cfp: Producer ref,
-    latest_ts: U64, metrics_id: U16,
-    metric_name: String, worker_ingress_ts: U64)
+    pipeline_time_spent: U64, producer_id: RoutingId, cfp: Producer ref,
+    latest_ts: U64, metrics_id: U16, metric_name: String,
+    worker_ingress_ts: U64)
   =>
     ifdef debug then
       match _step
@@ -88,6 +88,7 @@ class BoundaryRoute is Route
     end
     _send_message_on_route(delivery_msg,
       pipeline_time_spent,
+      producer_id,
       cfp,
       latest_ts,
       metrics_id,
@@ -101,7 +102,7 @@ class BoundaryRoute is Route
     _consumer.forward_unregister_producer(_step_id, target_id, _step)
 
   fun ref _send_message_on_route(delivery_msg: ReplayableDeliveryMsg,
-    pipeline_time_spent: U64, cfp: Producer ref,
+    pipeline_time_spent: U64, producer_id: RoutingId, cfp: Producer ref,
     latest_ts: U64, metrics_id: U16, metric_name: String,
     worker_ingress_ts: U64)
   =>
@@ -109,6 +110,7 @@ class BoundaryRoute is Route
 
     _consumer.forward(delivery_msg,
       pipeline_time_spent,
+      producer_id,
       cfp,
       o_seq_id,
       _route_id,

--- a/lib/wallaroo/core/routing/direct_route.pony
+++ b/lib/wallaroo/core/routing/direct_route.pony
@@ -75,7 +75,7 @@ class DirectRoute is Route
       cfp, msg_uid, frac_ids, latest_ts, metrics_id, worker_ingress_ts)
 
   fun ref forward(delivery_msg: ReplayableDeliveryMsg,
-    pipeline_time_spent: U64, cfp: Producer ref,
+    pipeline_time_spent: U64, producer_id: RoutingId, cfp: Producer ref,
     latest_ts: U64, metrics_id: U16, metric_name: String,
     worker_ingress_ts: U64)
   =>

--- a/lib/wallaroo/core/routing/route.pony
+++ b/lib/wallaroo/core/routing/route.pony
@@ -37,9 +37,9 @@ trait Route
     worker_ingress_ts: U64)
 
   fun ref forward(delivery_msg: ReplayableDeliveryMsg,
-    pipeline_time_spent: U64, cfp: Producer ref,
-    latest_ts: U64, metrics_id: U16,
-    metric_name: String, worker_ingress_ts: U64)
+    pipeline_time_spent: U64, producer_id: RoutingId, cfp: Producer ref,
+    latest_ts: U64, metrics_id: U16, metric_name: String,
+    worker_ingress_ts: U64)
 
   fun register_producer(target_id: RoutingId)
   fun unregister_producer(target_id: RoutingId)
@@ -108,9 +108,9 @@ class EmptyRoute is Route
     true
 
   fun ref forward(delivery_msg: ReplayableDeliveryMsg,
-    pipeline_time_spent: U64, cfp: Producer ref,
-    latest_ts: U64, metrics_id: U16,
-    metric_name: String, worker_ingress_ts: U64)
+    pipeline_time_spent: U64, producer_id: RoutingId, cfp: Producer ref,
+    latest_ts: U64, metrics_id: U16, metric_name: String,
+    worker_ingress_ts: U64)
   =>
     Fail()
     true

--- a/lib/wallaroo/core/source/barrier_source/barrier_source.pony
+++ b/lib/wallaroo/core/source/barrier_source/barrier_source.pony
@@ -243,10 +243,10 @@ actor BarrierSource is Source
   be disconnect_boundary(worker: WorkerName) =>
     None
 
-  be mute(c: Consumer) =>
+  be mute(a: Any tag) =>
     None
 
-  be unmute(c: Consumer) =>
+  be unmute(a: Any tag) =>
     None
 
   be initiate_barrier(token: BarrierToken) =>

--- a/lib/wallaroo/core/source/connector_source/connector_source.pony
+++ b/lib/wallaroo/core/source/connector_source/connector_source.pony
@@ -823,12 +823,12 @@ actor ConnectorSource is Source
       _unmute()
     end
 
-  be mute(c: Consumer) =>
-    _muted_downstream.set(c)
+  be mute(a: Any tag) =>
+    _muted_downstream.set(a)
     _mute()
 
-  be unmute(c: Consumer) =>
-    _muted_downstream.unset(c)
+  be unmute(a: Any tag) =>
+    _muted_downstream.unset(a)
 
     if _muted_downstream.size() == 0 then
       _unmute()

--- a/lib/wallaroo/core/source/connector_source/connector_source_listener.pony
+++ b/lib/wallaroo/core/source/connector_source/connector_source_listener.pony
@@ -111,6 +111,9 @@ actor ConnectorSourceListener is SourceListener
       + host + ":" + service + "\n").cstring())
     _notify_listening()
 
+  be recovery_protocol_complete() =>
+    None
+
   be update_router(router: Router) =>
     _source_builder = _source_builder.update_router(router)
     _router = router

--- a/lib/wallaroo/core/source/gen_source/gen_source.pony
+++ b/lib/wallaroo/core/source/gen_source/gen_source.pony
@@ -90,7 +90,7 @@ actor GenSource[V: Any val] is Source
   // Start muted. Wait for unmute to begin processing
   var _muted: Bool = true
   var _disposed: Bool = false
-  let _muted_downstream: SetIs[Any tag] = _muted_downstream.create()
+  let _muted_by: SetIs[Any tag] = _muted_by.create()
 
   var _is_pending: Bool = true
 
@@ -591,24 +591,24 @@ actor GenSource[V: Any val] is Source
     end
 
   fun ref _mute_local() =>
-    _muted_downstream.set(this)
+    _muted_by.set(this)
     _mute()
 
   fun ref _unmute_local() =>
-    _muted_downstream.unset(this)
+    _muted_by.unset(this)
 
-    if _muted_downstream.size() == 0 then
+    if _muted_by.size() == 0 then
       _unmute()
     end
 
-  be mute(c: Consumer) =>
-    _muted_downstream.set(c)
+  be mute(a: Any tag) =>
+    _muted_by.set(a)
     _mute()
 
-  be unmute(c: Consumer) =>
-    _muted_downstream.unset(c)
+  be unmute(a: Any tag) =>
+    _muted_by.unset(a)
 
-    if _muted_downstream.size() == 0 then
+    if _muted_by.size() == 0 then
       _unmute()
     end
 

--- a/lib/wallaroo/core/source/gen_source/gen_source.pony
+++ b/lib/wallaroo/core/source/gen_source/gen_source.pony
@@ -1,0 +1,616 @@
+/*
+
+Copyright (C) 2016-2017, Wallaroo Labs
+Copyright (C) 2016-2017, The Pony Developers
+Copyright (c) 2014-2015, Causality Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+use "buffered"
+use "collections"
+use "net"
+use "promises"
+use "serialise"
+use "time"
+use "wallaroo/core/boundary"
+use "wallaroo/core/common"
+use "wallaroo/core/initialization"
+use "wallaroo/core/invariant"
+use "wallaroo/core/metrics"
+use "wallaroo/core/routing"
+use "wallaroo/core/source"
+use "wallaroo/core/topology"
+use "wallaroo/ent/barrier"
+use "wallaroo/ent/data_receiver"
+use "wallaroo/ent/recovery"
+use "wallaroo/ent/router_registry"
+use "wallaroo/ent/checkpoint"
+use "wallaroo_labs/mort"
+
+use @pony_asio_event_create[AsioEventID](owner: AsioEventNotify, fd: U32,
+  flags: U32, nsec: U64, noisy: Bool)
+use @pony_asio_event_fd[U32](event: AsioEventID)
+use @pony_asio_event_unsubscribe[None](event: AsioEventID)
+use @pony_asio_event_resubscribe_read[None](event: AsioEventID)
+use @pony_asio_event_resubscribe_write[None](event: AsioEventID)
+use @pony_asio_event_destroy[None](event: AsioEventID)
+
+interface val GenSourceGenerator[V: Any val]
+  fun initial_value(): V
+  fun apply(v: V): V
+
+actor GenSource[V: Any val] is Source
+  """
+  # GenSource
+  """
+  var _cur_value: V
+  let _generator: GenSourceGenerator[V]
+
+  let _source_id: RoutingId
+  let _auth: AmbientAuth
+  let _routing_id_gen: RoutingIdGenerator = RoutingIdGenerator
+  var _router: Router
+  let _target_id_router: TargetIdRouter = EmptyTargetIdRouter
+
+  let _routes: MapIs[Consumer, Route] = _routes.create()
+  // _outputs keeps track of all output targets by step id. There might be
+  // duplicate consumers in this map (unlike _routes) since there might be
+  // multiple target step ids over a boundary
+  let _outputs: Map[RoutingId, Consumer] = _outputs.create()
+  let _outgoing_boundaries: Map[String, OutgoingBoundary] =
+    _outgoing_boundaries.create()
+  let _layout_initializer: LayoutInitializer
+  var _unregistered: Bool = false
+
+  let _metrics_reporter: MetricsReporter
+
+  let _pending_barriers: Array[BarrierToken] = _pending_barriers.create()
+
+  // Start muted. Wait for unmute to begin processing
+  var _muted: Bool = true
+  var _disposed: Bool = false
+  let _muted_downstream: SetIs[Any tag] = _muted_downstream.create()
+
+  var _is_pending: Bool = true
+
+  let _router_registry: RouterRegistry
+
+  let _event_log: EventLog
+
+  // Producer (Resilience)
+  var _seq_id: SeqId = 1 // 0 is reserved for "not seen yet"
+
+  // Checkpoint
+  var _next_checkpoint_id: CheckpointId = 1
+
+  let _pipeline_name: String
+  let _source_name: String
+  let _runner: Runner
+  let _msg_id_gen: MsgIdGenerator = MsgIdGenerator
+
+  new create(source_id: RoutingId, auth: AmbientAuth, pipeline_name: String,
+    runner_builder: RunnerBuilder, router': Router, target_router: Router,
+    generator: GenSourceGenerator[V], event_log: EventLog,
+    outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val,
+    layout_initializer: LayoutInitializer,
+    metrics_reporter: MetricsReporter iso, router_registry: RouterRegistry,
+    pre_state_target_ids: Array[RoutingId] val = recover Array[RoutingId] end)
+  =>
+    @printf[I32]("!@ Spinning up GenSource %s\n".cstring(), source_id.string().cstring())
+    _pipeline_name = pipeline_name
+    _source_name = pipeline_name + " source"
+
+    _cur_value = generator.initial_value()
+    _generator = generator
+
+    _source_id = source_id
+    _auth = auth
+    _event_log = event_log
+    _metrics_reporter = consume metrics_reporter
+
+    _layout_initializer = layout_initializer
+    _router_registry = router_registry
+
+    _runner = runner_builder(event_log, auth, None,
+      target_router, pre_state_target_ids)
+    _router = _runner.clone_router_and_set_input_type(router')
+
+    for (target_worker_name, builder) in outgoing_boundary_builders.pairs() do
+      if not _outgoing_boundaries.contains(target_worker_name) then
+        let new_boundary =
+          builder.build_and_initialize(_routing_id_gen(), target_worker_name,
+            _layout_initializer)
+        router_registry.register_disposable(new_boundary)
+        _outgoing_boundaries(target_worker_name) = new_boundary
+      end
+    end
+
+    _router = router'
+    _update_router(router')
+
+    for r in _routes.values() do
+      // TODO: this is a hack, we shouldn't be calling application events
+      // directly. route lifecycle needs to be broken out better from
+      // application lifecycle
+      r.application_created()
+    end
+
+    for r in _routes.values() do
+      r.application_initialized("GenSource")
+    end
+
+    // register resilient with event log
+    _event_log.register_resilient_source(_source_id, this)
+
+    _mute()
+    ifdef "resilience" then
+      _mute_local()
+    end
+
+  be next_message() =>
+    if not _muted and not _disposed then
+      process_message()
+    end
+
+  fun ref process_message() =>
+    _metrics_reporter.pipeline_ingest(_pipeline_name, _source_name)
+    let ingest_ts = Time.nanos()
+    let pipeline_time_spent: U64 = 0
+    var latest_metrics_id: U16 = 1
+
+    ifdef "trace" then
+      @printf[I32](("Rcvd msg at " + _pipeline_name + " source\n").cstring())
+    end
+
+    let decode_end_ts = Time.nanos()
+    _metrics_reporter.step_metric(_pipeline_name,
+      "Decode Time in TCP Source", latest_metrics_id, ingest_ts,
+      decode_end_ts)
+    latest_metrics_id = latest_metrics_id + 1
+
+    let next = _cur_value
+    _cur_value = _generator(next)
+    (let is_finished, let last_ts) =
+      _runner.run[V](_pipeline_name, pipeline_time_spent, next,
+        _source_id, this, _router, _target_id_router, _msg_id_gen(),
+        None, decode_end_ts, latest_metrics_id, ingest_ts,
+        _metrics_reporter)
+
+    if is_finished then
+      let end_ts = Time.nanos()
+      let time_spent = end_ts - ingest_ts
+
+      ifdef "detailed-metrics" then
+        _metrics_reporter.step_metric(_pipeline_name,
+          "Before end at TCP Source", 9999,
+          last_ts, end_ts)
+      end
+
+      _metrics_reporter.pipeline_metric(_pipeline_name, time_spent +
+        pipeline_time_spent)
+      _metrics_reporter.worker_metric(_pipeline_name, time_spent)
+    end
+    // !@ USE TIMER
+    next_message()
+
+  be first_checkpoint_complete() =>
+    """
+    In case we pop into existence midway through a checkpoint, we need to
+    wait until this is called to start processing.
+    """
+    _unmute_local()
+    _is_pending = false
+    for (id, c) in _outputs.pairs() do
+      try
+        let route = _routes(c)?
+        route.register_producer(id)
+      else
+        Fail()
+      end
+    end
+
+  be update_router(router': Router) =>
+    _update_router(router')
+
+  fun ref _update_router(router': Router) =>
+    let new_router =
+      match router'
+      | let pr: PartitionRouter =>
+        pr.update_boundaries(_auth, _outgoing_boundaries)
+      | let spr: StatelessPartitionRouter =>
+        spr.update_boundaries(_outgoing_boundaries)
+      else
+        router'
+      end
+
+    let old_router = _router
+    _router = new_router
+    for (old_id, outdated_consumer) in
+      old_router.routes_not_in(_router).pairs()
+    do
+      if _outputs.contains(old_id) then
+        _unregister_output(old_id, outdated_consumer)
+      end
+    end
+    for (c_id, consumer) in _router.routes().pairs() do
+      _register_output(c_id, consumer)
+    end
+
+  be remove_route_to_consumer(id: RoutingId, c: Consumer) =>
+    if _outputs.contains(id) then
+      ifdef debug then
+        Invariant(_routes.contains(c))
+      end
+      _unregister_output(id, c)
+    end
+
+  fun ref _register_output(id: RoutingId, c: Consumer) =>
+    if not _disposed then
+      if _outputs.contains(id) then
+        try
+          let old_c = _outputs(id)?
+          if old_c is c then
+            // We already know about this output.
+            return
+          end
+          _unregister_output(id, old_c)
+        else
+          Unreachable()
+        end
+      end
+
+      _outputs(id) = c
+      if not _routes.contains(c) then
+        let new_route = RouteBuilder(_source_id, this, c, _metrics_reporter)
+        _routes(c) = new_route
+        if not _is_pending then
+          new_route.register_producer(id)
+        end
+      else
+        try
+          if not _is_pending then
+            _routes(c)?.register_producer(id)
+          end
+        else
+          Unreachable()
+        end
+      end
+    end
+
+  be register_downstream() =>
+    _reregister_as_producer()
+
+  fun ref _reregister_as_producer() =>
+    if not _disposed then
+      for (id, c) in _outputs.pairs() do
+        match c
+        | let ob: OutgoingBoundary =>
+          if not _is_pending then
+            ob.forward_register_producer(_source_id, id, this)
+          end
+        else
+          if not _is_pending then
+            c.register_producer(_source_id, this)
+          end
+        end
+      end
+    end
+
+  //!@ rename
+  be register_downstreams(promise: Promise[Source]) =>
+    promise(this)
+
+  fun ref _unregister_output(id: RoutingId, c: Consumer) =>
+    try
+      if not _is_pending then
+        _routes(c)?.unregister_producer(id)
+      end
+      _outputs.remove(id)?
+      _remove_route_if_no_output(c)
+    else
+      Fail()
+    end
+
+  fun ref _remove_route_if_no_output(c: Consumer) =>
+    var have_output = false
+    for consumer in _outputs.values() do
+      if consumer is c then have_output = true end
+    end
+    if not have_output then
+      _remove_route(c)
+    end
+
+  fun ref _remove_route(c: Consumer) =>
+    try
+      _routes.remove(c)?._2
+    else
+      Fail()
+    end
+
+  be add_boundary_builders(
+    boundary_builders: Map[String, OutgoingBoundaryBuilder] val)
+  =>
+    """
+    Build a new boundary for each builder that corresponds to a worker we
+    don't yet have a boundary to. Each GenSource has its own
+    OutgoingBoundary to each worker to allow for higher throughput.
+    """
+    for (target_worker_name, builder) in boundary_builders.pairs() do
+      if not _outgoing_boundaries.contains(target_worker_name) then
+        let boundary = builder.build_and_initialize(_routing_id_gen(),
+          target_worker_name, _layout_initializer)
+        _router_registry.register_disposable(boundary)
+        _outgoing_boundaries(target_worker_name) = boundary
+        let new_route = RouteBuilder(_source_id, this, boundary,
+          _metrics_reporter)
+        _routes(boundary) = new_route
+      end
+    end
+
+  be add_boundaries(bs: Map[String, OutgoingBoundary] val) =>
+    //!@ Should we fail here?
+    None
+
+  be remove_boundary(worker: String) =>
+    _remove_boundary(worker)
+
+  fun ref _remove_boundary(worker: String) =>
+    None
+
+  be reconnect_boundary(target_worker_name: String) =>
+    try
+      _outgoing_boundaries(target_worker_name)?.reconnect()
+    else
+      Fail()
+    end
+
+  be disconnect_boundary(worker: WorkerName) =>
+    try
+      _outgoing_boundaries(worker)?.dispose()
+      _outgoing_boundaries.remove(worker)?
+    else
+      ifdef debug then
+        @printf[I32]("GenSource couldn't find boundary to %s to disconnect\n"
+          .cstring(), worker.cstring())
+      end
+    end
+
+  be remove_route_for(step: Consumer) =>
+    try
+      _routes.remove(step)?
+    else
+      Fail()
+    end
+
+  be initialize_seq_id_on_recovery(seq_id: SeqId) =>
+    ifdef "trace" then
+      @printf[I32](("initializing sequence id on recovery: " + seq_id.string() +
+        " in GenSource\n").cstring())
+    end
+    // update to use correct seq_id for recovery
+    _seq_id = seq_id
+
+  fun ref _unregister_all_outputs() =>
+    """
+    This method should only be called if we are removing this source from the
+    active graph (or on dispose())
+    """
+    let outputs_to_remove = Map[RoutingId, Consumer]
+    for (id, consumer) in _outputs.pairs() do
+      outputs_to_remove(id) = consumer
+    end
+    for (id, consumer) in outputs_to_remove.pairs() do
+      _unregister_output(id, consumer)
+    end
+
+  be dispose() =>
+    _dispose()
+
+  fun ref _dispose() =>
+    """
+    - Close the connection gracefully.
+    """
+    if not _disposed then
+      _router_registry.unregister_source(this, _source_id)
+      _event_log.unregister_resilient(_source_id, this)
+      _unregister_all_outputs()
+      @printf[I32]("Shutting down GenSource\n".cstring())
+      for b in _outgoing_boundaries.values() do
+        b.dispose()
+      end
+      _disposed = true
+    end
+
+  fun ref route_to(c: Consumer): (Route | None) =>
+    try
+      _routes(c)?
+    else
+      None
+    end
+
+  fun ref next_sequence_id(): SeqId =>
+    _seq_id = _seq_id + 1
+
+  fun ref current_sequence_id(): SeqId =>
+    _seq_id
+
+  be report_status(code: ReportStatusCode) =>
+    match code
+    | BoundaryCountStatus =>
+      var b_count: USize = 0
+      for r in _routes.values() do
+        match r
+        | let br: BoundaryRoute => b_count = b_count + 1
+        end
+      end
+      @printf[I32]("GenSource %s has %s boundaries.\n".cstring(),
+        _source_id.string().cstring(), b_count.string().cstring())
+    end
+    for route in _routes.values() do
+      route.report_status(code)
+    end
+
+  be update_worker_data_service(worker: WorkerName,
+    host: String, service: String)
+  =>
+    @printf[I32]("SLF: GenSource: update_worker_data_service: %s -> %s %s\n".cstring(), worker.cstring(), host.cstring(), service.cstring())
+    try
+      let b = _outgoing_boundaries(worker)?
+      b.update_worker_data_service(worker, host, service)
+    else
+      Fail()
+    end
+
+  //////////////
+  // BARRIER
+  //////////////
+  be initiate_barrier(token: BarrierToken) =>
+    @printf[I32]("!@ GenSource received initiate_barrier %s\n".cstring(), token.string().cstring())
+    if not _is_pending then
+      _initiate_barrier(token)
+    end
+
+  fun ref _initiate_barrier(token: BarrierToken) =>
+    if not _disposed then
+      match token
+      | let srt: CheckpointRollbackBarrierToken =>
+        _prepare_for_rollback()
+      end
+
+      match token
+      | let sbt: CheckpointBarrierToken =>
+        checkpoint_state(sbt.id)
+      end
+      for (o_id, o) in _outputs.pairs() do
+        match o
+        | let ob: OutgoingBoundary =>
+          ob.forward_barrier(o_id, _source_id, token)
+        else
+          o.receive_barrier(_source_id, this, token)
+        end
+      end
+    end
+
+  be barrier_complete(token: BarrierToken) =>
+    // @printf[I32]("!@ barrier_complete at GenSource %s\n".cstring(), _source_id.string().cstring())
+    None
+
+  //////////////
+  // CHECKPOINTS
+  //////////////
+  fun ref checkpoint_state(checkpoint_id: CheckpointId) =>
+    """
+    GenSources don't currently write out any data as part of the checkpoint.
+    """
+    _next_checkpoint_id = checkpoint_id + 1
+    _event_log.checkpoint_state(_source_id, checkpoint_id, _serialize())
+
+  fun ref _serialize(): Array[ByteSeq] val =>
+    let res = recover iso Array[ByteSeq] end
+    try
+      let bytes = Serialised(SerialiseAuth(_auth), _cur_value)?
+        .output(OutputSerialisedAuth(_auth))
+      res.push(bytes)
+    else
+      Fail()
+    end
+    consume res
+
+  be prepare_for_rollback() =>
+    _prepare_for_rollback()
+
+  fun ref _prepare_for_rollback() =>
+    None
+
+  be rollback(payload: ByteSeq val, event_log: EventLog,
+    checkpoint_id: CheckpointId)
+  =>
+    """
+    There is nothing for a GenSource to rollback to.
+    """
+    _next_checkpoint_id = checkpoint_id + 1
+
+    try
+      _cur_value = _deserialize(payload)?
+    else
+      Fail()
+    end
+
+    event_log.ack_rollback(_source_id)
+
+  fun _deserialize(data: ByteSeq val): V ? =>
+    try
+      match Serialised.input(InputSerialisedAuth(_auth),
+        data as Array[U8] val)(DeserialiseAuth(_auth))?
+      | let v: V => v
+      else
+        error
+      end
+    else
+      error
+    end
+
+  //////////
+  // MUTING
+  //////////
+  fun ref _mute() =>
+    ifdef debug then
+      @printf[I32]("Muting GenSource\n".cstring())
+    end
+    _muted = true
+
+  fun ref _unmute() =>
+    ifdef debug then
+      @printf[I32]("Unmuting GenSource\n".cstring())
+    end
+    let was_muted = _muted
+    _muted = false
+    if was_muted then
+      next_message()
+    end
+
+  fun ref _mute_local() =>
+    _muted_downstream.set(this)
+    _mute()
+
+  fun ref _unmute_local() =>
+    _muted_downstream.unset(this)
+
+    if _muted_downstream.size() == 0 then
+      _unmute()
+    end
+
+  be mute(c: Consumer) =>
+    _muted_downstream.set(c)
+    _mute()
+
+  be unmute(c: Consumer) =>
+    _muted_downstream.unset(c)
+
+    if _muted_downstream.size() == 0 then
+      _unmute()
+    end
+
+  fun ref is_muted(): Bool =>
+    _muted

--- a/lib/wallaroo/core/source/gen_source/gen_source_config.pony
+++ b/lib/wallaroo/core/source/gen_source/gen_source_config.pony
@@ -1,0 +1,35 @@
+/*
+
+Copyright 2017 The Wallaroo Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing
+ permissions and limitations under the License.
+
+*/
+
+use "options"
+use "wallaroo"
+use "wallaroo/core/source"
+
+class val GenSourceConfig[In: Any val]
+  let _gen: GenSourceGenerator[In]
+
+  new val create(gen: GenSourceGenerator[In]) =>
+    _gen = gen
+
+  fun source_listener_builder_builder(): GenSourceListenerBuilderBuilder =>
+    GenSourceListenerBuilderBuilder
+
+  fun source_builder(app_name: String, name: String):
+    TypedGenSourceBuilderBuilder[In]
+  =>
+    TypedGenSourceBuilderBuilder[In](app_name, name, _gen)

--- a/lib/wallaroo/core/source/gen_source/gen_source_listener.pony
+++ b/lib/wallaroo/core/source/gen_source/gen_source_listener.pony
@@ -1,0 +1,175 @@
+
+/*
+
+Copyright (C) 2016-2017, Wallaroo Labs
+Copyright (C) 2016-2017, The Pony Developers
+Copyright (c) 2014-2015, Causality Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+use "buffered"
+use "collections"
+use "crypto"
+use "wallaroo/core/boundary"
+use "wallaroo/core/common"
+use "wallaroo/ent/data_receiver"
+use "wallaroo/ent/recovery"
+use "wallaroo/ent/router_registry"
+use "wallaroo_labs/mort"
+use "wallaroo/core/initialization"
+use "wallaroo/core/metrics"
+use "wallaroo/core/routing"
+use "wallaroo/core/sink/tcp_sink"
+use "wallaroo/core/source"
+use "wallaroo/core/topology"
+
+interface _Sourcey
+  fun ref source(layout_initializer: LayoutInitializer,
+    router_registry: RouterRegistry,
+    outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val):
+    Source
+
+actor GenSourceListener is SourceListener
+  """
+  # GenSourceListener
+  """
+  let _routing_id_gen: RoutingIdGenerator = RoutingIdGenerator
+  let _env: Env
+  let _auth: AmbientAuth
+  let _pipeline_name: String
+  var _router: Router
+  let _router_registry: RouterRegistry
+  var _outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val
+  let _layout_initializer: LayoutInitializer
+  let _metrics_reporter: MetricsReporter
+  var _source_builder: SourceBuilder
+  let _event_log: EventLog
+  let _target_router: Router
+
+  new create(env: Env, source_builder: SourceBuilder, router: Router,
+    router_registry: RouterRegistry,
+    outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val,
+    event_log: EventLog, auth: AmbientAuth, pipeline_name: String,
+    layout_initializer: LayoutInitializer,
+    metrics_reporter: MetricsReporter iso,
+    target_router: Router = EmptyRouter)
+  =>
+    _env = env
+    _auth = auth
+    _pipeline_name = pipeline_name
+    _router = router
+    _router_registry = router_registry
+    _outgoing_boundary_builders = outgoing_boundary_builders
+    _layout_initializer = layout_initializer
+    _metrics_reporter = consume metrics_reporter
+    _source_builder = source_builder
+    _event_log = event_log
+    _target_router = target_router
+
+    match router
+    | let pr: PartitionRouter =>
+      _router_registry.register_partition_router_subscriber(pr.state_name(),
+        this)
+    | let spr: StatelessPartitionRouter =>
+      _router_registry.register_stateless_partition_router_subscriber(
+        spr.partition_id(), this)
+    end
+
+    _create_source()
+
+  fun ref _create_source() =>
+    let name = _pipeline_name + " source"
+    let temp_id = MD5(name)
+    let rb = Reader
+    rb.append(temp_id)
+
+    let source_id = try rb.u128_le()? else Fail(); 0 end
+
+    let notify = _source_builder(source_id, _event_log, _auth,
+      _target_router, _env)
+
+    match consume notify
+    | let gsn: _Sourcey =>
+      let s = gsn.source(_layout_initializer, _router_registry,
+        _outgoing_boundary_builders)
+      match s
+      | let source: (Source & RouterUpdatable) =>
+        _router_registry.register_source(source, source_id)
+        match _router
+        | let pr: PartitionRouter =>
+          _router_registry.register_partition_router_subscriber(
+            pr.state_name(), source)
+        | let spr: StatelessPartitionRouter =>
+          _router_registry.register_stateless_partition_router_subscriber(
+            spr.partition_id(), source)
+        end
+      else
+        Fail()
+      end
+    else
+      Fail()
+    end
+
+  be update_router(router: Router) =>
+    _source_builder = _source_builder.update_router(router)
+    _router = router
+
+  be remove_route_for(moving_step: Consumer) =>
+    None
+
+  be add_boundary_builders(
+    boundary_builders: Map[String, OutgoingBoundaryBuilder] val)
+  =>
+    let new_builders = recover trn Map[String, OutgoingBoundaryBuilder] end
+    // TODO: A persistent map on the field would be much more efficient here
+    for (target_worker_name, builder) in _outgoing_boundary_builders.pairs() do
+      new_builders(target_worker_name) = builder
+    end
+    for (target_worker_name, builder) in boundary_builders.pairs() do
+      if not new_builders.contains(target_worker_name) then
+        new_builders(target_worker_name) = builder
+      end
+    end
+    _outgoing_boundary_builders = consume new_builders
+
+  be add_boundaries(bs: Map[String, OutgoingBoundary] val) =>
+    //!@ Should we fail here?
+    None
+
+  be update_boundary_builders(
+    boundary_builders: Map[String, OutgoingBoundaryBuilder] val)
+  =>
+    _outgoing_boundary_builders = boundary_builders
+
+  be remove_boundary(worker: String) =>
+    let new_boundary_builders =
+      recover iso Map[String, OutgoingBoundaryBuilder] end
+    for (w, b) in _outgoing_boundary_builders.pairs() do
+      if w != worker then new_boundary_builders(w) = b end
+    end
+
+    _outgoing_boundary_builders = consume new_boundary_builders
+
+  be dispose() =>
+    @printf[I32]("Shutting down GenSourceListener\n".cstring())

--- a/lib/wallaroo/core/source/gen_source/gen_source_listener_builder.pony
+++ b/lib/wallaroo/core/source/gen_source/gen_source_listener_builder.pony
@@ -1,0 +1,79 @@
+/*
+
+Copyright 2017 The Wallaroo Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing
+ permissions and limitations under the License.
+
+*/
+
+use "collections"
+use "wallaroo/core/boundary"
+use "wallaroo/core/common"
+use "wallaroo/ent/recovery"
+use "wallaroo/ent/router_registry"
+use "wallaroo/core/initialization"
+use "wallaroo/core/metrics"
+use "wallaroo/core/routing"
+use "wallaroo/core/source"
+use "wallaroo/core/topology"
+
+class val GenSourceListenerBuilder
+  let _source_builder: SourceBuilder
+  let _pipeline_name: String
+  let _router: Router
+  let _router_registry: RouterRegistry
+  let _outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val
+  let _layout_initializer: LayoutInitializer
+  let _event_log: EventLog
+  let _auth: AmbientAuth
+  let _target_router: Router
+  let _metrics_reporter: MetricsReporter
+
+  new val create(source_builder: SourceBuilder, router: Router,
+    router_registry: RouterRegistry,
+    outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val,
+    event_log: EventLog, auth: AmbientAuth, pipeline_name: String,
+    layout_initializer: LayoutInitializer,
+    metrics_reporter: MetricsReporter iso,
+    target_router: Router = EmptyRouter)
+  =>
+    _source_builder = source_builder
+    _pipeline_name = pipeline_name
+    _router = router
+    _router_registry = router_registry
+    _outgoing_boundary_builders = outgoing_boundary_builders
+    _layout_initializer = layout_initializer
+    _event_log = event_log
+    _auth = auth
+    _target_router = target_router
+    _metrics_reporter = consume metrics_reporter
+
+  fun apply(env: Env): SourceListener =>
+    GenSourceListener(env, _source_builder, _router, _router_registry,
+      _outgoing_boundary_builders, _event_log, _auth,
+      _pipeline_name, _layout_initializer, _metrics_reporter.clone(),
+      _target_router)
+
+primitive GenSourceListenerBuilderBuilder
+  fun apply(source_builder: SourceBuilder, router: Router,
+    router_registry: RouterRegistry,
+    outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val,
+    event_log: EventLog, auth: AmbientAuth, pipeline_name: String,
+    layout_initializer: LayoutInitializer,
+    metrics_reporter: MetricsReporter iso, recovering: Bool,
+    target_router: Router = EmptyRouter): GenSourceListenerBuilder
+  =>
+    GenSourceListenerBuilder(source_builder, router, router_registry,
+      outgoing_boundary_builders, event_log, auth, pipeline_name,
+      layout_initializer, consume metrics_reporter,
+      target_router)

--- a/lib/wallaroo/core/source/gen_source/gen_source_notify.pony
+++ b/lib/wallaroo/core/source/gen_source/gen_source_notify.pony
@@ -1,0 +1,121 @@
+/*
+
+Copyright (C) 2016-2017, Wallaroo Labs
+Copyright (C) 2016-2017, The Pony Developers
+Copyright (c) 2014-2015, Causality Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+use "collections"
+use "wallaroo/core/boundary"
+use "wallaroo/core/common"
+use "wallaroo/ent/data_receiver"
+use "wallaroo/ent/recovery"
+use "wallaroo/ent/router_registry"
+use "wallaroo/core/initialization"
+use "wallaroo/core/messages"
+use "wallaroo/core/metrics"
+use "wallaroo/core/routing"
+use "wallaroo/core/source"
+use "wallaroo/core/topology"
+
+class val GenSourceNotifyBuilder[In: Any val] is
+  SourceNotifyBuilder[In val, GenSourceHandler[In val] val]
+  let _gen: GenSourceGenerator[In]
+
+  new val create(g: GenSourceGenerator[In]) =>
+    _gen = g
+
+  fun apply(source_id: RoutingId, pipeline_name: String, env: Env,
+    auth: AmbientAuth, handler: GenSourceHandler[In],
+    runner_builder: RunnerBuilder,
+    router: Router, metrics_reporter: MetricsReporter iso, event_log: EventLog,
+    target_router: Router,
+    pre_state_target_ids: Array[RoutingId] val = recover Array[RoutingId] end):
+    SourceNotify iso^
+  =>
+    GenSourceNotify[In](runner_builder, _gen, source_id, pipeline_name, env,
+      auth, handler, runner_builder, router, consume metrics_reporter,
+      event_log, target_router, pre_state_target_ids)
+
+class GenSourceNotify[In: Any val]
+  let _runner_builder: RunnerBuilder
+  let _generator: GenSourceGenerator[In]
+  let _source_id: RoutingId
+  let _pipeline_name: String
+  let _env: Env
+  let _auth: AmbientAuth
+  let _router: Router
+  let _metrics_reporter: MetricsReporter iso
+  let _event_log: EventLog
+  let _target_router: Router
+  let _pre_state_target_ids: Array[RoutingId] val
+
+  new iso create(r_builder: RunnerBuilder, g: GenSourceGenerator[In],
+    source_id: RoutingId, pipeline_name: String, env: Env,
+    auth: AmbientAuth, handler: GenSourceHandler[In] val,
+    runner_builder: RunnerBuilder, router: Router,
+    metrics_reporter: MetricsReporter iso, event_log: EventLog,
+    target_router: Router,
+    pre_state_target_ids: Array[RoutingId] val = recover Array[RoutingId] end)
+  =>
+    _runner_builder = r_builder
+    _generator = g
+    _source_id = source_id
+    _pipeline_name = pipeline_name
+    _env = env
+    _auth = auth
+    _router = router
+    _metrics_reporter = consume metrics_reporter
+    _event_log = event_log
+    _target_router = target_router
+    _pre_state_target_ids = pre_state_target_ids
+
+  // TODO: CREDITFLOW - this is weird that its here
+  // It exists so that a GenSource can get its routes
+  // on startup. It probably makes more sense to make this
+  // available via the source builder that Listener gets
+  // and it can then make routes available
+  fun ref routes(): Map[RoutingId, Consumer] val =>
+    recover Map[RoutingId, Consumer] end
+
+  fun ref update_router(router': Router) =>
+    None
+
+  fun ref update_boundaries(obs: box->Map[String, OutgoingBoundary]) =>
+    None
+
+  fun ref source(layout_initializer: LayoutInitializer,
+    router_registry: RouterRegistry,
+    outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val):
+    Source
+  =>
+    GenSource[In](_source_id, _auth, _pipeline_name, _runner_builder, _router,
+      _target_router, _generator, _event_log, outgoing_boundary_builders,
+      layout_initializer, _metrics_reporter.clone(), router_registry,
+      _pre_state_target_ids)
+
+primitive GenSourceHandler[In: Any val]
+  fun decode(data: Array[U8] val): In ? =>
+    error

--- a/lib/wallaroo/core/source/gen_source/typed_gen_source_builder_builder.pony
+++ b/lib/wallaroo/core/source/gen_source/typed_gen_source_builder_builder.pony
@@ -1,0 +1,47 @@
+/*
+
+Copyright 2017 The Wallaroo Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing
+ permissions and limitations under the License.
+
+*/
+
+use "wallaroo/core/common"
+use "wallaroo/core/metrics"
+use "wallaroo/core/source"
+use "wallaroo/core/topology"
+
+class val TypedGenSourceBuilderBuilder[In: Any val]
+  let _app_name: String
+  let _name: String
+  let _handler: GenSourceHandler[In] = GenSourceHandler[In]
+  let _gen: GenSourceGenerator[In]
+
+  new val create(app_name: String, name': String, gen: GenSourceGenerator[In])
+  =>
+    _app_name = app_name
+    _name = name'
+    _gen = gen
+
+  fun name(): String => _name
+
+  fun apply(runner_builder: RunnerBuilder, router: Router,
+    metrics_conn: MetricsSink,
+    pre_state_target_ids: Array[RoutingId] val = recover Array[RoutingId] end,
+    worker_name: String, metrics_reporter: MetricsReporter iso):
+      SourceBuilder
+  =>
+    BasicSourceBuilder[In, GenSourceHandler[In]](_app_name, worker_name,
+      _name, runner_builder, _handler, router,
+      metrics_conn, pre_state_target_ids, consume metrics_reporter,
+      GenSourceNotifyBuilder[In](_gen))

--- a/lib/wallaroo/core/source/kafka_source/kafka_source.pony
+++ b/lib/wallaroo/core/source/kafka_source/kafka_source.pony
@@ -73,7 +73,7 @@ actor KafkaSource[In: Any val] is (Source & KafkaConsumer)
 
   var _muted: Bool = true
   var _disposed: Bool = false
-  let _muted_downstream: SetIs[Any tag] = _muted_downstream.create()
+  let _muted_by: SetIs[Any tag] = _muted_by.create()
 
   let _router_registry: RouterRegistry
 
@@ -480,24 +480,24 @@ actor KafkaSource[In: Any val] is (Source & KafkaConsumer)
     _muted = false
 
   fun ref _mute_local() =>
-    _muted_downstream.set(this)
+    _muted_by.set(this)
     _mute()
 
   fun ref _unmute_local() =>
-    _muted_downstream.unset(this)
+    _muted_by.unset(this)
 
-    if _muted_downstream.size() == 0 then
+    if _muted_by.size() == 0 then
       _unmute()
     end
 
-  be mute(c: Consumer) =>
-    _muted_downstream.set(c)
+  be mute(a: Any tag) =>
+    _muted_by.set(a)
     _mute()
 
-  be unmute(c: Consumer) =>
-    _muted_downstream.unset(c)
+  be unmute(a: Any tag) =>
+    _muted_by.unset(a)
 
-    if _muted_downstream.size() == 0 then
+    if _muted_by.size() == 0 then
       _unmute()
     end
 

--- a/lib/wallaroo/core/source/kafka_source/kafka_source_listener.pony
+++ b/lib/wallaroo/core/source/kafka_source/kafka_source_listener.pony
@@ -187,6 +187,9 @@ actor KafkaSourceListener[In: Any val] is (SourceListener & KafkaClientManager)
       None
     end
 
+  be recovery_protocol_complete() =>
+    None
+
   be kafka_client_error(client: KafkaClient, error_report: KafkaErrorReport) =>
     @printf[I32](("ERROR: Kafka client encountered an unrecoverable error! " +
       error_report.string() + "\n").cstring())

--- a/lib/wallaroo/core/source/source.pony
+++ b/lib/wallaroo/core/source/source.pony
@@ -104,8 +104,8 @@ trait tag Source is (Producer & DisposableActor & BoundaryUpdatable &
     boundary_builders: Map[String, OutgoingBoundaryBuilder] val)
   be reconnect_boundary(target_worker_name: WorkerName)
   be disconnect_boundary(worker: WorkerName)
-  be mute(c: Consumer)
-  be unmute(c: Consumer)
+  be mute(a: Any tag)
+  be unmute(a: Any tag)
   be initiate_barrier(token: BarrierToken)
   be barrier_complete(token: BarrierToken)
   be update_worker_data_service(worker_name: String,
@@ -115,6 +115,7 @@ trait tag Source is (Producer & DisposableActor & BoundaryUpdatable &
   be first_checkpoint_complete()
 
 interface tag SourceListener is (DisposableActor & BoundaryUpdatable)
+  be recovery_protocol_complete()
   be update_router(router: PartitionRouter)
   be add_boundary_builders(
     boundary_builders: Map[String, OutgoingBoundaryBuilder] val)

--- a/lib/wallaroo/core/source/tcp_source/framed_source_notify.pony
+++ b/lib/wallaroo/core/source/tcp_source/framed_source_notify.pony
@@ -83,8 +83,10 @@ class TCPFramedSourceNotify[In: Any val] is TCPSourceNotify
 
   fun ref received(source: TCPSource ref, data: Array[U8] iso): Bool =>
     if _header then
+      @printf[I32]("!@ <><><> Header (size: %s)\n".cstring(), data.size().string().cstring())
       try
         let payload_size: USize = _handler.payload_length(consume data)?
+        @printf[I32]("!@ <><><> -- payload_size: %s\n".cstring(), payload_size.string().cstring())
 
         source.expect(payload_size)
         _header = false
@@ -93,6 +95,8 @@ class TCPFramedSourceNotify[In: Any val] is TCPSourceNotify
       end
       true
     else
+      @printf[I32]("!@ <><><> Payload (size: %s)\n".cstring(), data.size().string().cstring())
+
       _metrics_reporter.pipeline_ingest(_pipeline_name, _source_name)
       let ingest_ts = Time.nanos()
       let pipeline_time_spent: U64 = 0
@@ -182,10 +186,10 @@ class TCPFramedSourceNotify[In: Any val] is TCPSourceNotify
 
   fun ref accepted(source: TCPSource ref) =>
     @printf[I32]((_source_name + ": accepted a connection\n").cstring())
+    _header = true
     source.expect(_header_size)
 
   fun ref closed(source: TCPSource ref) =>
     @printf[I32]("TCPSource connection closed\n".cstring())
-    source._dispose()
 
   // TODO: implement connect_failed

--- a/lib/wallaroo/core/source/tcp_source/tcp_source.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source.pony
@@ -83,27 +83,26 @@ actor TCPSource is Source
   // TCP
   let _listen: TCPSourceListener
   let _notify: TCPSourceNotify
-  var _next_size: USize
-  let _max_size: USize
-  var _connect_count: U32
+  var _next_size: USize = 0
+  var _max_size: USize = 0
+  var _connect_count: U32 = 0
   var _fd: U32 = -1
   var _expect: USize = 0
   var _connected: Bool = false
   var _closed: Bool = false
   var _event: AsioEventID = AsioEvent.none()
-  var _read_buf: Array[U8] iso
+  var _read_buf: Array[U8] iso = recover Array[U8] end
   var _read_buf_offset: USize = 0
   var _shutdown_peer: Bool = false
   var _readable: Bool = false
-  var _read_len: USize = 0
   var _reading: Bool = false
   var _shutdown: Bool = false
   // Start muted. Wait for unmute to begin processing
   var _muted: Bool = true
   var _disposed: Bool = false
   var _expect_read_buf: Reader = Reader
-  let _muted_downstream: SetIs[Any tag] = _muted_downstream.create()
-  let _max_received_count: U8 = 50
+  var _max_received_count: U8 = 50
+  let _muted_by: SetIs[Any tag] = _muted_by.create()
 
   var _is_pending: Bool = true
 
@@ -117,17 +116,13 @@ actor TCPSource is Source
   // Checkpoint
   var _next_checkpoint_id: CheckpointId = 1
 
-  new _accept(source_id: RoutingId, auth: AmbientAuth,
+  new create(source_id: RoutingId, auth: AmbientAuth,
     listen: TCPSourceListener, notify: TCPSourceNotify iso,
     event_log: EventLog, router': Router,
     outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val,
     layout_initializer: LayoutInitializer,
-    fd: U32, init_size: USize = 64, max_size: USize = 16384,
     metrics_reporter: MetricsReporter iso, router_registry: RouterRegistry)
   =>
-    """
-    A new connection accepted on a server.
-    """
     @printf[I32]("!@ Spinning up TCPSource %s\n".cstring(), source_id.string().cstring())
     _source_id = source_id
     _auth = auth
@@ -135,15 +130,6 @@ actor TCPSource is Source
     _metrics_reporter = consume metrics_reporter
     _listen = listen
     _notify = consume notify
-    _connect_count = 0
-    _fd = fd
-    _event = @pony_asio_event_create(this, fd,
-      AsioEvent.read_write_oneshot(), 0, true)
-    _connected = true
-    _read_buf = recover Array[U8].>undefined(init_size) end
-    _next_size = init_size
-    _max_size = max_size
-
     _layout_initializer = layout_initializer
     _router_registry = router_registry
 
@@ -157,15 +143,8 @@ actor TCPSource is Source
       end
     end
 
-    _readable = true
-
     _router = router'
     _update_router(router')
-
-    _pending_reads()
-    //TODO: either only accept when we are done recovering or don't start
-    //listening until we are done recovering
-    _notify.accepted(this)
 
     _notify.update_boundaries(_outgoing_boundaries)
 
@@ -188,11 +167,40 @@ actor TCPSource is Source
       _mute_local()
     end
 
+  be accept(fd: U32, init_size: USize = 64, max_size: USize = 16384) =>
+    """
+    A new connection accepted on a server.
+    """
+    if not _disposed then
+      @printf[I32]("!@ TCPSource %s _accept()\n".cstring(), _source_id.string().cstring())
+
+      _notify.accepted(this)
+
+      _connect_count = 0
+      _fd = fd
+      _event = @pony_asio_event_create(this, fd,
+        AsioEvent.read_write_oneshot(), 0, true)
+      _connected = true
+      _read_buf = recover Array[U8].>undefined(init_size) end
+      _read_buf_offset = 0
+      _next_size = init_size
+      _max_size = max_size
+
+      _readable = true
+      _closed = false
+      _shutdown = false
+      _shutdown_peer = false
+
+      _pending_reads()
+    end
+
+  //!@
   be first_checkpoint_complete() =>
     """
     In case we pop into existence midway through a checkpoint, we need to
     wait until this is called to start processing.
     """
+    @printf[I32]("!@ TCPSource: first_checkpoint_complete()\n".cstring())
     _unmute_local()
     _is_pending = false
     for (id, c) in _outputs.pairs() do
@@ -417,6 +425,8 @@ actor TCPSource is Source
         b.dispose()
       end
       close()
+      _dispose_routes()
+      _muted = true
       _disposed = true
     end
 
@@ -465,7 +475,7 @@ actor TCPSource is Source
   //////////////
   be initiate_barrier(token: BarrierToken) =>
     @printf[I32]("!@ TCPSource received initiate_barrier %s\n".cstring(), token.string().cstring())
-    if not _is_pending then
+    if not _is_pending and not _disposed then
       _initiate_barrier(token)
     end
 
@@ -597,9 +607,7 @@ actor TCPSource is Source
     Shut our connection down immediately. Stop reading data from the incoming
     source.
     """
-
     _hard_close()
-
 
   fun ref _try_shutdown() =>
     """
@@ -625,10 +633,6 @@ actor TCPSource is Source
 
     if _connected and _shutdown and _shutdown_peer then
       _hard_close()
-    else
-      if not _unregistered then
-        _dispose_routes()
-      end
     end
 
   fun ref _hard_close() =>
@@ -649,16 +653,16 @@ actor TCPSource is Source
     _readable = false
     @pony_asio_event_set_readable[None](_event, false)
 
-
     @pony_os_socket_close[None](_fd)
     _fd = -1
 
+    _event = AsioEvent.none()
+    _expect_read_buf.clear()
+    _expect = 0
+
     _notify.closed(this)
 
-    _listen._conn_closed()
-    if not _unregistered then
-      _dispose_routes()
-    end
+    _listen._conn_closed(this)
 
   fun ref _dispose_routes() =>
     if not _unregistered then
@@ -667,7 +671,6 @@ actor TCPSource is Source
       end
       _unregistered = true
     end
-    _muted = true
 
   fun ref _pending_reads() =>
     """
@@ -813,24 +816,25 @@ actor TCPSource is Source
     end
 
   fun ref _mute_local() =>
-    _muted_downstream.set(this)
+    _muted_by.set(this)
     _mute()
 
   fun ref _unmute_local() =>
-    _muted_downstream.unset(this)
+    _muted_by.unset(this)
 
-    if _muted_downstream.size() == 0 then
+    if _muted_by.size() == 0 then
       _unmute()
     end
 
-  be mute(c: Consumer) =>
-    _muted_downstream.set(c)
+  be mute(a: Any tag) =>
+    _muted_by.set(a)
     _mute()
 
-  be unmute(c: Consumer) =>
-    _muted_downstream.unset(c)
+  be unmute(a: Any tag) =>
+    @printf[I32]("!@ TCPSource %s: Somebody called unmute() with %s left\n".cstring(), _source_id.string().cstring(), _muted_by.size().string().cstring())
+    _muted_by.unset(a)
 
-    if _muted_downstream.size() == 0 then
+    if _muted_by.size() == 0 then
       _unmute()
     end
 
@@ -844,3 +848,4 @@ actor TCPSource is Source
     """
     // TODO: verify that removal of "in_sent" check is harmless
     _expect = _notify.expect(this, qty)
+    @printf[I32]("!@ TCPSource: set expect to %s\n".cstring(), _expect.string().cstring())

--- a/lib/wallaroo/core/source/tcp_source/tcp_source_config.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source_config.pony
@@ -63,19 +63,26 @@ class val TCPSourceConfig[In: Any val]
   let _handler: FramedSourceHandler[In] val
   let _host: String
   let _service: String
+  let _parallelism: USize
 
-  new val create(handler': FramedSourceHandler[In] val, host': String, service': String) =>
+  new val create(handler': FramedSourceHandler[In] val, host': String,
+    service': String, parallelism': USize = 10)
+  =>
     _handler = handler'
     _host = host'
     _service = service'
+    _parallelism = parallelism'
 
-  new val from_options(handler': FramedSourceHandler[In] val, opts: TCPSourceConfigOptions) =>
+  new val from_options(handler': FramedSourceHandler[In] val,
+    opts: TCPSourceConfigOptions, parallelism': USize = 10)
+  =>
     _handler = handler'
     _host = opts.host
     _service = opts.service
+    _parallelism = parallelism'
 
   fun source_listener_builder_builder(): TCPSourceListenerBuilderBuilder =>
-    TCPSourceListenerBuilderBuilder(_host, _service)
+    TCPSourceListenerBuilderBuilder(_host, _service, _parallelism)
 
   fun source_builder(app_name: String, name: String):
     TypedTCPSourceBuilderBuilder[In]

--- a/lib/wallaroo/core/source/tcp_source/tcp_source_listener_builder.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source_listener_builder.pony
@@ -40,6 +40,7 @@ class val TCPSourceListenerBuilder
   let _host: String
   let _service: String
   let _metrics_reporter: MetricsReporter
+  let _parallelism: USize
 
   new val create(source_builder: SourceBuilder, router: Router,
     router_registry: RouterRegistry,
@@ -47,7 +48,7 @@ class val TCPSourceListenerBuilder
     event_log: EventLog, auth: AmbientAuth, pipeline_name: String,
     layout_initializer: LayoutInitializer,
     metrics_reporter: MetricsReporter iso,
-    target_router: Router = EmptyRouter,
+    target_router: Router = EmptyRouter, parallelism: USize,
     host: String = "", service: String = "0")
   =>
     _source_builder = source_builder
@@ -62,20 +63,23 @@ class val TCPSourceListenerBuilder
     _host = host
     _service = service
     _metrics_reporter = consume metrics_reporter
+    _parallelism = parallelism
 
   fun apply(env: Env): SourceListener =>
     TCPSourceListener(env, _source_builder, _router, _router_registry,
       _outgoing_boundary_builders, _event_log, _auth,
       _pipeline_name, _layout_initializer, _metrics_reporter.clone(),
-      _target_router, _host, _service)
+      _target_router, _parallelism, _host, _service)
 
 class val TCPSourceListenerBuilderBuilder
   let _host: String
   let _service: String
+  let _parallelism: USize
 
-  new val create(host: String, service: String) =>
+  new val create(host: String, service: String, parallelism: USize) =>
     _host = host
     _service = service
+    _parallelism = parallelism
 
   fun apply(source_builder: SourceBuilder, router: Router,
     router_registry: RouterRegistry,
@@ -88,4 +92,4 @@ class val TCPSourceListenerBuilderBuilder
     TCPSourceListenerBuilder(source_builder, router, router_registry,
       outgoing_boundary_builders, event_log, auth, pipeline_name,
       layout_initializer, consume metrics_reporter,
-      target_router, _host, _service)
+      target_router, _parallelism, _host, _service)

--- a/lib/wallaroo/core/source/tcp_source/tcp_source_notify.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source_notify.pony
@@ -93,7 +93,6 @@ trait TCPSourceNotify
     """
     qty
 
-
   fun ref closed(conn: TCPSource ref) =>
     """
     Called when the connection is closed.

--- a/lib/wallaroo/core/topology/router.pony
+++ b/lib/wallaroo/core/topology/router.pony
@@ -252,7 +252,7 @@ class val ProxyRouter is Router
         _target_proxy_address,
         i_msg_uid, frac_ids)
 
-      r.forward(delivery_msg, pipeline_time_spent, producer,
+      r.forward(delivery_msg, pipeline_time_spent, producer_id, producer,
         latest_ts, metrics_id, metric_name, worker_ingress_ts)
 
       (false, latest_ts)
@@ -535,7 +535,7 @@ class val StateStepRouter is TargetIdRouter
                 _worker_name, data, metric_name,
                 pa, msg_uid, frac_ids)
 
-              r.forward(delivery_msg, pipeline_time_spent,
+              r.forward(delivery_msg, pipeline_time_spent, producer_id,
                 producer, latest_ts, metrics_id,
                 metric_name, worker_ingress_ts)
               (false, latest_ts)
@@ -1918,7 +1918,7 @@ class val HashedProxyRouter is Router
 
       match data
       | let m: ReplayableDeliveryMsg =>
-        r.forward(m, pipeline_time_spent, producer,
+        r.forward(m, pipeline_time_spent, producer_id, producer,
           latest_ts, metrics_id, metric_name, worker_ingress_ts)
       else
         Fail()

--- a/lib/wallaroo/core/topology/steps.pony
+++ b/lib/wallaroo/core/topology/steps.pony
@@ -347,6 +347,7 @@ actor Step is (Producer & Consumer & BarrierProcessor)
     i_seq_id: SeqId, i_route_id: RouteId, latest_ts: U64, metrics_id: U16,
     worker_ingress_ts: U64)
   =>
+    @printf[I32]("!@ Step %s process_message from %s\n".cstring(), _id.string().cstring(), i_producer_id.string().cstring())
     _seq_id_generator.new_incoming_message()
 
     let my_latest_ts = ifdef "detailed-metrics" then
@@ -540,7 +541,7 @@ actor Step is (Producer & Consumer & BarrierProcessor)
   be receive_barrier(step_id: RoutingId, producer: Producer,
     barrier_token: BarrierToken)
   =>
-    // @printf[I32]("!@ Step %s received barrier %s from %s\n".cstring(), _id.string().cstring(), barrier_token.string().cstring(), step_id.string().cstring())
+    @printf[I32]("!@ Step %s received barrier %s from %s\n".cstring(), _id.string().cstring(), barrier_token.string().cstring(), step_id.string().cstring())
     process_barrier(step_id, producer, barrier_token)
 
   fun ref process_barrier(step_id: RoutingId, producer: Producer,
@@ -588,7 +589,7 @@ actor Step is (Producer & Consumer & BarrierProcessor)
     end
 
   fun ref barrier_complete(barrier_token: BarrierToken) =>
-    // @printf[I32]("!@ Barrier complete at Step %s\n".cstring(), _id.string().cstring())
+    @printf[I32]("!@ Barrier complete at Step %s\n".cstring(), _id.string().cstring())
     ifdef debug then
       Invariant(_step_message_processor.barrier_in_progress())
     end

--- a/lib/wallaroo/ent/barrier/barrier_step_forwarder.pony
+++ b/lib/wallaroo/ent/barrier/barrier_step_forwarder.pony
@@ -91,6 +91,8 @@ class BarrierStepForwarder
       if not _removed_inputs.contains(step_id) then
         @printf[I32]("!@ %s: Forwarder at %s doesn't know about %s\n".cstring(), barrier_token.string().cstring(), _step_id.string().cstring(), step_id.string().cstring())
         Fail()
+      else
+        @printf[I32]("!@ %s: Forwarder at %s doesn't know about %s but it's in removed_inputs so we're ignoring\n".cstring(), barrier_token.string().cstring(), _step_id.string().cstring(), step_id.string().cstring())
       end
     end
 

--- a/lib/wallaroo/ent/data_receiver/data_receiver.pony
+++ b/lib/wallaroo/ent/data_receiver/data_receiver.pony
@@ -32,7 +32,7 @@ use "wallaroo/ent/checkpoint"
 use "wallaroo_labs/mort"
 
 
-actor DataReceiver is (Producer)
+actor DataReceiver is Producer
   let _id: RoutingId
   let _auth: AmbientAuth
   let _worker_name: String
@@ -122,18 +122,8 @@ actor DataReceiver is (Producer)
       end
     end
 
-    let resend = _phase.flush()
     _phase = _NormalDataReceiverPhase(this)
-    for m in resend.values() do
-      match m
-      | let qdm: _QueuedDeliveryMessage =>
-        qdm.process_message(this)
-      | let qrdm: _QueuedReplayableDeliveryMessage =>
-        qrdm.replay_process_message(this)
-      | let pb: _QueuedBarrier =>
-        _forward_barrier(pb._1, pb._2, pb._3, pb._4)
-      end
-    end
+
   be remove_route_to_consumer(id: RoutingId, c: Consumer) =>
     // DataReceiver doesn't have its own routes
     None
@@ -165,35 +155,42 @@ actor DataReceiver is (Producer)
   /////////////////////////////////////////////////////////////////////////////
   // MESSAGES
   /////////////////////////////////////////////////////////////////////////////
-  be received(d: DeliveryMsg, pipeline_time_spent: U64, seq_id: SeqId,
-    latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64)
-  =>
-    process_message(d, pipeline_time_spent, seq_id, latest_ts,
-      metrics_id, worker_ingress_ts)
-
-  fun ref process_message(d: DeliveryMsg, pipeline_time_spent: U64,
+  be received(d: DeliveryMsg, producer_id: RoutingId, pipeline_time_spent: U64,
     seq_id: SeqId, latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64)
   =>
-    _phase.deliver(d, pipeline_time_spent, seq_id, latest_ts, metrics_id,
-      worker_ingress_ts)
+    @printf[I32]("!@ DataReceiver (%s): received seq id %s\n".cstring(), _sender_name.cstring(), seq_id.string().cstring())
+    process_message(d, producer_id, pipeline_time_spent, seq_id, latest_ts,
+      metrics_id, worker_ingress_ts)
 
-  fun ref deliver(d: DeliveryMsg, pipeline_time_spent: U64, seq_id: SeqId,
-    latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64)
+  fun ref process_message(d: DeliveryMsg, producer_id: RoutingId,
+    pipeline_time_spent: U64, seq_id: SeqId, latest_ts: U64, metrics_id: U16,
+    worker_ingress_ts: U64)
+  =>
+    _phase.deliver(d, producer_id, pipeline_time_spent, seq_id, latest_ts,
+      metrics_id, worker_ingress_ts)
+
+  fun ref deliver(d: DeliveryMsg, producer_id: RoutingId,
+    pipeline_time_spent: U64, seq_id: SeqId, latest_ts: U64, metrics_id: U16,
+    worker_ingress_ts: U64)
   =>
     ifdef "trace" then
       @printf[I32]("Rcvd pipeline msg at DataReceiver\n".cstring())
     end
     if seq_id > _last_id_seen then
+      ifdef debug then
+        Invariant((seq_id - _last_id_seen) == 1)
+      end
       _ack_counter = _ack_counter + 1
       _last_id_seen = seq_id
-      _router.route(d, pipeline_time_spent, _id, this, seq_id, latest_ts,
-        metrics_id, worker_ingress_ts)
+      _router.route(d, pipeline_time_spent, producer_id, this, seq_id,
+        latest_ts, metrics_id, worker_ingress_ts)
       _maybe_ack()
     end
 
   be replay_received(r: ReplayableDeliveryMsg, pipeline_time_spent: U64,
     seq_id: SeqId, latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64)
   =>
+    @printf[I32]("!@ DataReceiver (%s): replay_received seq id %s\n".cstring(), _sender_name.cstring(), seq_id.string().cstring())
     if seq_id > _last_id_seen then
       replay_process_message(r, pipeline_time_spent, seq_id, latest_ts,
         metrics_id, worker_ingress_ts)
@@ -210,6 +207,9 @@ actor DataReceiver is (Producer)
     seq_id: SeqId, latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64)
   =>
     if seq_id > _last_id_seen then
+      ifdef debug then
+        Invariant((seq_id - _last_id_seen) == 1)
+      end
       _last_id_seen = seq_id
       _router.replay_route(r, pipeline_time_spent, _id, this, seq_id,
         latest_ts, metrics_id, worker_ingress_ts)
@@ -269,14 +269,19 @@ actor DataReceiver is (Producer)
     if highest_seq_id < _last_id_seen then
       _last_id_seen = highest_seq_id
     end
-    if highest_seq_id < _last_id_acked then
-      _last_id_acked = highest_seq_id
-    end
 
     _phase.data_connect(highest_seq_id)
 
-  fun ref _update_last_id_seen(seq_id: SeqId) =>
-    _last_id_seen = seq_id
+  fun ref _update_last_id_seen(seq_id: SeqId, on_increase: Bool = false) =>
+    if on_increase then
+      if seq_id > _last_id_seen then
+        @printf[I32]("!@ DataReceiver (%s): _update_last_id_seen on increase to %s\n".cstring(), _sender_name.cstring(), seq_id.string().cstring())
+        _last_id_seen = seq_id
+      end
+    else
+      @printf[I32]("!@ DataReceiver (%s): _update_last_id_seen update to new value to %s\n".cstring(), _sender_name.cstring(), seq_id.string().cstring())
+      _last_id_seen = seq_id
+    end
 
   fun _inform_boundary_to_send_normal_messages() =>
     try
@@ -347,7 +352,7 @@ actor DataReceiver is (Producer)
   be forward_barrier(target_step_id: RoutingId, origin_step_id: RoutingId,
     barrier_token: BarrierToken, seq_id: SeqId)
   =>
-    @printf[I32]("!@ DataReceiver: forward_barrier to %s -> seq id %s, last_seen: %s\n".cstring(), target_step_id.string().cstring(), seq_id.string().cstring(), _last_id_seen.string().cstring())
+    @printf[I32]("!@ DataReceiver (%s): forward_barrier to %s -> seq id %s, last_seen: %s\n".cstring(), _sender_name.cstring(), target_step_id.string().cstring(), seq_id.string().cstring(), _last_id_seen.string().cstring())
     if seq_id > _last_id_seen then
       // @printf[I32]("!@ DataReceiver: received token %s from %s at DataReceiver %s\n".cstring(), barrier_token.string().cstring(), origin_step_id.string().cstring(), _id.string().cstring())
       match barrier_token
@@ -375,6 +380,10 @@ actor DataReceiver is (Producer)
   =>
     // @printf[I32]("!@ DataReceiver: send_barrier %s -> seq id %s, last_seen: %s\n".cstring(), barrier_token.string().cstring(), seq_id.string().cstring(), _last_id_seen.string().cstring())
     if seq_id > _last_id_seen then
+      //!@
+      // ifdef debug then
+      //   Invariant((seq_id - _last_id_seen) == 1)
+      // end
       _ack_counter = _ack_counter + 1
       _last_id_seen = seq_id
       match barrier_token

--- a/lib/wallaroo/ent/data_receiver/data_receiver_phase.pony
+++ b/lib/wallaroo/ent/data_receiver/data_receiver_phase.pony
@@ -27,10 +27,9 @@ trait _DataReceiverPhase
   fun has_pending(): Bool =>
     false
 
-  fun ref flush(): Array[_Queued]
-
-  fun ref deliver(d: DeliveryMsg, pipeline_time_spent: U64, seq_id: SeqId,
-    latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64)
+  fun ref deliver(d: DeliveryMsg, producer_id: RoutingId,
+    pipeline_time_spent: U64, seq_id: SeqId, latest_ts: U64, metrics_id: U16,
+    worker_ingress_ts: U64)
   =>
     _invalid_call()
     Fail()
@@ -64,9 +63,6 @@ class _DataReceiverNotProcessingPhase is _DataReceiverPhase
     @printf[I32](("DataReceiver: data_connect received, but still waiting " +
       "for DataReceivers to initialize.\n").cstring())
 
-  fun ref flush(): Array[_Queued] =>
-    Array[_Queued]
-
 class _RecoveringDataReceiverPhase is _DataReceiverPhase
   let _data_receiver: DataReceiver ref
 
@@ -79,15 +75,16 @@ class _RecoveringDataReceiverPhase is _DataReceiverPhase
   fun has_pending(): Bool =>
     false
 
-  fun ref deliver(d: DeliveryMsg, pipeline_time_spent: U64, seq_id: SeqId,
-    latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64)
+  fun ref deliver(d: DeliveryMsg, producer_id: RoutingId,
+    pipeline_time_spent: U64, seq_id: SeqId, latest_ts: U64, metrics_id: U16,
+    worker_ingress_ts: U64)
   =>
     // Drop non-barriers
     ifdef debug then
       @printf[I32]("Recovering DataReceiver dropping non-rollback-barrier\n"
         .cstring())
     end
-    None
+    _data_receiver._update_last_id_seen(seq_id, true)
 
   fun ref replay_deliver(r: ReplayableDeliveryMsg, pipeline_time_spent: U64,
     seq_id: SeqId, latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64)
@@ -97,7 +94,7 @@ class _RecoveringDataReceiverPhase is _DataReceiverPhase
       @printf[I32]("Recovering DataReceiver dropping non-rollback-barrier\n"
         .cstring())
     end
-    None
+    _data_receiver._update_last_id_seen(seq_id, true)
 
   fun ref forward_barrier(input_id: RoutingId, output_id: RoutingId,
     token: BarrierToken, seq_id: SeqId)
@@ -113,6 +110,7 @@ class _RecoveringDataReceiverPhase is _DataReceiverPhase
         @printf[I32]("Recovering DataReceiver dropping non-rollback barrier\n"
           .cstring())
       end
+      _data_receiver._update_last_id_seen(seq_id, true)
     end
 
   fun ref data_connect(highest_seq_id: SeqId) =>
@@ -120,9 +118,6 @@ class _RecoveringDataReceiverPhase is _DataReceiverPhase
     // boundaries, which will be cleared as part of rollback.
     _data_receiver._update_last_id_seen(highest_seq_id)
     _data_receiver._inform_boundary_to_send_normal_messages()
-
-  fun ref flush(): Array[_Queued] =>
-    Array[_Queued]
 
 class _NormalDataReceiverPhase is _DataReceiverPhase
   let _data_receiver: DataReceiver ref
@@ -136,11 +131,12 @@ class _NormalDataReceiverPhase is _DataReceiverPhase
   fun has_pending(): Bool =>
     false
 
-  fun ref deliver(d: DeliveryMsg, pipeline_time_spent: U64, seq_id: SeqId,
-    latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64)
+  fun ref deliver(d: DeliveryMsg, producer_id: RoutingId,
+    pipeline_time_spent: U64, seq_id: SeqId, latest_ts: U64, metrics_id: U16,
+    worker_ingress_ts: U64)
   =>
-    _data_receiver.deliver(d, pipeline_time_spent, seq_id, latest_ts,
-      metrics_id, worker_ingress_ts)
+    _data_receiver.deliver(d, producer_id, pipeline_time_spent, seq_id,
+      latest_ts, metrics_id, worker_ingress_ts)
 
   fun ref replay_deliver(r: ReplayableDeliveryMsg, pipeline_time_spent: U64,
     seq_id: SeqId, latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64)
@@ -155,95 +151,3 @@ class _NormalDataReceiverPhase is _DataReceiverPhase
 
   fun ref data_connect(highest_seq_id: SeqId) =>
     _data_receiver._inform_boundary_to_send_normal_messages()
-
-  fun ref flush(): Array[_Queued] =>
-    Array[_Queued]
-
-class _QueuingDataReceiverPhase is _DataReceiverPhase
-  let _data_receiver: DataReceiver ref
-  var _queued: Array[_Queued] = _queued.create()
-
-  new create(dr: DataReceiver ref) =>
-    _data_receiver = dr
-
-  fun name(): String =>
-    "_QueuingDataReceiverPhase"
-
-  fun has_pending(): Bool =>
-    _queued.size() == 0
-
-  fun ref deliver(d: DeliveryMsg, pipeline_time_spent: U64, seq_id: SeqId,
-    latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64)
-  =>
-    let qdm = _QueuedDeliveryMessage(d, pipeline_time_spent, seq_id,
-      latest_ts, metrics_id, worker_ingress_ts)
-    _queued.push(qdm)
-
-  fun ref replay_deliver(r: ReplayableDeliveryMsg, pipeline_time_spent: U64,
-    seq_id: SeqId, latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64)
-  =>
-    let qrdm = _QueuedReplayableDeliveryMessage(r, pipeline_time_spent, seq_id,
-      latest_ts, metrics_id, worker_ingress_ts)
-    _queued.push(qrdm)
-
-  fun ref forward_barrier(input_id: RoutingId, output_id: RoutingId,
-    token: BarrierToken, seq_id: SeqId)
-  =>
-    @printf[I32]("!@ DataReceiver: Queuing barrier to %s\n".cstring(), output_id.string().cstring())
-    _queued.push((input_id, output_id, token, seq_id))
-
-  fun ref data_connect(highest_seq_id: SeqId) =>
-    _data_receiver._inform_boundary_to_send_normal_messages()
-
-  fun ref flush(): Array[_Queued] =>
-    // Return and clear
-    _queued = Array[_Queued]
-
-type _Queued is (_QueuedBarrier | _QueuedDeliveryMessage |
-  _QueuedReplayableDeliveryMessage)
-
-type _QueuedBarrier is (RoutingId, RoutingId, BarrierToken, SeqId)
-
-class _QueuedDeliveryMessage
-  let msg: DeliveryMsg
-  let pipeline_time_spent: U64
-  let seq_id: SeqId
-  let latest_ts: U64
-  let metrics_id: U16
-  let worker_ingress_ts: U64
-
-  new create(msg': DeliveryMsg, pipeline_time_spent': U64, seq_id': SeqId,
-    latest_ts': U64, metrics_id': U16, worker_ingress_ts': U64)
-  =>
-    msg = msg'
-    pipeline_time_spent = pipeline_time_spent'
-    seq_id = seq_id'
-    latest_ts = latest_ts'
-    metrics_id = metrics_id'
-    worker_ingress_ts = worker_ingress_ts'
-
-  fun process_message(dr: DataReceiver ref) =>
-    dr.process_message(msg, pipeline_time_spent, seq_id, latest_ts,
-      metrics_id, worker_ingress_ts)
-
-class _QueuedReplayableDeliveryMessage
-  let msg: ReplayableDeliveryMsg
-  let pipeline_time_spent: U64
-  let seq_id: SeqId
-  let latest_ts: U64
-  let metrics_id: U16
-  let worker_ingress_ts: U64
-
-  new create(msg': ReplayableDeliveryMsg, pipeline_time_spent': U64,
-    seq_id': SeqId, latest_ts': U64, metrics_id': U16, worker_ingress_ts': U64)
-  =>
-    msg = msg'
-    pipeline_time_spent = pipeline_time_spent'
-    seq_id = seq_id'
-    latest_ts = latest_ts'
-    metrics_id = metrics_id'
-    worker_ingress_ts = worker_ingress_ts'
-
-  fun replay_process_message(dr: DataReceiver ref) =>
-    dr.replay_process_message(msg, pipeline_time_spent, seq_id, latest_ts,
-      metrics_id, worker_ingress_ts)

--- a/lib/wallaroo/ent/recovery/event_log.pony
+++ b/lib/wallaroo/ent/recovery/event_log.pony
@@ -205,6 +205,7 @@ actor EventLog is SimpleJournalAsyncResponseReceiver
     @printf[I32]("EventLog: dispose\n".cstring())
     _backend.dispose()
     _disposed = true
+    _phase = _DisposedEventLogPhase
     @printf[I32]("EventLog: dispose 2\n".cstring())
 
   /////////////////

--- a/lib/wallaroo/ent/recovery/event_log_phase.pony
+++ b/lib/wallaroo/ent/recovery/event_log_phase.pony
@@ -317,6 +317,46 @@ class _RollbackEventLogPhase is _EventLogPhase
     _promise(_token)
     _event_log.rollback_complete(_token.checkpoint_id)
 
+class _DisposedEventLogPhase is _EventLogPhase
+  fun name(): String => "_DisposedRollbackEventLogPhase"
+
+  fun ref initiate_checkpoint(checkpoint_id: CheckpointId,
+    promise: Promise[CheckpointId], event_log: EventLog ref)
+  =>
+    None
+
+  fun ref checkpoint_state(resilient_id: RoutingId,
+    checkpoint_id: CheckpointId, payload: Array[ByteSeq] val)
+  =>
+    None
+
+  fun ref state_checkpointed(resilient_id: RoutingId) =>
+    None
+
+  fun ref write_initial_checkpoint_id(checkpoint_id: CheckpointId) =>
+    None
+
+  fun ref write_checkpoint_id(checkpoint_id: CheckpointId,
+    promise: Promise[CheckpointId])
+  =>
+    None
+
+  fun ref checkpoint_id_written(checkpoint_id: CheckpointId,
+    promise: Promise[CheckpointId])
+  =>
+    None
+
+  fun ref expect_rollback_count(count: USize) =>
+    None
+
+  fun ref ack_rollback(resilient_id: RoutingId) =>
+    None
+
+  fun ref complete_early() =>
+    None
+
+  fun ref check_completion() =>
+    None
 
 class _QueuedCheckpointState
   let resilient_id: RoutingId

--- a/lib/wallaroo/ent/recovery/recovery.pony
+++ b/lib/wallaroo/ent/recovery/recovery.pony
@@ -66,7 +66,8 @@ actor Recovery
   new create(auth: AmbientAuth, worker_name: WorkerName, event_log: EventLog,
     recovery_reconnecter: RecoveryReconnecter,
     checkpoint_initiator: CheckpointInitiator, connections: Connections,
-    router_registry: RouterRegistry, data_receivers: DataReceivers)
+    router_registry: RouterRegistry, data_receivers: DataReceivers,
+    is_recovering: Bool)
   =>
     _auth = auth
     _worker_name = worker_name
@@ -76,6 +77,9 @@ actor Recovery
     _connections = connections
     _router_registry = router_registry
     _data_receivers = data_receivers
+    if not is_recovering then
+      _router_registry.recovery_protocol_complete()
+    end
 
   be update_initializer(initializer: LocalTopologyInitializer) =>
     _initializer = initializer
@@ -264,6 +268,7 @@ actor Recovery
     end
     _router_registry.resume_the_world(_worker_name)
     _data_receivers.recovery_complete(this)
+    _router_registry.recovery_protocol_complete()
     _recovery_phase = _FinishedRecovering
     match _initializer
     | let lti: LocalTopologyInitializer =>
@@ -298,4 +303,5 @@ actor Recovery
     else
       Fail()
     end
+    _router_registry.recovery_protocol_complete()
     _recovery_phase = _RecoveryOverrideAccepted

--- a/lib/wallaroo/startup.pony
+++ b/lib/wallaroo/startup.pony
@@ -336,7 +336,7 @@ actor Startup
 
       let recovery = Recovery(auth, _startup_options.worker_name,
         event_log, recovery_reconnecter, checkpoint_initiator, connections,
-        router_registry, data_receivers)
+        router_registry, data_receivers, _is_recovering)
 
       let local_topology_initializer =
         LocalTopologyInitializer(
@@ -552,7 +552,7 @@ actor Startup
 
       let recovery = Recovery(auth, _startup_options.worker_name,
         event_log, recovery_reconnecter, checkpoint_initiator, connections,
-        router_registry, data_receivers)
+        router_registry, data_receivers, _is_recovering)
 
       let local_topology_initializer =
         LocalTopologyInitializer(

--- a/testing/correctness/apps/multi_partition_detector/Makefile
+++ b/testing/correctness/apps/multi_partition_detector/Makefile
@@ -45,6 +45,9 @@ build-testing-correctness-apps-multi_partition_detector: build-testing-correctne
 integration-tests-testing-correctness-apps-multi_partition_detector: build-testing-correctness-apps-multi_partition_detector
 integration-tests-testing-correctness-apps-multi_partition_detector: multi_partition_detector_test
 integration-tests-testing-correctness-apps-multi_partition_detector: multi_partition_detector_test_10_worker
+integration-tests-testing-correctness-apps-multi_partition_detector: multi_partition_detector_test_internal_source
+integration-tests-testing-correctness-apps-multi_partition_detector: multi_partition_detector_test_internal_source_10_worker
+
 
 multi_partition_detector_test:
 	cd $(MULTI_PARTITION_DETECTOR_PATH) && \
@@ -58,6 +61,19 @@ multi_partition_detector_test:
 		--batch-size 10 \
 		--workers 2 \
 		--sink-expect 200
+
+multi_partition_detector_test_internal_source:
+	cd $(MULTI_PARTITION_DETECTOR_PATH) && \
+	integration_test \
+	  --log-level error \
+		--command './multi_partition_detector --internal-source' \
+		--sources 0 \
+		--validation-cmd './validator/validator -a -i' \
+		--output 'received.txt' \
+		--batch-size 10 \
+		--workers 2 \
+		--sink-expect 200 \
+		--sink-expect-allow-more
 
 multi_partition_detector_test_10_worker:
 	cd $(MULTI_PARTITION_DETECTOR_PATH) && \
@@ -78,7 +94,20 @@ multi_partition_detector_test_10_worker:
 		--output 'received.txt' \
 		--batch-size 10 \
 		--workers 10 \
-		--sink-expect 10000 
+		--sink-expect 10000
+
+multi_partition_detector_test_internal_source_10_worker:
+	cd $(MULTI_PARTITION_DETECTOR_PATH) && \
+	integration_test \
+	  --log-level error \
+		--command './multi_partition_detector --internal-source' \
+		--sources 0 \
+		--validation-cmd './validator/validator -a -i' \
+		--output 'received.txt' \
+		--batch-size 10 \
+		--workers 10 \
+		--sink-expect 10000 \
+		--sink-expect-allow-more
 
 # end of prevent rules from being evaluated/included multiple times
 endif

--- a/testing/correctness/tests/resilience/resilience.py
+++ b/testing/correctness/tests/resilience/resilience.py
@@ -18,6 +18,7 @@ import logging
 from numbers import Number
 import os
 import re
+import shutil
 import time
 
 
@@ -60,6 +61,9 @@ def parse_sink_value(s):
 # TODO: refactor and move to control.py
 def pause_senders_and_sink_await(cluster, timeout=10):
     logging.debug("pause_senders_and_sink_await")
+    if not cluster.senders:
+        logging.debug("No senders to pause. Continuing.")
+        return
     cluster.pause_senders()
     time.sleep(5)
     for s in cluster.senders:
@@ -269,7 +273,7 @@ def _test_resilience(command, ops=[], initial=None, sources=1,
     `validate_output` - whether or not to validate the output
     """
     t0 = datetime.datetime.now()
-    log_stream = add_in_memory_log_stream()
+    log_stream = add_in_memory_log_stream(level=logging.DEBUG)
     persistent_data = {}
     res_ops = []
     try:
@@ -316,8 +320,7 @@ def _test_resilience(command, ops=[], initial=None, sources=1,
                             FROM_TAIL,
                             runner_data_format(
                                 persistent_data.get('runner_data'),
-                                from_tail=FROM_TAIL,
-                                filter_fn=lambda r: True)))
+                                from_tail=FROM_TAIL)))
                 raise
             except TimeoutError:
                 if persistent_data.get('runner_data'):
@@ -326,8 +329,7 @@ def _test_resilience(command, ops=[], initial=None, sources=1,
                             FROM_TAIL,
                             runner_data_format(
                                 persistent_data.get('runner_data'),
-                                from_tail=FROM_TAIL,
-                                filter_fn=lambda r: True)))
+                                from_tail=FROM_TAIL)))
                 raise
             except:
                 if persistent_data.get('runner_data'):
@@ -336,16 +338,28 @@ def _test_resilience(command, ops=[], initial=None, sources=1,
                         .format(FROM_TAIL,
                             runner_data_format(
                                 persistent_data.get('runner_data'),
-                                from_tail=FROM_TAIL,
-                                filter_fn=lambda r: True)))
+                                from_tail=FROM_TAIL)))
                 raise
     except Exception as err:
-        logging.exception(err)
         # save log stream to file
-        base_dir = 'error/{ops}/{time}'.format(
-            time=t0.strftime('%Y%m%d_%H%M%S'),
-            ops='_'.join((o.name().replace(':','') for o in ops*cycles)))
+        base_dir = ('/tmp/wallaroo_test_errors/testing/correctness/'
+            'tests/resilience/{ops}/{time}'.format(
+                time=t0.strftime('%Y%m%d_%H%M%S'),
+                ops='_'.join((o.name().replace(':','') for o in ops*cycles))))
         save_logs_to_file(base_dir, log_stream, persistent_data)
+        # get core file names
+        try:
+            rex = re.compile('core.*')
+            cores = filter(lambda s: rex.match(s), os.listdir(os.getcwd()))
+            if cores:
+                logging.warn("Core files detected: {}".format(cores))
+            for core in cores:
+                logging.info("Moving core {} to {}".format(core, base_dir))
+                shutil.move(core, os.path.join(base_dir, core))
+        except Exception as err_inner:
+            logging.exception(err_inner)
+            logging.warn("Failed to move core files {}".format(base_dir))
+        logging.exception(err)
         raise
 
 
@@ -413,7 +427,6 @@ def _run(persistent_data, res_ops, command, ops=[], initial=None, sources=1,
 
         # loop over ops, keeping the result and passing it to the next op
         res = None
-        sender_paused = False
         assert(not cluster.get_crashed_workers())
         for op in ops:
             res_ops.append(op)
@@ -424,37 +437,38 @@ def _run(persistent_data, res_ops, command, ops=[], initial=None, sources=1,
         # Wait a full second for things to calm down
         time.sleep(1)
 
-        # Tell the multi-sequence-sender to stop
-        msg.stop()
+        # If using external senders, wait for them to stop cleanly
+        if cluster.senders:
+            # Tell the multi-sequence-sender to stop
+            msg.stop()
 
-        # wait for senders to reach the end of their readers and stop
-        for s in cluster.senders:
-            cluster.wait_for_sender(s)
+            # wait for senders to reach the end of their readers and stop
+            for s in cluster.senders:
+                cluster.wait_for_sender(s)
 
-        # Validate all sender values caught up
-        stop_value = max(msg.seqs)
-        t0 = time.time()
-        while True:
-            try:
-                assert(len(msg.seqs) == msg.seqs.count(stop_value))
-                break
-            except:
-                if time.time() - t0 > 2:
-                    logging.error("msg.seqs aren't all equal: {}"
-                        .format(msg.seqs))
-                    raise
-            time.sleep(0.1)
+            # Validate all sender values caught up
+            stop_value = max(msg.seqs)
+            t0 = time.time()
+            while True:
+                try:
+                    assert(len(msg.seqs) == msg.seqs.count(stop_value))
+                    break
+                except:
+                    if time.time() - t0 > 2:
+                        logging.error("msg.seqs aren't all equal: {}"
+                            .format(msg.seqs))
+                        raise
+                time.sleep(0.1)
 
-        # Create await_values for the sink based on the stop values from the
-        # multi sequence generator
+            # Create await_values for the sink based on the stop values from
+            # the multi sequence generator
+            await_values = []
+            for part, val in enumerate(msg.seqs):
+                key = '{:07d}'.format(part)
+                data = '[{},{},{},{}]'.format(*[val-x for x in range(3,-1,-1)])
+                await_values.append((key, data))
+            cluster.sink_await(values=await_values, func=parse_sink_value)
 
-        await_values = []
-        for part, val in enumerate(msg.seqs):
-            key = '{:07d}'.format(part)
-            data = '[{},{},{},{}]'.format(*[val-x for x in range(3,-1,-1)])
-            await_values.append((key, data))
-
-        cluster.sink_await(values=await_values, func=parse_sink_value)
         logging.info("Completion condition achieved. Shutting down cluster.")
 
         # Use validator to validate the data in at-least-once mode
@@ -466,9 +480,14 @@ def _run(persistent_data, res_ops, command, ops=[], initial=None, sources=1,
 
             # Validate captured output
             logging.info("Validating output")
-            cmd_validate = ('validator -i {out_file} -e {expect} -a'
-                            .format(out_file = out_file,
-                                    expect = stop_value))
+            # if senders == 0, using internal source
+            if cluster.senders:
+                cmd_validate = ('validator -i {out_file} -e {expect} -a'
+                                .format(out_file = out_file,
+                                        expect = stop_value))
+            else:
+                cmd_validate = ('validator -i {out_file} -a'
+                                .format(out_file = out_file))
             res = run_shell_cmd(cmd_validate)
             try:
                 assert(res.success)

--- a/testing/correctness/tests/resilience/resilience_tests.py
+++ b/testing/correctness/tests/resilience/resilience_tests.py
@@ -101,27 +101,27 @@ def test_auto15():
 
 # some fixed tests:
 def test_grow1_shrink1_crash2_wait2_recover2():
-    command = 'multi_partition_detector --depth 1'
+    command = 'multi_partition_detector --depth 1 --internal-source'
     ops = [Grow(1), Wait(2), Shrink(1), Wait(2), Crash(2), Wait(2), Recover(2)]
-    _test_resilience(command, ops, validate_output=True)
+    _test_resilience(command, ops, validate_output=True, sources=0)
 
 
 def test_crash1_wait2_recover1():
-    command = 'multi_partition_detector --depth 1'
+    command = 'multi_partition_detector --depth 1 --internal-source'
     ops = [Crash(1), Wait(2), Recover(1)]
-    _test_resilience(command, ops, validate_output=True)
+    _test_resilience(command, ops, validate_output=True, sources=0)
 
 
 def test_crash2_wait2_recover2():
-    command = 'multi_partition_detector --depth 1'
+    command = 'multi_partition_detector --depth 1 --internal-source'
     ops = [Crash(2), Wait(2), Recover(2)]
-    _test_resilience(command, ops, validate_output=True)
+    _test_resilience(command, ops, validate_output=True, sources=0)
 
 
 def test_grow1_wait2_shrink1_wait_2_times_ten():
-    command = 'multi_partition_detector --depth 1'
+    command = 'multi_partition_detector --depth 1 --internal-source'
     ops = [Wait(2), Grow(1), Wait(2), Shrink(1), Wait(2)]
-    _test_resilience(command, ops, validate_output=True, cycles=10)
+    _test_resilience(command, ops, validate_output=True, cycles=10, sources=0)
 
 
 # The following tests only works if multi_partition_detector is compiled

--- a/testing/correctness/tests/resilience/resilience_tests.py
+++ b/testing/correctness/tests/resilience/resilience_tests.py
@@ -65,7 +65,7 @@ def test_auto8():
 
 def test_auto9():
     command = 'multi_partition_detector --depth 1'
-    ops = [Wait(2), Shrink(1), Wait(2), Shrink(4)]
+    ops = [Shrink(1), Wait(2), Shrink(4)]
     _test_resilience(command, ops, validate_output=True)
 
 def test_auto10():
@@ -102,26 +102,26 @@ def test_auto15():
 # some fixed tests:
 def test_grow1_shrink1_crash2_wait2_recover2():
     command = 'multi_partition_detector --depth 1 --internal-source'
-    ops = [Grow(1), Wait(2), Shrink(1), Wait(2), Crash(2), Wait(2), Recover(2)]
+    ops = [Wait(2), Grow(1), Wait(2), Shrink(1), Wait(2), Crash(2), Wait(2), Recover(2)]
     _test_resilience(command, ops, validate_output=True, sources=0)
 
 
 def test_crash1_wait2_recover1():
     command = 'multi_partition_detector --depth 1 --internal-source'
-    ops = [Crash(1), Wait(2), Recover(1)]
+    ops = [Wait(2), Crash(1), Wait(2), Recover(1)]
     _test_resilience(command, ops, validate_output=True, sources=0)
 
 
 def test_crash2_wait2_recover2():
     command = 'multi_partition_detector --depth 1 --internal-source'
-    ops = [Crash(2), Wait(2), Recover(2)]
+    ops = [Wait(2), Crash(2), Wait(2), Recover(2)]
     _test_resilience(command, ops, validate_output=True, sources=0)
 
 
-def test_grow1_wait2_shrink1_wait_2_times_ten():
-    command = 'multi_partition_detector --depth 1 --internal-source'
-    ops = [Wait(2), Grow(1), Wait(2), Shrink(1), Wait(2)]
-    _test_resilience(command, ops, validate_output=True, cycles=10, sources=0)
+# def test_grow1_wait2_shrink1_wait_2_times_ten():
+#     command = 'multi_partition_detector --depth 1 --internal-source'
+#     ops = [Wait(2), Grow(1), Wait(2), Shrink(1), Wait(2)]
+#     _test_resilience(command, ops, validate_output=True, cycles=10, sources=0)
 
 
 # The following tests only works if multi_partition_detector is compiled

--- a/testing/tools/integration/cluster.py
+++ b/testing/tools/integration/cluster.py
@@ -209,8 +209,8 @@ class Runner(threading.Thread):
 
 
 BASE_COMMAND = r'''{command} \
-    --in {inputs} \
-    --out {outputs} \
+    {in_block} \
+    {out_block} \
     --metrics {metrics_addr} \
     --resilience-dir {res_dir} \
     --name {{name}} \
@@ -222,6 +222,8 @@ BASE_COMMAND = r'''{command} \
     --ponythreads=1 \
     --ponypinasio \
     --ponynoblock'''
+IN_BLOCK = r'''--in {inputs}'''
+OUT_BLOCK = r'''--out {outputs}'''
 INITIALIZER_CMD = r'''{worker_count} \
     --data {data_addr} \
     --external {external_addr} \
@@ -247,8 +249,14 @@ def start_runners(runners, command, source_addrs, sink_addrs, metrics_addr,
                   res_dir, workers, worker_addrs=[], alt_block=None,
                   alt_func=lambda x: False, spikes={}):
     cmd_stub = BASE_COMMAND.format(command=command,
-                                   inputs=','.join(source_addrs),
-                                   outputs=','.join(sink_addrs),
+                                   in_block=(
+                                       IN_BLOCK.format(inputs=','.join(
+                                           source_addrs))
+                                       if source_addrs else ''),
+                                   out_block=(
+                                       OUT_BLOCK.format(outputs=','.join(
+                                           sink_addrs))
+                                       if sink_addrs else ''),
                                    metrics_addr=metrics_addr,
                                    res_dir=res_dir)
 
@@ -336,8 +344,14 @@ def add_runner(worker_id, runners, command, source_addrs, sink_addrs, metrics_ad
                my_control_addr, my_data_addr, my_external_addr,
                alt_block=None, alt_func=lambda x: False, spikes={}):
     cmd_stub = BASE_COMMAND.format(command=command,
-                                   inputs=','.join(source_addrs),
-                                   outputs=','.join(sink_addrs),
+                                   in_block=(
+                                       IN_BLOCK.format(inputs=','.join(
+                                           source_addrs))
+                                       if source_addrs else ''),
+                                   out_block=(
+                                       OUT_BLOCK.format(outputs=','.join(
+                                           sink_addrs))
+                                       if sink_addrs else ''),
                                    metrics_addr=metrics_addr,
                                    res_dir=res_dir)
 
@@ -718,14 +732,14 @@ class Cluster(object):
             raise t.error
         return sink
 
-    def sink_expect(self, expected, timeout=30, sink=-1):
+    def sink_expect(self, expected, timeout=30, sink=-1, allow_more=False):
         logging.log(1, "sink_expect(expected={}, timeout={}, sink={})".format(
             expected, timeout, sink))
         if isinstance(sink, Sink):
             pass
         else:
             sink = self.sinks[sink]
-        t = SinkExpect(sink, expected, timeout)
+        t = SinkExpect(sink, expected, timeout, allow_more=allow_more)
         self._stoppables.add(t)
         t.start()
         t.join()

--- a/testing/tools/integration/control.py
+++ b/testing/tools/integration/control.py
@@ -78,24 +78,26 @@ class SinkExpect(StoppableThread):
     """
     __base_name__ = 'SinkExpect'
 
-    def __init__(self, sink, expected, timeout=30):
+    def __init__(self, sink, expected, timeout=30, allow_more=False):
         super(SinkExpect, self).__init__()
         self.sink = sink
         self.expected = expected
         self.timeout = timeout
         self.name = self.__base_name__
         self.error = None
+        self.allow_more = allow_more
 
     def run(self):
         started = time.time()
         while not self.stopped():
             msgs = len(self.sink.data)
             if msgs > self.expected:
-                self.error = ExpectationError('{}: has received too many '
-                                              'messages. Expected {} but got '
-                                              '{}.'.format(self.name,
-                                                           self.expected,
-                                                           msgs))
+                if not self.allow_more:
+                    self.error = ExpectationError('{}: has received too many '
+                                                  'messages. Expected {} but got '
+                                                  '{}.'.format(self.name,
+                                                               self.expected,
+                                                               msgs))
                 self.stop()
                 break
             if msgs == self.expected:

--- a/testing/tools/integration/external.py
+++ b/testing/tools/integration/external.py
@@ -150,10 +150,11 @@ def save_logs_to_file(base_dir, log_stream=None, persistent_data={}):
         runner_data = persistent_data.get('runner_data', [])
         # save worker data to files
         for rd in runner_data:
-            worker_log_name = '{name}_{code}_{time}.error.log'.format(
+            worker_log_name = '{name}.{pid}.{code}.{time}.error.log'.format(
                 name=rd.name,
                 code=rd.returncode,
-                time=rd.start_time.strftime('%Y%m%d_%H%M%S'))
+                pid=rd.pid,
+                time=rd.start_time.strftime('%Y%m%d_%H%M%S.%f'))
             with open(os.path.join(base_dir, worker_log_name), 'wb') as f:
                 f.write('{identifier} ->\n\n{stdout}\n\n{identifier} <-'
                     .format(identifier="--- {name} (pid: {pid}, rc: {rc})"
@@ -165,7 +166,7 @@ def save_logs_to_file(base_dir, log_stream=None, persistent_data={}):
         for sd in sender_data:
             sender_log_name = 'sender_{address}_{time}.error.dat'.format(
                 address=sd.address.replace(':', '.'),
-                time=sd.start_time.strftime('%Y%m%d_%H%M%S'))
+                time=sd.start_time.strftime('%Y%m%d_%H%M%S.%f'))
             with open(os.path.join(base_dir, sender_log_name), 'wb') as f:
                 f.write(''.join(sd.data))
         # save sinks data to files
@@ -173,7 +174,7 @@ def save_logs_to_file(base_dir, log_stream=None, persistent_data={}):
         for sk in sink_data:
             sink_log_name = 'sink_{address}_{time}.error.dat'.format(
                 address=sk.address.replace(':', '.'),
-                time=sk.start_time.strftime('%Y%m%d_%H%M%S'))
+                time=sk.start_time.strftime('%Y%m%d_%H%M%S.%f'))
             with open(os.path.join(base_dir, sink_log_name), 'wb') as f:
                 f.write(''.join(sk.data))
         logging.warn("Error logs saved to {}".format(base_dir))

--- a/testing/tools/integration/integration.py
+++ b/testing/tools/integration/integration.py
@@ -41,7 +41,7 @@ FROM_TAIL = int(os.environ.get("FROM_TAIL", 10))
 
 def pipeline_test(generator, expected, command, workers=1, sources=1,
                   mode='framed', sinks=1, decoder=None, pre_processor=None,
-                  batch_size=1, sink_expect=None,
+                  batch_size=1, sink_expect=None, sink_expect_allow_more=False,
                   sink_stop_timeout=DEFAULT_SINK_STOP_TIMEOUT,
                   sink_await=None, delay=30,
                   validate_file=None, giles_mode=False,
@@ -83,6 +83,8 @@ def pipeline_test(generator, expected, command, workers=1, sources=1,
     - `sink_expect`: the number of messages to expect at the sink. This allows
         directly relying on received output for timing control. Default: None
         Should be a list of `len(sinks)`.
+    - `sink_expect_allow_more`: Bool (default False): allow more messages in sink
+        after `sink_expect` values have been received.
     - `sink_await`: a list of (binary) strings to await for at the sink.
         Once all of the await values have been seen at the sink, the test may
         be stopped.
@@ -140,46 +142,47 @@ def pipeline_test(generator, expected, command, workers=1, sources=1,
                      persistent_data=persistent_data) as cluster:
 
             # Create senders
-            senders = []
-            if not isinstance(generator, list):
-                generator = [(generator, 0)]
-            for gen, idx in generator:
-                reader = Reader(gen)
-                sender = Sender(cluster.source_addrs[idx], reader,
-                                batch_size=batch_size)
-                cluster.add_sender(sender)
+            if generator:
+                if not isinstance(generator, list):
+                    generator = [(generator, 0)]
+                for gen, idx in generator:
+                    reader = Reader(gen)
+                    sender = Sender(cluster.source_addrs[idx], reader,
+                                    batch_size=batch_size)
+                    cluster.add_sender(sender)
 
-            # start each sender and await its completion before startin the next
-            for sender in cluster.senders:
-                sender.start()
-                sender.join()
-                try:
-                    assert(sender.error is None)
-                except Exception as err:
-                    logging.error("Sender exited with an error")
-                    raise sender.error
-            logging.debug('All senders completed sending.')
+            # start each sender and await its completion before starting the next
+            if cluster.senders:
+                for sender in cluster.senders:
+                    sender.start()
+                    sender.join()
+                    try:
+                        assert(sender.error is None)
+                    except Exception as err:
+                        logging.error("Sender exited with an error")
+                        raise sender.error
+                logging.debug('All senders completed sending.')
+            else:
+                logging.debug("No external senders were given for the cluster.")
             # Use sink, metrics, or a timer to determine when to stop the
             # runners and sinks and begin validation
-            stoppers = []
             if sink_expect:
                 logging.debug('Waiting for {} messages at the sinks with a timeout'
                               ' of {} seconds'.format(sink_expect,
                                                       sink_stop_timeout))
                 for sink, sink_expect_val in zip(cluster.sinks, sink_expect):
-                    stopper = SinkExpect(sink, sink_expect_val, sink_stop_timeout)
-                    stopper.start()
-                    stoppers.append(stopper)
+                    cluster.sink_expect(expected=sink_expect_val,
+                                        timeout=sink_stop_timeout,
+                                        sink=sink,
+                                        allow_more=sink_expect_allow_more)
             elif sink_await:
                 logging.debug('Awaiting {} values at the sinks with a timeout of '
                               '{} seconds'.format(sum(map(len, sink_await)),
                                                   sink_stop_timeout))
-                stoppers = []
                 for sink, sink_await_vals in zip(cluster.sinks, sink_await):
-                    stopper = SinkAwaitValue(sink, sink_await_vals,
-                                             sink_stop_timeout)
-                    stopper.start()
-                    stoppers.append(stopper)
+                    cluster.sink_await(values=sink_await_vals,
+                                       timeout=sink_stop_timeout,
+                                       sink=sink)
             else:
                 logging.debug('Waiting {} seconds before shutting down '
                               'cluster.'
@@ -187,17 +190,6 @@ def pipeline_test(generator, expected, command, workers=1, sources=1,
                 time.sleep(delay)
 
             # join stoppers and check for errors
-            for stopper in stoppers:
-                stopper.join()
-                if stopper.error:
-                    print(cluster.sinks)
-                    for s in cluster.sinks:
-                        print
-                        print(len(s.data))
-                        print()
-                    raise stopper.error
-            logging.debug('Shutting down cluster.')
-
             cluster.stop_cluster()
 
             ############

--- a/testing/tools/integration/integration_test
+++ b/testing/tools/integration/integration_test
@@ -7,6 +7,7 @@ import logging
 import os
 import random
 import re
+import shutil
 import struct
 
 from cluster import runner_data_format
@@ -20,7 +21,6 @@ from logger import (add_in_memory_log_stream,
                     INFO2,
                     set_logging)
 
-set_logging(name='integration', level=logging.DEBUG)
 
 """
 Run an integration test as a CLI
@@ -318,10 +318,9 @@ LOG_LEVELS = {'none': 0,
               'warn': 30,
               'error': 40,
               'critical': 50}
-def set_log_level(value):
-    """Set the effective log level"""
-    level = LOG_LEVELS.get(value, 20)
-    logging.root.setLevel(level)
+def get_log_level(value):
+    """Get the effective log level"""
+    return LOG_LEVELS.get(value, 10)
 
 
 class SetLogFile(argparse.Action):
@@ -448,6 +447,9 @@ def CLI():
     expect = stopper.add_argument_group('Sink Expect')
     expect.add_argument('--sink-expect', type=int, action='append',
                         help=("How many messages to expect at each sink."))
+    stopper.add_argument('--sink-expect-allow-more', action='store_true',
+                         help=("Allow sink to receive more than the expected"
+                               " number of values"))
     stopper.add_argument('--sink-await', nargs='+', action=SinkAwaitAction,
                          metavar=('value', 'header'),
                          help=("Stop after receiving all await values in the"
@@ -480,7 +482,8 @@ def CLI():
                                   "error."))
 
     args = parser.parse_args()
-    set_log_level(args.log_level)
+    log_level = get_log_level(args.log_level)
+    set_logging(name='integration', level=log_level)
 
     # If --validation-cmp, make sure expected_val is not None
     if args.validation_cmp:
@@ -499,8 +502,12 @@ def CLI():
 
 
     t0 = datetime.datetime.now()
-    base_dir = 'errors/{}'.format(t0.strftime('%Y%m%d_%H%M%S'))
-    log_stream = add_in_memory_log_stream()
+    log_stream = add_in_memory_log_stream(level=logging.DEBUG)
+    cwd = os.getcwd()
+    trunc_head = cwd.find('/wallaroo/') + len('/wallaroo/')
+    base_dir = '/tmp/wallaroo_test_errors/{}/{}'.format(
+        cwd[trunc_head:],
+        t0.strftime('%Y%m%d_%H%M%S'))
     persistent_data = {}
 
     logging.debug("Running integration test with the following options:")
@@ -519,6 +526,7 @@ def CLI():
             mode = args.sink_mode,
             batch_size = args.batch_size,
             sink_expect = args.sink_expect,
+            sink_expect_allow_more = args.sink_expect_allow_more,
             sink_stop_timeout = args.sink_stop_timeout,
             sink_await = args.sink_await,
             delay = args.delay,
@@ -535,6 +543,18 @@ def CLI():
                       % args.command)
         # Save logs to file in case of error
         save_logs_to_file(base_dir, log_stream, persistent_data)
+        # get core file names
+        try:
+            rex = re.compile('core.*')
+            cores = filter(lambda s: rex.match(s), os.listdir(os.getcwd()))
+            if cores:
+                logging.warn("Core files detected: {}".format(cores))
+            for core in cores:
+                logging.info("Moving core {} to {}".format(core, base_dir))
+                shutil.move(core, os.path.join(base_dir, core))
+        except Exception as err_inner:
+            logging.exception(err_inner)
+            logging.warn("Failed to move core files {}".format(base_dir))
         parser.exit(1)
 
     if validation_cmd:
@@ -551,7 +571,7 @@ def CLI():
             outputs = runner_data_format(persistent_data.get('runner_data', []))
             logging.error("Application outputs:\n{}".format(outputs))
             logging.error("Validation command '%s' failed with the output:\n"
-                          "--\n%s\nThe application output is shown above.\n",
+                          "--\n%s",
                           res.command, res.output)
             # Save logs to file in case of error
             save_logs_to_file(base_dir, log_stream, persistent_data)

--- a/testing/tools/integration/logger.py
+++ b/testing/tools/integration/logger.py
@@ -26,7 +26,7 @@ DEFAULT_LOG_FMT_NAME = '%(asctime)s %(name)s %(levelname)-8s [%(filename)s:%(lin
 
 def set_logging(name='', level=logging.INFO, fmt=None):
     logging.root.name = name
-    logging.root.setLevel(level)
+    logging.root.setLevel(0)
     if not fmt:
         if name:
             fmt = DEFAULT_LOG_FMT_NAME
@@ -34,11 +34,13 @@ def set_logging(name='', level=logging.INFO, fmt=None):
             fmt = DEFAULT_LOG_FMT
     logging.root.formatter = logging.Formatter(fmt)
     stream_handler = logging.StreamHandler()
+    stream_handler.setLevel(level)
     stream_handler.setFormatter(logging.root.formatter)
     logging.root.addHandler(stream_handler)
 
 
 def add_in_memory_log_stream(name='', level=None, fmt=None):
+    logging.root.setLevel(0)
     log_stream = StringIO()
     if not fmt:
         if name:
@@ -49,8 +51,6 @@ def add_in_memory_log_stream(name='', level=None, fmt=None):
     sh = logging.StreamHandler(log_stream)
     if level:
         sh.setLevel(level)
-    else:
-        sh.setLevel(logging.root.level)
     sh.setFormatter(formatter)
     logging.root.addHandler(sh)
     return log_stream


### PR DESCRIPTION
**This PR should only be merged after the `gensource` branch is merged, as that's the branch that contains the test harness updates that save the logs and cores**

This PR adds artifact storage to the `integration-tests` and `integration-tests-with-resilience` CircleCI jobs.
When an integration test or resilience test fails, the logs of each of the workers, as well as the binary dumps of each sender and sink are saved to `/tmp/wallaroo_test_errors/<path to test>/<test name>/<test start time>/`.
If there are any core dumps in the current working directory (because in circleCI they are local to the CWD), those too are moved to that directory.

The two CircleCI jobs are then set up to upload those artifacts to S3 with the full path.

This gives us full run logs as well as core dumps from any failing test on CircleCI, which we've been finding to be very helpful in local dev work over the last few weeks.

/cc @jtfmumm @slfritchie 