### PR TITLE
Remove reference to Enterprise license from book

### DIFF
--- a/book/getting-started/docker-setup.md
+++ b/book/getting-started/docker-setup.md
@@ -44,7 +44,7 @@ docker pull wallaroo-labs-docker-wallaroolabs.bintray.io/{{ docker_version_url }
 
 * **Wallaroo Source Code**: full Wallaroo source code is provided, including Python example applications.
 
-* **Machida with Resilience**: runs Wallaroo Python applications and writes state to disk for recovery. This version of Machida can be used via the `machida-resilience` binary. Note that this is an Enterprise feature and requires a paid user agreement for use in production. See the [Interworker Serialization and Resilience](/book/python/interworker-serialization-and-resilience.md) documentation for general information and the [Resilience](/book/running-wallaroo/wallaroo-command-line-options.md#resilience) section of our [Command Line Options](/book/running-wallaroo/wallaroo-command-line-options.md) documentation for information on its usage.
+* **Machida with Resilience**: runs Wallaroo Python applications and writes state to disk for recovery. This version of Machida can be used via the `machida-resilience` binary. See the [Interworker Serialization and Resilience](/book/python/interworker-serialization-and-resilience.md) documentation for general information and the [Resilience](/book/running-wallaroo/wallaroo-command-line-options.md#resilience) section of our [Command Line Options](/book/running-wallaroo/wallaroo-command-line-options.md) documentation for information on its usage.
 
 ## Additional Windows Setup
 
@@ -86,4 +86,3 @@ Your email address will only be used to facilitate the above.
 ## Conclusion
 
 Awesome! All set. Time to try running your first Wallaroo application in Docker.
-


### PR DESCRIPTION
Resilience is no longer an enterprise-licensed feature. This update
removes language that states that it is.

Closes #2432