### PR TITLE
Restore behavior where workers can restart without resilience flag on (using initial state)

### DIFF
--- a/book/running-wallaroo/resilience.md
+++ b/book/running-wallaroo/resilience.md
@@ -76,7 +76,7 @@ cd examples/python/word_count_with_dynamic_keys
       --data 127.0.0.1:6001 --external 127.0.0.1:5050 \
       --name initializer --cluster-initializer --worker-count 2 \
       --resilience-dir /tmp/resilience-dir \
-      --ponythreads=1 --ponynoblock \
+      --ponythreads=1 --ponynoblock --run-with-resilience \
       | tee initializer.log
     ```
 
@@ -90,7 +90,7 @@ cd examples/python/word_count_with_dynamic_keys
       --external 127.0.0.1:5051 \
       --name worker1 \
       --resilience-dir /tmp/resilience-dir \
-      --ponythreads=1 --ponynoblock \
+      --ponythreads=1 --ponynoblock --run-with-resilience \
       | tee worker1.log
     ```
 
@@ -126,7 +126,7 @@ cd examples/python/word_count_with_dynamic_keys
       --external 127.0.0.1:5051 \
       --name worker1 \
       --resilience-dir /tmp/resilience-dir \
-      --ponythreads=1 --ponynoblock \
+      --ponythreads=1 --ponynoblock --run-with-resilience \
       | tee worker1.recovered.log
     ```
 

--- a/lib/wallaroo/ent/network/connections.pony
+++ b/lib/wallaroo/ent/network/connections.pony
@@ -132,7 +132,8 @@ actor Connections is Cluster
         let host' = file_lines.next()?
         let port' = file_lines.next()?
 
-        @printf[I32]("Restarting a listener ...\n\n".cstring())
+        @printf[I32]("Restarting a listener at %s:%s\n\n".cstring(),
+          host'.cstring(), port'.cstring())
 
         let listener = TCPListener(auth, consume notifier, consume host',
             consume port')

--- a/lib/wallaroo/startup.pony
+++ b/lib/wallaroo/startup.pony
@@ -110,12 +110,7 @@ actor Startup
       let auth = _env.root as AmbientAuth
       _startup_options = WallarooConfig.wallaroo_args(_env.args)?
       _set_recovery_file_names(auth)
-      _is_recovering =
-        ifdef "resilience" then
-          is_recovering(auth)
-        else
-          false
-        end
+      _is_recovering = is_recovering(auth)
       _is_joining = (not _is_recovering) and _startup_options.is_joining
 
       if _is_joining then
@@ -749,8 +744,10 @@ actor Startup
       let required_files: Set[String] = Set[String]
       ifdef "resilience" then
         required_files.set(event_log_filepath.path)
+        required_files.set(checkpoint_ids_filepath.path)
       end
       required_files.set(local_topology_filepath.path)
+      required_files.set(local_keys_filepath.path)
       required_files.set(control_channel_filepath.path)
       required_files.set(worker_names_filepath.path)
       if not _startup_options.is_initializer then

--- a/lib/wallaroo/startup_help.pony
+++ b/lib/wallaroo/startup_help.pony
@@ -44,6 +44,8 @@ primitive StartupHelp
           of all file I/O (regardless of resilience build type)]
         --resilience-no-local-file-io [Disables local file I/O; writes to I/O
           journal are not affected by this flag]
+        --run-with-resilience [Enables resilience. Required (and only works)
+          if the Wallaroo binary was built in resilience mode.]
         --log-rotation [Enables log rotation. Default: off]
         --event-log-file-size/-l [Optionally sets rotation size for the event
           log file backend]

--- a/testing/correctness/tests/autoscale/autoscale_tests.py
+++ b/testing/correctness/tests/autoscale/autoscale_tests.py
@@ -32,6 +32,11 @@ CMD_PYTHON = 'machida --application-module multi_partition_detector --depth 1'
 
 APIS = {'pony': CMD_PONY, 'python': CMD_PYTHON}
 
+# If resilience is on, add --run-with-resilience to commands
+import os
+if os.environ.get("resilience") == 'on':
+    for a in APIS:
+        APIS[a] += ' --run-with-resilience'
 
 ##############
 # Test spec(s)

--- a/testing/correctness/tests/resilience/resilience.py
+++ b/testing/correctness/tests/resilience/resilience.py
@@ -314,22 +314,10 @@ def _test_resilience(command, ops=[], initial=None, sources=1,
                     logging.error("Max retry attempts reached.")
                     raise
             except SinkAwaitTimeoutError:
-                if persistent_data.get('runner_data'):
-                    logging.error("SinkAWaitTimeoutError encountered. The "
-                        "last {} lines of each worker were:\n\n{}".format(
-                            FROM_TAIL,
-                            runner_data_format(
-                                persistent_data.get('runner_data'),
-                                from_tail=FROM_TAIL)))
+                logging.error("SinkAWaitTimeoutError encountered.")
                 raise
             except TimeoutError:
-                if persistent_data.get('runner_data'):
-                    logging.error("TimeoutError encountered. The last {} lines"
-                        " of each worker were:\n\n{}".format(
-                            FROM_TAIL,
-                            runner_data_format(
-                                persistent_data.get('runner_data'),
-                                from_tail=FROM_TAIL)))
+                logging.error("TimeoutError encountered.")
                 raise
             except:
                 if persistent_data.get('runner_data'):

--- a/testing/correctness/tests/resilience/resilience_tests.py
+++ b/testing/correctness/tests/resilience/resilience_tests.py
@@ -37,9 +37,8 @@ TC = Creator(this)
 # - [x] Clean out dev debug logs
 
 
-
-CMD_PONY = 'multi_partition_detector --depth 1 --gen-source'
-CMD_PYTHON = 'machida --application-module multi_partition_detector --depth 1 --gen-source'
+CMD_PONY = 'multi_partition_detector --depth 1 --gen-source --run-with-resilience'
+CMD_PYTHON = 'machida --application-module multi_partition_detector --depth 1 --gen-source --run-with-resilience'
 
 APIS = {'pony': CMD_PONY, 'python': CMD_PYTHON}
 

--- a/testing/correctness/tests/restart_without_resilience/Makefile
+++ b/testing/correctness/tests/restart_without_resilience/Makefile
@@ -40,7 +40,6 @@ restart_without_resilience_tests : CUSTOM_PYTHONPATH = $(SEQUENCE_WINDOW_PYTHON_
 # standard rules generation makefile
 include $(rules_mk_path)
 
-ifeq ($(resilience),on)
 
 build-testing-correctness-tests-restart_without_resilience: build-testing-correctness-apps-sequence_window
 build-testing-correctness-tests-restart_without_resilience: build-testing-tools-external_sender
@@ -48,12 +47,13 @@ build-testing-correctness-tests-restart_without_resilience: build-machida
 integration-tests-testing-correctness-tests-restart_without_resilience: build-testing-correctness-tests-restart_without_resilience
 integration-tests-testing-correctness-tests-restart_without_resilience: restart_without_resilience_tests
 
+ifeq ($(resilience),on)
 restart_without_resilience_tests:
 	$(QUIET)printf "restart_without_resilience_tests not run.\nRun make with 'resilience=off' to run this test.\n"
 else
 restart_without_resilience_tests:
 	cd $(RESTART_WITHOUT_RESILIENCE_PATH) && \
-	python2 -m pytest --color=yes --tb=native --verbose --exitfirst restart_without_resilience.py $(pytest_exp)
+	python2 -m pytest -c $(integration_path)/pytest.ini restart_without_resilience.py $(pytest_exp)
 endif
 
 endif


### PR DESCRIPTION
This restores the old behavior where with resilience flag off, you can still restart failed workers.  They will restart in their initial state and successfully connect to the the cluster and continue work (which means likely the system will be in a weird or at least unexpected global state).  

During the last release process, people expressed concern that allowing a worker to restart with resilience off might be confusing as users might think they have built with resilience and be surprised that their state was not restored.  This PR closes #2539 by restoring old behavior, but is this the behavior we want?  If we do want this behavior, is there a way we'd like to make it clearer what's happening?  For example, should we require a command line flag indicating that you want to be able to restart without recovery in this way?

I've added the DO NOT MERGE tag so there can be some discussion before merging.

@nisanharamati @slfritchie @dipinhora @SeanTAllen 