### PR TITLE
Add `_write_again` behavior to TCP actors with `_pending_writes`

### DIFF
--- a/lib/wallaroo/core/data_channel/data_channel.pony
+++ b/lib/wallaroo/core/data_channel/data_channel.pony
@@ -479,6 +479,12 @@ actor DataChannel
       end
     end
 
+  be _write_again() =>
+    """
+    Resume writing.
+    """
+    _pending_writes()
+
   fun ref _pending_writes(): Bool =>
     """
     Send pending data. If any data can't be sent, keep it and mark as not
@@ -490,9 +496,15 @@ actor DataChannel
       let writev_batch_size: USize = @pony_os_writev_max[I32]().usize()
       var num_to_send: USize = 0
       var bytes_to_send: USize = 0
+      var bytes_sent: USize = 0
       while _writeable and not _shutdown_peer
         and (_pending_writev_total > 0)
       do
+        // yield if we sent max bytes
+        if bytes_sent > _max_size then
+          _write_again()
+          return false
+        end
         try
           //determine number of bytes and buffers to send
           if (_pending_writev.size()/2) < writev_batch_size then
@@ -511,6 +523,8 @@ actor DataChannel
           // Write as much data as possible.
           var len = @pony_os_writev[USize](_event,
             _pending_writev.cpointer(), num_to_send) ?
+
+          bytes_sent = bytes_sent + len
 
           if len < bytes_to_send then
             while len > 0 do

--- a/lib/wallaroo/core/sink/tcp_sink/tcp_sink.pony
+++ b/lib/wallaroo/core/sink/tcp_sink/tcp_sink.pony
@@ -738,6 +738,12 @@ actor TCPSink is Sink
       _schedule_reconnect()
     end
 
+  be _write_again() =>
+    """
+    Resume writing.
+    """
+    _pending_writes()
+
   fun ref _pending_writes(): Bool =>
     """
     Send pending data. If any data can't be sent, keep it and mark as not
@@ -756,6 +762,15 @@ actor TCPSink is Sink
     end
 
     while _writeable and not _shutdown_peer and (_pending_writev_total > 0) do
+      // yield if we sent max bytes
+      if bytes_sent > _max_size then
+        // do tracking finished stuff
+        _tracking_finished(bytes_sent)
+
+        _write_again()
+        return false
+      end
+
       try
         //determine number of bytes and buffers to send
         if (_pending_writev.size()/2) < writev_batch_size then


### PR DESCRIPTION
This commit adds at `_write_again` behavior to all custom wallaroo
tcp actors that have a `_pending_writes` function and modifies
the `_pending_writes` to yield by calling `_write_again` after
having sent at least `_max_size` bytes. This will allow other
actors and GC to run when a large amount of data has been queued
up to be sent.

Resolves #1622