### PR TITLE
Generative python topology tests

### DIFF
--- a/testing/correctness/tests/topology/Makefile
+++ b/testing/correctness/tests/topology/Makefile
@@ -1,0 +1,58 @@
+# include root makefile
+ifndef ROOT_MAKEFILE_MK
+include ../../../../Makefile
+endif
+
+# prevent rules from being evaluated/included multiple times
+ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
+$(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
+
+
+# The following are control variables that determine what logic from `rules.mk` is enabled
+
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
+
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
+TOPOLOGY_TESTS_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+# standard rules generation makefile
+include $(rules_mk_path)
+
+
+build-testing-correctness-tests-topology: build-machida
+#build-testing-correctness-tests-topology: build-machida3
+unit-tests-testing-correctness-tests-topology: topology_python_unit_tests
+integration-tests-testing-correctness-tests-topology: build-testing-correctness-tests-topology
+integration-tests-testing-correctness-tests-topology: topology_tests
+
+topology_python_unit_tests:
+	cd $(TOPOLOGY_TESTS_PATH) && \
+		python2 -m pytest -c $(integration_path)/pytest.ini components.py $(pytest_exp)
+
+topology_tests:
+	cd $(TOPOLOGY_TESTS_PATH) && \
+		python2 -m pytest -c $(integration_path)/pytest.ini topology_tests.py $(pytest_exp)
+
+# end of prevent rules from being evaluated/included multiple times
+endif

--- a/testing/correctness/tests/topology/app_gen.py
+++ b/testing/correctness/tests/topology/app_gen.py
@@ -1,0 +1,216 @@
+#
+# Copyright 2018 The Wallaroo Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+#
+
+
+import argparse
+from collections import Counter
+import logging
+import struct
+
+from integration.logger import (add_in_memory_log_stream,
+                                INFO2,
+                                set_logging)
+
+import wallaroo
+
+import components
+
+
+# TODO:
+# - [ ] build topology programmatically from args
+# - [ ] create validation logic from topology
+# - [ ] make this file the runnable validator
+#       - e.g. wallaroo runs application_setup(args)
+#              validation runs `python app_gen.py --topology ... --output received.txt`
+# - [ ] create topos for parity with pony tests. See new_tests.md for details
+
+
+######################
+# Logging functionality
+######################
+
+LOG_LEVELS = {'none': 0,
+              '1': 1,
+              'debug': 10,
+              'info': 20,
+              'warn': 30,
+              'error': 40,
+              'critical': 50}
+
+def get_log_level(value):
+    """Get the effective log level"""
+    return LOG_LEVELS.get(value, 10)
+
+
+#######################
+# Wallaroo functionality
+#######################
+
+def parser_add_args(parser):
+    parser.add_argument('--to', dest='topology', action='append_const',
+                        const='to')
+    parser.add_argument('--to-parallel', dest='topology', action='append_const',
+                        const='to_parallel')
+    parser.add_argument('--to-stateful', dest='topology', action='append_const',
+                        const='to_stateful')
+    parser.add_argument('--to-state-partition', dest='topology', action='append_const',
+                        const='to_state_partition')
+    parser.add_argument('--log-level', help=("Set the logging level."),
+                           choices=['none', '1', 'debug', 'info', 'warning',
+                                    'error', 'critical'],
+                           default='info')
+
+def application_setup(args):
+    # Parse user options
+    parser = argparse.ArgumentParser("Topology Test Generator")
+    parser_add_args(parser)
+    pargs, _ = parser.parse_known_args(args)
+
+    log_level = get_log_level(pargs.log_level)
+    set_logging(name='integration', level=log_level)
+
+    for k, v in pargs._get_kwargs():
+        logging.debug('%s: %r' % (k, v))
+
+    app_name = "topology test"
+    pipe_name = "topology test pipeline"
+
+    ab = wallaroo.ApplicationBuilder(app_name)
+
+    logging.info("Using TCP Source")
+    in_host, in_port = wallaroo.tcp_parse_input_addrs(args)[0]
+    source = wallaroo.TCPSourceConfig(in_host, in_port, decoder)
+
+    ab.new_pipeline(pipe_name, source)
+
+    # programmatically add computations
+    topology = Topology(pargs.topology)
+    ab = topology.build(ab)
+
+
+    logging.info("Using TCP Sink")
+    out_host, out_port = wallaroo.tcp_parse_output_addrs(args)[0]
+    ab.to_sink(wallaroo.TCPSinkConfig(out_host, out_port, encoder))
+    return ab.build()
+
+
+class Topology(object):
+    def __init__(self, topology):
+        logging.info("Topology({!r})".format(topology))
+        c = Counter()
+        self.steps = []
+        for node in topology:
+            c[node] += 1
+            if node == 'to':
+                # to
+                f = components.Tag('{}{}'.format(node, c[node]))
+                comp = wallaroo.computation(f.func_name)(f)
+                self.steps.append((node, comp, f.func_name))
+            elif node == 'to_stateful':
+                # to_stateful
+                f = components.TagState('{}{}'.format(node, c[node]))
+                comp = wallaroo.state_computation(f.func_name)(f)
+                self.steps.append((node, comp, f.func_name))
+            elif node == 'to_parallel':
+
+                # to_parallel
+                f = components.Tag('{}{}'.format(node, c[node]))
+                comp = wallaroo.computation(f.func_name)(f)
+                self.steps.append((node, comp, f.func_name))
+            elif node == 'to_state_partition':
+                # to_state_partition
+                f = components.TagState('{}{}'.format(node, c[node]))
+                comp = wallaroo.state_computation(f.func_name)(f)
+                self.steps.append((node, comp, f.func_name))
+            else:
+                raise ValueError("Unknown topology node type: {!r}. Please use "
+                                 "'to', 'to_parallel', 'to_stateful', or "
+                                 "'to_state_partition'".format(node))
+
+    def build(self, ab):
+        logging.info("Building topology")
+        partition = wallaroo.partition(components.partition)
+        for node, comp, tag in self.steps:
+            logging.info("Adding step: ({!r}, {!r}, {!r})".format(
+                node, tag, comp))
+            if node == 'to':
+                ab.to(comp)
+            elif node == 'to_stateful':
+                ab = ab.to_stateful(comp, components.State, tag)
+            elif node == 'to_parallel':
+                ab = ab.to_parallel(comp)
+            elif node == 'to_state_partition':
+                ab = ab.to_state_partition(comp, components.State,
+                                      tag, partition, [])
+        return ab
+
+
+    # onetomany
+    #f = components.Tag(2, flow_mod=components.OneToN(3))
+    #comp = wallaroo.computation_multi(f.func_name)(f)
+    #ab = ab.to(comp)
+
+    # filter by (only keep key 1.0)
+    #f = components.Tag(3, flow_mod=components.FilterBy('key1.0', by=(
+    #    lambda data: data.key.endswith('.1') )))
+    #comp = wallaroo.computation(f.func_name)(f)
+    #ab = ab.to(comp)
+
+
+@wallaroo.decoder(header_length=4, length_fmt=">I")
+def decoder(bs):
+    # Expecting a 64-bit unsigned int in big endian followed by a string
+    val, key = struct.unpack(">Q", bs[:8])[0], bs[8:].decode()
+    return components.Message(val, key)
+
+
+@wallaroo.encoder
+def encoder(msg):
+    s = msg.encode()  # pickled object
+    return struct.pack(">I{}s".format(len(s)), len(s), s)
+
+
+#################
+# Validation code
+#################
+
+def validate_api():
+    parser = argparse.ArgumentParser(prog='Topology App Gen Validator')
+    parser.add_argument("--output", type=argparse.FileType("rb"),
+                        help="The output from the application.")
+    parser_add_args(parser)
+    pargs, _ = parser.parse_known_args()
+
+    log_level = get_log_level(pargs.log_level)
+    set_logging(name='integration', level=log_level)
+
+    for k, v in pargs._get_kwargs():
+        logging.debug('%s: %r' % (k, v))
+
+    topology = Topology(pargs.topology)
+    tags = [step[2] for step in topology.steps]
+
+    while True:
+        d = pargs.output.read(4)
+        if not d:
+            break
+        h = struct.unpack('>I', d)[0]
+        m = components.Message.decode(pargs.output.read(h))
+        assert(tags == m.tags)
+
+
+if __name__ == '__main__':
+    validate_api()

--- a/testing/correctness/tests/topology/components.py
+++ b/testing/correctness/tests/topology/components.py
@@ -1,0 +1,246 @@
+from pickle import dumps, loads
+
+def attach_to_module(func, identifier):
+    # Do some scope mangling to create a uniquely named class based on
+    # the decorated function's name and place it in the wallaroo module's
+    # namespace so that pickle can find it.
+
+    func.__name__ = identifier
+    globals()[identifier] = func
+    return globals()[identifier]
+
+
+class Message(object):
+    def __init__(self, value, key=None, tags=None, states=None):
+        self.value = value
+        self.key = str(key)
+        self.tags = tags if tags else []
+        self.states = states if states else []
+
+    def new_from_key(self, key):
+        return Message(self.value, "{}.{}".format(self.key, key),
+                       list(self.tags), list(self.states))
+
+    def tag(self, tag, state=None, key=None):
+        self.tags.append(tag)
+        self.states.append(state)
+
+    def encode(self):
+        return dumps(self)
+
+    def __str__(self):
+        return ("{{key: {key}, value: {value}, tags: {tags}, "
+                " states: {states}}}".format(
+                    key=self.key,
+                    value=self.value,
+                    tags=self.tags,
+                    states=self.states))
+
+    @staticmethod
+    def decode(bs):
+        return loads(bs)
+
+
+class State(object):
+    _partitioned = False
+    def __init__(self):
+        self._a = None
+        self._b = None
+        self._initialized = False
+
+    def update(self, data):
+        if self._initialized:
+            if self._partitioned:
+                assert(self._b[0] == data.key) # check key compatibility
+        else:
+            self._initialized = True
+
+        # state update:
+        self._a = self._b
+        self._b = (data.key, data.value)
+
+    def __str__(self):
+        return ("{{_a: {a}, _b: {b}, _initialized: "
+                "{initialized}}}".format(
+                    a = self._a,
+                    b = self._b,
+                    initialized = self._initialized))
+
+    def clone(self):
+        return (self._a, self._b)
+
+
+class PartitionedState(State):
+    _partitioned = True
+
+
+def partition(msg):
+    return msg.key
+
+
+# Computations
+def Tag(identifier, flow_mod=None):
+    identifier = "tag_{}".format(identifier)
+    def tag(data, state=None):
+        print("{}({})".format(identifier, data))
+        data.tag(identifier)
+        return data
+    # apply flow_modifier
+    if flow_mod:
+        tag = flow_mod(tag)
+    return attach_to_module(tag, identifier)
+
+
+def TagState(identifier, flow_mod=None):
+    identifier = "tagstate_{}".format(identifier)
+    def tagstate(data, state):
+        print("{}({}, {})".format(identifier, data, state))
+        state.update(data)
+        # Really important to be sure we use `state.clone` and not `state`
+        # in the data.tag function! State is mutable and is gonna be a mess
+        # if we put it in there.
+        data.tag(identifier, state.clone())
+        return(data, True)
+    # apply flow_modifier
+    if flow_mod:
+        tagstate = flow_mod(tagstate)
+    return attach_to_module(tagstate, identifier)
+
+
+
+# Flow modifiers
+def OneToN(num):
+    identifier = "oneton_{}".format(num)
+    def oneton(func):
+        def oneton_wrapped(data, state=None):
+            data = func(data, state)
+            print("{}({})".format(identifier, data))
+            if data and state:
+                return [data[0].new_from_key(x) for x in range(num)]
+            elif data:
+                return [data.new_from_key(x) for x in range(num)]
+            return None
+        return oneton_wrapped
+    return attach_to_module(oneton, identifier)
+
+
+def FilterBy(identifier, by=()):
+    """
+    Use a function to determine whether to drop the message.
+    Drop message if by(message) returns True.
+    Default: no drop (same as Tag)
+    if `by` is a tuple, use a lazy modulo test to filter every position in
+    the tuple. e.g. if `by=(3,4)`, drop every case where
+        `data.value % 3 == 0 or data.value % 4 == 0`
+    """
+    identifier = "filterby_{}".format(identifier)
+    def filterby(data):
+        def filterby_wrapped(data, state=None):
+            if isinstance(by, (tuple,list)):
+                if any((data.value % d == 0) for d in by):
+                    print("{}({})".format(identifier, data))
+                    return None
+            else:
+                if by(data):
+                    print("{}({})".format(identifier, data))
+                    return None
+            print("filterby_pass({})".format(data))
+            return data
+        return filterby_wrapped
+    return attach_to_module(filterby, identifier)
+
+
+def test_components():
+    m = Message(1,1)
+    s = State()
+    t1 = Tag(1)
+    ts1 = TagState(1)
+    t1(m)
+    ts1(m,s)
+    assert(m.value == 1)
+    assert(m.key == "1")
+    assert(m.tags == ['tag_1', 'tagstate_1'])
+    assert(m.states == [None, (None, ("1", 1))])
+
+
+def test_flow_mods():
+    m = Message(1,1)
+    s = State()
+    # one to 2
+    t1 = Tag(1, OneToN(2))
+    t2 = Tag(2, FilterBy('filter', lambda d: not d.key.endswith(".0")))
+    ts1 = TagState(1, OneToN(2))
+    ts2 = TagState(2, FilterBy('filter', lambda d: not d.key.endswith(".0")))
+    res_t1 = t1(m)
+    res_t2 = [t2(v) for v in res_t1]
+    assert(res_t2[1] is None)
+    assert(res_t2[0].key == '1.0')
+
+    res_ts1 = ts1(res_t2[0], s)
+    res_ts2 = [ts2(v,s) for v in res_ts1]
+    assert(res_ts2[1] is None)
+    assert(res_ts2[0].key == '1.0.0')
+    assert(len(res_t1) == 2)
+    assert(len(res_ts1) == 2)
+    assert(res_ts2[0].value == 1)
+    assert(res_ts2[0].tags == ['tag_1', 'tagstate_1'])
+    assert(res_ts2[0].states == [None, (None, ('1.0', 1))])
+
+
+def test_serialisation():
+    import wallaroo
+
+    m1 = Message(1,1)
+    m2 = Message(1,1)
+    s1 = State()
+    s2 = State()
+    s3 = State()
+    s4 = State()
+    t1 = Tag(1)
+    t2 = Tag(2, OneToN(2))
+    ts1 = TagState(1)
+    ts2 = TagState(2, OneToN(2))
+    wt1 = wallaroo.computation("tag1")(t1)
+    wt2 = wallaroo.computation("tag2_to2")(t2)
+    wts1 = wallaroo.state_computation("tagstate1")(ts1)
+    wts2 = wallaroo.state_computation("tagstate2_to2")(ts2)
+    res = wt1.compute(m1)  # returns data
+    res = wts1.compute(res, s1)  # returns (data, flag)
+    res = wt2.compute(res[0])  # returns [data]
+    res = wts2.compute(res[0], s2)  # returns ([data], flag)
+    r1 = res[0]
+    print('r1', str(r1))
+    assert(r1.value == 1)
+    assert(r1.key == "1.0.0")
+    assert(r1.tags == ['tag_1', 'tagstate_1', 'tag_2', 'tagstate_2'])
+    assert(r1.states == [None, (None, ("1", 1)), None, (None, ('1.0', 1))])
+
+    # serialise, deserialse, then run again
+    ds_wt1 = loads(dumps(wt1))
+    ds_wt2 = loads(dumps(wt2))
+    ds_wts1 = loads(dumps(wts1))
+    ds_wts2 = loads(dumps(wts2))
+    res = ds_wt1.compute(m2)  # returns data
+    res = ds_wts1.compute(res, s3)  # returns (data, flag)
+    res = ds_wt2.compute(res[0])  # returns [data]
+    res = ds_wts2.compute(res[0], s4)  # returns ([data], flag)
+    r2 = res[0]
+    assert(r2.value == 1)
+    assert(r2.key == "1.0.0")
+    assert(r2.tags == ['tag_1', 'tagstate_1', 'tag_2', 'tagstate_2'])
+    assert(r2.states == [None, (None, ("1", 1)), None, (None, ('1.0', 1))])
+
+
+def test_state():
+    s = State()
+    sp = PartitionedState()
+    m1 = Message(1,1)
+    m2 = Message(2,2)
+    s.update(m1)
+    s.update(m2)
+    sp.update(m1)
+    sp.update(m1)
+    try:
+        sp.update(m2)
+    except Exception as err:
+        assert(isinstance(err, AssertionError))

--- a/testing/correctness/tests/topology/conftest.py
+++ b/testing/correctness/tests/topology/conftest.py
@@ -1,0 +1,3 @@
+# Sort the tests alphabetically
+def pytest_collection_modifyitems(session, config, items):
+    items.sort(key=lambda i: i.name)

--- a/testing/correctness/tests/topology/new_tests.md
+++ b/testing/correctness/tests/topology/new_tests.md
@@ -1,0 +1,73 @@
+# Wallaroo Topology Layout Tests
+
+This section tests Wallaroo topology layouts. Its purpose is to:
+1. verify that known topologies work, and continue to work as we make changes to the core of Wallaroo.
+2. identify topology layouts that do not work, so that we can fix them and add them to the test above.
+
+The testing is done via integration testing:
+1. a topology is specified
+2. that topology is described in an application
+3. the application is run (with 1,2,3) workers, input is sent in, and output is validated to match an expectation.
+
+The spec generation is done manually for now.
+It is not easy to come up with a set of computations from which we can derive validation logic, given a known input set, that we can use to validate outputs.
+
+
+## Generative Topology Tests
+As per the above, we do not generate all possible types at the moment. However, we do aim to generate the basic matrix of combinations, so that we can add API entries (pony, machida, machida3, go, etc.) to it without having to duplicate too much code or compile a very large number of applications.
+
+### Computations List
+Types of computations we need to test
+
+- stateless comp
+- state comp
+- parallel comp
+- partitioned state comp
+
+Their API build methods are:
+- to
+- to_stateful
+- to_parallel
+- to_state_partition
+
+tests:
+   4: {apis}
+  16: {apis} x {apis}
+  64: {apis} x {apis} x {apis}
+
+### Flow Modifiers
+Types of flow modifiers we need to test (as computations)
+
+- 1:1
+- 1:<1 (filtered)
+- 1:>1 (OneToMany)
+
+tests:
+  {apis} x {flows}
+  {flows} x {apis}
+
+### Topologies
+Types of topologies
+
+- single
+- double, parallel stream (no intersection)
+- double, intersecting stream
+- ?
+
+## Testing
+For now, we aim to have every permutation of 1, and 2 computations in single stream apps.
+This means, for example, if we had a base set of {a,b,c}, we would produce the following topologies:
+
+    a
+    aa
+    ab
+    ac
+    b
+    ba
+    bb
+    bc
+    c
+    ca
+    cb
+    cc
+

--- a/testing/correctness/tests/topology/topology_tests.py
+++ b/testing/correctness/tests/topology/topology_tests.py
@@ -1,0 +1,164 @@
+#
+# Copyright 2018 The Wallaroo Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+#
+
+
+import datetime
+import itertools
+import logging
+import os
+import time
+
+from integration.cluster import runner_data_format
+from integration.end_points import sequence_generator
+from integration.errors import RunnerHasntStartedError
+from integration.external import (run_shell_cmd,
+                                  save_logs_to_file)
+from integration.integration import pipeline_test
+from integration.logger import add_in_memory_log_stream
+
+from app_gen import LOG_LEVELS
+
+LEVEL_LOGS = {v: k for k, v in LOG_LEVELS.items()}
+
+
+def run_test(cmd, validation_cmd, topology):
+    max_retries = 5
+    t0 = datetime.datetime.now()
+    log_stream = add_in_memory_log_stream(level=logging.DEBUG)
+    cwd = os.getcwd()
+    trunc_head = cwd.find('/wallaroo/') + len('/wallaroo/')
+    base_dir = '/tmp/wallaroo_test_errors/{}/{}/{}'.format(
+        cwd[trunc_head:],
+        '_'.join('--{}'.format(api) for api in topology),
+        t0.strftime('%Y%m%d_%H%M%S'))
+    persistent_data = {}
+
+    log_level = LEVEL_LOGS.get(logging.root.level, 'none')
+    steps_val = ' '.join('--{}'.format(s) for s in topology)
+    cmd_val = ("{cmd} --log-level {log_level} {steps}".format(
+                   cmd=cmd,
+                   log_level=log_level,
+                   steps=steps_val))
+    validation_cmd_val = ("{validation_cmd} --log-level {log_level} {steps} "
+                      "--output".format(
+                          validation_cmd=validation_cmd,
+                          log_level=log_level,
+                          steps=steps_val))
+
+    # Run the test!
+    attempt = 0
+    try:
+        while True:
+            attempt += 1
+            try:
+                # clean up data collection before each attempt
+                persistent_data.clear()
+                log_stream.reset()
+                log_stream.truncate()
+
+                # start test attempt
+                logging.info("Integration test attempt {}".format(attempt))
+                logging.debug("Running integration test with the following"
+                              " options:")
+
+                gens = [(sequence_generator(10, 0, '>I', 'key_0'), 0),
+                        (sequence_generator(10, 0, '>I', 'key_1'), 0)]
+
+                pipeline_test(
+                    generator = gens,
+                    expected = None,
+                    command = cmd_val,
+                    workers = 1,
+                    sources = 1,
+                    sinks = 1,
+                    mode = 'framed',
+                    batch_size = 1,
+                    sink_expect = 20,
+                    validate_file = 'received.txt',
+                    persistent_data = persistent_data)
+                # Test run was successful, break out of loop and proceed to
+                # validation
+                logging.info("Run phase complete. Proceeding to validation.")
+                break
+            except RunnerHasntStartedError:
+                logging.warn("Runner failed to start properly.")
+                if attempt < max_retries:
+                    logging.info("Restarting the test!")
+                    time.sleep(0.5)
+                    continue
+                else:
+                    logging.error("Max retry attempts reached.")
+                    raise
+            except:
+                raise
+    except Exception as err:
+        logging.exception("Encountered an error while running the test for"
+                          " %r\n===\n" % cmd)
+        # Save logs to file in case of error
+        try:
+            save_logs_to_file(base_dir, log_stream, persistent_data)
+        except Exception as err:
+            logging.warn("failed to save logs to file")
+            logging.exception(err)
+        raise
+
+    res = run_shell_cmd(validation_cmd_val)
+    if res.success:
+        if res.output:
+            logging.info("Validation command '%s' completed successfully "
+                         "with the output:\n--\n%s", ' '.join(res.command),
+                                                              res.output)
+        else:
+            logging.info("Validation command '%s' completed successfully",
+                         ' '.join(res.command))
+    else:
+        outputs = runner_data_format(persistent_data.get('runner_data', []))
+        logging.error("Application outputs:\n{}".format(outputs))
+        logging.error("Validation command '%s' failed with the output:\n"
+                      "--\n%s",
+                      res.command, res.output)
+        # Save logs to file in case of error
+        save_logs_to_file(base_dir, log_stream, persistent_data)
+
+        if logging.root.level > logging.ERROR:
+            # If failed, and logging level means we didn't log error, include it
+            # in exit message
+            print(res.output)
+            exit(res.return_code)
+
+    # Reached the end and nothing broke. Success!
+    logging.info("Topology test completed successfully for topology {!r}"
+                 .format(topology))
+
+
+def create_test(api, cmd, validation_cmd, steps):
+    test_name = 'test_topology_{}_{}'.format(api, '_'.join(steps))
+    def f():
+        run_test(cmd, validation_cmd, steps)
+    f.func_name = test_name
+    globals()[test_name] = f
+
+# Create tests!
+APIS = {'python': {'cmd': 'machida --application-module app_gen',
+                   'validation_cmd': 'python2 app_gen.py'},}
+        #'python3': {'cmd': 'machida3 --application-module app_gen',
+        #            'validation_cmd': 'python2 app_gen.py'}}
+
+
+COMPS = ['to', 'to-parallel', 'to-stateful', 'to-state-partition']
+for steps in itertools.combinations_with_replacement(COMPS, 3):
+    for api in APIS:
+        create_test(api, APIS[api]['cmd'], APIS[api]['validation_cmd'], steps)


### PR DESCRIPTION
closes #2546

This PR adds generative topology tests to `testing/correctness/tests/topology`.

Currently it tests any combination of `[to, to-parallel, to-stateful, to-state-partition]` up to a depth of 3.
It is set up so that adding python3 tests involves uncommenting 3 lines.

It does not test filter and onetomany for now, although the underlying test app is capable of it. Validation for that is more tricky, and I figured that doing this incrementally is a better way to go about it.