### PR TITLE
Python3 topo tests

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -42,7 +42,7 @@ wallaroo_path := $(abs_wallaroo_dir)
 
 # Set global path variables
 integration_path := $(wallaroo_path)/testing/tools
-integration_bin_path := $(integration_path)/integration
+integration_bin_path := $(integration_path)
 wallaroo_lib :=  $(wallaroo_path)/lib
 wallaroo_python_path := $(wallaroo_path)/machida/lib
 machida_bin_path := $(wallaroo_path)/machida/build

--- a/testing/correctness/apps/multi_partition_detector/Makefile
+++ b/testing/correctness/apps/multi_partition_detector/Makefile
@@ -45,8 +45,8 @@ build-testing-correctness-apps-multi_partition_detector: build-machida
 build-testing-correctness-apps-multi_partition_detector: build-machida3
 build-testing-correctness-apps-multi_partition_detector: build-testing-correctness-apps-multi_partition_detector-validator
 integration-tests-testing-correctness-apps-multi_partition_detector: build-testing-correctness-apps-multi_partition_detector
-#integration-tests-testing-correctness-apps-multi_partition_detector: multi_partition_detector_tests_pony
-#integration-tests-testing-correctness-apps-multi_partition_detector: multi_partition_detector_tests_python
+integration-tests-testing-correctness-apps-multi_partition_detector: multi_partition_detector_tests_pony
+integration-tests-testing-correctness-apps-multi_partition_detector: multi_partition_detector_tests_python
 integration-tests-testing-correctness-apps-multi_partition_detector: multi_partition_detector_tests_python3
 
 # group the tests by target API (Pony, Python, Python3)

--- a/testing/correctness/tests/topology/Makefile
+++ b/testing/correctness/tests/topology/Makefile
@@ -41,14 +41,15 @@ include $(rules_mk_path)
 
 
 build-testing-correctness-tests-topology: build-machida
-#build-testing-correctness-tests-topology: build-machida3
+build-testing-correctness-tests-topology: build-machida3
 unit-tests-testing-correctness-tests-topology: topology_python_unit_tests
 integration-tests-testing-correctness-tests-topology: build-testing-correctness-tests-topology
 integration-tests-testing-correctness-tests-topology: topology_tests
 
 topology_python_unit_tests:
 	cd $(TOPOLOGY_TESTS_PATH) && \
-		python2 -m pytest -c $(integration_path)/pytest.ini components.py $(pytest_exp)
+		python2 -m pytest -c $(integration_path)/pytest.ini components.py $(pytest_exp) && \
+		python3 -m pytest -c $(integration_path)/pytest.ini components.py $(pytest_exp)
 
 topology_tests:
 	cd $(TOPOLOGY_TESTS_PATH) && \

--- a/testing/correctness/tests/topology/components.py
+++ b/testing/correctness/tests/topology/components.py
@@ -244,3 +244,14 @@ def test_state():
         sp.update(m2)
     except Exception as err:
         assert(isinstance(err, AssertionError))
+
+
+def test_attach_to_module():
+    identifier = 'my_function'
+    def my_function():
+        return 'my function result'
+    assert(globals().get(identifier) is None)
+    assert(my_function.__name__ == identifier)
+    my_function = attach_to_module(my_function, identifier)
+    assert(globals().get(identifier) is not None)
+    assert(my_function.__name__ == identifier)

--- a/testing/correctness/tests/topology/topology_tests.py
+++ b/testing/correctness/tests/topology/topology_tests.py
@@ -21,42 +21,42 @@ import logging
 import os
 import time
 
+
 from integration.cluster import runner_data_format
 from integration.end_points import sequence_generator
-from integration.errors import RunnerHasntStartedError
+from integration.errors import (ClusterError,
+                                RunnerHasntStartedError)
 from integration.external import (run_shell_cmd,
                                   save_logs_to_file)
 from integration.integration import pipeline_test
 from integration.logger import add_in_memory_log_stream
 
-from app_gen import LOG_LEVELS
 
-LEVEL_LOGS = {v: k for k, v in LOG_LEVELS.items()}
-
-
-def run_test(cmd, validation_cmd, topology):
+def run_test(api, cmd, validation_cmd, topology, workers=1):
     max_retries = 5
     t0 = datetime.datetime.now()
     log_stream = add_in_memory_log_stream(level=logging.DEBUG)
     cwd = os.getcwd()
     trunc_head = cwd.find('/wallaroo/') + len('/wallaroo/')
-    base_dir = '/tmp/wallaroo_test_errors/{}/{}/{}'.format(
-        cwd[trunc_head:],
-        '_'.join('--{}'.format(api) for api in topology),
-        t0.strftime('%Y%m%d_%H%M%S'))
+    base_dir = ('/tmp/wallaroo_test_errors/{path}/{api}/{topo}/{workers}'
+        '/{timestamp}'.format(
+            path=cwd[trunc_head:],
+            api=api,
+            topo='_'.join(topology),
+            workers='{}_workers'.format(workers),
+            timestamp=t0.strftime('%Y%m%d_%H%M%S')))
     persistent_data = {}
 
-    log_level = LEVEL_LOGS.get(logging.root.level, 'none')
     steps_val = ' '.join('--{}'.format(s) for s in topology)
-    cmd_val = ("{cmd} --log-level {log_level} {steps}".format(
+    output = 'received.txt'
+    cmd_val = ("{cmd} {steps}".format(
                    cmd=cmd,
-                   log_level=log_level,
                    steps=steps_val))
-    validation_cmd_val = ("{validation_cmd} --log-level {log_level} {steps} "
-                      "--output".format(
+    validation_cmd_val = ("{validation_cmd} {steps} "
+                      "--output {output}".format(
                           validation_cmd=validation_cmd,
-                          log_level=log_level,
-                          steps=steps_val))
+                          steps=steps_val,
+                          output=output))
 
     # Run the test!
     attempt = 0
@@ -81,13 +81,14 @@ def run_test(cmd, validation_cmd, topology):
                     generator = gens,
                     expected = None,
                     command = cmd_val,
-                    workers = 1,
+                    workers = workers,
                     sources = 1,
                     sinks = 1,
                     mode = 'framed',
                     batch_size = 1,
                     sink_expect = 20,
-                    validate_file = 'received.txt',
+                    sink_stop_timeout = 5,
+                    validate_file = output,
                     persistent_data = persistent_data)
                 # Test run was successful, break out of loop and proceed to
                 # validation
@@ -102,6 +103,13 @@ def run_test(cmd, validation_cmd, topology):
                 else:
                     logging.error("Max retry attempts reached.")
                     raise
+            except ClusterError as err:
+                outputs = runner_data_format(
+                    persistent_data.get('runner_data', []),
+                    from_tail=20,
+                    filter_fn=lambda r: True)
+                logging.error("Worker outputs:\n\n{}\n".format(outputs))
+                raise
             except:
                 raise
     except Exception as err:
@@ -126,10 +134,11 @@ def run_test(cmd, validation_cmd, topology):
                          ' '.join(res.command))
     else:
         outputs = runner_data_format(persistent_data.get('runner_data', []))
-        logging.error("Application outputs:\n{}".format(outputs))
-        logging.error("Validation command '%s' failed with the output:\n"
+        if outputs:
+            logging.error("Application outputs:\n{}".format(outputs))
+        logging.error("Validation command\n    '%s'\nfailed with the output:\n"
                       "--\n%s",
-                      res.command, res.output)
+                      ' '.join(res.command), res.output)
         # Save logs to file in case of error
         save_logs_to_file(base_dir, log_stream, persistent_data)
 
@@ -144,21 +153,31 @@ def run_test(cmd, validation_cmd, topology):
                  .format(topology))
 
 
-def create_test(api, cmd, validation_cmd, steps):
-    test_name = 'test_topology_{}_{}'.format(api, '_'.join(steps))
+def create_test(api, cmd, validation_cmd, steps, workers=1):
+    test_name = ('test_{api}_topology_{workers}_workers_{topo}'.format(
+        api=api,
+        workers=workers,
+        topo='_'.join(steps)))
     def f():
-        run_test(cmd, validation_cmd, steps)
+        run_test(api, cmd, validation_cmd, steps)
     f.func_name = test_name
     globals()[test_name] = f
 
 # Create tests!
 APIS = {'python': {'cmd': 'machida --application-module app_gen',
-                   'validation_cmd': 'python2 app_gen.py'},}
-        #'python3': {'cmd': 'machida3 --application-module app_gen',
-        #            'validation_cmd': 'python2 app_gen.py'}}
+                   'validation_cmd': 'python2 app_gen.py'},
+        'python3': {'cmd': 'machida3 --application-module app_gen',
+                    'validation_cmd': 'python3 app_gen.py'},
+       }
 
 
+sizes = [1,2,3]
+depth = 3
 COMPS = ['to', 'to-parallel', 'to-stateful', 'to-state-partition']
-for steps in itertools.combinations_with_replacement(COMPS, 3):
-    for api in APIS:
-        create_test(api, APIS[api]['cmd'], APIS[api]['validation_cmd'], steps)
+for size in sizes:
+    for steps in itertools.chain.from_iterable(
+            (itertools.combinations_with_replacement(COMPS, d)
+             for d in range(1, depth+1))):
+        for api in APIS:
+            create_test(api, APIS[api]['cmd'], APIS[api]['validation_cmd'],
+                        steps, size)

--- a/testing/tools/integration/__init__.py
+++ b/testing/tools/integration/__init__.py
@@ -14,56 +14,9 @@
 
 
 """
-Integration contains everything that's required to run integration
-tests for a Wallaro application (Python, Pony, or otherwise) via a Python
-script.
-
-It has:
-    - TCPReceiver: a multi-client TCP sink receiver
-    - Metrics: an alias for TCPReceiver
-    - Sink: an alias for TCPReceiver
-    - Sender: a TCP sender
-    - Reader: a buffered reader interface wrapper for bytestream generators
-    - files_generator: a file source supporting both newlines and framed modes
-    - sequence_generator: a framed source encoded U64 sequence generator
-        (binary)
-    - iter_generator: a generic framed source encoded generator that operates
-        on iterators. It takes an optional `to_string` lambda for converting
-        iterator items to strings.
-    - files_generator: a generic
-    - Runner: Runs a single Wallaroo worker with command line parameters.
-    - ex_validation: a function to execute external validation commands and
-      capture their outputs
-
-You will need to include /testing/tools in your PYTHONPATH, and the
-application binary in your PATH before running your integration test.
-
-Below is an example for running the integration test on reverse, a
-python-wallaroo application, using the machida binary, the wallaroo python
-api, and the the integration tester utility. The integration test script
-can be found at
-https://github.com/WallarooLabs/wallaroo/examples/python/reverse/_test.py.
-
-```bash
-# Add integration utility to PYTHONPATH
-export PYTHONPATH="$PYTHONPATH:~/wallaroo-tutorial/wallaroo/testing/tools"
-# Add wallaroo to PYTHONPATH
-export PYTHONPATH="$PYTHONPATH:~/wallaroo-tutorial/wallaroo/machida/lib:."
-# Add machida to PATH
-export PATH="%PATH:~/wallaroo-tutorial/wallaroo/machida/build"
-
-# Run integration test
-python2 -m pytest _test.py --verbose
-```
-
-
-Alternatively, for a CLI style integration tester, you may use the
-`integration_test` CLI. Add
-`~/wallaroo-tutorial/wallaroo/testing/tools/integration` to your PATH, then
-`integration_test -h` for instructions.
 """
 
-from cluster import (add_runner,
+from .cluster import (add_runner,
                      Cluster,
                      ClusterError,
                      Runner,
@@ -71,12 +24,12 @@ from cluster import (add_runner,
                      runner_data_format,
                      start_runners)
 
-from control import (SinkAwaitValue,
+from .control import (SinkAwaitValue,
                      SinkExpect,
                      TryUntilTimeout,
                      WaitForClusterToResumeProcessing)
 
-from end_points import (Metrics,
+from .end_points import (Metrics,
                         MultiSequenceGenerator,
                         Reader,
                         Sender,
@@ -87,7 +40,7 @@ from end_points import (Metrics,
                         newline_file_generator,
                         sequence_generator)
 
-from errors import (AutoscaleError,
+from .errors import (AutoscaleError,
                     CrashedWorkerError,
                     DuplicateKeyError,
                     ExpectationError,
@@ -96,24 +49,24 @@ from errors import (AutoscaleError,
                     StopError,
                     TimeoutError)
 
-from external import (clean_resilience_path,
+from .external import (clean_resilience_path,
                       create_resilience_dir,
                       run_shell_cmd,
                       get_port_values,
                       is_address_available,
                       setup_resilience_path)
 
-from integration import pipeline_test
+from .integration import pipeline_test
 
-from logger import (DEFAULT_LOG_FMT,
+from .logger import (DEFAULT_LOG_FMT,
                     INFO2,
                     set_logging)
 
-from metrics_parser import (MetricsData,
+from .metrics_parser import (MetricsData,
                             MetricsParser,
                             MetricsParseError)
 
-from observability import (cluster_status_query,
+from .observability import (cluster_status_query,
                            get_func_name,
                            multi_states_query,
                            ObservabilityNotifier,
@@ -123,6 +76,6 @@ from observability import (cluster_status_query,
                            partitions_query,
                            state_entity_query)
 
-from stoppable_thread import StoppableThread
+from .stoppable_thread import StoppableThread
 
-from typed_list import TypedList
+from .typed_list import TypedList

--- a/testing/tools/integration/cluster.py
+++ b/testing/tools/integration/cluster.py
@@ -23,17 +23,17 @@ import time
 import subprocess
 
 
-from control import (CrashChecker,
+from .control import (CrashChecker,
                      SinkExpect,
                      SinkAwaitValue,
                      TryUntilTimeout,
                      WaitForClusterToResumeProcessing)
 
-from end_points import (Metrics,
+from .end_points import (Metrics,
                         Sender,
                         Sink)
 
-from errors import (ClusterError,
+from .errors import (ClusterError,
                     CrashedWorkerError,
                     NotEmptyError,
                     RunnerHasntStartedError,
@@ -41,22 +41,22 @@ from errors import (ClusterError,
                     StopError,
                     TimeoutError)
 
-from external import (clean_resilience_path,
+from .external import (clean_resilience_path,
                       get_port_values,
                       send_shrink_command,
                       setup_resilience_path)
 
-from logger import INFO2
+from .logger import INFO2
 
-from observability import (cluster_status_query,
+from .observability import (cluster_status_query,
                            coalesce_partition_query_responses,
                            multi_states_query,
                            ObservabilityNotifier,
                            state_entity_query)
 
-from typed_list import TypedList
+from .typed_list import TypedList
 
-from validations import (validate_migration,
+from .validations import (validate_migration,
                          validate_sender_is_flushed,
                          worker_count_matches,
                          worker_has_state_entities)

--- a/testing/tools/integration/cluster.py
+++ b/testing/tools/integration/cluster.py
@@ -486,6 +486,9 @@ class Cluster(object):
             self.runners.extend(self.workers)
             self._worker_id_counter = len(self.workers)
 
+            # Give workers time to exit if they crashed on startup.
+            # This makes these errors show faster.
+            time.sleep(0.25)
             # Wait for all runners to report ready to process
             self.wait_to_resume_processing(self.is_ready_timeout)
             # make sure `workers` runners are active and listed in the

--- a/testing/tools/integration/control.py
+++ b/testing/tools/integration/control.py
@@ -16,15 +16,15 @@ import logging
 from inspect import isfunction
 import time
 
-from errors import (ClusterError,
+from .errors import (ClusterError,
                     ExpectationError,
                     TimeoutError)
-from stoppable_thread import StoppableThread
-from observability import (cluster_status_query,
+from .stoppable_thread import StoppableThread
+from .observability import (cluster_status_query,
                            get_func_name,
                            ObservabilityNotifier)
 
-from validations import is_processing
+from .validations import is_processing
 
 
 class WaitForClusterToResumeProcessing(StoppableThread):

--- a/testing/tools/integration/control.py
+++ b/testing/tools/integration/control.py
@@ -38,9 +38,12 @@ class WaitForClusterToResumeProcessing(StoppableThread):
 
     def run(self):
         waiting = set()
-        for r in self.runners:
-            if not r.is_alive():
-                continue
+        # get live runners
+        live = [r for r in self.runners if r.is_alive()]
+        if not live:
+            self.stop(ClusterError("No live runners found. Cluster cannot "
+                                   "resume processing."))
+        for r in live:
             obs = ObservabilityNotifier(cluster_status_query,
                 r.external,
                 tests=is_processing, timeout=self.timeout)

--- a/testing/tools/integration/end_points.py
+++ b/testing/tools/integration/end_points.py
@@ -20,9 +20,9 @@ import time
 import socket
 import struct
 
-from errors import TimeoutError
-from logger import INFO2
-from stoppable_thread import StoppableThread
+from .errors import TimeoutError
+from .logger import INFO2
+from .stoppable_thread import StoppableThread
 
 
 class SingleSocketReceiver(StoppableThread):

--- a/testing/tools/integration/external.py
+++ b/testing/tools/integration/external.py
@@ -181,6 +181,9 @@ def save_logs_to_file(base_dir, log_stream=None, persistent_data={}):
         # save sender data to files
         sender_data = persistent_data.get('sender_data', [])
         for sd in sender_data:
+            # skip empty data
+            if not sd.data:
+                continue
             sender_log_name = 'sender_{host}!{port}_{time}.error.dat'.format(
                 host=sd.host,
                 port=sd.port,
@@ -191,6 +194,9 @@ def save_logs_to_file(base_dir, log_stream=None, persistent_data={}):
         # save sinks data to files
         sink_data = persistent_data.get('sink_data', [])
         for sk in sink_data:
+            # skip empty data
+            if not sk.data:
+                continue
             sink_log_name = 'sink_{host}!{port}_{time}.error.dat'.format(
                 host=sk.host,
                 port=sk.port,

--- a/testing/tools/integration/integration.py
+++ b/testing/tools/integration/integration.py
@@ -21,14 +21,14 @@ import os
 import re
 import time
 
-from cluster import (Cluster,
+from .cluster import (Cluster,
                      runner_data_format)
-from control import (SinkAwaitValue,
+from .control import (SinkAwaitValue,
                      SinkExpect)
-from end_points import (Sender,
+from .end_points import (Sender,
                         Reader)
-from errors import PipelineTestError
-from logger import INFO2
+from .errors import PipelineTestError
+from .logger import INFO2
 
 
 

--- a/testing/tools/integration/integration_test
+++ b/testing/tools/integration/integration_test
@@ -10,15 +10,15 @@ import shutil
 import struct
 import time
 
-from cluster import runner_data_format
-from end_points import (files_generator,
+from .cluster import runner_data_format
+from .end_points import (files_generator,
                         iter_generator,
                         sequence_generator)
-from errors import RunnerHasntStartedError
-from external import (run_shell_cmd,
+from .errors import RunnerHasntStartedError
+from .external import (run_shell_cmd,
                       save_logs_to_file)
-from integration import pipeline_test
-from logger import (add_in_memory_log_stream,
+from .integration import pipeline_test
+from .logger import (add_in_memory_log_stream,
                     INFO2,
                     set_logging)
 

--- a/testing/tools/integration/observability.py
+++ b/testing/tools/integration/observability.py
@@ -24,11 +24,11 @@ import traceback
 import sys
 import time
 
-from errors import (DuplicateKeyError,
+from .errors import (DuplicateKeyError,
                     TimeoutError)
-from external import run_shell_cmd
-from logger import INFO2
-from stoppable_thread import StoppableThread
+from .external import run_shell_cmd
+from .logger import INFO2
+from .stoppable_thread import StoppableThread
 
 
 # Make string instance checking py2 and py3 compatible below

--- a/testing/tools/integration/validations.py
+++ b/testing/tools/integration/validations.py
@@ -15,7 +15,7 @@
 from itertools import chain
 import logging
 
-from errors import (MigrationError,
+from .errors import (MigrationError,
                     NotEmptyError)
 
 

--- a/testing/tools/integration_test
+++ b/testing/tools/integration_test
@@ -1,5 +1,7 @@
 #!/usr/bin/env python2
 
+__package__ == 'integration'
+
 import argparse
 from collections import namedtuple
 import datetime
@@ -10,17 +12,17 @@ import shutil
 import struct
 import time
 
-from .cluster import runner_data_format
-from .end_points import (files_generator,
-                        iter_generator,
-                        sequence_generator)
-from .errors import RunnerHasntStartedError
-from .external import (run_shell_cmd,
-                      save_logs_to_file)
-from .integration import pipeline_test
-from .logger import (add_in_memory_log_stream,
-                    INFO2,
-                    set_logging)
+from integration.cluster import runner_data_format
+from integration.end_points import (files_generator,
+                                    iter_generator,
+                                    sequence_generator)
+from integration.errors import RunnerHasntStartedError
+from integration.external import (run_shell_cmd,
+                                  save_logs_to_file)
+from integration.integration import pipeline_test
+from integration.logger import (add_in_memory_log_stream,
+                                INFO2,
+                                set_logging)
 
 
 """


### PR DESCRIPTION
This PR 
- adds python3 topology tests.
- fixes some test error log saving issues.
- expands the existing python topology tests to cover:
    - 1,2, and 3 worker clusters for each topology
    - all topology combinations of length 1, 2, and 3 from {to, to-parallel, to-stateful, to-state-partition}

In all, this means we now have 102 topology tests per python version.
They run pretty fast though, because we only have to build machida and machida3 once each.

These are also now placed in `testing/correctness/tests`, which means they run with both `resilience=on` and `resilience=off`.

related to #2546 
