### PR TITLE
Fix windows docker metrics UI error and fix windows vagrant book download issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get install -y \
     ln -s ~/wallaroo-tutorial/wallaroo-${WALLAROO_VERSION} /wallaroo-src && \
     cd /wallaroo-src && \
     sed -i "s@^WALLAROO_ROOT=.*@WALLAROO_ROOT=\"/src/wallaroo\"@" bin/activate && \
+    sed -i "s@^RELEASE_MUTABLE_DIR=.*@RELEASE_MUTABLE_DIR=\"/tmp/metrics_ui\"@" bin/activate && \
     mkdir /wallaroo-bin && \
     cp docker/env-setup /wallaroo-bin && \
     make clean && \

--- a/book/getting-started/vagrant-setup.md
+++ b/book/getting-started/vagrant-setup.md
@@ -2,11 +2,9 @@
 
 To get you up and running quickly with Wallaroo, we have provided a Vagrantfile which includes Wallaroo and related tools needed to run and modify a few example applications. We should warn that this Vagrantfile was created with the intent of getting users started quickly with Wallaroo and is not intended to be suitable for production. Wallaroo in Vagrant runs on Ubuntu Linux Xenial.
 
-**Note:** For Windows users, this section of the guide assumes you are using Powershell.
-
 ## Set up Environment for the Wallaroo Tutorial
 
-### Linux Ubuntu, MacOS, and Windows via Powershell
+### Linux Ubuntu and MacOS
 
 If you haven't already done so, create a directory called `~/wallaroo-tutorial` and navigate there by running:
 
@@ -24,6 +22,28 @@ mkdir wallaroo-{{ book.wallaroo_version }}
 tar -C wallaroo-{{ book.wallaroo_version }} --strip-components=1 -xzf wallaroo-{{ book.wallaroo_version }}.tar.gz
 rm wallaroo-{{ book.wallaroo_version }}.tar.gz
 cd wallaroo-{{ book.wallaroo_version }}
+```
+
+### Windows via Powershell
+
+**Note:** This section of the guide assumes you are using Powershell.
+
+Download and install git from [Git for Windows](https://gitforwindows.org/) and install it.
+
+If you haven't already done so, create a directory called `~/wallaroo-tutorial` and navigate there by running:
+
+```bash
+cd ~/
+mkdir ~/wallaroo-tutorial
+cd ~/wallaroo-tutorial
+```
+
+This will be our base directory in what follows. If you haven't already cloned the Wallaroo repo, do so now (this will create a subdirectory called `wallaroo-{{ book.wallaroo_version }}`):
+
+```bash
+git clone https://github.com/WallarooLabs/wallaroo wallaroo-{{ book.wallaroo_version }}
+cd wallaroo-{{ book.wallaroo_version }}
+git checkout {{ book.wallaroo_version }}
 ```
 
 ## Installing VirtualBox

--- a/book/go/getting-started/vagrant-setup.md
+++ b/book/go/getting-started/vagrant-setup.md
@@ -2,11 +2,9 @@
 
 To get you up and running quickly with Wallaroo, we have provided a Vagrantfile which includes Wallaroo and related tools needed to run and modify a few example applications. We should warn that this Vagrantfile was created with the intent of getting users started quickly with Wallaroo and is not intended to be suitable for production. Wallaroo in Vagrant runs on Ubuntu Linux Xenial.
 
-**Note:** For Windows users, this section of the guide assumes you are using Powershell.
-
 ## Set up Environment for the Wallaroo Tutorial
 
-### Linux Ubuntu, MacOS, and Windows via Powershell
+### Linux Ubuntu and MacOS
 
 If you haven't already done so, create a directory called `~/wallaroo-tutorial` and navigate there by running:
 
@@ -24,6 +22,28 @@ mkdir wallaroo-{{ book.wallaroo_version }}
 tar -C wallaroo-{{ book.wallaroo_version }} --strip-components=1 -xzf wallaroo-{{ book.wallaroo_version }}.tar.gz
 rm wallaroo-{{ book.wallaroo_version }}.tar.gz
 cd wallaroo-{{ book.wallaroo_version }}
+```
+
+### Windows via Powershell
+
+**Note:** This section of the guide assumes you are using Powershell.
+
+Download and install git from [Git for Windows](https://gitforwindows.org/) and install it.
+
+If you haven't already done so, create a directory called `~/wallaroo-tutorial` and navigate there by running:
+
+```bash
+cd ~/
+mkdir ~/wallaroo-tutorial
+cd ~/wallaroo-tutorial
+```
+
+This will be our base directory in what follows. If you haven't already cloned the Wallaroo repo, do so now (this will create a subdirectory called `wallaroo-{{ book.wallaroo_version }}`):
+
+```bash
+git clone https://github.com/WallarooLabs/wallaroo wallaroo-{{ book.wallaroo_version }}
+cd wallaroo-{{ book.wallaroo_version }}
+git checkout {{ book.wallaroo_version }}
 ```
 
 ## Installing VirtualBox

--- a/misc/example-tester.bash
+++ b/misc/example-tester.bash
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+HERE=$(dirname "$(readlink -e "${0}")")
+WALLAROO_DIR="$(readlink -e "${HERE}/..")"
+. "$(readlink -e "${WALLAROO_DIR}/bin/activate")"
+
 set -eEuo pipefail
 
 export PATH=$PATH:/sbin
@@ -169,8 +173,6 @@ log() {
 LANG_TO_TEST=${1:-*}
 EXAMPLE_TO_TEST=${2:-*}
 
-HERE=$(dirname "$(readlink -e "${0}")")
-WALLAROO_DIR="$(readlink -e "${HERE}/..")"
 SOURCE_ACTIVATE="source $(readlink -e "${WALLAROO_DIR}/bin/activate")"
 BASH_HEADER="#!/bin/bash -ex"
 
@@ -357,7 +359,7 @@ parse_and_run() {
       sleep 1
       i=1
       # look for erlang prompt in log file to confirm metrics UI is running successfully since the command forks and returns prior to the UI being up and functional
-      while [[ "$(tail -n 1 "${WALLAROO_DIR}/tmp/log/erlang.log.1")" != "iex(metrics_reporter_ui@127.0.0.1)1> " ]]; do
+      while [[ "$(tail -n 1 "${RELEASE_MUTABLE_DIR:-${WALLAROO_DIR}/tmp}/log/erlang.log.1")" != "iex(metrics_reporter_ui@127.0.0.1)1> " ]]; do
         sleep 1
         (( i=i+1 ))
         RET_CODE=0


### PR DESCRIPTION
The docker metrics UI issue occurs because the directory that erlang is trying
to write to is a volume mapped from the windows host. This commit changes
things so that for our docker image, erlang is directed to write the log file
to the `/tmp/metrics_ui` directory instead.

resolves #2473

The vagrant setup issues relating to curl/tar occur because a plain windows
install does not have these utilities. The current/quick fix is to have
windows users continue to clone the wallaroo repo using `git`.

resolves #2458