### PR TITLE
Remove debug printf statements

### DIFF
--- a/lib/wallaroo/core/boundary/boundary.pony
+++ b/lib/wallaroo/core/boundary/boundary.pony
@@ -268,7 +268,6 @@ actor OutgoingBoundary is Consumer
 
     @printf[I32](("RE-Connecting OutgoingBoundary to " + _host + ":" + _service
       + "\n").cstring())
-    @printf[I32]("!@ reconnect() RE-Connecting OutgoingBoundary %s to %s:%s on %s\n".cstring(), _step_id.string().cstring(), _host.cstring(), _service.cstring(), _target_worker.cstring())
 
   be migrate_key(step_id: RoutingId, state_name: String, key: Key,
     checkpoint_id: CheckpointId, state: ByteSeq val)
@@ -450,8 +449,6 @@ actor OutgoingBoundary is Consumer
     None
 
   be register_producer(id: RoutingId, producer: Producer) =>
-    // @printf[I32]("!@ Registered producer %s at boundary %s. Total %s upstreams.\n".cstring(), id.string().cstring(), (digestof this).string().cstring(), _upstreams.size().string().cstring())
-
     ifdef debug then
       Invariant(not _upstreams.contains(producer))
     end
@@ -459,8 +456,6 @@ actor OutgoingBoundary is Consumer
     _upstreams.set(producer)
 
   be unregister_producer(id: RoutingId, producer: Producer) =>
-    // @printf[I32]("!@ Unregistered producer %s at boundary %s. Total %s upstreams.\n".cstring(), id.string().cstring(), (digestof this).string().cstring(), _upstreams.size().string().cstring())
-
     // TODO: Determine if we need this Invariant.
     // ifdef debug then
     //   Invariant(_upstreams.contains(producer))
@@ -476,7 +471,6 @@ actor OutgoingBoundary is Consumer
   fun ref _forward_register_producer(source_id: RoutingId,
     target_id: RoutingId, producer: Producer)
   =>
-    // @printf[I32]("!@ Forward Registered producer at boundary %s. sourceid: %s, target_id: %s\n".cstring(), (digestof this).string().cstring(), source_id.string().cstring(), target_id.string().cstring())
     _registered_producers.register_producer(source_id, producer, target_id)
     try
       let msg = ChannelMsgEncoder.register_producer(_worker_name,
@@ -490,8 +484,6 @@ actor OutgoingBoundary is Consumer
   be forward_unregister_producer(source_id: RoutingId, target_id: RoutingId,
     producer: Producer)
   =>
-    // @printf[I32]("!@ Forward UNRegistered producer at boundary %s. sourceid: %s, target_id: %s\n".cstring(), (digestof this).string().cstring(), source_id.string().cstring(), target_id.string().cstring())
-
     _registered_producers.unregister_producer(source_id, producer, target_id)
     try
       let msg = ChannelMsgEncoder.unregister_producer(_worker_name,
@@ -730,7 +722,6 @@ actor OutgoingBoundary is Consumer
     if (_host != "") and (_service != "") and not _no_more_reconnect then
       @printf[I32]("RE-Connecting OutgoingBoundary to %s:%s\n".cstring(),
         _host.cstring(), _service.cstring())
-        @printf[I32]("!@ _schedule_reconnect() RE-Connecting OutgoingBoundary %s to %s:%s on %s\n".cstring(), _step_id.string().cstring(), _host.cstring(), _service.cstring(), _target_worker.cstring())
       let timer = Timer(_PauseBeforeReconnect(this), _reconnect_pause)
       _timers(consume timer)
     end

--- a/lib/wallaroo/core/common/step_message_processor.pony
+++ b/lib/wallaroo/core/common/step_message_processor.pony
@@ -122,7 +122,6 @@ class BarrierStepMessageProcessor is StepMessageProcessor
     barrier_token: BarrierToken)
   =>
     if _barrier_forwarder.input_blocking(input_id) then
-      @printf[I32]("!@ StepMessageProcessor: Queueing %s\n".cstring(), barrier_token.string().cstring())
       _queued.push(QueuedBarrier(input_id, producer, barrier_token))
     else
       _barrier_forwarder.receive_barrier(input_id, producer, barrier_token)

--- a/lib/wallaroo/core/data_channel/data_channel_tcp.pony
+++ b/lib/wallaroo/core/data_channel/data_channel_tcp.pony
@@ -182,10 +182,7 @@ class DataChannelConnectNotifier is DataChannelNotify
       _layout_initializer, _data_receivers, _recovery_replayer,
       _router_registry, this, dr)
     dr.data_connect(sender_boundary_id, highest_seq_id, conn)
-    //!@
-    if _queue.size() > 0 then @printf[I32]("!@ DataChannel: playing queued msgs:\n".cstring()) end
     for msg in _queue.values() do
-      @printf[I32]("!@ -- Playing msg size %s\n".cstring(), msg.size().string().cstring())
       _receiver.decode_and_process(conn, msg)
     end
     _queue.clear()

--- a/lib/wallaroo/core/initialization/local_topology.pony
+++ b/lib/wallaroo/core/initialization/local_topology.pony
@@ -918,8 +918,7 @@ actor LocalTopologyInitializer is LayoutInitializer
             end
           end
 
-        //!@ This needs to take account of keys
-        if t.is_empty() then
+        if t.is_empty() and (local_keys.size() == 0) then
           @printf[I32]("----This worker has no steps----\n".cstring())
         end
 

--- a/lib/wallaroo/core/keys/local_keys_file.pony
+++ b/lib/wallaroo/core/keys/local_keys_file.pony
@@ -92,32 +92,23 @@ class LocalKeysFile
           /////
           //// QQQ r.append(_file.read(1))
           let qqq = _file.read(1)
-          @printf[I32]("@! read result size = %d\n".cstring(), qqq.size())
           r.append(consume qqq)
-          @printf[I32]("!@cmd\n".cstring())
           let cmd: U8 = r.u8()?
-          @printf[I32]("!@next_cpoint_id\n".cstring())
           r.append(_file.read(8))
           let next_cpoint_id = r.u64_be()?
-          @printf[I32]("!@payload_size\n".cstring())
           r.append(_file.read(4))
           let payload_size = r.u32_be()?
           if next_cpoint_id > checkpoint_id then
             // Skip this entry
-             @printf[I32]("!@ next_cpoint_id %d > checkpoint_id %d, payload_size = %d\n".cstring(), next_cpoint_id, checkpoint_id, payload_size)
             _file.seek(payload_size.isize())
           else
             r.append(_file.read(4))
-            @printf[I32]("!@s_name_size\n".cstring())
             let s_name_size = r.u32_be()?.usize()
             r.append(_file.read(s_name_size))
-            @printf[I32]("!@s_name\n".cstring())
             let s_name: StateName = String.from_array(r.block(s_name_size)?)
             r.append(_file.read(4))
-            @printf[I32]("!@k_size\n".cstring())
             let k_size = r.u32_be()?.usize()
             r.append(_file.read(k_size))
-            @printf[I32]("!@key\n".cstring())
             let key: Key = String.from_array(r.block(k_size)?)
 
             match cmd
@@ -126,7 +117,6 @@ class LocalKeysFile
             | LocalKeysFileCommand.remove() =>
               if lks.contains(s_name) then
                 try
-                  @printf[I32]("!@lks(s_name)?\n".cstring())
                   let keys = lks(s_name)?
                   if keys.contains(key) then
                     keys.unset(key)
@@ -143,20 +133,12 @@ class LocalKeysFile
           @printf[I32]("Error reading local keys file!\n".cstring())
           Fail()
         end
-        @printf[I32]("!@bottom of loop: _file.size() %d vs _file.position() %d\n".cstring(), _file.size(), _file.position())
         if _file.size() == _file.position() then
           end_of_checkpoint = true
-        //!@
-        elseif _file.size() < _file.position() then
-          @printf[I32]("!@ BAD: overshot end of local keys file by %s\n".cstring(), (_file.position().isize() - _file.size().isize()).string().cstring())
         end
       end
     end
-    @printf[I32]("!@ Finished reading local keys\n".cstring())
-
-    // Truncate rest of file since we are rolling back to an earlier
-    // checkpoint.
-    // _file.set_length(_file.position())
+    @printf[I32]("Finished reading local keys\n".cstring())
 
     let lks_iso = recover iso Map[StateName, SetIs[Key] val] end
     for (s, keys) in lks.pairs() do

--- a/lib/wallaroo/core/sink/connector_sink/connector_sink.pony
+++ b/lib/wallaroo/core/sink/connector_sink/connector_sink.pony
@@ -285,7 +285,6 @@ actor ConnectorSink is Sink
     _inputs
 
   be register_producer(id: RoutingId, producer: Producer) =>
-    // @printf[I32]("!@ Registered producer %s at sink %s. Total %s upstreams.\n".cstring(), id.string().cstring(), _sink_id.string().cstring(), _upstreams.size().string().cstring())
     // If we have at least one input, then we are involved in checkpointing.
     if _inputs.size() == 0 then
       _barrier_initiator.register_sink(this)
@@ -296,8 +295,6 @@ actor ConnectorSink is Sink
     _upstreams.set(producer)
 
   be unregister_producer(id: RoutingId, producer: Producer) =>
-    // @printf[I32]("!@ Unregistered producer %s at sink %s. Total %s upstreams.\n".cstring(), id.string().cstring(), _sink_id.string().cstring(), _upstreams.size().string().cstring())
-
     ifdef debug then
       Invariant(_upstreams.contains(producer))
     end
@@ -333,7 +330,9 @@ actor ConnectorSink is Sink
   be receive_barrier(input_id: RoutingId, producer: Producer,
     barrier_token: BarrierToken)
   =>
-    // @printf[I32]("!@ Receive barrier %s at ConnectorSink %s\n".cstring(), barrier_token.string().cstring(), _sink_id.string().cstring())
+    ifdef "checkpoint_trace" then
+      @printf[I32]("Receive barrier %s at ConnectorSink %s\n".cstring(), barrier_token.string().cstring(), _sink_id.string().cstring())
+    end
     process_barrier(input_id, producer, barrier_token)
 
   fun ref process_barrier(input_id: RoutingId, producer: Producer,
@@ -371,7 +370,9 @@ actor ConnectorSink is Sink
     end
 
   fun ref barrier_complete(barrier_token: BarrierToken) =>
-    @printf[I32]("!@ Barrier %s complete at ConnectorSink %s\n".cstring(), barrier_token.string().cstring(), _sink_id.string().cstring())
+    ifdef "checkpoint_trace" then
+      @printf[I32]("Barrier %s complete at ConnectorSink %s\n".cstring(), barrier_token.string().cstring(), _sink_id.string().cstring())
+    end
     ifdef debug then
       Invariant(_message_processor.barrier_in_progress())
     end

--- a/lib/wallaroo/core/sink/kafka_sink/kafka_sink.pony
+++ b/lib/wallaroo/core/sink/kafka_sink/kafka_sink.pony
@@ -241,7 +241,6 @@ actor KafkaSink is (Sink & KafkaClientManager & KafkaProducer)
     None
 
   be register_producer(id: RoutingId, producer: Producer) =>
-    // @printf[I32]("!@ Registered producer %s at sink %s. Total %s upstreams.\n".cstring(), id.string().cstring(), _sink_id.string().cstring(), _upstreams.size().string().cstring())
     // If we have at least one input, then we are involved in checkpointing.
     if _inputs.size() == 0 then
       _barrier_initiator.register_sink(this)
@@ -252,8 +251,6 @@ actor KafkaSink is (Sink & KafkaClientManager & KafkaProducer)
     _upstreams.set(producer)
 
   be unregister_producer(id: RoutingId, producer: Producer) =>
-    // @printf[I32]("!@ Unregistered producer %s at sink %s. Total %s upstreams.\n".cstring(), id.string().cstring(), _sink_id.string().cstring(), _upstreams.size().string().cstring())
-
     ifdef debug then
       Invariant(_upstreams.contains(producer))
     end

--- a/lib/wallaroo/core/sink/tcp_sink/tcp_sink.pony
+++ b/lib/wallaroo/core/sink/tcp_sink/tcp_sink.pony
@@ -285,7 +285,6 @@ actor TCPSink is Sink
     _inputs
 
   be register_producer(id: RoutingId, producer: Producer) =>
-    // @printf[I32]("!@ Registered producer %s at sink %s. Total %s upstreams.\n".cstring(), id.string().cstring(), _sink_id.string().cstring(), _upstreams.size().string().cstring())
     // If we have at least one input, then we are involved in checkpointing.
     if _inputs.size() == 0 then
       _barrier_initiator.register_sink(this)
@@ -296,8 +295,6 @@ actor TCPSink is Sink
     _upstreams.set(producer)
 
   be unregister_producer(id: RoutingId, producer: Producer) =>
-    // @printf[I32]("!@ Unregistered producer %s at sink %s. Total %s upstreams.\n".cstring(), id.string().cstring(), _sink_id.string().cstring(), _upstreams.size().string().cstring())
-
     ifdef debug then
       Invariant(_upstreams.contains(producer))
     end
@@ -333,7 +330,10 @@ actor TCPSink is Sink
   be receive_barrier(input_id: RoutingId, producer: Producer,
     barrier_token: BarrierToken)
   =>
-    // @printf[I32]("!@ Receive barrier %s at TCPSink %s\n".cstring(), barrier_token.string().cstring(), _sink_id.string().cstring())
+    ifdef "checkpoint_trace" then
+      @printf[I32]("Receive barrier %s at TCPSink %s\n".cstring(),
+        barrier_token.string().cstring(), _sink_id.string().cstring())
+    end
     process_barrier(input_id, producer, barrier_token)
 
   fun ref process_barrier(input_id: RoutingId, producer: Producer,
@@ -371,7 +371,10 @@ actor TCPSink is Sink
     end
 
   fun ref barrier_complete(barrier_token: BarrierToken) =>
-    @printf[I32]("!@ Barrier %s complete at TCPSink %s\n".cstring(), barrier_token.string().cstring(), _sink_id.string().cstring())
+    ifdef "checkpoint_trace" then
+      @printf[I32]("Barrier %s complete at TCPSink %s\n".cstring(),
+        barrier_token.string().cstring(), _sink_id.string().cstring())
+    end
     ifdef debug then
       Invariant(_message_processor.barrier_in_progress())
     end

--- a/lib/wallaroo/core/source/barrier_source/barrier_source.pony
+++ b/lib/wallaroo/core/source/barrier_source/barrier_source.pony
@@ -250,7 +250,10 @@ actor BarrierSource is Source
     None
 
   be initiate_barrier(token: BarrierToken) =>
-    @printf[I32]("!@ BarrierSource initiate_barrier. Forwarding to %s outputs\n".cstring(), _outputs.size().string().cstring())
+    ifdef "checkpoint_trace" then
+      @printf[I32]("BarrierSource initiate_barrier. Forwarding to %s outputs\n"
+        .cstring(), _outputs.size().string().cstring())
+    end
     match token
     | let sbt: CheckpointBarrierToken =>
       checkpoint_state(sbt.id)
@@ -258,7 +261,6 @@ actor BarrierSource is Source
     for (o_id, o) in _outputs.pairs() do
       match o
       | let ob: OutgoingBoundary =>
-        // @printf[I32]("!@ BarrierSource: barrier over boundary to %s!\n".cstring(), o_id.string().cstring())
         ob.forward_barrier(o_id, _source_id, token)
       else
         o.receive_barrier(_source_id, this, token)
@@ -266,7 +268,9 @@ actor BarrierSource is Source
     end
 
   be barrier_complete(token: BarrierToken) =>
-    @printf[I32]("!@ barrier_complete at BarrierSource %s\n".cstring(), _source_id.string().cstring())
+    ifdef "checkpoint_trace" then
+      @printf[I32]("barrier_complete at BarrierSource %s\n".cstring(), _source_id.string().cstring())
+    end
     None
 
   be update_worker_data_service(worker_name: String,

--- a/lib/wallaroo/core/source/connector_source/connector_source.pony
+++ b/lib/wallaroo/core/source/connector_source/connector_source.pony
@@ -128,7 +128,6 @@ actor ConnectorSource is Source
     """
     A new connection accepted on a server.
     """
-    @printf[I32]("!@ Spinning up ConnectorSource %s\n".cstring(), source_id.string().cstring())
     _source_id = source_id
     _auth = auth
     _event_log = event_log
@@ -464,7 +463,10 @@ actor ConnectorSource is Source
   // BARRIER
   //////////////
   be initiate_barrier(token: BarrierToken) =>
-    @printf[I32]("!@ ConnectorSource received initiate_barrier %s\n".cstring(), token.string().cstring())
+    ifdef "checkpoint_trace" then
+      @printf[I32]("ConnectorSource received initiate_barrier %s\n".cstring(),
+        token.string().cstring())
+    end
     if not _is_pending then
       _initiate_barrier(token)
     end
@@ -491,9 +493,10 @@ actor ConnectorSource is Source
     end
 
   be barrier_complete(token: BarrierToken) =>
-    // @printf[I32]("!@ barrier_complete at ConnectorSource %s\n".cstring(), _source_id.string().cstring())
-    // !@ Here's where we could ack finished messages up to checkpoint point.
-    // We should also match for rollback token.
+    ifdef "checkpoint_trace" then
+      @printf[I32]("barrier_complete at ConnectorSource %s\n".cstring(),
+        _source_id.string().cstring())
+    end
     None
 
   //////////////

--- a/lib/wallaroo/core/source/kafka_source/kafka_source.pony
+++ b/lib/wallaroo/core/source/kafka_source/kafka_source.pony
@@ -385,15 +385,12 @@ actor KafkaSource[In: Any val] is (Source & KafkaConsumer)
     end
 
   be barrier_complete(token: BarrierToken) =>
-    // !@ Here's where we could ack finished messages up to checkpoint point.
-    // We should also match for rollback token.
     None
 
   //////////////
   // CHECKPOINTS
   //////////////
   fun ref checkpoint_state(checkpoint_id: CheckpointId) =>
-    //!@ We probably need to checkpoint info about last seq id for checkpoint.
     ifdef "trace" then
       @printf[I32]("checkpoint_state in %s\n".cstring(), _name.cstring())
     end
@@ -411,7 +408,6 @@ actor KafkaSource[In: Any val] is (Source & KafkaConsumer)
   be rollback(payload: ByteSeq val, event_log: EventLog,
     checkpoint_id: CheckpointId)
   =>
-    //!@ Rollback!
     _next_checkpoint_id = checkpoint_id + 1
     event_log.ack_rollback(_source_id)
 

--- a/lib/wallaroo/core/source/tcp_source/tcp_source.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source.pony
@@ -128,7 +128,6 @@ actor TCPSource is Source
     """
     A new connection accepted on a server.
     """
-    @printf[I32]("!@ Spinning up TCPSource %s\n".cstring(), source_id.string().cstring())
     _source_id = source_id
     _auth = auth
     _event_log = event_log
@@ -464,7 +463,10 @@ actor TCPSource is Source
   // BARRIER
   //////////////
   be initiate_barrier(token: BarrierToken) =>
-    @printf[I32]("!@ TCPSource received initiate_barrier %s\n".cstring(), token.string().cstring())
+    ifdef "checkpoint_trace" then
+      @printf[I32]("TCPSource received initiate_barrier %s\n".cstring(),
+        token.string().cstring())
+    end
     if not _is_pending then
       _initiate_barrier(token)
     end
@@ -491,9 +493,10 @@ actor TCPSource is Source
     end
 
   be barrier_complete(token: BarrierToken) =>
-    // @printf[I32]("!@ barrier_complete at TCPSource %s\n".cstring(), _source_id.string().cstring())
-    // !@ Here's where we could ack finished messages up to checkpoint point.
-    // We should also match for rollback token.
+    ifdef "checkpoint_trace" then
+      @printf[I32]("barrier_complete at TCPSource %s\n".cstring(),
+        _source_id.string().cstring())
+    end
     None
 
   //////////////

--- a/lib/wallaroo/core/topology/router.pony
+++ b/lib/wallaroo/core/topology/router.pony
@@ -1459,29 +1459,7 @@ class val LocalPartitionRouter[S: State ref] is PartitionRouter
       a.push(id.string())
     end
     digest(_worker_name) = consume a
-
-    // Now the other workers
-    //!@ Others needs to be filled in another way. We don't know about
-    // ProxyRouters anymore.  We need this distribution digest for partition
-    // queries, which are used in autoscale tests.
     let others = Map[WorkerName, Array[String]]
-    // try
-    //   for target in _local_routes.values() do
-    //     match target
-    //     | let pr: ProxyRouter =>
-    //       let pa = pr.proxy_address()
-    //       if others.contains(pa.worker) then
-    //         others(pa.worker)?.push(pa.routing_id.string())
-    //       else
-    //         let next = Array[String]
-    //         next.push(pa.routing_id.string())
-    //         others(pa.worker) = next
-    //       end
-    //     end
-    //   end
-    // else
-    //   Fail()
-    // end
     for (k, v) in others.pairs() do
       let next = recover iso Array[String] end
       for id in v.values() do

--- a/lib/wallaroo/ent/autoscale/autoscale.pony
+++ b/lib/wallaroo/ent/autoscale/autoscale.pony
@@ -221,7 +221,6 @@ class Autoscale
   fun ref begin_join_migration(joining_workers: Array[WorkerName] val,
     checkpoint_id: CheckpointId)
   =>
-    @printf[I32]("!@ ---> begin_join_migration\n".cstring())
     _phase = _WaitingForJoinMigration(this, _auth, joining_workers
       where is_coordinator = false)
     _router_registry.begin_join_migration(joining_workers,
@@ -230,7 +229,6 @@ class Autoscale
   fun ref prepare_grow_migration(
     joining_workers: Array[WorkerName] val)
   =>
-    @printf[I32]("!@ ---> initiate_stop_the_world_for_join_migration\n".cstring())
     _phase = _WaitingForJoinMigration(this, _auth, joining_workers
       where is_coordinator = true)
     // TODO: For now, we're handing control of the join protocol over to
@@ -254,7 +252,6 @@ class Autoscale
   fun ref send_migration_batch_complete(joining_workers: Array[WorkerName] val,
     is_coordinator: Bool)
   =>
-    @printf[I32]("!@ ---> send_migration_batch_complete\n".cstring())
     _phase = _WaitingForJoinMigrationAcks(this, _auth, joining_workers,
       is_coordinator)
     for target in joining_workers.values() do
@@ -307,12 +304,6 @@ class Autoscale
     _phase = _InitiatingShrink(this, remaining_workers, leaving_workers)
     _router_registry.initiate_shrink(remaining_workers, leaving_workers)
 
-    //!@
-  // fun ref prepare_shrink(remaining_workers: Array[WorkerName] val,
-  //   leaving_workers: Array[WorkerName] val)
-  // =>
-  //   _phase = _ShrinkInProgress(this, remaining_workers, leaving_workers)
-
   fun ref begin_leaving_migration(remaining_workers: Array[WorkerName] val) =>
     _phase = _WaitingForLeavingMigration(this, remaining_workers)
 
@@ -322,7 +313,6 @@ class Autoscale
   fun ref all_leaving_workers_finished(leaving_workers: Array[WorkerName] val,
     is_coordinator: Bool = false)
   =>
-    @printf[I32]("!@ Autoscale: all_leaving_workers_finished\n".cstring())
     _phase = _WaitingForResumeTheWorld(this, _auth, is_coordinator)
     _router_registry.all_leaving_workers_finished(leaving_workers)
 
@@ -696,7 +686,6 @@ class _WaitingForConnections is _AutoscalePhase
     @printf[I32](("AUTOSCALE: Waiting for %s current workers to connect " +
       "to joining workers.\n").cstring(),
       _connecting_worker_count.string().cstring())
-    @printf[I32]("!@ -- current_worker_count: %s\n".cstring(), current_worker_count.string().cstring())
 
   fun name(): String => "WaitingForConnections"
 
@@ -704,7 +693,6 @@ class _WaitingForConnections is _AutoscalePhase
     """
     Indicates that another worker has connected to joining workers.
     """
-    @printf[I32]("!@ worker_connected_to_joining_workers from %s\n".cstring(), worker.cstring())
     _connected_workers.set(worker)
     if _connected_workers.size() == _connecting_worker_count then
       _autoscale.prepare_grow_migration(_new_workers)
@@ -946,7 +934,6 @@ class _ShrinkInProgress is _AutoscalePhase
   fun name(): String => "ShrinkInProgress"
 
   fun ref leaving_worker_finished_migration(worker: WorkerName) =>
-    @printf[I32]("!@ autoscale: leaving_worker_finished_migration from %s\n".cstring(), worker.cstring())
     ifdef debug then
       Invariant(_leaving_workers_waiting_list.size() > 0)
     end
@@ -976,7 +963,6 @@ class _WaitingForLeavingMigration is _AutoscalePhase
     None
 
   fun ref all_key_migration_complete() =>
-    @printf[I32]("!@ AUTOSCALENOTES: Leaving worker all_key_migration_complete\n".cstring())
     _autoscale.wait_for_leaving_migration_acks(_remaining_workers)
 
 class _WaitingForLeavingMigrationAcks is _AutoscalePhase
@@ -1034,7 +1020,6 @@ class _WaitingForResumeTheWorld is _AutoscalePhase
 
   fun ref autoscale_complete() =>
     if _is_coordinator then
-      @printf[I32]("!@ _WaitingForResumeTheWorld AUTOSCALE: sending out autoscale complete messages\n".cstring())
       try
         let msg = ChannelMsgEncoder.autoscale_complete(_auth)?
         _autoscale.send_control_to_cluster(msg)

--- a/lib/wallaroo/ent/barrier/active_barriers.pony
+++ b/lib/wallaroo/ent/barrier/active_barriers.pony
@@ -27,7 +27,10 @@ class ActiveBarriers
 
   fun ref add_barrier(barrier_token: BarrierToken, handler: BarrierHandler) ?
   =>
-    @printf[I32]("!@ ACTIVE_BARRIERS: Adding barrier %s\n".cstring(), barrier_token.string().cstring())
+    ifdef "checkpoint_trace" then
+      @printf[I32]("ACTIVE_BARRIERS: Adding barrier %s\n".cstring(),
+        barrier_token.string().cstring())
+    end
     if _barriers.contains(barrier_token) then
       try
         let old_handler = _barriers(barrier_token)?
@@ -44,7 +47,10 @@ class ActiveBarriers
   fun ref remove_barrier(barrier_token: BarrierToken) ? =>
     if _barriers.contains(barrier_token) then
       try
-        @printf[I32]("!@ ACTIVE_BARRIERS: Removing barrier %s\n".cstring(), barrier_token.string().cstring())
+        ifdef "checkpoint_trace" then
+          @printf[I32]("ACTIVE_BARRIERS: Removing barrier %s\n".cstring(),
+            barrier_token.string().cstring())
+        end
         _barriers.remove(barrier_token)?
       else
         Fail()
@@ -107,5 +113,7 @@ class ActiveBarriers
     end
 
   fun ref clear() =>
-    @printf[I32]("!@ ACTIVE_BARRIERS: Clearing!!\n".cstring())
+    ifdef "checkpoint_trace" then
+      @printf[I32]("ACTIVE_BARRIERS: Clearing!!\n".cstring())
+    end
     _barriers.clear()

--- a/lib/wallaroo/ent/barrier/barrier_handler.pony
+++ b/lib/wallaroo/ent/barrier/barrier_handler.pony
@@ -97,7 +97,6 @@ class PendingBarrierHandler is BarrierHandler
     """
     If we receive barrier acks in this phase, we hold on to them for later.
     """
-    // @printf[I32]("!@ ack sink barrier at PendingBarrierHandler\n".cstring())
     if not _sinks.contains(s) then Fail() end
 
     _acked_sinks.set(s)
@@ -138,7 +137,6 @@ class PendingBarrierHandler is BarrierHandler
     _workers_acked_barrier.set(w)
 
   fun ref check_for_completion() =>
-    // @printf[I32]("!@ PendingBarrierHandler _check_for_completion with %s _acked_workers and %s _workers\n".cstring(), _workers_acked_start.size().string().cstring(), _workers.size().string().cstring())
     if _workers_acked_start.size() == _workers.size() then
       _initiator.confirm_start_barrier(_barrier_token)
       _start_barrier()
@@ -195,7 +193,6 @@ class InProgressPrimaryBarrierHandler is BarrierHandler
     true
 
   fun ref ack_barrier(s: BarrierReceiver) =>
-    // @printf[I32]("!@ ack_barrier at InProgressPrimaryBarrierHandler\n".cstring())
     if not _sinks.contains(s) then Fail() end
 
     _acked_sinks.set(s)
@@ -213,7 +210,6 @@ class InProgressPrimaryBarrierHandler is BarrierHandler
     _workers_acked.set(w)
 
   fun ref check_for_completion() =>
-    // @printf[I32]("!@ InProgressPrimaryBarrierHandler _check_for_completion with %s _acked_sinks and %s _sinks\n".cstring(), _acked_sinks.size().string().cstring(), _sinks.size().string().cstring())
     if _acked_sinks.size() == _sinks.size() then
       let acked_ws = recover iso SetIs[String] end
       for w in _workers_acked.values() do
@@ -254,17 +250,23 @@ class InProgressSecondaryBarrierHandler is BarrierHandler
     if not _sinks.contains(s) then Fail() end
 
     _acked_sinks.set(s)
-    @printf[I32]("!@ InProgressSecondaryBarrierHandler: Ack received.".cstring())
+    ifdef "checkpoint_trace" then
+      @printf[I32]("InProgressSecondaryBarrierHandler: Ack received."
+        .cstring())
+    end
 
     check_for_completion()
 
   fun ref check_for_completion() =>
-    @printf[I32]("!@ BarrierHandler: check_for_completion: acked_sinks: %s, sinks: %s\n".cstring(), _acked_sinks.size().string().cstring(), _sinks.size().string().cstring())
+    ifdef "checkpoint_trace" then
+      @printf[I32]("BarrierHandler: check_for_completion: acked_sinks: %s, sinks: %s\n".cstring(), _acked_sinks.size().string().cstring(), _sinks.size().string().cstring())
+    end
     if _acked_sinks.size() == _sinks.size() then
       _initiator.all_secondary_sinks_acked(_barrier_token, _primary_worker)
-    //!@
     else
-      @printf[I32]("!@ InProgressSecondaryBarrierHandler: waiting for %s sinks to ack\n".cstring(), (_sinks.size() - _acked_sinks.size()).string().cstring())
+      ifdef "checkpoint_trace" then
+        @printf[I32]("InProgressSecondaryBarrierHandler: waiting for %s sinks to ack\n".cstring(), (_sinks.size() - _acked_sinks.size()).string().cstring())
+      end
     end
 
 class WorkerAcksBarrierHandler is BarrierHandler
@@ -298,7 +300,10 @@ class WorkerAcksBarrierHandler is BarrierHandler
     true
 
   fun ref worker_ack_barrier(w: String) =>
-    @printf[I32]("!@ worker_ack_barrier for %s from WorkerAcksBarrierHandler\n".cstring(), w.cstring())
+    ifdef "checkpoint_trace" then
+      @printf[I32]("worker_ack_barrier for %s from WorkerAcksBarrierHandler\n"
+        .cstring(), w.cstring())
+    end
     if not SetHelpers[String].contains[String](_workers, w) then Fail() end
 
     _acked_workers.set(w)
@@ -306,9 +311,5 @@ class WorkerAcksBarrierHandler is BarrierHandler
 
   fun ref check_for_completion() =>
     if _acked_workers.size() == _workers.size() then
-      // @printf[I32]("!@ All workers are completed for acks!\n".cstring())
       _initiator.all_workers_acked(_barrier_token, _result_promise)
-    else
-      None
-      // @printf[I32]("!@ Only %s of %s workers have acked!\n".cstring(), _acked_workers.size().string().cstring(), _workers.size().string().cstring())
     end

--- a/lib/wallaroo/ent/barrier/barrier_initiator_phase.pony
+++ b/lib/wallaroo/ent/barrier/barrier_initiator_phase.pony
@@ -202,10 +202,16 @@ class _BlockingBarrierInitiatorPhase is _BarrierInitiatorPhase
     if (barrier_token == _initial_token) or
       (barrier_token == _wait_for_token)
     then
-      @printf[I32]("!@ BlockPhase: Initiating barrier %s!\n".cstring(), barrier_token.string().cstring())
+      ifdef "checkpoint_trace" then
+        @printf[I32]("BlockPhase: Initiating barrier %s!\n".cstring(),
+          barrier_token.string().cstring())
+      end
       _initiator.initiate_barrier(barrier_token, result_promise)
     else
-      @printf[I32]("!@ BlockPhase: Queuing barrier %s!\n".cstring(), barrier_token.string().cstring())
+      ifdef "checkpoint_trace" then
+        @printf[I32]("BlockPhase: Queuing barrier %s!\n".cstring(),
+          barrier_token.string().cstring())
+      end
       // !@ We need to ensure that we don't queue checkpoints when we're
       // rolling back. This is a crude way to test that.
       if not (_wait_for_token > barrier_token) then

--- a/lib/wallaroo/ent/barrier/barrier_sink_acker.pony
+++ b/lib/wallaroo/ent/barrier/barrier_sink_acker.pony
@@ -30,7 +30,8 @@ class BarrierSinkAcker
   let _inputs_blocking: Map[RoutingId, Producer] = _inputs_blocking.create()
 
   // !@ Perhaps to add invariant wherever inputs can be updated in
-  // the encapsulating actor to check if barrier is in progress.
+  // the encapsulating actor to check if barrier is in progress. <-- This
+  // shouldn't matter with a static graph.
   new create(sink_id: RoutingId, sink: Sink ref,
     barrier_initiator: BarrierInitiator)
   =>
@@ -39,7 +40,6 @@ class BarrierSinkAcker
     _barrier_initiator = barrier_initiator
 
   fun ref higher_priority(token: BarrierToken): Bool =>
-    // @printf[I32]("!@ SINKACKER: Comparing %s to %s. higher_priority: %s\n".cstring(), token.string().cstring(), _barrier_token.string().cstring(), (token > _barrier_token).string().cstring())
     token > _barrier_token
 
   fun ref lower_priority(token: BarrierToken): Bool =>
@@ -67,7 +67,7 @@ class BarrierSinkAcker
       _inputs_blocking(step_id) = producer
       _check_completion(inputs)
     else
-      @printf[I32]("!@ Failed to find step_id %s in inputs at Sink %s\n".cstring(), step_id.string().cstring(), _sink_id.string().cstring())
+      @printf[I32]("Failed to find step_id %s in inputs at Sink %s\n".cstring(), step_id.string().cstring(), _sink_id.string().cstring())
       Fail()
     end
 
@@ -87,7 +87,6 @@ class BarrierSinkAcker
     _check_completion(_sink.inputs())
 
   fun ref _check_completion(inputs: Map[RoutingId, Producer] box) =>
-    // @printf[I32]("!@ receive_barrier at TCPSink: %s inputs, %s received\n".cstring(), inputs.size().string().cstring(), _inputs_blocking.size().string().cstring())
     if inputs.size() == _inputs_blocking.size() then
       _barrier_initiator.ack_barrier(_sink, _barrier_token)
       let b_token = _barrier_token

--- a/lib/wallaroo/ent/barrier/pending_rollback_barrier_acks.pony
+++ b/lib/wallaroo/ent/barrier/pending_rollback_barrier_acks.pony
@@ -62,7 +62,6 @@ class PendingRollbackBarrierAcks
   fun ref flush(token: BarrierToken, ab: ActiveBarriers) =>
     if token == latest_rollback_token then
       for (r, t) in barrier_acks.values() do
-        // @printf[I32]("!@ -- Flushing ack for %s\n".cstring(), t.string().cstring())
         ab.ack_barrier(r, t)
       end
       for (w, t) in worker_barrier_start_acks.values() do
@@ -73,7 +72,6 @@ class PendingRollbackBarrierAcks
       end
       clear()
     else
-      // @printf[I32]("!@ PendingRollbackBarrierAcks: Flushing but acks are outdated.\n".cstring())
       match token
       | let srbt: CheckpointRollbackBarrierToken =>
         if srbt > latest_rollback_token then

--- a/lib/wallaroo/ent/barrier/queued_barrier.pony
+++ b/lib/wallaroo/ent/barrier/queued_barrier.pony
@@ -37,5 +37,8 @@ class val QueuedBarrier
     _barrier_token = barrier_token
 
   fun inject_barrier(b_processor: BarrierProcessor ref) =>
-    @printf[I32]("!@ Injecting queued barrier %s\n".cstring(), _barrier_token.string().cstring())
+    ifdef "checkpoint_trace" then
+      @printf[I32]("Injecting queued barrier %s\n".cstring(),
+        _barrier_token.string().cstring())
+    end
     b_processor.process_barrier(_input_id, _producer, _barrier_token)

--- a/lib/wallaroo/ent/checkpoint/checkpoint_initiator_phase.pony
+++ b/lib/wallaroo/ent/checkpoint/checkpoint_initiator_phase.pony
@@ -78,13 +78,20 @@ class _CheckpointingPhase is _CheckpointInitiatorPhase
   fun ref event_log_checkpoint_complete(worker: WorkerName,
     checkpoint_id: CheckpointId)
   =>
-    @printf[I32]("!@ _CheckpointingPhase: event_log_checkpoints_complete from %s for %s\n".cstring(), worker.cstring(), checkpoint_id.string().cstring())
+    ifdef "checkpoint_trace" then
+      @printf[I32]("_CheckpointingPhase: event_log_checkpoints_complete from %s for %s\n".cstring(),
+        worker.cstring(), checkpoint_id.string().cstring())
+    end
     ifdef debug then
       Invariant(checkpoint_id == _token.id)
       Invariant(_c_initiator.workers().contains(worker))
     end
     _acked_workers.set(worker)
-    @printf[I32]("!@ _CheckpointingPhase: acked_workers: %s, workers: %s\n".cstring(), _acked_workers.size().string().cstring(), _c_initiator.workers().size().string().cstring())
+    ifdef "checkpoint_trace" then
+      @printf[I32]("_CheckpointingPhase: acked_workers: %s, workers: %s\n"
+        .cstring(), _acked_workers.size().string().cstring(),
+        _c_initiator.workers().size().string().cstring())
+    end
     if (_acked_workers.size() == _c_initiator.workers().size()) then
       _event_log_checkpoints_complete = true
       _check_completion()
@@ -114,13 +121,20 @@ class _WaitingForEventLogIdWrittenPhase is _CheckpointInitiatorPhase
   fun ref event_log_id_written(worker: WorkerName,
     checkpoint_id: CheckpointId)
   =>
-    @printf[I32]("!@ _WaitingForEventLogIdWrittenPhase: event_log_id_written from %s for %s\n".cstring(), worker.cstring(), checkpoint_id.string().cstring())
+    ifdef "checkpoint_trace" then
+      @printf[I32]("_WaitingForEventLogIdWrittenPhase: event_log_id_written from %s for %s\n".cstring(),
+        worker.cstring(), checkpoint_id.string().cstring())
+    end
     ifdef debug then
       Invariant(checkpoint_id == _token.id)
       Invariant(_c_initiator.workers().contains(worker))
     end
     _acked_workers.set(worker)
-    @printf[I32]("!@ _WaitingForEventLogIdWrittenPhase: acked_workers: %s, workers: %s\n".cstring(), _acked_workers.size().string().cstring(), _c_initiator.workers().size().string().cstring())
+    ifdef "checkpoint_trace" then
+      @printf[I32]("_WaitingForEventLogIdWrittenPhase: acked_workers: %s, workers: %s\n".cstring(),
+        _acked_workers.size().string().cstring(),
+        _c_initiator.workers().size().string().cstring())
+    end
     if (_acked_workers.size() == _c_initiator.workers().size()) then
       _c_initiator.checkpoint_complete(_token, _repeating)
     end

--- a/lib/wallaroo/ent/data_receiver/data_receiver_phase.pony
+++ b/lib/wallaroo/ent/data_receiver/data_receiver_phase.pony
@@ -189,7 +189,10 @@ class _QueuingDataReceiverPhase is _DataReceiverPhase
   fun ref forward_barrier(input_id: RoutingId, output_id: RoutingId,
     token: BarrierToken, seq_id: SeqId)
   =>
-    @printf[I32]("!@ DataReceiver: Queuing barrier to %s\n".cstring(), output_id.string().cstring())
+    ifdef "checkpoint_trace" then
+      @printf[I32]("DataReceiver: Queuing barrier to %s\n".cstring(),
+        output_id.string().cstring())
+    end
     _queued.push((input_id, output_id, token, seq_id))
 
   fun ref data_connect(highest_seq_id: SeqId) =>

--- a/lib/wallaroo/ent/data_receiver/data_receivers.pony
+++ b/lib/wallaroo/ent/data_receiver/data_receivers.pony
@@ -82,19 +82,16 @@ actor DataReceivers
     is the first time that OutgoingBoundary has connected to this worker,
     then we create a new DataReceiver here.
     """
-    // @printf[I32]("!@ IDENTIFYING BOUNDARY %s from %s\n".cstring(), sender_boundary_id.string().cstring(), sender_name.cstring())
     let boundary_id = BoundaryId(sender_name, sender_boundary_id)
     let dr =
       try
         _data_receivers(boundary_id)?
       else
-        // !@ this should be recoverable
+        // !@ TODO: This should be recoverable
         let id = RoutingIdGenerator()
 
         let new_dr = DataReceiver(_auth, id, _worker_name, sender_name,
           _data_router, _initialized, _is_recovering)
-        //!@
-        // new_dr.update_router(_data_router)
         match _router_registry
         | let rr: RouterRegistry =>
           rr.register_data_receiver(sender_name, new_dr)
@@ -103,19 +100,14 @@ actor DataReceivers
         end
         _data_receivers(boundary_id) = new_dr
         _connections.register_disposable(new_dr)
-        // @printf[I32]("!@ -- CREATED New DR for it\n".cstring())
         new_dr
       end
     conn.identify_data_receiver(dr, sender_boundary_id, highest_seq_id)
     _inform_subscribers(boundary_id, dr)
 
-    //!@
+    //!@ TODO: Remove
   be start_replay_processing() =>
     None
-    //!@
-    // for dr in _data_receivers.values() do
-    //   dr.start_replay_processing()
-    // end
 
   be start_normal_message_processing() =>
     _initialized = true

--- a/lib/wallaroo/ent/network/cluster.pony
+++ b/lib/wallaroo/ent/network/cluster.pony
@@ -45,11 +45,6 @@ trait tag Cluster
   be send_data_to_cluster(data: Array[ByteSeq] val) =>
     None
 
-    //!@
-  // be notify_cluster_of_new_key(key: Key,
-  //   state_name: String, exclusions: Array[String] val =
-  //   recover Array[String] end)
-
   be stop_the_world(exclusions: Array[String] val) =>
     None
 

--- a/lib/wallaroo/ent/network/connections.pony
+++ b/lib/wallaroo/ent/network/connections.pony
@@ -319,7 +319,6 @@ actor Connections is Cluster
 
   be notify_cluster_of_new_key(key: Key, state_name: String) =>
     try
-      @printf[I32]("!@ Notify cluster about key %s\n".cstring(), key.cstring())
       let migration_complete_msg =
         ChannelMsgEncoder.key_migration_complete(key, _auth)?
       _send_control_to_cluster(migration_complete_msg)
@@ -366,27 +365,6 @@ actor Connections is Cluster
     else
       Fail()
     end
-
-//!@
-  // be create_boundary_to_joining_worker(target: String, boundary_id: U128,
-  //   state_routing_ids: Map[StateName, RoutingId] val,
-  //   local_topology_initializer: LocalTopologyInitializer)
-  // =>
-  //   try
-  //     (let host, let service) = _data_addrs(target)?
-  //     let reporter = MetricsReporter(_app_name,
-  //       _worker_name, _metrics_conn)
-  //     let builder = OutgoingBoundaryBuilder(_auth, _worker_name,
-  //       consume reporter, host, service, _spike_config)
-  //     let boundary = builder.build_and_initialize(boundary_id, target,
-  //       local_topology_initializer)
-  //     _register_disposable(boundary)
-  //     local_topology_initializer.add_boundary_to_joining_worker(target,
-  //       boundary, builder, state_routing_ids)
-  //   else
-  //     @printf[I32]("Can't find data address for worker\n".cstring())
-  //     Fail()
-  //   end
 
   // TODO: Passing in checkpoint target here is a hack because we currently
   // do recovery initialization at the point boundary updates are complete.
@@ -512,11 +490,6 @@ actor Connections is Cluster
     let data_map = recover trn Map[WorkerName, (String, String)] end
     for (key, value) in data_addrs.pairs() do
       data_map(key) = value
-    end
-
-    //!@
-    for (w, a) in control_map.pairs() do
-      @printf[I32]("!@ CONN TO WORKER WWW %s\n".cstring(), w.cstring())
     end
 
     map("control") = consume control_map

--- a/lib/wallaroo/ent/network/control_channel_tcp.pony
+++ b/lib/wallaroo/ent/network/control_channel_tcp.pony
@@ -440,7 +440,6 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
           @printf[I32](("Received PrepareShrinkMsg on Control " +
             "Channel\n").cstring())
         end
-        @printf[I32]("!@ Got PrepareShrinkMsg\n".cstring())
         match _layout_initializer
         | let lti: LocalTopologyInitializer =>
           lti.prepare_shrink(m.remaining_workers, m.leaving_workers)
@@ -515,11 +514,15 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
         })
         _event_log.write_checkpoint_id(m.checkpoint_id, promise)
       | let m: EventLogAckCheckpointMsg =>
-        @printf[I32]("!@ Rcvd EventLogAckCheckpointMsg!!!\n".cstring())
+        ifdef "checkpoint_trace" then
+          @printf[I32]("Rcvd EventLogAckCheckpointMsg!\n".cstring())
+        end
         _checkpoint_initiator.event_log_checkpoint_complete(m.sender,
           m.checkpoint_id)
       | let m: EventLogAckCheckpointIdWrittenMsg =>
-        @printf[I32]("!@ Rcvd EventLogAckCheckpointIdWrittenMsg!!!\n".cstring())
+        ifdef "checkpoint_trace" then
+          @printf[I32]("Rcvd EventLogAckCheckpointIdWrittenMsg!\n".cstring())
+        end
         _checkpoint_initiator.event_log_id_written(m.sender,
           m.checkpoint_id)
       | let m: CommitCheckpointIdMsg =>
@@ -547,7 +550,9 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
         let promise = Promise[None]
         _event_log.prepare_for_rollback(promise, _checkpoint_initiator)
       | let m: RollbackLocalKeysMsg =>
-        @printf[I32]("!@ Rcvd RollbackLocalKeysMsg\n".cstring())
+        ifdef "checkpoint_trace" then
+          @printf[I32]("Rcvd RollbackLocalKeysMsg\n".cstring())
+        end
         let promise = Promise[None]
         promise.next[None]({(n: None) =>
           try
@@ -592,7 +597,9 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
       | let m: EventLogAckRollbackMsg =>
         _recovery.rollback_complete(m.sender, m.token)
       | let m: ResumeCheckpointMsg =>
-        @printf[I32]("!@ Rcvd ResumeCheckpointMsg!!\n".cstring())
+        ifdef "checkpoint_trace" then
+          @printf[I32]("Rcvd ResumeCheckpointMsg!!\n".cstring())
+        end
         _checkpoint_initiator.resume_checkpoint()
       | let m: ResumeProcessingMsg =>
         ifdef "trace" then

--- a/lib/wallaroo/ent/network/recovery_control_tcp.pony
+++ b/lib/wallaroo/ent/network/recovery_control_tcp.pony
@@ -26,7 +26,7 @@ use "wallaroo/ent/recovery"
 use "wallaroo_labs/bytes"
 use "wallaroo_labs/mort"
 
-//!@
+//!@ Remove
 class RecoveryControlSenderConnectNotifier is TCPConnectionNotify
   let _auth: AmbientAuth
   let _worker_name: String

--- a/lib/wallaroo/ent/rebalancing/step_state_migrator.pony
+++ b/lib/wallaroo/ent/rebalancing/step_state_migrator.pony
@@ -45,7 +45,6 @@ primitive StepStateMigrator
     match runner
     | let r: SerializableStateRunner =>
       let state_bytes = r.export_key_state(step, key)
-      @printf[I32]("!@ READY TO EXPORT %s bytes for key %s\n".cstring(), state_bytes.size().string().cstring(), key.cstring())
       boundary.migrate_key(id, state_name, key, checkpoint_id,
         state_bytes)
     else

--- a/lib/wallaroo/ent/recovery/backend.pony
+++ b/lib/wallaroo/ent/recovery/backend.pony
@@ -231,10 +231,6 @@ class FileBackend is Backend
       Fail()
     end
 
-    @printf[I32](("!@ Backend: Found end of entries for checkpoint %s" +
-      " between offset %d and %d.\n").cstring(),
-      current_checkpoint_id.string().cstring(), target_checkpoint_offset_start,
-      target_checkpoint_offset_end)
     _file.seek_start(target_checkpoint_offset_start)
 
     while _file.position() < target_checkpoint_offset_end do
@@ -255,7 +251,7 @@ class FileBackend is Backend
         // put entry into temporary recovered buffer
         replay_buffer.push((resilient_id, payload))
       | _LogCheckpointIdEntry =>
-        break      
+        break
       | _LogRestartEntry =>
         replay_buffer.clear()
         _file.seek(_restart_len.isize() - 1)
@@ -580,7 +576,7 @@ class AsyncJournalledFile
       _file.dispose()
     end
 
-  fun ref errno(): (FileOK val | FileError val | FileEOF val | 
+  fun ref errno(): (FileOK val | FileError val | FileEOF val |
     FileBadFileNumber val | FileExists val | FilePermissionDenied val)
   =>
     // TODO journal!  Perhaps fake a File* error if journal write failed?

--- a/lib/wallaroo/ent/recovery/event_log.pony
+++ b/lib/wallaroo/ent/recovery/event_log.pony
@@ -167,7 +167,6 @@ actor EventLog is SimpleJournalAsyncResponseReceiver
     initializer.report_event_log_ready_to_work()
 
   be register_resilient(id: RoutingId, resilient: Resilient) =>
-    // @printf[I32]("!@ EventLog register_resilient %s\n".cstring(), id.string().cstring())
     ifdef debug then
       match resilient
       | let s: Source =>
@@ -192,7 +191,6 @@ actor EventLog is SimpleJournalAsyncResponseReceiver
     end
 
   be unregister_resilient(id: RoutingId, resilient: Resilient) =>
-    // @printf[I32]("!@ EventLog unregister_resilient %s\n".cstring(), id.string().cstring())
     try
       _resilients.remove(id)?
       _phase.unregister_resilient(id, resilient)
@@ -213,7 +211,9 @@ actor EventLog is SimpleJournalAsyncResponseReceiver
   be initiate_checkpoint(checkpoint_id: CheckpointId,
     promise: Promise[CheckpointId])
   =>
-    @printf[I32]("!@ EventLog: initiate_checkpoint\n".cstring())
+    ifdef "checkpoint_trace" then
+      @printf[I32]("EventLog: initiate_checkpoint\n".cstring())
+    end
     _phase.initiate_checkpoint(checkpoint_id, promise, this)
 
   be checkpoint_state(resilient_id: RoutingId, checkpoint_id: CheckpointId,
@@ -229,7 +229,10 @@ actor EventLog is SimpleJournalAsyncResponseReceiver
     _phase = _CheckpointEventLogPhase(this, checkpoint_id, promise,
       _resilients)
     for p in pending_checkpoint_states.values() do
-      @printf[I32]("!@ EventLog: Process pending checkpoint_state for resilient %s for checkpoint %s\n".cstring(), p.resilient_id.string().cstring(), checkpoint_id.string().cstring())
+      ifdef "checkpoint_trace" then
+        @printf[I32]("EventLog: Process pending checkpoint_state for resilient %s for checkpoint %s\n".cstring(),
+          p.resilient_id.string().cstring(), checkpoint_id.string().cstring())
+      end
       _phase.checkpoint_state(p.resilient_id, checkpoint_id, p.payload)
     end
 
@@ -279,7 +282,10 @@ actor EventLog is SimpleJournalAsyncResponseReceiver
   fun ref _write_checkpoint_id(checkpoint_id: CheckpointId,
     promise: Promise[CheckpointId])
   =>
-    @printf[I32]("!@ EventLog: write_checkpoint_id !!!!!!!!!!!\n".cstring())
+    ifdef "checkpoint_trace" then
+      @printf[I32]("EventLog: write_checkpoint_id %s!!\n".cstring(),
+        checkpoint_id.string().cstring())
+    end
     _backend.encode_checkpoint_id(checkpoint_id)
     for (r_id, s) in _pending_sources.values() do
       s.first_checkpoint_complete()
@@ -288,16 +294,7 @@ actor EventLog is SimpleJournalAsyncResponseReceiver
     _pending_sources.clear()
     _phase.checkpoint_id_written(checkpoint_id, promise)
 
-//!@
-  // fun ref update_normal_event_log_checkpoint_id(checkpoint_id: CheckpointId)
-  // =>
-  //   // We need to update the next checkpoint id we're expecting.
-  //   //!@ This should go through a phase
-  //   _phase = _WaitingForCheckpointInitiationEventLogPhase(
-  //  checkpoint_id + 1, this)
-
   fun ref checkpoint_id_written(checkpoint_id: CheckpointId) =>
-    // @printf[I32]("!@ EventLog: checkpoint_complete()\n".cstring())
     write_log()
     _phase = _WaitingForCheckpointInitiationEventLogPhase(checkpoint_id + 1,
       this)
@@ -346,9 +343,8 @@ actor EventLog is SimpleJournalAsyncResponseReceiver
     try
       _resilients(resilient_id)?.rollback(payload, this, checkpoint_id)
     else
-      //!@ Update message
-      @printf[I32](("Can't find resilient for rollback data\n").cstring())
-      @printf[I32](("!@ Can't find resilient %s for rollback data\n").cstring(), resilient_id.string().cstring())
+      @printf[I32](("Can't find resilient %s for rollback data\n").cstring(),
+        resilient_id.string().cstring())
       Fail()
     end
 
@@ -364,56 +360,22 @@ actor EventLog is SimpleJournalAsyncResponseReceiver
 
   //!@
   /////////////
-  // STUFF
+  // STUFF TO REMOVE
   ////////////
-    //!@
-  // be start_log_replay(recovery: Recovery) =>
-  //   _recovery = recovery
-  //   _backend.start_log_replay()
-
+  //!@
   be log_replay_finished() =>
-    //!@
     None
-    //!@
-    // for r in _resilients.values() do
-    //   r.log_replay_finished()
-    // end
-
-    // match _recovery
-    // | let r: Recovery =>
-    //   r.log_replay_finished()
-    // else
-    //   Fail()
-    // end
-
+  //!@
   be replay_log_entry(resilient_id: RoutingId,
     uid: U128, frac_ids: FractionalMessageId,
     statechange_id: U64, payload: ByteSeq val)
   =>
     None
-    //!@
-    // try
-    //   _resilients(resilient_id)?.replay_log_entry(uid, frac_ids,
-    //     statechange_id, payload)
-    // else
-    //   @printf[I32](("FATAL: Unable to replay event log, because a replay " +
-    //     "buffer has disappeared").cstring())
-    //   Fail()
-    // end
-
+  //!@
   be initialize_seq_ids(seq_ids: Map[RoutingId, SeqId] val) =>
-    //!@
     None
-    // for (resilient_id, seq_id) in seq_ids.pairs() do
-    //   try
-    //     _resilients(resilient_id)?.initialize_seq_id_on_recovery(seq_id)
-    //   else
-    //     @printf[I32](("Could not initialize seq id " + seq_id.string() +
-    //       ". Resilient " + resilient_id.string() + " does not exist\n")
-    //       .cstring())
-    //     Fail()
-    //   end
-    // end
+
+
 
 
 

--- a/lib/wallaroo/ent/recovery/recovery.pony
+++ b/lib/wallaroo/ent/recovery/recovery.pony
@@ -172,7 +172,6 @@ actor Recovery
         let checkpoint_id = _checkpoint_id as CheckpointId
         _recovery_phase = _RollbackLocalKeys(this, checkpoint_id, _workers)
 
-        //!@ Tell someone to start rolling back topology
         let promise = Promise[None]
         promise.next[None]({(n: None) =>
           _self.worker_ack_local_keys_rollback(_worker_name, checkpoint_id)

--- a/lib/wallaroo/ent/recovery/recovery_phase.pony
+++ b/lib/wallaroo/ent/recovery/recovery_phase.pony
@@ -161,7 +161,10 @@ class _RollbackLocalKeys is _RecoveryPhase
 
   fun ref worker_ack_local_keys_rollback(w: WorkerName, checkpoint_id: CheckpointId)
   =>
-    @printf[I32]("!@ _RollbackLocalKeys rcvd ack from %s\n".cstring(), w.cstring())
+    ifdef "checkpoint_trace" then
+      @printf[I32]("_RollbackLocalKeys rcvd ack from %s\n".cstring(),
+        w.cstring())
+    end
     //!@ Should we just ignore misses here (which indicate an overlapping
     // recovery)?
     if checkpoint_id == _checkpoint_id then
@@ -177,9 +180,12 @@ class _RollbackLocalKeys is _RecoveryPhase
   fun ref _check_completion() =>
     if _workers.size() == _acked_workers.size() then
       _recovery._local_keys_rollback_complete()
-    //!@
     else
-      @printf[I32]("!@ _RollbackTopology: %s acked out of %s\n".cstring(), _acked_workers.size().string().cstring(), _workers.size().string().cstring())
+      ifdef "checkpoint_trace" then
+        @printf[I32]("_RollbackTopology: %s acked out of %s\n".cstring(),
+          _acked_workers.size().string().cstring(),
+          _workers.size().string().cstring())
+      end
     end
 
 class _RollbackBarrier is _RecoveryPhase

--- a/lib/wallaroo/ent/recovery/recovery_reconnecter.pony
+++ b/lib/wallaroo/ent/recovery/recovery_reconnecter.pony
@@ -108,12 +108,6 @@ actor RecoveryReconnecter
   be start_recovery_reconnect(workers: Array[WorkerName] val,
     recovery: Recovery)
   =>
-    @printf[I32]("!@ RecoveryReconnecter start_recovery_reconnect with workers\n".cstring())
-    //!@
-    for w in workers.values() do
-      @printf[I32]("!@ -- %s\n".cstring(), w.cstring())
-    end
-
     if single_worker(workers) then
       @printf[I32]("|~~ -- Skipping Reconnect: Only One Worker -- ~~|\n"
         .cstring())
@@ -127,7 +121,6 @@ actor RecoveryReconnecter
     let expected_workers: SetIs[WorkerName] = expected_workers.create()
     for w in workers.values() do
       if w != _worker_name then
-        @printf[I32]("!@ RecoveryReconnecter: SETTING expected worker %s\n".cstring(), w.cstring())
         expected_workers.set(w)
       end
     end
@@ -258,9 +251,6 @@ class _ReadyForNormalProcessing is _ReconnectPhase
   =>
     //!@ Do we need this anymore?
     None
-    // If we experience a reconnect outside recovery, then we can immediately
-    // clear deduplication lists when it's complete
-    // _reconnecter._clear_deduplication_lists()
 
 class _WaitingForBoundaryCounts is _ReconnectPhase
   let _expected_workers: SetIs[WorkerName]
@@ -280,7 +270,6 @@ class _WaitingForBoundaryCounts is _ReconnectPhase
   fun name(): String => "Waiting for Boundary Counts Phase"
 
   fun ref add_expected_boundary_count(worker: WorkerName, count: USize) =>
-    @printf[I32]("!@ add_expected_boundary_count: w: %s, c: %s\n".cstring(), worker.cstring(), count.string().cstring())
     ifdef debug then
       // This should only be called once per worker
       Invariant(not _expected_boundaries.contains(worker))

--- a/lib/wallaroo/ent/recovery/step_rollbacker.pony
+++ b/lib/wallaroo/ent/recovery/step_rollbacker.pony
@@ -23,7 +23,9 @@ primitive StepRollbacker
   fun apply(payload: ByteSeq val, runner: Runner) =>
     match runner
     | let r: RollbackableRunner =>
-      @printf[I32]("!@ Step rolling back!\n".cstring())
+      ifdef "checkpoint_trace" then
+        @printf[I32]("Step rolling back!\n".cstring())
+      end
       r.rollback(payload)
     else
       @printf[I32]("trying to rollback on a non-rollbackable runner!"

--- a/lib/wallaroo/ent/recovery/step_state_snapshotter.pony
+++ b/lib/wallaroo/ent/recovery/step_state_snapshotter.pony
@@ -26,18 +26,25 @@ primitive StepStateCheckpointer
   fun apply(runner: Runner, id: RoutingId, checkpoint_id: CheckpointId,
     event_log: EventLog, wb: Writer = Writer)
   =>
-    @printf[I32]("!@ StepStateCheckpointer apply()\n".cstring())
+    ifdef "checkpoint_trace" then
+      @printf[I32]("StepStateCheckpointer apply()\n".cstring())
+    end
     match runner
     | let r: SerializableStateRunner =>
       let serialized: ByteSeq val = r.serialize_state()
-      @printf[I32]("!@ -- Got %s serialized bytes\n".cstring(), serialized.size().string().cstring())
+      ifdef "checkpoint_trace" then
+        @printf[I32]("-- Got %s serialized bytes\n".cstring(),
+          serialized.size().string().cstring())
+      end
       wb.write(serialized)
       let payload = wb.done()
-      // @printf[I32]("!@ State Step %s calling EventLog.checkpoint_state()\n".cstring(), id.string().cstring())
       event_log.checkpoint_state(id, checkpoint_id, consume payload)
     else
       // Currently, non-state steps don't have anything to checkpoint.
-      @printf[I32]("!@ Stateless Step %s calling EventLog.checkpoint_state()\n".cstring(), id.string().cstring())
+      ifdef "checkpoint_trace" then
+        @printf[I32]("Stateless Step %s calling EventLog.checkpoint_state()\n"
+          .cstring(), id.string().cstring())
+      end
       event_log.checkpoint_state(id, checkpoint_id,
         recover val Array[ByteSeq] end)
     end

--- a/lib/wallaroo_labs/messages/external_messages.pony
+++ b/lib/wallaroo_labs/messages/external_messages.pony
@@ -165,14 +165,6 @@ primitive ExternalMsgEncoder
     local_keys: Map[StateName, SetIs[Key]],
     wb: Writer = Writer): Array[ByteSeq] val
   =>
-    @printf[I32]("!@ Creating StateEntityQueryResponse with local keys\n".cstring())
-    //!@
-    for (k, v) in local_keys.pairs() do
-      for key in v.values() do
-        @printf[I32]("!@ -- %s\n".cstring(), key.cstring())
-      end
-    end
-
     let digest_map = _state_entity_digest(local_keys)
     let seqr = StateEntityQueryEncoder.state_entity_keys(digest_map)
     _encode(_StateEntityQueryResponse(), seqr, wb)


### PR DESCRIPTION
Last week, we discussed that these changes would come after release testing Phase I but are still meant for release 0.5.3.  The only changes in here are related to removing printfs or placing them in `ifdef "checkpoint_trace"` blocks.