### PR TITLE
Multiple DOS client support

### DIFF
--- a/demos/resilience-demo/50-copy-worker-resilience.sh
+++ b/demos/resilience-demo/50-copy-worker-resilience.sh
@@ -14,9 +14,9 @@ else
 fi
 
 if [ $RESTORE_VIA_JOURNAL_DUMP = y ]; then
-    echo Rsync journal file from DOS server $DOS_SERVER to $TARGET
+    echo Rsync journal file from DOS server $DOS_SERVER1 to $TARGET
     ssh -n $USER@$TARGET_EXT "rm -vf /tmp/${WALLAROO_NAME}-worker${SOURCE_WORKER}*"
-    ssh -A -n $USER@$TARGET_EXT "rsync -raH -v -e 'ssh -o \"StrictHostKeyChecking no\"' ${DOS_SERVER}:/tmp/dos-data/worker${SOURCE_WORKER}/\* /tmp"
+    ssh -A -n $USER@$TARGET_EXT "rsync -raH -v -e 'ssh -o \"StrictHostKeyChecking no\"' ${DOS_SERVER1}:/tmp/dos-data/worker${SOURCE_WORKER}/\* /tmp"
 
     echo Extract journalled I/O ops from the journal file
     # ssh -n $USER@$TARGET_EXT "echo BEFORE ; ls -l /tmp/mar*"

--- a/demos/resilience-demo/COMMON-4machine.sh
+++ b/demos/resilience-demo/COMMON-4machine.sh
@@ -73,8 +73,10 @@ ORDERS_PORT=7000
 # DOS server-related flags: if USE_DOS_SERVER=n then following two
 # variables will be ignored.
 USE_DOS_SERVER=y
-DOS_SERVER_EXT=$SERVER1_EXT
-DOS_SERVER=$SERVER1
+DOS_SERVER1_EXT=$SERVER1_EXT
+DOS_SERVER1=$SERVER1
+DOS_SERVER2_EXT=$SERVER2_EXT
+DOS_SERVER2=$SERVER2
 
 # Choice for data copy step from former/dead worker -> new worker:
 # if "n", then rsync all /tmp/market-spread-worker2* files;

--- a/demos/resilience-demo/START-DOS-SERVER.sh
+++ b/demos/resilience-demo/START-DOS-SERVER.sh
@@ -6,11 +6,14 @@ if [ "$USE_DOS_SERVER" = y ]; then
     if [ "$SKIP_DOS_SERVER_START" = y ]; then
         echo Use DOS server but skip starting it
     else
-        echo Start DOS server
-        ssh -n $USER@$DOS_SERVER_EXT "rm -rf /tmp/dos-data ; mkdir /tmp/dos-data"
-        ssh -n $USER@$DOS_SERVER_EXT "cd wallaroo ; python ./testing/tools/dos-dumb-object-service/dos-server.py /tmp/dos-data > /tmp/dos-data/errout.txt 2>&1" > /dev/null 2>&1 &
+        echo Start DOS server 1
+        ssh -n $USER@$DOS_SERVER1_EXT "rm -rf /tmp/dos-data ; mkdir /tmp/dos-data"
+        ssh -n $USER@$DOS_SERVER1_EXT "cd wallaroo ; python ./testing/tools/dos-dumb-object-service/dos-server.py /tmp/dos-data > /tmp/dos-data/errout.txt 2>&1" > /dev/null 2>&1 &
+        echo Start DOS server 2
+        ssh -n $USER@$DOS_SERVER2_EXT "rm -rf /tmp/dos-data ; mkdir /tmp/dos-data"
+        ssh -n $USER@$DOS_SERVER2_EXT "cd wallaroo ; python ./testing/tools/dos-dumb-object-service/dos-server.py /tmp/dos-data > /tmp/dos-data/errout.txt 2>&1" > /dev/null 2>&1 &
     fi
-    W_DOS_SERVER_ARG="--resilience-enable-io-journal --resilience-dos-server $DOS_SERVER:9999"
+    W_DOS_SERVER_ARG="--resilience-enable-io-journal --resilience-dos-server $DOS_SERVER1:9999,$DOS_SERVER2:9999"
 else
     echo Skip starting DOS server
     W_DOS_SERVER_ARG=""

--- a/lib/wallaroo/ent/recovery/event_log.pony
+++ b/lib/wallaroo/ent/recovery/event_log.pony
@@ -46,8 +46,7 @@ class val EventLogConfig
   let is_recovering: Bool
   let do_local_file_io: Bool
   let worker_name: String
-  let dos_host: String
-  let dos_service: String
+  let dos_servers: Array[(String,String)] val
 
   new val create(log_dir': (FilePath | AmbientAuth | None) = None,
     filename': (String val | None) = None,
@@ -58,8 +57,7 @@ class val EventLogConfig
     is_recovering': Bool = false,
     do_local_file_io': Bool = true,
     worker_name': String = "unknown-worker-name",
-    dos_host': String = "localhost",
-    dos_service': String = "9999")
+    dos_servers': Array[(String,String)] val = recover val [] end)
   =>
     filename = filename'
     log_dir = log_dir'
@@ -70,8 +68,7 @@ class val EventLogConfig
     is_recovering = is_recovering'
     do_local_file_io = do_local_file_io'
     worker_name = worker_name'
-    dos_host = dos_host'
-    dos_service = dos_service'
+    dos_servers = dos_servers'
 
 actor EventLog is SimpleJournalAsyncResponseReceiver
   let _auth: AmbientAuth
@@ -118,7 +115,7 @@ actor EventLog is SimpleJournalAsyncResponseReceiver
               RotatingFileBackend(ld, f, _config.suffix, this,
                 _config.backend_file_length, _the_journal, _auth,
                 _config.worker_name, _config.do_local_file_io,
-                _config.dos_host, _config.dos_service
+                _config.dos_servers
                 where rotation_enabled = true)?
             else
               Fail()
@@ -130,13 +127,13 @@ actor EventLog is SimpleJournalAsyncResponseReceiver
               RotatingFileBackend(ld, f, "", this,
                 _config.backend_file_length, _the_journal, _auth,
                 _config.worker_name, _config.do_local_file_io,
-                _config.dos_host, _config.dos_service
+                _config.dos_servers
                 where rotation_enabled = false)?
             | let ld: AmbientAuth =>
               RotatingFileBackend(FilePath(ld, f)?, f, "", this,
                 _config.backend_file_length, _the_journal, _auth,
                 _config.worker_name, _config.do_local_file_io,
-                _config.dos_host, _config.dos_service
+                _config.dos_servers
                 where rotation_enabled = false)?
             else
               Fail()

--- a/lib/wallaroo/startup_help.pony
+++ b/lib/wallaroo/startup_help.pony
@@ -39,7 +39,7 @@ primitive StartupHelp
           initializing process (that status is meaningless after init is done)]
         --resilience-dir/-r [Sets directory to write resilience files to,
           e.g. -r /tmp/data (no trailing slash)]
-        --resilience-dos-server [Sets the hostname+port of the remote DOS server]
+        --resilience-dos-server [Comma-separated list of hostname:port of the remote DOS server(s)]
         --resilience-enable-io-journal [Enables the write-ahead logging
           of all file I/O (regardless of resilience build type)]
         --resilience-no-local-file-io [Disables local file I/O; writes to I/O

--- a/lib/wallaroo/wallaroo_config.pony
+++ b/lib/wallaroo/wallaroo_config.pony
@@ -51,9 +51,8 @@ class StartupOptions
   var checkpoints_enabled: Bool = true
   var time_between_checkpoints: U64 = 1_000_000_000
   var spike_config: (SpikeConfig | None) = None
-  var dos_host: String = ""
-  var dos_service: String = "9999"
   var run_with_resilience: Bool = false
+  var dos_servers: Array[(String,String)] val = recover dos_servers.create() end
 
 primitive WallarooConfig
   fun application_args(args: Array[String] val): Array[String] val ? =>
@@ -172,9 +171,12 @@ primitive WallarooConfig
           so.resilience_dir = arg
         end
       | ("resilience-dos-server", let arg: String) =>
-        let a = arg.split(":")
-        so.dos_host = a(0)?
-        so.dos_service = a(1)?
+        let dos_servers: Array[(String,String)] trn = recover dos_servers.create() end
+        for s in arg.split(",").values() do
+          let h_s = s.split(":")
+          dos_servers.push((h_s(0)?, h_s(1)?))
+        end
+        so.dos_servers = consume dos_servers
       | ("resilience-no-local-file-io", let arg: None) =>
         so.do_local_file_io = false
       | ("resilience-enable-io-journal", let arg: None) =>
@@ -242,7 +244,7 @@ primitive WallarooConfig
       end
     end
 
-    if not so.is_initializer and
+    if (not so.is_initializer and (so.dos_servers.size() > 0)) and
       ((so.my_d_host == "") or (so.my_c_host == "")) then
         FatalUserError("Non-initializer nodes must specify --my-control and " +
           " --my-data flags")


### PR DESCRIPTION
Add support for multiple DOS clients: the `--resilience-dos-server` flag now accepts a comma-separated list of server:port strings.

Lightly tested via the demos/resilience-demo scripts (also patched by this PR) for 2 DOS server replicas: run market-spread for a while, stop the cluster with `cluster-shutdown`, check that both workers have indeed shut down cleanly, then use `shasum` to check that all 4 journal files on both DOS servers are identical.
