### PR TITLE
Fix script paths in move from utils -> demos subdir

### DIFF
--- a/demos/resilience-demo/50-copy-worker-resilience.sh
+++ b/demos/resilience-demo/50-copy-worker-resilience.sh
@@ -20,7 +20,7 @@ if [ $RESTORE_VIA_JOURNAL_DUMP = y ]; then
 
     echo Extract journalled I/O ops from the journal file
     # ssh -n $USER@$TARGET_EXT "echo BEFORE ; ls -l /tmp/mar*"
-    ssh -n $USER@$TARGET_EXT "cd wallaroo ; python ./utils/dos-dumb-object-service/journal-dump.py /tmp/${WALLAROO_NAME}-worker${SOURCE_WORKER}.journal"
+    ssh -n $USER@$TARGET_EXT "cd wallaroo ; python ./testing/tools/dos-dumb-object-service/journal-dump.py /tmp/${WALLAROO_NAME}-worker${SOURCE_WORKER}.journal"
     echo Copy ${WALLAROO_NAME}-worker${SOURCE_WORKER}.evlog.journal '->' ${WALLAROO_NAME}-worker${SOURCE_WORKER}.evlog
     ssh -n $USER@$TARGET_EXT "cp /tmp/${WALLAROO_NAME}-worker${SOURCE_WORKER}.evlog.journal /tmp/${WALLAROO_NAME}-worker${SOURCE_WORKER}.evlog"
     # ssh -n $USER@$TARGET_EXT "echo AFTER ; ls -l /tmp/mar*"

--- a/demos/resilience-demo/SEND-1k.sh
+++ b/demos/resilience-demo/SEND-1k.sh
@@ -1,50 +1,50 @@
 #!/bin/sh
 
 export START_SENDER_CMD1='env PYTHONPATH="./testing/tools/integration" \
-  python ./utils/resilience-demo/validation-sender.py ${SERVER1}:7000 \
+  python ./demos/resilience-demo/validation-sender.py ${SERVER1}:7000 \
   0 500 100 0.05 11'
 export START_SENDER_CMD1b='env PYTHONPATH="./testing/tools/integration" \
-  python ./utils/resilience-demo/validation-sender.py ${SERVER1}:7000 \
+  python ./demos/resilience-demo/validation-sender.py ${SERVER1}:7000 \
   500 600 100 0.05 11'
 export START_SENDER_CMD1c='env PYTHONPATH="./testing/tools/integration" \
-  python ./utils/resilience-demo/validation-sender.py ${SERVER1}:7000 \
+  python ./demos/resilience-demo/validation-sender.py ${SERVER1}:7000 \
   600 700 100 0.05 11'
 export START_SENDER_CMD1d='env PYTHONPATH="./testing/tools/integration" \
-  python ./utils/resilience-demo/validation-sender.py ${SERVER1}:7000 \
+  python ./demos/resilience-demo/validation-sender.py ${SERVER1}:7000 \
   700 800 100 0.05 11'
 export START_SENDER_CMD1e='env PYTHONPATH="./testing/tools/integration" \
-  python ./utils/resilience-demo/validation-sender.py ${SERVER1}:7000 \
+  python ./demos/resilience-demo/validation-sender.py ${SERVER1}:7000 \
   800 900 100 0.05 11'
 export START_SENDER_CMD1f='env PYTHONPATH="./testing/tools/integration" \
-  python ./utils/resilience-demo/validation-sender.py ${SERVER1}:7000 \
+  python ./demos/resilience-demo/validation-sender.py ${SERVER1}:7000 \
   900 1000 100 0.05 11'
 
-ssh -n $USER@$SERVER1_EXT "cd wallaroo ; ./utils/resilience-demo/received-wait-for.sh ./received.txt 11 500 20" & P2=$!
+ssh -n $USER@$SERVER1_EXT "cd wallaroo ; ./demos/resilience-demo/received-wait-for.sh ./received.txt 11 500 20" & P2=$!
 env START_SENDER_CMD="$START_SENDER_CMD1" START_SENDER_BG=n \
     ./30-start-sender.sh & P1=$!
 wait $P2 ; if [ $? -ne 0 ]; then echo status check failed; exit 7; fi; wait $P1
 
-ssh -n $USER@$SERVER1_EXT "cd wallaroo ; ./utils/resilience-demo/received-wait-for.sh ./received.txt 11 600 20" & P2=$!
+ssh -n $USER@$SERVER1_EXT "cd wallaroo ; ./demos/resilience-demo/received-wait-for.sh ./received.txt 11 600 20" & P2=$!
 env START_SENDER_CMD="$START_SENDER_CMD1b" START_SENDER_BG=n \
     ./30-start-sender.sh & P1=$!
 wait $P2 ; if [ $? -ne 0 ]; then echo status check failed; exit 7; fi; wait $P1
 
-ssh -n $USER@$SERVER1_EXT "cd wallaroo ; ./utils/resilience-demo/received-wait-for.sh ./received.txt 11 700 20" & P2=$!
+ssh -n $USER@$SERVER1_EXT "cd wallaroo ; ./demos/resilience-demo/received-wait-for.sh ./received.txt 11 700 20" & P2=$!
 env START_SENDER_CMD="$START_SENDER_CMD1c" START_SENDER_BG=n \
     ./30-start-sender.sh & P1=$!
 wait $P2 ; if [ $? -ne 0 ]; then echo status check failed; exit 7; fi; wait $P1
 
-ssh -n $USER@$SERVER1_EXT "cd wallaroo ; ./utils/resilience-demo/received-wait-for.sh ./received.txt 11 800 20" & P2=$!
+ssh -n $USER@$SERVER1_EXT "cd wallaroo ; ./demos/resilience-demo/received-wait-for.sh ./received.txt 11 800 20" & P2=$!
 env START_SENDER_CMD="$START_SENDER_CMD1d" START_SENDER_BG=n \
     ./30-start-sender.sh & P1=$!
 wait $P2 ; if [ $? -ne 0 ]; then echo status check failed; exit 7; fi; wait $P1
 
-ssh -n $USER@$SERVER1_EXT "cd wallaroo ; ./utils/resilience-demo/received-wait-for.sh ./received.txt 11 900 20" & P2=$!
+ssh -n $USER@$SERVER1_EXT "cd wallaroo ; ./demos/resilience-demo/received-wait-for.sh ./received.txt 11 900 20" & P2=$!
 env START_SENDER_CMD="$START_SENDER_CMD1e" START_SENDER_BG=n \
     ./30-start-sender.sh & P1=$!
 wait $P2 ; if [ $? -ne 0 ]; then echo status check failed; exit 7; fi; wait $P1
 
-ssh -n $USER@$SERVER1_EXT "cd wallaroo ; ./utils/resilience-demo/received-wait-for.sh ./received.txt 11 1000 20" & P2=$!
+ssh -n $USER@$SERVER1_EXT "cd wallaroo ; ./demos/resilience-demo/received-wait-for.sh ./received.txt 11 1000 20" & P2=$!
 env START_SENDER_CMD="$START_SENDER_CMD1f" START_SENDER_BG=n \
     ./30-start-sender.sh & P1=$!
 wait $P2 ; if [ $? -ne 0 ]; then echo status check failed; exit 7; fi; wait $P1

--- a/demos/resilience-demo/START-DOS-SERVER.sh
+++ b/demos/resilience-demo/START-DOS-SERVER.sh
@@ -8,7 +8,7 @@ if [ "$USE_DOS_SERVER" = y ]; then
     else
         echo Start DOS server
         ssh -n $USER@$DOS_SERVER_EXT "rm -rf /tmp/dos-data ; mkdir /tmp/dos-data"
-        ssh -n $USER@$DOS_SERVER_EXT "cd wallaroo ; python ./utils/dos-dumb-object-service/dos-server.py /tmp/dos-data > /tmp/dos-data/errout.txt 2>&1" > /dev/null 2>&1 &
+        ssh -n $USER@$DOS_SERVER_EXT "cd wallaroo ; python ./testing/tools/dos-dumb-object-service/dos-server.py /tmp/dos-data > /tmp/dos-data/errout.txt 2>&1" > /dev/null 2>&1 &
     fi
     W_DOS_SERVER_ARG="--resilience-enable-io-journal --resilience-dos-server $DOS_SERVER:9999"
 else

--- a/demos/resilience-demo/VERIFY.2worker.sh
+++ b/demos/resilience-demo/VERIFY.2worker.sh
@@ -4,13 +4,13 @@ VALIDATION_TOTAL=2000
 VALIDATION_MIDWAY=1000
 
 export START_RECEIVER_CMD='env PYTHONPATH="./testing/tools/integration" \
-  python ./utils/resilience-demo/validation-receiver.py ${SERVER1}:5555 \
+  python ./demos/resilience-demo/validation-receiver.py ${SERVER1}:5555 \
   '$VALIDATION_TOTAL' 11 600 ./received.txt'
 
 export WALLAROO_BIN="./testing/correctness/apps/multi_partition_detector/multi_partition_detector"
 
 export START_SENDER_CMD2='env PYTHONPATH="./testing/tools/integration" \
-  python ./utils/resilience-demo/validation-sender.py ${SERVER1}:7000 \
+  python ./demos/resilience-demo/validation-sender.py ${SERVER1}:7000 \
   '$VALIDATION_MIDWAY' '$VALIDATION_TOTAL' 100 0.05 11'
 
 . ./COMMON.sh
@@ -37,7 +37,7 @@ echo Move worker2 journal files, restart worker2 on server 3
 echo Send 2nd half of messages
 env START_SENDER_CMD="$START_SENDER_CMD2" START_SENDER_BG=n \
   ./30-start-sender.sh
-ssh -n $USER@$SERVER1_EXT "cd wallaroo ; ./utils/resilience-demo/received-wait-for.sh ./received.txt 11 2000 20"
+ssh -n $USER@$SERVER1_EXT "cd wallaroo ; ./demos/resilience-demo/received-wait-for.sh ./received.txt 11 2000 20"
 if [ $? -ne 0 ]; then echo status check failed; exit 7; fi;
 
 echo Run validator to check for sequence validity.

--- a/demos/resilience-demo/VERIFY.2worker.simple-restart.sh
+++ b/demos/resilience-demo/VERIFY.2worker.simple-restart.sh
@@ -4,13 +4,13 @@ VALIDATION_TOTAL=2000
 VALIDATION_MIDWAY=1000
 
 export START_RECEIVER_CMD='env PYTHONPATH="./testing/tools/integration" \
-  python ./utils/resilience-demo/validation-receiver.py ${SERVER1}:5555 \
+  python ./demos/resilience-demo/validation-receiver.py ${SERVER1}:5555 \
   '$VALIDATION_TOTAL' 11 600 ./received.txt'
 
 export WALLAROO_BIN="./testing/correctness/apps/multi_partition_detector/multi_partition_detector"
 
 export START_SENDER_CMD2='env PYTHONPATH="./testing/tools/integration" \
-  python ./utils/resilience-demo/validation-sender.py ${SERVER1}:7000 \
+  python ./demos/resilience-demo/validation-sender.py ${SERVER1}:7000 \
   '$VALIDATION_MIDWAY' '$VALIDATION_TOTAL' 100 0.05 11'
 
 . ./COMMON.sh
@@ -38,7 +38,7 @@ fi
 
 env START_SENDER_CMD="$START_SENDER_CMD2" START_SENDER_BG=n \
   ./30-start-sender.sh
-ssh -n $USER@$SERVER1_EXT "cd wallaroo ; ./utils/resilience-demo/received-wait-for.sh ./received.txt 11 2000 20"
+ssh -n $USER@$SERVER1_EXT "cd wallaroo ; ./demos/resilience-demo/received-wait-for.sh ./received.txt 11 2000 20"
 if [ $? -ne 0 ]; then echo status check failed; exit 7; fi;
 
 echo Run validator to check for sequence validity.

--- a/demos/resilience-demo/VERIFY.3worker.sh
+++ b/demos/resilience-demo/VERIFY.3worker.sh
@@ -4,13 +4,13 @@ VALIDATION_TOTAL=2000
 VALIDATION_MIDWAY=1000
 
 export START_RECEIVER_CMD='env PYTHONPATH="./testing/tools/integration" \
-  python ./utils/resilience-demo/validation-receiver.py ${SERVER1}:5555 \
+  python ./demos/resilience-demo/validation-receiver.py ${SERVER1}:5555 \
   '$VALIDATION_TOTAL' 11 600 ./received.txt'
 
 export WALLAROO_BIN="./testing/correctness/apps/multi_partition_detector/multi_partition_detector"
 
 export START_SENDER_CMD2='env PYTHONPATH="./testing/tools/integration" \
-  python ./utils/resilience-demo/validation-sender.py ${SERVER1}:7000 \
+  python ./demos/resilience-demo/validation-sender.py ${SERVER1}:7000 \
   '$VALIDATION_MIDWAY' '$VALIDATION_TOTAL' 100 0.05 11'
 
 . ./COMMON.sh
@@ -37,7 +37,7 @@ echo Move worker2 journal files, restart worker2 on server 4
 echo Send 2nd half of messages
 env START_SENDER_CMD="$START_SENDER_CMD2" START_SENDER_BG=n \
   ./30-start-sender.sh
-ssh -n $USER@$SERVER1_EXT "cd wallaroo ; ./utils/resilience-demo/received-wait-for.sh ./received.txt 11 2000 20"
+ssh -n $USER@$SERVER1_EXT "cd wallaroo ; ./demos/resilience-demo/received-wait-for.sh ./received.txt 11 2000 20"
 if [ $? -ne 0 ]; then echo status check failed; exit 7; fi;
 
 echo Run validator to check for sequence validity.


### PR DESCRIPTION
While I was away from work last week, I wasn't available to quickly twiddle the PR that moved the resilience demo scripts from the `utils` subdirectory to the `demos` directory.  (Oh, and also moving the DOS server to a different locatino.) This commit fixes up the script paths that were hosed by those moves.