### PR TITLE
Add `--max-retries` parameter to integration_test

### DIFF
--- a/testing/tools/integration_test
+++ b/testing/tools/integration_test
@@ -481,6 +481,10 @@ def CLI():
                             help=("Timeout in seconds before killing any "
                                   "remaining live workers and raising an "
                                   "error."))
+    term_group.add_argument('--max-retries', type=int, default=5,
+                            help=("Max number of times to attempt the test"
+                                  " if it fails due a "
+                                  "RunnerHasntStartedError"))
 
     args = parser.parse_args()
     log_level = get_log_level(args.log_level)


### PR DESCRIPTION
- Allow CLI to determine max number of retries in case test fails
  because of a RunnerHasntStartedError

The logic that uses this parameter is already in place in `integration_test` from a previous PR, but the parameter wasn't created. This PR addresses that.