### PR TITLE
Update `activate` script to be location independent

### DIFF
--- a/.release/rc.sh
+++ b/.release/rc.sh
@@ -60,8 +60,6 @@ update_version() {
   # add version to wallaroo-up.sh map
   PONYC_VERSION=$(grep -Po '(?<=PONYC_VERSION=").*(?=")' .release/bootstrap.sh)
   sed -i "s/WALLAROO_PONYC_MAP=\"/WALLAROO_PONYC_MAP=\"\nW${version}=${PONYC_VERSION}/" misc/wallaroo-up.sh
-  # update activate script for latest release
-  sed -i "s@^WALLAROO_ROOT=.*@WALLAROO_ROOT=\"\${HOME}/wallaroo-tutorial/wallaroo-${version}\"@" misc/activate
   # update activate script for golang version
   sed -i "s@^export GOROOT=.*@export GOROOT=\$WALLAROO_ROOT/bin/go${GO_VERSION}@" misc/activate
   # update checksum in wallaroo-up.sh

--- a/.release/release.sh
+++ b/.release/release.sh
@@ -75,8 +75,6 @@ update_version() {
   sed -i "s/WALLAROO_PONYC_MAP=\"/WALLAROO_PONYC_MAP=\"\nW${for_version}=${PONYC_VERSION}/" misc/wallaroo-up.sh
   # remove old release candidate versions from wallaroo-up.sh map
   sed -i "/Wrelease-/d" misc/wallaroo-up.sh
-  # update activate script for latest release
-  sed -i "s@^WALLAROO_ROOT=.*@WALLAROO_ROOT=\"\${HOME}/wallaroo-tutorial/wallaroo-${for_version}\"@" misc/activate
   # update activate script for golang version
   sed -i "s@^export GOROOT=.*@export GOROOT=\$WALLAROO_ROOT/bin/go${GO_VERSION}@" misc/activate
   # update checksum in wallaroo-up.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ RUN apt-get install -y \
     echo y | ./wallaroo-up.sh -t all && \
     ln -s ~/wallaroo-tutorial/wallaroo-${WALLAROO_VERSION} /wallaroo-src && \
     cd /wallaroo-src && \
-    sed -i "s@^WALLAROO_ROOT=.*@WALLAROO_ROOT=\"/src/wallaroo\"@" bin/activate && \
     sed -i "s@^export RELEASE_MUTABLE_DIR=.*@export RELEASE_MUTABLE_DIR=\"/tmp/metrics_ui\"@" bin/activate && \
     mkdir /wallaroo-bin && \
     cp docker/env-setup /wallaroo-bin && \

--- a/misc/activate
+++ b/misc/activate
@@ -3,7 +3,7 @@
 WALLAROO_ACTIVATE="${BASH_SOURCE[0]}"
 HERE=$(dirname "$(readlink -e "${WALLAROO_ACTIVATE}")")
 
-WALLAROO_ROOT="${HOME}/wallaroo-tutorial/wallaroo-0.5.3"
+WALLAROO_ROOT="${HERE}/.."
 export WALLAROO_ROOT
 
 export GOROOT=$WALLAROO_ROOT/bin/go1.9.4


### PR DESCRIPTION
Make `activate` script be location independent (i.e. dynamically
figure out where it is) when determining `WALLAROO_ROOT`.

THis also removes places where we manually override `WALLAROO_ROOT`
via search/replace in `activate`.