### PR TITLE
Add Python3 resilience+autoscale tests

### DIFF
--- a/machida3/cpp/python-wallaroo.c
+++ b/machida3/cpp/python-wallaroo.c
@@ -123,6 +123,28 @@ extern PyObject *source_decoder_decode(PyObject *source_decoder, char *bytes, si
   return pValue;
 }
 
+extern PyObject *source_generator_initial_value(PyObject *source_generator)
+{
+  PyObject *pFunc, *pValue;
+
+  pFunc = PyObject_GetAttrString(source_generator, "initial_value");
+  pValue = PyObject_CallFunctionObjArgs(pFunc,  NULL);
+  Py_DECREF(pFunc);
+
+  return pValue;
+}
+
+extern PyObject *source_generator_apply(PyObject *source_generator, PyObject *data)
+{
+  PyObject *pFunc, *pValue;
+
+  pFunc = PyObject_GetAttrString(source_generator, "apply");
+  pValue = PyObject_CallFunctionObjArgs(pFunc, data, NULL);
+  Py_DECREF(pFunc);
+
+  return pValue;
+}
+
 extern PyObject *instantiate_python_class(PyObject *class)
 {
   return PyObject_CallFunctionObjArgs(class, NULL);

--- a/machida3/machida.pony
+++ b/machida3/machida.pony
@@ -27,6 +27,7 @@ use "wallaroo/core/sink/kafka_sink"
 use "wallaroo/core/sink/tcp_sink"
 use "wallaroo/core/source"
 use "wallaroo/core/source/kafka_source"
+use "wallaroo/core/source/gen_source"
 use "wallaroo/core/source/tcp_source"
 use "wallaroo/core/topology"
 use "wallaroo/core/state"
@@ -67,6 +68,10 @@ use @source_decoder_payload_length[USize](source_decoder: Pointer[U8] val,
   data: Pointer[U8] tag, size: USize)
 use @source_decoder_decode[Pointer[U8] val](source_decoder: Pointer[U8] val,
   data: Pointer[U8] tag, size: USize)
+use @source_generator_initial_value[Pointer[U8] val](
+  source_generator: Pointer[U8] val)
+use @source_generator_apply[Pointer[U8] val](source_generator: Pointer[U8] val,
+  data: Pointer[U8] tag)
 
 use @sink_encoder_encode[Pointer[U8] val](sink_encoder: Pointer[U8] val,
   data: Pointer[U8] val)
@@ -275,6 +280,40 @@ class PyFramedSourceHandler is FramedSourceHandler[(PyData val | None)]
 
   fun _final() =>
     Machida.dec_ref(_source_decoder)
+
+class PyGenSourceHandler is GenSourceGenerator[PyData val]
+  var _source_generator: Pointer[U8] val
+
+  new create(source_generator: Pointer[U8] val) =>
+    _source_generator = source_generator
+
+  fun initial_value(): (PyData val | None) =>
+    let r = Machida.source_generator_initial_value(_source_generator)
+    if not Machida.is_py_none(r) then
+      recover PyData(r) end
+    else
+      None
+    end
+
+  fun apply(data: PyData val): (PyData val | None) =>
+    let r = Machida.source_generator_apply(_source_generator, data.obj())
+    if not Machida.is_py_none(r) then
+      recover PyData(r) end
+    else
+      None
+    end
+
+  fun _serialise_space(): USize =>
+    Machida.user_serialization_get_size(_source_generator)
+
+  fun _serialise(bytes: Pointer[U8] tag) =>
+    Machida.user_serialization(_source_generator, bytes)
+
+  fun ref _deserialise(bytes: Pointer[U8] tag) =>
+    _source_generator = recover Machida.user_deserialization(bytes) end
+
+  fun _final() =>
+    Machida.dec_ref(_source_generator)
 
 class PyComputationBuilder
   var _computation: PyComputation val
@@ -666,6 +705,22 @@ primitive Machida
     if r.is_null() then Fail() end
     r
 
+  fun source_generator_initial_value(source_decoder: Pointer[U8] val):
+    Pointer[U8] val
+  =>
+    let r = @source_generator_initial_value(source_decoder)
+    print_errors()
+    if r.is_null() then Fail() end
+    r
+
+  fun source_generator_apply(source_decoder: Pointer[U8] val,
+    data: Pointer[U8] val): Pointer[U8] val
+  =>
+    let r = @source_generator_apply(source_decoder, data)
+    print_errors()
+    if r.is_null() then Fail() end
+    r
+
   fun sink_encoder_encode(sink_encoder: Pointer[U8] val, data: Pointer[U8] val):
     Pointer[U8] val
   =>
@@ -851,6 +906,13 @@ primitive _SourceConfig
     end
 
     match name
+    | "gen" =>
+      let gen = recover val
+        let g = @PyTuple_GetItem(source_config_tuple, 1)
+        Machida.inc_ref(g)
+        PyGenSourceHandler(g)
+      end
+      GenSourceConfig[PyData val](gen)
     | "tcp" =>
       let host = recover val
         Machida.py_bytes_or_unicode_to_pony_string(@PyTuple_GetItem(source_config_tuple, 1))

--- a/testing/correctness/apps/multi_partition_detector/Makefile
+++ b/testing/correctness/apps/multi_partition_detector/Makefile
@@ -42,12 +42,12 @@ include $(rules_mk_path)
 
 
 build-testing-correctness-apps-multi_partition_detector: build-machida
-#build-testing-correctness-apps-multi_partition_detector: build-machida3
+build-testing-correctness-apps-multi_partition_detector: build-machida3
 build-testing-correctness-apps-multi_partition_detector: build-testing-correctness-apps-multi_partition_detector-validator
 integration-tests-testing-correctness-apps-multi_partition_detector: build-testing-correctness-apps-multi_partition_detector
-integration-tests-testing-correctness-apps-multi_partition_detector: multi_partition_detector_tests_pony
-integration-tests-testing-correctness-apps-multi_partition_detector: multi_partition_detector_tests_python
-#integration-tests-testing-correctness-apps-multi_partition_detector: multi_partition_detector_tests_python3
+#integration-tests-testing-correctness-apps-multi_partition_detector: multi_partition_detector_tests_pony
+#integration-tests-testing-correctness-apps-multi_partition_detector: multi_partition_detector_tests_python
+integration-tests-testing-correctness-apps-multi_partition_detector: multi_partition_detector_tests_python3
 
 # group the tests by target API (Pony, Python, Python3)
 # Pony

--- a/testing/correctness/apps/multi_partition_detector/multi_partition_detector.py
+++ b/testing/correctness/apps/multi_partition_detector/multi_partition_detector.py
@@ -195,6 +195,7 @@ def trace_window(msg, state):
 def decoder(bs):
     # Expecting a 64-bit unsigned int in big endian followed by a string
     val, key = struct.unpack(">Q", bs[:8])[0], bs[8:]
+    key = key.decode("utf-8")  # python3 compat in downstream string concat
     return Message(key, val)
 
 

--- a/testing/correctness/tests/autoscale/autoscale_tests.py
+++ b/testing/correctness/tests/autoscale/autoscale_tests.py
@@ -29,8 +29,9 @@ TC = Creator(this)
 
 CMD_PONY = 'multi_partition_detector --depth 1'
 CMD_PYTHON = 'machida --application-module multi_partition_detector --depth 1'
+CMD_PYTHON3 = 'machida3 --application-module multi_partition_detector --depth 1'
 
-APIS = {'pony': CMD_PONY, 'python': CMD_PYTHON}
+APIS = {'pony': CMD_PONY, 'python': CMD_PYTHON, 'python3': CMD_PYTHON3}
 
 
 ##############

--- a/testing/correctness/tests/resilience/resilience_tests.py
+++ b/testing/correctness/tests/resilience/resilience_tests.py
@@ -58,13 +58,13 @@ RESILIENCE_TEST_NAME_FMT = 'test_resilience_{api}_{ops}'
 RESILIENCE_SEQS = [
     # wait, grow1, wait, shrink1, wait, crash2, wait, recover
     [Wait(2), Grow(1), Wait(2), Shrink(1), Wait(2), Crash(2),
-     Wait(2), Recover(2), Wait(2)],
+     Wait(2), Recover(2), Wait(5)],
 
     # crash1, recover1
-    [Wait(2), Crash(1), Wait(2), Recover(1), Wait(2)],
+    [Wait(2), Crash(1), Wait(2), Recover(1), Wait(5)],
 
     # crash2, recover2
-    [Wait(2), Crash(2), Wait(2), Recover(2), Wait(2)]]
+    [Wait(2), Crash(2), Wait(2), Recover(2), Wait(5)]]
 
 # Generate resilience test functions for each api, for each of the op seqs
 for api, cmd in APIS.items():

--- a/testing/correctness/tests/resilience/resilience_tests.py
+++ b/testing/correctness/tests/resilience/resilience_tests.py
@@ -40,8 +40,9 @@ TC = Creator(this)
 
 CMD_PONY = 'multi_partition_detector --depth 1 --gen-source'
 CMD_PYTHON = 'machida --application-module multi_partition_detector --depth 1 --gen-source'
+CMD_PYTHON3 = 'machida3 --application-module multi_partition_detector --depth 1 --gen-source'
 
-APIS = {'pony': CMD_PONY, 'python': CMD_PYTHON}
+APIS = {'pony': CMD_PONY, 'python': CMD_PYTHON, 'python3': CMD_PYTHON3}
 
 
 ##############

--- a/testing/correctness/tests/resilience/test_creator.py
+++ b/testing/correctness/tests/resilience/test_creator.py
@@ -27,6 +27,7 @@ class Creator(object):
                                                        for o in ops*cycles)))
         def f():
             _test_resilience(cmd, ops=ops, cycles=cycles, initial=initial,
-                             validate_output=validate_output, sources=sources)
+                             validate_output=validate_output, sources=sources,
+                             api=api)
         f.func_name = test_name
         setattr(self.module, test_name, f)

--- a/testing/tools/integration/cluster.py
+++ b/testing/tools/integration/cluster.py
@@ -416,8 +416,9 @@ RunnerData = namedtuple('RunnerData',
                          'stdout',
                          'start_time'])
 SenderData = namedtuple('SenderData',
-                        ['name', 'address', 'start_time', 'data'])
-SinkData = namedtuple('SinkData', ['name', 'address', 'start_time', 'data'])
+                        ['name', 'host', 'port', 'start_time', 'data'])
+SinkData = namedtuple('SinkData',
+                         ['name', 'host', 'port', 'start_time', 'data'])
 
 
 class Cluster(object):
@@ -937,9 +938,11 @@ class Cluster(object):
                        r.get_output(), r.start_time)
             for r in self.runners]
         self.persistent_data['sender_data'] = [
-            SenderData(s.name, s.address, s.start_time, s.data) for s in self.senders]
+            SenderData(s.name, s.host, s.port, s.start_time, s.data)
+            for s in self.senders]
         self.persistent_data['sink_data'] = [
-            SinkData(s.name, s.address, s.start_time, s.data) for s in self.sinks]
+            SinkData(s.name, s.host, s.port, s.start_time, s.data)
+            for s in self.sinks]
         clean_resilience_path(self.res_dir)
         self._finalized = True
 

--- a/testing/tools/integration/external.py
+++ b/testing/tools/integration/external.py
@@ -181,8 +181,9 @@ def save_logs_to_file(base_dir, log_stream=None, persistent_data={}):
         # save sender data to files
         sender_data = persistent_data.get('sender_data', [])
         for sd in sender_data:
-            sender_log_name = 'sender_{address}_{time}.error.dat'.format(
-                address=sd.address.replace(':', '.'),
+            sender_log_name = 'sender_{host}!{port}_{time}.error.dat'.format(
+                host=sd.host,
+                port=sd.port,
                 time=strftime(sd.start_time, STRFTIME_FMT))
             with open(os.path.join(base_dir, sender_log_name), 'wb') as f:
                 f.write(''.join(sd.data))

--- a/testing/tools/integration/external.py
+++ b/testing/tools/integration/external.py
@@ -190,8 +190,9 @@ def save_logs_to_file(base_dir, log_stream=None, persistent_data={}):
         # save sinks data to files
         sink_data = persistent_data.get('sink_data', [])
         for sk in sink_data:
-            sink_log_name = 'sink_{address}_{time}.error.dat'.format(
-                address=sk.address.replace(':', '.'),
+            sink_log_name = 'sink_{host}!{port}_{time}.error.dat'.format(
+                host=sk.host,
+                port=sk.port,
                 time=strftime(sk.start_time, STRFTIME_FMT))
             with open(os.path.join(base_dir, sink_log_name), 'wb') as f:
                 f.write(''.join(sk.data))

--- a/testing/tools/integration/integration.py
+++ b/testing/tools/integration/integration.py
@@ -129,6 +129,14 @@ def pipeline_test(generator, expected, command, workers=1, sources=1,
         if sink_expect is not None:
             if not isinstance(sink_expect, (list, tuple)):
                 sink_expect = [sink_expect for x in range(sinks)]
+            elif len(sink_expect) != sinks:  # list/tuple, but wrong length
+                if len(sink_expect) == 1:
+                    sink_expect = sink_expect * sinks
+                else: # throw error, we don't know how to handle this
+                    raise ValueError("sink_expect must be either an integer "
+                        "or a list of integers whose length is the same as "
+                        "the number of sinks. Got {}."
+                        .format(sink_expect))
         elif sink_await is not None:
             if len(sink_await) != sinks:
                 sink_await = [sink_await[:] for x in range(sinks)]
@@ -171,6 +179,7 @@ def pipeline_test(generator, expected, command, workers=1, sources=1,
                               ' of {} seconds'.format(sink_expect,
                                                       sink_stop_timeout))
                 for sink, sink_expect_val in zip(cluster.sinks, sink_expect):
+                    logging.debug("SinkExpect on {} for {} msgs".format(sink, sink_expect_val))
                     cluster.sink_expect(expected=sink_expect_val,
                                         timeout=sink_stop_timeout,
                                         sink=sink,


### PR DESCRIPTION
- Add python3 GenSourceConfig support in `machida.pony` and `python-wallaroo.c`
- Add python3 tests for:
    - multi_partition_detector integration tests
    - autoscale
    - resilience

closes #2561 