### PR TITLE
Remove possiblity of duplicating sequence ids when reading latest id

### DIFF
--- a/lib/wallaroo/core/topology/_test_step_seq_id_generator.pony
+++ b/lib/wallaroo/core/topology/_test_step_seq_id_generator.pony
@@ -26,9 +26,10 @@ actor _TestStepSeqIdGenerator is TestList
 
   fun tag tests(test: PonyTest) =>
     test(_TestNewIncrementsByOne)
-    test(_TestLatestAfterNew)
-    test(_TestLatestWithNew)
-    test(_TestLatestWithoutNew)
+    test(_TestCurrentAfterNew)
+    test(_TestCurrentWithoutNew)
+    test(_TestCurrentWithNew)
+    test(_TestCurrentDoesNotIncrement)
 
 class iso _TestNewIncrementsByOne is UnitTest
   """
@@ -47,58 +48,78 @@ class iso _TestNewIncrementsByOne is UnitTest
     h.assert_ne[SeqId](0, x)
     h.assert_eq[SeqId]((x + 1), y)
 
-class iso _TestLatestAfterNew is UnitTest
+class iso _TestCurrentAfterNew is UnitTest
   """
-  Verify calling `latest_for_run` after `new_id` results in the same id.
+  Verify calling `current_seq_id` after `new_id` results in the same id.
   """
   fun name(): String =>
-    "step_seq_id_generator/latest_after_new"
+    "step_seq_id_generator/current_after_new"
 
   fun ref apply(h: TestHelper) =>
     let gen = StepSeqIdGenerator
 
     gen.new_incoming_message()
     let x = gen.new_id()
-    let y = gen.latest_for_run()
+    let y = gen.current_seq_id()
 
     h.assert_ne[SeqId](0, x)
     h.assert_eq[SeqId](x, y)
 
-class iso _TestLatestWithNew is UnitTest
+class iso _TestCurrentDoesNotIncrement is UnitTest
   """
-  Verify calling `latest_for_run` returns a new id when used in conjunction
-  with a call to new. We do this by doing more than one "run" and verify that
-  the ids are different.
+  `current_seq_id()` will not increment the id value, even
+  if the generator has never had `new_id()` called on it before.
   """
   fun name(): String =>
-    "step_seq_id_generator/latest_without_new"
+    "step_seq_id_generator/current_doesnt_increment"
 
   fun ref apply(h: TestHelper) =>
     let gen = StepSeqIdGenerator
 
     gen.new_incoming_message()
-    let x = gen.latest_for_run()
-    gen.new_incoming_message()
-    let y = gen.latest_for_run()
+    h.assert_eq[SeqId](0,gen.current_seq_id())
 
-    h.assert_ne[SeqId](0, x)
-    h.assert_true(x < y)
 
-class iso _TestLatestWithoutNew is UnitTest
+class iso _TestCurrentWithoutNew is UnitTest
   """
-  Verify calling `latest_for_run` doesn't return a new id when not used
+  Verify calling `current_seq_id()` doesn't return a new id when not used
   in conjunction with a call to new. We do this by doing more than one
   "run" and verify that the ids are the same.
   """
   fun name(): String =>
-    "step_seq_id_generator/latest_without_new"
+    "step_seq_id_generator/current_without_new"
 
   fun ref apply(h: TestHelper) =>
     let gen = StepSeqIdGenerator
 
     gen.new_incoming_message()
-    let x = gen.latest_for_run()
-    let y = gen.latest_for_run()
+    let x = gen.current_seq_id()
+    let y = gen.current_seq_id()
 
-    h.assert_ne[SeqId](0, x)
     h.assert_eq[SeqId](x, y)
+
+
+class iso _TestCurrentWithNew is UnitTest
+  """
+  Verify calling `current_seq_id()` returns the freshest id generated with
+  `new_id`.
+  """
+  fun name(): String =>
+    "step_seq_id_generator/current_with_new"
+
+  fun ref apply(h: TestHelper) =>
+    let gen = StepSeqIdGenerator
+
+    gen.new_incoming_message()
+    let x = gen.new_id()
+    let x_current = gen.current_seq_id()
+
+    let y = gen.new_id()
+    let y_current = gen.current_seq_id()
+
+    h.assert_ne[SeqId](x, 0)
+    h.assert_ne[SeqId](y, 0)
+    h.assert_ne[SeqId](x, y)
+
+    h.assert_eq[SeqId](x, x_current)
+    h.assert_eq[SeqId](y, y_current)

--- a/lib/wallaroo/core/topology/_test_step_seq_id_generator.pony
+++ b/lib/wallaroo/core/topology/_test_step_seq_id_generator.pony
@@ -40,8 +40,6 @@ class iso _TestNewIncrementsByOne is UnitTest
 
   fun ref apply(h: TestHelper) =>
     let gen = StepSeqIdGenerator
-
-    gen.new_incoming_message()
     let x = gen.new_id()
     let y = gen.new_id()
 
@@ -58,7 +56,6 @@ class iso _TestCurrentAfterNew is UnitTest
   fun ref apply(h: TestHelper) =>
     let gen = StepSeqIdGenerator
 
-    gen.new_incoming_message()
     let x = gen.new_id()
     let y = gen.current_seq_id()
 
@@ -76,7 +73,7 @@ class iso _TestCurrentDoesNotIncrement is UnitTest
   fun ref apply(h: TestHelper) =>
     let gen = StepSeqIdGenerator
 
-    gen.new_incoming_message()
+    h.assert_eq[SeqId](0,gen.current_seq_id())
     h.assert_eq[SeqId](0,gen.current_seq_id())
 
 
@@ -92,7 +89,6 @@ class iso _TestCurrentWithoutNew is UnitTest
   fun ref apply(h: TestHelper) =>
     let gen = StepSeqIdGenerator
 
-    gen.new_incoming_message()
     let x = gen.current_seq_id()
     let y = gen.current_seq_id()
 
@@ -110,7 +106,6 @@ class iso _TestCurrentWithNew is UnitTest
   fun ref apply(h: TestHelper) =>
     let gen = StepSeqIdGenerator
 
-    gen.new_incoming_message()
     let x = gen.new_id()
     let x_current = gen.current_seq_id()
 

--- a/lib/wallaroo/core/topology/router.pony
+++ b/lib/wallaroo/core/topology/router.pony
@@ -1585,7 +1585,6 @@ class val LocalStatelessPartitionRouter is StatelessPartitionRouter
       @printf[I32]("Rcvd msg at StatelessPartitionRouter\n".cstring())
     end
     let stateless_partition_id = producer.current_sequence_id() % size().u64()
-
     try
       match _partition_routes(stateless_partition_id)?
       | let s: Step =>
@@ -1600,7 +1599,8 @@ class val LocalStatelessPartitionRouter is StatelessPartitionRouter
             worker_ingress_ts)
           (false, latest_ts)
         else
-          // TODO: What do we do if we get None?
+          @printf[I32]("Rcvd msg at StatelessPartitionRouter\n".cstring())
+          Fail()
           (true, latest_ts)
         end
       | let p: ProxyRouter =>
@@ -1609,7 +1609,8 @@ class val LocalStatelessPartitionRouter is StatelessPartitionRouter
           worker_ingress_ts)
       end
     else
-      // Can't find route
+      @printf[I32]("Can't find route!\n".cstring())
+      Fail()
       (true, latest_ts)
     end
 

--- a/lib/wallaroo/core/topology/step_seq_id_generator.pony
+++ b/lib/wallaroo/core/topology/step_seq_id_generator.pony
@@ -40,18 +40,8 @@ class ref StepSeqIdGenerator
   new create(initial_seq_id: SeqId = 0) =>
     _seq_id = initial_seq_id
 
-  fun ref latest_for_run(): SeqId =>
-    """
-    Gets the most recent id for a given step run.
-
-    If no id, has been generated yet, then we want to generate a
-    new one, otherwise, use the most recent for this run.
-    """
-    if _generate_new then
-      new_id()
-    else
-      _seq_id
-    end
+  fun ref current_seq_id(): SeqId =>
+    _seq_id
 
   fun ref new_id(): SeqId =>
     """
@@ -67,6 +57,3 @@ class ref StepSeqIdGenerator
     `latest_for_run` usage.
     """
     _generate_new = true
-
-  fun last_id(): SeqId =>
-    _seq_id

--- a/lib/wallaroo/core/topology/step_seq_id_generator.pony
+++ b/lib/wallaroo/core/topology/step_seq_id_generator.pony
@@ -23,15 +23,9 @@ class ref StepSeqIdGenerator
   """
   Generate a new sequence id based on what has happened so far in the step.
 
-  **`new_incoming_message` must be called at the start of handling each
-  incoming message**
+  `new_id` always generates the next id in the sequence
 
-  `new_id` always generates the next id in the sequence.
-
-  `latest_for_run` will generate a new id if we haven't yet generated one when
-  handling the current message (as denoted by calling `new_incoming_message`).
-  If we have already generated a message, then `latest_for_run` will return the
-  most recently generated sequence id.
+  `current_seq_id` will return the most recently generated sequence id.
   """
   var _generate_new: Bool = true
   // 0 is reserved for "not seen yet"
@@ -44,16 +38,5 @@ class ref StepSeqIdGenerator
     _seq_id
 
   fun ref new_id(): SeqId =>
-    """
-    Generate a new id
-    """
-    _generate_new = false
     _seq_id = _seq_id + 1
     _seq_id
-
-  fun ref new_incoming_message() =>
-    """
-    Needs to be called at the beginning of a run on a step to set up correct
-    `latest_for_run` usage.
-    """
-    _generate_new = true

--- a/lib/wallaroo/core/topology/steps.pony
+++ b/lib/wallaroo/core/topology/steps.pony
@@ -347,7 +347,7 @@ actor Step is (Producer & Consumer & BarrierProcessor)
     i_seq_id: SeqId, i_route_id: RouteId, latest_ts: U64, metrics_id: U16,
     worker_ingress_ts: U64)
   =>
-    _seq_id_generator.new_incoming_message()
+    _seq_id_generator.new_id()
 
     let my_latest_ts = ifdef "detailed-metrics" then
         Time.nanos()
@@ -424,7 +424,7 @@ actor Step is (Producer & Consumer & BarrierProcessor)
         @printf[I32]("Filtering a dupe in replay\n".cstring())
       end
 
-      _seq_id_generator.new_incoming_message()
+      _seq_id_generator.new_id()
     end
 
   be initialize_seq_id_on_recovery(seq_id: SeqId) =>

--- a/lib/wallaroo/core/topology/steps.pony
+++ b/lib/wallaroo/core/topology/steps.pony
@@ -401,7 +401,7 @@ actor Step is (Producer & Consumer & BarrierProcessor)
     _seq_id_generator.new_id()
 
   fun ref current_sequence_id(): SeqId =>
-    _seq_id_generator.latest_for_run()
+    _seq_id_generator.current_seq_id()
 
   ///////////
   // RECOVERY


### PR DESCRIPTION
These changes resolve an issue I was seeing whereby sequence ids for messages going from a state partition to a parallel computation would grow by 2. This meant that the messages were not routed to all the parallel workers, leaving some workers completely idle forever.

This change makes sure that reading the `current_seq_id` from the generator cannot produce the side effect of incrementing the id.
cc: @jtfmumm 