### PR TITLE
Resilience doc fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,6 @@ RUN apt-get install -y \
     mkdir /wallaroo-bin && \
     cp docker/env-setup /wallaroo-bin && \
     make clean && \
-    make target_cpu=x86-64 build-machida-all resilience=on && \
-    cp machida/build/machida bin/machida-resilience && \
-    make clean && \
     mkdir /src && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get -y autoremove --purge && \

--- a/book/getting-started/linux-setup.md
+++ b/book/getting-started/linux-setup.md
@@ -179,6 +179,9 @@ Machida is the program that runs Wallaroo Python applications. Change to the Wal
 
 ```bash
 cd ~/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/
+make build-machida-all resilience=on
+cp machida/build/machida bin/machida-resilience
+make clean-machida-all
 make build-machida-all
 cp machida/build/machida bin
 cp machida/wallaroo.py bin

--- a/book/running-wallaroo/resilience.md
+++ b/book/running-wallaroo/resilience.md
@@ -4,7 +4,7 @@ Wallaroo is designed with built-in resilience. However, since the operations inv
 
 ## How Does Wallaroo Implement Resilience
 
-Wallaroo's resilience is based on the Chandy-Lamport snapshotting algorithm that minimizes the impact of checkpointing on processing in-flight messages. A checkpoint represents a consistent recovery line. This means that when a failed worker recovers, we can roll back to the last checkpoint and begin processing again with the guarantee that all state in the system reflects a causally consistent history. The interval between checkpoints is configurable with the `--time-between-checkpoints` command line parameter (in nanoseconds).
+Wallaroo's resilience is based on the Chandy-Lamport snapshotting algorithm that minimizes the impact of checkpointing on processing in-flight messages. Each worker maintains a resilience file, where it periodically saves a snapshot of its latest state. A checkpoint represents a consistent recovery line—a specific generation of individual worker snapshots. This means that when a failed worker recover, we can roll back the states in the cluster to the last checkpoint and begin processing again with the guarantee that all state in the system reflects a causally consistent history. The interval between checkpoints is configurable with the `--time-between-checkpoints` command line parameter (in nanoseconds).
 
 Since recovery involves a rollback to the last successful checkpoint, any data that was processed _after_ that checkpoint will have to be resent by the sources.
 
@@ -12,64 +12,102 @@ Since recovery involves a rollback to the last successful checkpoint, any data t
 
 When a crashed worker is restarted, if it can find its resilience files in the path specified by `--resilience-dir`, it will automatically start the recovery process. The simplest way to do this is to rerun the worker using the same command it was originally run with.
 
-For example, if we were running the bundle Python example [word_count](/examples/python/word_count_with_dynamic_keys/README.md), this might look something like:
+For example, if we were running the bundled Python example [word_count_with_dynamic_keys](https://github.com/WallarooLabs/wallaroo/tree/master/examples/python/word_count_with_dynamic_keys/), this might look something like:
 
-1. Start a data receiver
+### Running the resilience example
 
-        data_receiver --listen 127.0.0.1 7000 | tee received.txt
- 
-2. Start initializer
+In order to run the example you will need Machida with resilience enabled, Giles Sender, Data Receiver, and the Cluster Shutdown tool. If you're using our Docker or Vagrant installation, these should already be set up.
 
-        machida --application-module word_count_with_dynamic_keys --in 127.0.0.1:7010 \
-        --out 127.0.0.1:7002 --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 \
-        --data 127.0.0.1:6001 --name worker-name --external 127.0.0.1:5050 \
-        --cluster-initializer --ponythreads=1 --ponynoblock \
-        --resilience-dir /tmp/res-dir/wc \
-        | tee initializer.log
+If you built Wallaroo from source, please run the following commands:
 
-3. Start worker
+    cd ~/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/
+    make build-machida-all resilience=on
+    cp machida/build/machida bin/machida-resilience
 
-        machida --application-module word_count_with_dynamic_keys --in 127.0.0.1:7010 \
-        --out 127.0.0.1:7002 --metrics 127.0.0.1:5001 --join 127.0.0.1:6000 \
-        --my-data 127.0.0.1:6003 --my-control 127.0.0.1:6002 --name worker1 \
-        --external 127.0.0.1:5051 --ponythreads=1 --ponynoblock \
-        --resilience-dir /tmp/res-dir/wc \
-        | tee worker1.log
+If you haven't yet set up wallaroo, please visit our [setup](https://docs.wallaroolabs.com/book/getting-started/choosing-an-installation-option.html) instructions to get started.
 
-4. Start sender
+### Running the example
 
+The rest of the example should be run in the `examples/python/word_count_with_dynamic_keys` directory in the Wallaroo repository.
+You will need 4 terminals to run this example.
+
+1. Create the path where the workers will save their resilience snapshots.
+
+        mkdir -p /tmp/resilience-dir
+
+2. Terminal 1: Start a data receiver
+
+        cd ~/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/examples/python/word_count_with_dynamic_keys
+        data_receiver --listen 127.0.0.1 7002 | tee received.txt
+
+3. Terminal 2: Start initializer
+
+        cd ~/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/examples/python/word_count_with_dynamic_keys
+        machida-resilience --application-module word_count_with_dynamic_keys \
+          --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
+          --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 \
+          --data 127.0.0.1:6001 --external 127.0.0.1:5050 \
+          --name initializer --cluster-initializer --worker-count 2 \
+          --resilience-dir /tmp/resilience-dir \
+          --ponythreads=1 --ponynoblock \
+          | tee initializer.log
+
+4. Terminal 3: Start worker
+
+        cd ~/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/examples/python/word_count_with_dynamic_keys
+        machida-resilience --application-module word_count_with_dynamic_keys \
+          --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
+          --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 \
+          --my-data 127.0.0.1:6003 --my-control 127.0.0.1:6002 \
+          --external 127.0.0.1:5051 \
+          --name worker1 \
+          --resilience-dir /tmp/resilience-dir \
+          --ponythreads=1 --ponynoblock \
+          | tee worker1.log
+
+5. Terminal 4: Start sender
+
+        cd ~/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/examples/python/word_count_with_dynamic_keys
         sender --host 127.0.0.1:7010 --file count_this.txt --batch-size 5 \
-        --interval 1_000_000_000 --messages 10000000 --ponythreads=1 \
-        --ponynoblock --repeat --no-write
+          --interval 1_000_000_000 --messages 10000000 --ponythreads=1 \
+          --ponynoblock --repeat --no-write
 
-5. Wait a few seconds for the internal states to update and for some checkpoints to complete
-6. Stop the sender (`ctrl-C`)
-7. Kill the worker to simulate a crash (using SIGKILL)
+6. Wait a few seconds for the internal states to update and for some checkpoints to complete
+7. Terminal 4: Stop the sender (`Ctrl-C`)
+8. Terminal 4: Kill the worker to simulate a crash (using SIGKILL)
 
         pkill -f -KILL machida.*worker1
 
-8. Send some data directly to our data receiver to mark in the sink where the crash occurred (for demonstration purposes)
+9. Terminal 4: Send some data directly to our data receiver to mark in the sink where the crash occurred (for demonstration purposes)
 
         echo '<<CRASH-and-RECOVER>>' | nc -q1 127.0.0.1 7002
 
-8. Restart worker1 with the same command we used above, but save its log output to a new file
+10. Terminal 3: Restart worker1 with the same command we used above, but save its log output to a new file
 
-        machida --application-module word_count_with_dynamic_keys --in 127.0.0.1:7010 \
-        --out 127.0.0.1:7002 --metrics 127.0.0.1:5001 --join 127.0.0.1:6000 \
-        --my-data 127.0.0.1:6003 --my-control 127.0.0.1:6002 --name worker1 \
-        --external 127.0.0.1:5051 --ponythreads=1 --ponynoblock \
-        --resilience-dir /tmp/res-dir/wc \
-        | tee worker1.recovered.log
+        machida-resilience --application-module word_count_with_dynamic_keys \
+          --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
+          --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 \
+          --my-data 127.0.0.1:6003 --my-control 127.0.0.1:6002 \
+          --external 127.0.0.1:5051 \
+          --name worker1 \
+          --resilience-dir /tmp/resilience-dir \
+          --ponythreads=1 --ponynoblock \
+          | tee worker1.recovered.log
 
-9. Restart the sender
+11. Terminal 4: Restart the sender
 
         sender --host 127.0.0.1:7010 --file count_this.txt --batch-size 5 \
-        --interval 1_000_000_000 --messages 10000000 --ponythreads=1 \
-        --ponynoblock --repeat --no-write
+          --interval 1_000_000_000 --messages 10000000 --ponythreads=1 \
+          --ponynoblock --repeat --no-write
 
-10. Let things run for a few more seconds before shutting everything down.
+12. Terminal 4: Let things run for a few more seconds before shutting down the sender (`Ctrl-C`), and then shut down the cluster with the `cluster_shutdown` tool.
 
-To verify that recoery was successful, we turn first to the recovering worker's log file, and look for the text
+        cluster_shutdown 127.0.0.1:5050
+
+
+### Verifying that recovery was successful
+
+To verify that recovery was successful, we turn first to the recovering worker's log file, and look for the text
 
       Recovering from recovery files!
       Attempting to recover...
@@ -83,7 +121,7 @@ To see that recovery was successful, we next look for the text
 
 This informs us that the worker has recovered successfully and that the cluster is now ready to process incoming data again.
 
-To further see that the state was indeed recovered, we can look at the data received by the sink, in `received.txt`:
+To further see that the state was indeed recovered, we can look at the data received by the sink, in `received.txt`. In this case, we will look at a particular key, `amendment`, but you can do the same with any of the other keys:
 
         amendment => 11
         ...

--- a/book/running-wallaroo/resilience.md
+++ b/book/running-wallaroo/resilience.md
@@ -4,7 +4,7 @@ Wallaroo is designed with built-in resilience. However, since the operations inv
 
 ## How Does Wallaroo Implement Resilience
 
-Wallaroo's resilience is based on the Chandy-Lamport snapshotting algorithm that minimizes the impact of checkpointing on processing in-flight messages. Each worker maintains a resilience file, where it periodically saves a snapshot of its latest state. A checkpoint represents a consistent recovery line—a specific generation of individual worker snapshots. This means that when a failed worker recover, we can roll back the states in the cluster to the last checkpoint and begin processing again with the guarantee that all state in the system reflects a causally consistent history. The interval between checkpoints is configurable with the `--time-between-checkpoints` command line parameter (in nanoseconds).
+Wallaroo's resilience is based on the Chandy-Lamport snapshotting algorithm that minimizes the impact of checkpointing on processing in-flight messages. Each worker maintains a resilience file, where it periodically saves a snapshot of its latest state. A checkpoint represents a consistent recovery line—a specific generation of individual worker snapshots. This means that when a failed worker recovers, we can roll back the states in the cluster to the last checkpoint and begin processing again with the guarantee that all state in the system reflects a causally consistent history. The interval between checkpoints is configurable with the `--time-between-checkpoints` command line parameter (in nanoseconds).
 
 Since recovery involves a rollback to the last successful checkpoint, any data that was processed _after_ that checkpoint will have to be resent by the sources.
 

--- a/book/running-wallaroo/resilience.md
+++ b/book/running-wallaroo/resilience.md
@@ -29,18 +29,18 @@ If you haven't yet set up wallaroo, please visit our [setup](https://docs.wallar
 ### Running the example
 
 The rest of the example should be run in the `examples/python/word_count_with_dynamic_keys` directory in the Wallaroo repository.
-You will need 4 terminals to run this example.
+You will need 4 shells to run this example.
 
 1. Create the path where the workers will save their resilience snapshots.
 
         mkdir -p /tmp/resilience-dir
 
-2. Terminal 1: Start a data receiver
+2. Shell 1: Start a data receiver
 
         cd ~/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/examples/python/word_count_with_dynamic_keys
         data_receiver --listen 127.0.0.1 7002 | tee received.txt
 
-3. Terminal 2: Start initializer
+3. Shell 2: Start initializer
 
         cd ~/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/examples/python/word_count_with_dynamic_keys
         machida-resilience --application-module word_count_with_dynamic_keys \
@@ -52,7 +52,7 @@ You will need 4 terminals to run this example.
           --ponythreads=1 --ponynoblock \
           | tee initializer.log
 
-4. Terminal 3: Start worker
+4. Shell 3: Start worker
 
         cd ~/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/examples/python/word_count_with_dynamic_keys
         machida-resilience --application-module word_count_with_dynamic_keys \
@@ -65,7 +65,7 @@ You will need 4 terminals to run this example.
           --ponythreads=1 --ponynoblock \
           | tee worker1.log
 
-5. Terminal 4: Start sender
+5. Shell 4: Start sender
 
         cd ~/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/examples/python/word_count_with_dynamic_keys
         sender --host 127.0.0.1:7010 --file count_this.txt --batch-size 5 \
@@ -73,16 +73,16 @@ You will need 4 terminals to run this example.
           --ponynoblock --repeat --no-write
 
 6. Wait a few seconds for the internal states to update and for some checkpoints to complete
-7. Terminal 4: Stop the sender (`Ctrl-C`)
-8. Terminal 4: Kill the worker to simulate a crash (using SIGKILL)
+7. Shell 4: Stop the sender (`Ctrl-C`)
+8. Shell 4: Kill the worker to simulate a crash (using SIGKILL)
 
         pkill -f -KILL machida.*worker1
 
-9. Terminal 4: Send some data directly to our data receiver to mark in the sink where the crash occurred (for demonstration purposes)
+9. Shell 4: Send some data directly to our data receiver to mark in the sink where the crash occurred (for demonstration purposes)
 
         echo '<<CRASH-and-RECOVER>>' | nc -q1 127.0.0.1 7002
 
-10. Terminal 3: Restart worker1 with the same command we used above, but save its log output to a new file
+10. Shell 3: Restart worker1 with the same command we used above, but save its log output to a new file
 
         machida-resilience --application-module word_count_with_dynamic_keys \
           --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
@@ -94,13 +94,13 @@ You will need 4 terminals to run this example.
           --ponythreads=1 --ponynoblock \
           | tee worker1.recovered.log
 
-11. Terminal 4: Restart the sender
+11. Shell 4: Restart the sender
 
         sender --host 127.0.0.1:7010 --file count_this.txt --batch-size 5 \
           --interval 1_000_000_000 --messages 10000000 --ponythreads=1 \
           --ponynoblock --repeat --no-write
 
-12. Terminal 4: Let things run for a few more seconds before shutting down the sender (`Ctrl-C`), and then shut down the cluster with the `cluster_shutdown` tool.
+12. Shell 4: Let things run for a few more seconds before shutting down the sender (`Ctrl-C`), and then shut down the cluster with the `cluster_shutdown` tool.
 
         cluster_shutdown 127.0.0.1:5050
 

--- a/book/running-wallaroo/resilience.md
+++ b/book/running-wallaroo/resilience.md
@@ -16,15 +16,7 @@ For example, if we were running the bundled Python example [word_count_with_dyna
 
 ### Running the resilience example
 
-In order to run the example you will need Machida with resilience enabled, Giles Sender, Data Receiver, and the Cluster Shutdown tool. If you're using our Docker or Vagrant installation, these should already be set up.
-
-If you built Wallaroo from source, please run the following commands:
-
-    cd ~/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/
-    make build-machida-all resilience=on
-    cp machida/build/machida bin/machida-resilience
-
-If you haven't yet set up wallaroo, please visit our [setup](https://docs.wallaroolabs.com/book/getting-started/choosing-an-installation-option.html) instructions to get started.
+In order to run the example you will need Machida with resilience enabled, Giles Sender, Data Receiver, and the Cluster Shutdown tool. If you haven't yet set up wallaroo, please visit our [setup](https://docs.wallaroolabs.com/book/getting-started/choosing-an-installation-option.html) instructions to get started.
 
 ### Running the example
 

--- a/book/running-wallaroo/resilience.md
+++ b/book/running-wallaroo/resilience.md
@@ -38,7 +38,7 @@ You will need 4 shells to run this example.
 2. Shell 1: Start a data receiver
 
         cd ~/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/examples/python/word_count_with_dynamic_keys
-        data_receiver --listen 127.0.0.1 7002 | tee received.txt
+        data_receiver --listen 127.0.0.1:7002 | tee received.txt
 
 3. Shell 2: Start initializer
 

--- a/misc/wallaroo-up.sh
+++ b/misc/wallaroo-up.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # md5 for validatiing script checksum
-MD5="026ab150766f06fb12c3d8e2d9c0f5c8  -"
+MD5="2e746d8b2150eb1b2b25e414d1be9527  -"
 
 set -eEuo pipefail
 

--- a/misc/wallaroo-up.sh
+++ b/misc/wallaroo-up.sh
@@ -681,7 +681,11 @@ configure_wallaroo() {
       log "Compiling Machida for running Python Wallaroo Applications..."
     fi
 
+    run_cmd "make ${CUSTOM_WALLAROO_BUILD_ARGS:-} build-machida-all resilience=on $REDIRECT"
+    run_cmd "mv machida/build/machida bin/machida-resilience $REDIRECT"
     run_cmd "make ${CUSTOM_WALLAROO_BUILD_ARGS:-} build-machida-all $REDIRECT"
+    run_cmd "cp machida/build/machida bin $REDIRECT"
+    run_cmd "cp -r machida/lib bin/pylib $REDIRECT"
   fi
 
   # copy binaries to the bin directory
@@ -690,11 +694,6 @@ configure_wallaroo() {
   run_cmd "cp utils/cluster_shrinker/cluster_shrinker bin $REDIRECT"
   run_cmd "cp giles/sender/sender bin $REDIRECT"
   run_cmd "ln -s metrics_ui/AppRun bin/metrics_reporter_ui $REDIRECT"
-
-  if [ "$PYTHON_INSTALL" == "true" ]; then
-    run_cmd "cp machida/build/machida bin $REDIRECT"
-    run_cmd "cp -r machida/lib bin/pylib $REDIRECT"
-  fi
 
   # clean up built artifacts
   run_cmd "make clean $REDIRECT $REDIRECT"


### PR DESCRIPTION
- Add step to create `/tmp/resilience-dir`
closes #2446

- Fix data receiver command and port
closes #2427
closes #2433

- Fix machida commands and multi-line formatting
  - do not use --join for worker, instead use --worker-count 2 in
    initializer
  - fix multi-line command formatting
closes #2476
closes #2440

- Fix spelling of "recovery" on line 84
closes #2430

- "bundle" -> "bundled" on line 15
closes #2460

- Add one-line explanation of resilience files' role in the snapshot
  algorithm.
closes #2462

- word_count link should be called [word_count_with_dynamic_keys] and
should point to the example in the repo directly (non-relative link)
closes #2438

- Improve instructions in resilience.md
  - add setup section
  - include description of where commands ought to be run
  - include description of the number of terminals needed, and which
    command to run in which terminal
  - use cluster_shutdown tool to shut down the cluster at the end
  - improve description of post-run verification
closes #2443
closes #2461

- Add additional machida-resilience build to wallaroo-up.sh
  - Negates need to have user do a special build with resilience=on
  - obviates special docker build instruction for same
closes #2437

- Add `cd ....` instructions to the terminal commands
closes #2463 

@dipinhora please take a look at the changes to `wallaroo-up.sh` and `Dockerfile` in particular