### PR TITLE
Fix docker python virtualenv version issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,10 @@ RUN apt-get install -y \
     python-pip \
     python3-dev \
     python3-pip && \
-    pip2 install virtualenv virtualenvwrapper && \
-    pip2 install --upgrade pip && \
     pip3 install virtualenv virtualenvwrapper && \
     pip3 install --upgrade pip && \
+    pip2 install virtualenv virtualenvwrapper && \
+    pip2 install --upgrade pip && \
     cd /tmp && \
     curl https://raw.githubusercontent.com/WallarooLabs/wallaroo/${WALLAROO_VERSION}/misc/wallaroo-up.sh -o wallaroo-up.sh -J -L && \
     chmod +x wallaroo-up.sh && \


### PR DESCRIPTION
Prior to this commit the docker virtualenv would default to `python3`.
This was due to `pip3 virtualenv` being installed after `pip2 virtualenv`.

This commit ensures that `pip2 virtualenv` runs last so that `python2` is
used for the virtualenv.