### PR TITLE
Update sender command in README to be more in-line with expectations

### DIFF
--- a/examples/pony/alphabet/README.md
+++ b/examples/pony/alphabet/README.md
@@ -89,7 +89,7 @@ cd data_gen
 ./data_gen --message-count 1000
 cd ..
 sender --host 127.0.0.1:7010 \
-  --file data_gen/votes.msg --batch-size 5 --interval 100_000_000 \
+  --file data_gen/votes.msg --batch-size 1000 --interval 100_000 \
   --messages 150000000 --binary --variable-size --repeat --ponythreads=1 \
   --ponynoblock --no-write
 ```


### PR DESCRIPTION
This really confused me when I was running these examples last week.

Before:
![image](https://user-images.githubusercontent.com/5035876/46628835-cec9de80-caf3-11e8-80f8-758f71025af8.png)

After:
![image](https://user-images.githubusercontent.com/5035876/46628852-d6898300-caf3-11e8-9cf4-31b277ee82fb.png)

P.S. Anyone remember why in even the pony examples we set `ponythreads` to 1?