### PR TITLE
Use ponyc 0.25.0 to build release

### DIFF
--- a/.release/bootstrap.sh
+++ b/.release/bootstrap.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 export DEBIAN_FRONTEND=noninteractive
 
-export PONYC_VERSION="0.24.4"
+export PONYC_VERSION="0.25.0"
 export OTP_VERSION="1:20.1-1"
 export ELIXIR_VERSION="1.5.2-1"
 export GO_VERSION="1.9.4"


### PR DESCRIPTION
In the interest of reaping the benefits of ponyc 0.25 as soon as possible, this PR tells the vagrant release environment to use this freshest ponyc version.

