### PR TITLE
Clean resilience dir when closing cluster context

### DIFF
--- a/testing/tools/integration/cluster.py
+++ b/testing/tools/integration/cluster.py
@@ -918,7 +918,6 @@ class Cluster(object):
         for s in self.senders:
             s.stop()
         self.metrics.stop()
-        # clean_resilience_path(self.res_dir)
         self.persistent_data['runner_data'] = [
             RunnerData(r.name, r.command, r.pid, r.returncode(),
                        r.get_output(), r.start_time)
@@ -927,6 +926,7 @@ class Cluster(object):
             SenderData(s.name, s.address, s.start_time, s.data) for s in self.senders]
         self.persistent_data['sink_data'] = [
             SinkData(s.name, s.address, s.start_time, s.data) for s in self.sinks]
+        clean_resilience_path(self.res_dir)
         self._finalized = True
 
 


### PR DESCRIPTION
This was commented out of the test code a few weeks back to help debug some difficult to reproduce issues. It should be included as part of this release in case anybody runs our test suite, to ensure the tests clean up after themselves.

Related to #2422