### PR TITLE
Don't prevent barrier forwarding after a TCPSource closes

### DIFF
--- a/lib/wallaroo/core/source/tcp_source/tcp_source.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source.pony
@@ -482,7 +482,7 @@ actor TCPSource[In: Any val] is Source
     end
 
   fun ref _initiate_barrier(token: BarrierToken) =>
-    if not _disposed and not _shutdown then
+    if not _disposed then
       match token
       | let srt: CheckpointRollbackBarrierToken =>
         _prepare_for_rollback()


### PR DESCRIPTION
With the static TCPSource graph, we no longer use the closing of a TCPSource as a criterion for determining whether to forward barriers.  However, there is still a point where we check this, making it possible for checkpoints to stall.  This PR is intended to fix the problem.

Closes #2507 
