### PR TITLE
Issue 2448

### DIFF
--- a/book/getting-started/linux-setup.md
+++ b/book/getting-started/linux-setup.md
@@ -68,6 +68,12 @@ gcc --version
 To upgrade to GCC 5:
 
 ```bash
+sudo apt-get install software-properties-common
+```
+
+then
+
+```bash
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 ```
 

--- a/book/getting-started/linux-setup.md
+++ b/book/getting-started/linux-setup.md
@@ -57,15 +57,15 @@ sudo apt-get install -y build-essential
 sudo apt-get install -y libssl-dev
 ```
 
-### Install GCC 5 or Higher
+### Install GCC 4.7 or Higher
 
- If you have at least GCC 5 installed on your machine, you don't need to do anything. If you have gcc 4.9 or lower, you'll need to upgrade. You can check your `gcc` version by running:
+ If you have at least GCC 4.7 installed on your machine, you don't need to do anything. If you have gcc 4.6 or lower, you'll need to upgrade. You can check your `gcc` version by running:
 
 ```bash
 gcc --version
 ```
 
-To upgrade to GCC 5:
+To upgrade to GCC 5 if you don't have at least GCC 4.7:
 
 ```bash
 sudo apt-get install software-properties-common

--- a/book/go/getting-started/linux-setup.md
+++ b/book/go/getting-started/linux-setup.md
@@ -81,6 +81,12 @@ gcc --version
 To upgrade to GCC 5 if you don't have at least GCC 4.7:
 
 ```bash
+sudo apt-get install software-properties-common
+```
+
+then
+
+```bash
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 ```
 

--- a/book/go/getting-started/linux-setup.md
+++ b/book/go/getting-started/linux-setup.md
@@ -70,15 +70,15 @@ sudo apt-get install -y build-essential
 sudo apt-get install -y libssl-dev
 ```
 
-### Install GCC 5 or Higher
+### Install GCC 4.7 or Higher
 
- If you have at least GCC 5 installed on your machine, you don't need to do anything. If you have gcc 4.9 or lower, you'll need to upgrade. You can check your `gcc` version by running:
+ If you have at least GCC 4.7 installed on your machine, you don't need to do anything. If you have gcc 4.6 or lower, you'll need to upgrade. You can check your `gcc` version by running:
 
 ```bash
 gcc --version
 ```
 
-To upgrade to GCC 5:
+To upgrade to GCC 5 if you don't have at least GCC 4.7:
 
 ```bash
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test


### PR DESCRIPTION
Addresses #2448 by reverting commit that made GCC 5 mandatory, and also adds instructions on installing `software-properties-common`.