### PR TITLE
Prevent StepSeqIdGenerator from skipping sequence ids and failing to send work to some parallel computations

### DIFF
--- a/examples/python/parallel-classifier/.gitignore
+++ b/examples/python/parallel-classifier/.gitignore
@@ -1,0 +1,1 @@
+inputs.txt

--- a/examples/python/parallel-classifier/Makefile
+++ b/examples/python/parallel-classifier/Makefile
@@ -1,0 +1,91 @@
+# include root makefile
+ifndef ROOT_MAKEFILE_MK
+include ../../../Makefile
+endif
+
+# prevent rules from being evaluated/included multiple times
+ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
+$(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
+
+
+# The following are control variables that determine what logic from `rules.mk` is enabled
+
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
+
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := false
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := false
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := false
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := false
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := false
+
+
+PARALLEL_CLASSIFIER_PY_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+# standard rules generation makefile
+include $(rules_mk_path)
+
+build-examples-python-parallel_classifier: build-machida
+integration-tests-examples-python-parallel_classifier: build-examples-python-parallel_classifier
+integration-tests-examples-python-parallel_classifier: parallel_classifier_py_test
+clean-examples-python-alphabet: parallel_classifier_py_clean
+
+INPUT_ITEMS:=2500
+.PHONY: generate_inputs
+generate_inputs:
+	seq 1 $(INPUT_ITEMS) > inputs.txt
+
+parallel_classifier_py_test: generate_inputs
+	cd $(PARALLEL_CLASSIFIER_PY_PATH) && \
+	 integration_test --newline-file-sender inputs.txt \
+	 	--validation-cmd 'validate.py 1 $(INPUT_ITEMS)' \
+	 	--output 'received.txt' \
+	 	--batch-size 100 \
+	 	--log-level error \
+	 	--command 'machida --application-module parallel_classifier' \
+	 	--sink-mode framed \
+	 	--sink-stop-timeout 10 \
+	 	--sink-expect $(INPUT_ITEMS)
+	cd $(PARALLEL_CLASSIFIER_PY_PATH) && \
+	integration_test --newline-file-sender inputs.txt \
+		--validation-cmd './validate.py 2 $(INPUT_ITEMS)' \
+		--output 'received.txt' \
+		--log-level error \
+		--batch-size 100 \
+		--command 'machida --application-module parallel_classifier' \
+		--sink-mode framed \
+		--sink-expect $(INPUT_ITEMS) \
+		--sink-stop-timeout 20 \
+		--workers 2
+	cd $(PARALLEL_CLASSIFIER_PY_PATH) && \
+	integration_test --newline-file-sender inputs.txt \
+		--validation-cmd './validate.py 15 $(INPUT_ITEMS)' \
+		--output 'received.txt' \
+		--log-level error \
+		--batch-size 100 \
+		--command 'machida --application-module parallel_classifier' \
+		--sink-mode framed \
+		--sink-expect $(INPUT_ITEMS) \
+		--sink-stop-timeout 20 \
+		--workers 15
+
+parallel_classifier_py_clean:
+	$(QUIET)rm -f $(PARALLEL_CLASSIFIER_PY_PATH)/received.txt
+	$(QUIET)rm -f $(PARALLEL_CLASSIFIER_PY_PATH)/inputs.txt
+
+endif

--- a/examples/python/parallel-classifier/parallel_classifier.py
+++ b/examples/python/parallel-classifier/parallel_classifier.py
@@ -1,0 +1,55 @@
+# Copyright 2017 The Wallaroo Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+
+"""
+This is a test example that showcases the parallelization capabilites of
+Wallaroo, by tagging every input message with the OS-level PID of the
+worker that has processed the input.
+
+"""
+
+from collections import namedtuple
+import struct
+import wallaroo
+import time
+import os
+
+PID=None
+
+def application_setup(args):
+    global PID
+    PID=str(os.getpid())
+    in_host, in_port = wallaroo.tcp_parse_input_addrs(args)[0]
+    out_host, out_port = wallaroo.tcp_parse_output_addrs(args)[0]
+
+    ab = wallaroo.ApplicationBuilder("Parallel Application")
+    ab.new_pipeline("App",
+                    wallaroo.TCPSourceConfig(in_host, in_port, decode))
+    ab.to_parallel(classify)
+    ab.to_sink(wallaroo.TCPSinkConfig(out_host, out_port, encode))
+    return ab.build()
+
+@wallaroo.computation(name="Classify")
+def classify(x):
+    return str(x)+":"+PID
+
+@wallaroo.decoder(header_length=4, length_fmt=">I")
+def decode(bs):
+    return bs
+
+@wallaroo.encoder
+def encode(thing):
+    x = str(thing)
+    return struct.pack('>I',len(x)) + x

--- a/examples/python/parallel-classifier/validate.py
+++ b/examples/python/parallel-classifier/validate.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python2
+"""
+validate.py N_WORKERS N_INPUT_ITEMS OUTPUTFILE
+"""
+import sys
+n_workers = int(sys.argv[1])
+n_input_items = int(sys.argv[2])
+output_file = open(sys.argv[3])
+
+decoded = filter(lambda x: x!='',
+                 "".join(output_file.readlines()).split("\x00"))
+ids_pids = [ item.split(":") for item in decoded ]
+n_output_ids = len([ id_pid[0] for id_pid in ids_pids ])
+n_worker_pids = len(set([ id_pid[1] for id_pid in ids_pids ]))
+
+if (n_input_items == n_output_ids) and (n_worker_pids == n_workers):
+    sys.exit(0)
+else:
+    print "Expected {} pids, {} items".format(n_workers, n_input_items)
+    print "GOT {} pids, {} items".format(unique_pids, n_output_ids)
+    sys.exit(1)

--- a/lib/wallaroo/core/topology/router.pony
+++ b/lib/wallaroo/core/topology/router.pony
@@ -1585,7 +1585,6 @@ class val LocalStatelessPartitionRouter is StatelessPartitionRouter
       @printf[I32]("Rcvd msg at StatelessPartitionRouter\n".cstring())
     end
     let stateless_partition_id = producer.current_sequence_id() % size().u64()
-
     try
       match _partition_routes(stateless_partition_id)?
       | let s: Step =>
@@ -1600,7 +1599,8 @@ class val LocalStatelessPartitionRouter is StatelessPartitionRouter
             worker_ingress_ts)
           (false, latest_ts)
         else
-          // TODO: What do we do if we get None?
+          @printf[I32]("Rcvd msg at StatelessPartitionRouter\n".cstring())
+          Fail()
           (true, latest_ts)
         end
       | let p: ProxyRouter =>
@@ -1609,7 +1609,8 @@ class val LocalStatelessPartitionRouter is StatelessPartitionRouter
           worker_ingress_ts)
       end
     else
-      // Can't find route
+      @printf[I32]("Can't find route!\n".cstring())
+      Fail()
       (true, latest_ts)
     end
 

--- a/lib/wallaroo/core/topology/step_seq_id_generator.pony
+++ b/lib/wallaroo/core/topology/step_seq_id_generator.pony
@@ -23,15 +23,9 @@ class ref StepSeqIdGenerator
   """
   Generate a new sequence id based on what has happened so far in the step.
 
-  **`new_incoming_message` must be called at the start of handling each
-  incoming message**
+  `new_id` always generates the next id in the sequence
 
-  `new_id` always generates the next id in the sequence.
-
-  `latest_for_run` will generate a new id if we haven't yet generated one when
-  handling the current message (as denoted by calling `new_incoming_message`).
-  If we have already generated a message, then `latest_for_run` will return the
-  most recently generated sequence id.
+  `current_seq_id` will return the most recently generated sequence id.
   """
   var _generate_new: Bool = true
   // 0 is reserved for "not seen yet"
@@ -40,33 +34,9 @@ class ref StepSeqIdGenerator
   new create(initial_seq_id: SeqId = 0) =>
     _seq_id = initial_seq_id
 
-  fun ref latest_for_run(): SeqId =>
-    """
-    Gets the most recent id for a given step run.
-
-    If no id, has been generated yet, then we want to generate a
-    new one, otherwise, use the most recent for this run.
-    """
-    if _generate_new then
-      new_id()
-    else
-      _seq_id
-    end
-
-  fun ref new_id(): SeqId =>
-    """
-    Generate a new id
-    """
-    _generate_new = false
-    _seq_id = _seq_id + 1
+  fun ref current_seq_id(): SeqId =>
     _seq_id
 
-  fun ref new_incoming_message() =>
-    """
-    Needs to be called at the beginning of a run on a step to set up correct
-    `latest_for_run` usage.
-    """
-    _generate_new = true
-
-  fun last_id(): SeqId =>
+  fun ref new_id(): SeqId =>
+    _seq_id = _seq_id + 1
     _seq_id

--- a/lib/wallaroo/core/topology/steps.pony
+++ b/lib/wallaroo/core/topology/steps.pony
@@ -347,7 +347,7 @@ actor Step is (Producer & Consumer & BarrierProcessor)
     i_seq_id: SeqId, i_route_id: RouteId, latest_ts: U64, metrics_id: U16,
     worker_ingress_ts: U64)
   =>
-    _seq_id_generator.new_incoming_message()
+    _seq_id_generator.new_id()
 
     let my_latest_ts = ifdef "detailed-metrics" then
         Time.nanos()
@@ -401,7 +401,7 @@ actor Step is (Producer & Consumer & BarrierProcessor)
     _seq_id_generator.new_id()
 
   fun ref current_sequence_id(): SeqId =>
-    _seq_id_generator.latest_for_run()
+    _seq_id_generator.current_seq_id()
 
   ///////////
   // RECOVERY
@@ -424,7 +424,7 @@ actor Step is (Producer & Consumer & BarrierProcessor)
         @printf[I32]("Filtering a dupe in replay\n".cstring())
       end
 
-      _seq_id_generator.new_incoming_message()
+      _seq_id_generator.new_id()
     end
 
   be initialize_seq_id_on_recovery(seq_id: SeqId) =>


### PR DESCRIPTION
This fixes issue #2517.

Prior to the fix, the `StepSeqIdGenerator` could be put into a state where asking for the `latest` sequence id would actually increment it's internal counter and generate a new sequence id. This situation occurred in the router when running `to_parallel` loads, and cause sequence ids to always increase by 2.
This resulted in skewing the round-robin algorithm in such a way that certain workers were always skipped when distributing parallel work.

This PR fixes the issue and introduces a `parallel-classifier` example app, which tests that all workers in a parallel python workflow actually get work assigned to them.
