### PR TITLE
Update git book for Python3 (2nd pass)

### DIFF
--- a/book/appendix/virtualenv.md
+++ b/book/appendix/virtualenv.md
@@ -54,7 +54,7 @@ If you use a different Python, such as `python2` or `python3.5`, then substitute
 virtualenv --python=`which python3.5` ENV
 ```
 
-**Note**: it is critical that the python version in the virtualenv is compatible with the version of machida. For example, if you're using machida3, you need to setup your virtualenv for Python 3, and if you are using machida, you need to set up the virtualenv for Python 2.
+**Note**: it is critical that the Python version in the virtualenv is compatible with the version of Machida. For example, if you're using machida3, you need to setup your virtualenv for Python 3, and if you are using machida, you need to set up the virtualenv for Python 2.
 
 ## Cleaning up a Virtualenv
 

--- a/book/appendix/virtualenv.md
+++ b/book/appendix/virtualenv.md
@@ -12,9 +12,13 @@ Follow the instructions on [the virtualenv website](https://virtualenv.pypa.io/e
 
 To create a virtualenv for your application, run the following command
 
-```bash
+
+{% codetabs name="Python 2.7", type="py" -%}
 virtualenv --python=python2 ENV
-```
+{% language name="Python 3", type="py" -%}
+virtualenv --python=python3 ENV
+{%- endcodetabs %}
+
 
 This will create a directory named `ENV` and set up all of the scripts and dependencies required to run an isolated Python2 virtual environment, located in `ENV`.
 
@@ -44,11 +48,13 @@ In order to work correctly, virtualenv needs to be set up with the correct Pytho
 virtualenv --python=`which python` ENV
 ```
 
-If you use a different Python, such as `python2` or `python2.7`, then substitute that into the `which` command:
+If you use a different Python, such as `python2` or `python3.5`, then substitute that into the `which` command:
 
 ```bash
-virtualenv --python=`which python2.7` ENV
+virtualenv --python=`which python3.5` ENV
 ```
+
+**Note**: it is critical that the python version in the virtualenv is compatible with the version of machida. For example, if you're using machida3, you need to setup your virtualenv for Python 3, and if you are using machida, you need to set up the virtualenv for Python 2.
 
 ## Cleaning up a Virtualenv
 
@@ -86,7 +92,7 @@ To exit the virtualenv, use the `deactivate` command.
 
 To run a Wallaroo application with virtualenv, run it within an activated shell:
 
-```bash
+{% codetabs name="Python 2.7", type="py" -%}
 source ENV/bin/activate
 export PYTHONPATH="$HOME/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/machida/lib:$HOME/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/examples/python/celsius"
 $HOME/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/machida/build/machida --application-module celsius \
@@ -94,7 +100,15 @@ $HOME/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/machida/build/machi
   --control 127.0.0.1:6000 --data 127.0.0.1:6001 --name worker-name \
   --external 127.0.0.1:5050 --cluster-initializer --ponythreads=1 \
   --ponynoblock
-```
+{% language name="Python 3", type="py" -%}
+source ENV/bin/activate
+export PYTHONPATH="$HOME/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/machida/lib:$HOME/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/examples/python/celsius"
+$HOME/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/machida3/build/machida3 --application-module celsius \
+  --in 127.0.0.1:7000 --out 127.0.0.1:5555 --metrics 127.0.0.1:5001 \
+  --control 127.0.0.1:6000 --data 127.0.0.1:6001 --name worker-name \
+  --external 127.0.0.1:5050 --cluster-initializer --ponythreads=1 \
+  --ponynoblock
+{%- endcodetabs %}
 
 Please be aware that you'll still need to setup a source and sink as well. To learn more you can look at [Giles Sender](/book/wallaroo-tools/giles-sender.md) for more detailed instructions on building and running Giles.
 

--- a/book/getting-started/docker-setup.md
+++ b/book/getting-started/docker-setup.md
@@ -32,7 +32,9 @@ docker pull wallaroo-labs-docker-wallaroolabs.bintray.io/{{ docker_version_url }
 
 ## What's Included in the Wallaroo Docker image
 
-* **Machida**: runs Wallaroo Python applications.
+* **Machida**: runs Wallaroo Python applications for Python 2.7.
+
+* **Machida3**: runs Wallaroo Python applications for Python 3.x.
 
 * **Giles Sender**: supplies data to Wallaroo applications over TCP.
 
@@ -44,7 +46,9 @@ docker pull wallaroo-labs-docker-wallaroolabs.bintray.io/{{ docker_version_url }
 
 * **Wallaroo Source Code**: full Wallaroo source code is provided, including Python example applications.
 
-* **Machida with Resilience**: runs Wallaroo Python applications and writes state to disk for recovery. This version of Machida can be used via the `machida-resilience` and `machida3-resilience` binaries. See the [Interworker Serialization and Resilience](/book/python/interworker-serialization-and-resilience.md) documentation for general information and the [Resilience](/book/running-wallaroo/wallaroo-command-line-options.md#resilience) section of our [Command Line Options](/book/running-wallaroo/wallaroo-command-line-options.md) documentation for information on its usage.
+* **Machida with Resilience**: runs Wallaroo Python 2.7 applications and writes state to disk for recovery. This version of Machida can be used via the `machida-resilience` and `machida3-resilience` binaries. See the [Interworker Serialization and Resilience](/book/python/interworker-serialization-and-resilience.md) documentation for general information and the [Resilience](/book/running-wallaroo/wallaroo-command-line-options.md#resilience) section of our [Command Line Options](/book/running-wallaroo/wallaroo-command-line-options.md) documentation for information on its usage.
+
+* **Machida3 with Resilience**: similar to Machida with Resilience, but for Python 3.x.
 
 ## Additional Windows Setup
 

--- a/book/getting-started/docker-setup.md
+++ b/book/getting-started/docker-setup.md
@@ -34,7 +34,7 @@ docker pull wallaroo-labs-docker-wallaroolabs.bintray.io/{{ docker_version_url }
 
 * **Machida**: runs Wallaroo Python applications for Python 2.7.
 
-* **Machida3**: runs Wallaroo Python applications for Python 3.x.
+* **Machida3**: runs Wallaroo Python applications for Python 3.6+.
 
 * **Giles Sender**: supplies data to Wallaroo applications over TCP.
 
@@ -48,7 +48,7 @@ docker pull wallaroo-labs-docker-wallaroolabs.bintray.io/{{ docker_version_url }
 
 * **Machida with Resilience**: runs Wallaroo Python 2.7 applications and writes state to disk for recovery. This version of Machida can be used via the `machida-resilience` and `machida3-resilience` binaries. See the [Interworker Serialization and Resilience](/book/python/interworker-serialization-and-resilience.md) documentation for general information and the [Resilience](/book/running-wallaroo/wallaroo-command-line-options.md#resilience) section of our [Command Line Options](/book/running-wallaroo/wallaroo-command-line-options.md) documentation for information on its usage.
 
-* **Machida3 with Resilience**: similar to Machida with Resilience, but for Python 3.x.
+* **Machida3 with Resilience**: similar to Machida with Resilience, but for Python 3.6+.
 
 ## Additional Windows Setup
 

--- a/book/getting-started/docker-setup.md
+++ b/book/getting-started/docker-setup.md
@@ -34,7 +34,7 @@ docker pull wallaroo-labs-docker-wallaroolabs.bintray.io/{{ docker_version_url }
 
 * **Machida**: runs Wallaroo Python applications for Python 2.7.
 
-* **Machida3**: runs Wallaroo Python applications for Python 3.6+.
+* **Machida3**: runs Wallaroo Python applications for Python 3.5+.
 
 * **Giles Sender**: supplies data to Wallaroo applications over TCP.
 
@@ -48,7 +48,7 @@ docker pull wallaroo-labs-docker-wallaroolabs.bintray.io/{{ docker_version_url }
 
 * **Machida with Resilience**: runs Wallaroo Python 2.7 applications and writes state to disk for recovery. This version of Machida can be used via the `machida-resilience` and `machida3-resilience` binaries. See the [Interworker Serialization and Resilience](/book/python/interworker-serialization-and-resilience.md) documentation for general information and the [Resilience](/book/running-wallaroo/wallaroo-command-line-options.md#resilience) section of our [Command Line Options](/book/running-wallaroo/wallaroo-command-line-options.md) documentation for information on its usage.
 
-* **Machida3 with Resilience**: similar to Machida with Resilience, but for Python 3.6+.
+* **Machida3 with Resilience**: similar to Machida with Resilience, but for Python 3.5+.
 
 ## Additional Windows Setup
 

--- a/book/getting-started/linux-setup.md
+++ b/book/getting-started/linux-setup.md
@@ -161,8 +161,16 @@ sudo make install
 
 ## Install Python Development Libraries
 
+### Python 2.7
+
 ```bash
-sudo apt-get install -y python-dev
+sudo apt-get install -y python python-dev
+```
+
+### Python 3
+
+```bash
+sudo apt-get install -y python3 python3-dev
 ```
 
 ## Download and configure the Metrics UI

--- a/book/getting-started/run-a-wallaroo-application-docker.md
+++ b/book/getting-started/run-a-wallaroo-application-docker.md
@@ -7,7 +7,7 @@ There are a few Wallaroo support applications that you'll be interacting with fo
 - Our Metrics UI allows you to monitor the performance and health of your applications.
 - Data receiver is designed to capture TCP output from Wallaroo applications.
 - Giles sender is used to send test data into Wallaroo applications over TCP.
-- Machida, our program for running Wallaroo Python applications.
+- Machida or Machida3, our program for running Wallaroo Python applications, for Python 2.7 and 3.x respectively..
 
 You're going to set up our "Celsius to Fahrenheit" example application. Giles sender will be used to pump data into the application. Data receiver will receive the output, and our Metrics UI will be running so you can observe the overall performance.
 

--- a/book/getting-started/run-a-wallaroo-application-docker.md
+++ b/book/getting-started/run-a-wallaroo-application-docker.md
@@ -7,7 +7,7 @@ There are a few Wallaroo support applications that you'll be interacting with fo
 - Our Metrics UI allows you to monitor the performance and health of your applications.
 - Data receiver is designed to capture TCP output from Wallaroo applications.
 - Giles sender is used to send test data into Wallaroo applications over TCP.
-- Machida or Machida3, our program for running Wallaroo Python applications, for Python 2.7 and 3.6+ respectively..
+- Machida or Machida3, our program for running Wallaroo Python applications, for Python 2.7 and 3.5+ respectively..
 
 You're going to set up our "Celsius to Fahrenheit" example application. Giles sender will be used to pump data into the application. Data receiver will receive the output, and our Metrics UI will be running so you can observe the overall performance.
 

--- a/book/getting-started/run-a-wallaroo-application-docker.md
+++ b/book/getting-started/run-a-wallaroo-application-docker.md
@@ -7,7 +7,7 @@ There are a few Wallaroo support applications that you'll be interacting with fo
 - Our Metrics UI allows you to monitor the performance and health of your applications.
 - Data receiver is designed to capture TCP output from Wallaroo applications.
 - Giles sender is used to send test data into Wallaroo applications over TCP.
-- Machida or Machida3, our program for running Wallaroo Python applications, for Python 2.7 and 3.x respectively..
+- Machida or Machida3, our program for running Wallaroo Python applications, for Python 2.7 and 3.6+ respectively..
 
 You're going to set up our "Celsius to Fahrenheit" example application. Giles sender will be used to pump data into the application. Data receiver will receive the output, and our Metrics UI will be running so you can observe the overall performance.
 

--- a/book/getting-started/run-a-wallaroo-application-vagrant.md
+++ b/book/getting-started/run-a-wallaroo-application-vagrant.md
@@ -7,7 +7,7 @@ There are a few Wallaroo support applications that you'll be interacting with fo
 - Our Metrics UI allows you to monitor the performance and health of your applications.
 - Data receiver is designed to capture TCP output from Wallaroo applications.
 - Giles sender is used to send test data into Wallaroo applications over TCP.
-- Machida, our program for running Wallaroo Python applications.
+- Machida or Machida3, our programs for running Wallaroo Python 2.7 and Python 3.x applications, respectively.
 
 You're going to set up our "Celsius to Fahrenheit" example application. Giles sender will be used to pump data into the application. Data receiver will receive the output, and our Metrics UI will be running so you can observe the overall performance.
 

--- a/book/getting-started/run-a-wallaroo-application-vagrant.md
+++ b/book/getting-started/run-a-wallaroo-application-vagrant.md
@@ -7,7 +7,7 @@ There are a few Wallaroo support applications that you'll be interacting with fo
 - Our Metrics UI allows you to monitor the performance and health of your applications.
 - Data receiver is designed to capture TCP output from Wallaroo applications.
 - Giles sender is used to send test data into Wallaroo applications over TCP.
-- Machida or Machida3, our programs for running Wallaroo Python 2.7 and Python 3.x applications, respectively.
+- Machida or Machida3, our programs for running Wallaroo Python 2.7 and Python 3.6+ applications, respectively.
 
 You're going to set up our "Celsius to Fahrenheit" example application. Giles sender will be used to pump data into the application. Data receiver will receive the output, and our Metrics UI will be running so you can observe the overall performance.
 

--- a/book/getting-started/run-a-wallaroo-application-vagrant.md
+++ b/book/getting-started/run-a-wallaroo-application-vagrant.md
@@ -7,7 +7,7 @@ There are a few Wallaroo support applications that you'll be interacting with fo
 - Our Metrics UI allows you to monitor the performance and health of your applications.
 - Data receiver is designed to capture TCP output from Wallaroo applications.
 - Giles sender is used to send test data into Wallaroo applications over TCP.
-- Machida or Machida3, our programs for running Wallaroo Python 2.7 and Python 3.6+ applications, respectively.
+- Machida or Machida3, our programs for running Wallaroo Python 2.7 and Python 3.5+ applications, respectively.
 
 You're going to set up our "Celsius to Fahrenheit" example application. Giles sender will be used to pump data into the application. Data receiver will receive the output, and our Metrics UI will be running so you can observe the overall performance.
 

--- a/book/getting-started/run-a-wallaroo-application.md
+++ b/book/getting-started/run-a-wallaroo-application.md
@@ -7,7 +7,7 @@ There are a few Wallaroo support applications that you'll be interacting with fo
 - Our Metrics UI allows you to monitor the performance and health of your applications.
 - Data receiver is designed to capture TCP output from Wallaroo applications.
 - Giles sender is used to send test data into Wallaroo applications over TCP.
-- Machida, our program for running Wallaroo Python applications.
+- Machida or Machida3, our programs for running Wallaroo Python 2.7 and Python 3.x applications, respectively.
 
 You're going to set up our "Celsius to Fahrenheit" example application. Giles sender will be used to pump data into the application. Data receiver will receive the output, and our Metrics UI will be running so you can observe the overall performance.
 
@@ -74,7 +74,7 @@ First, we will need to set up the `PYTHONPATH` environment variable. Machida nee
 export PYTHONPATH="$HOME/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/examples/python/celsius:$PYTHONPATH"
 ```
 
-Now that we have Machida set up to run the "Celsius to Fahrenheit" application, and the metrics UI and something it can send output to up and running, we can run the application itself by executing the following command:
+Now that we have Machida set up to run the "Celsius to Fahrenheit" application, and the metrics UI and something it can send output to up and running, we can run the application itself by executing the following command (remember to use the `machida3` executable instead of `machida` if you are using Python 3.X):
 
 ```bash
 machida --application-module celsius --in 127.0.0.1:7000 \

--- a/book/getting-started/run-a-wallaroo-application.md
+++ b/book/getting-started/run-a-wallaroo-application.md
@@ -7,7 +7,7 @@ There are a few Wallaroo support applications that you'll be interacting with fo
 - Our Metrics UI allows you to monitor the performance and health of your applications.
 - Data receiver is designed to capture TCP output from Wallaroo applications.
 - Giles sender is used to send test data into Wallaroo applications over TCP.
-- Machida or Machida3, our programs for running Wallaroo Python 2.7 and Python 3.x applications, respectively.
+- Machida or Machida3, our programs for running Wallaroo Python 2.7 and Python 3.6+ applications, respectively.
 
 You're going to set up our "Celsius to Fahrenheit" example application. Giles sender will be used to pump data into the application. Data receiver will receive the output, and our Metrics UI will be running so you can observe the overall performance.
 

--- a/book/getting-started/run-a-wallaroo-application.md
+++ b/book/getting-started/run-a-wallaroo-application.md
@@ -7,7 +7,7 @@ There are a few Wallaroo support applications that you'll be interacting with fo
 - Our Metrics UI allows you to monitor the performance and health of your applications.
 - Data receiver is designed to capture TCP output from Wallaroo applications.
 - Giles sender is used to send test data into Wallaroo applications over TCP.
-- Machida or Machida3, our programs for running Wallaroo Python 2.7 and Python 3.6+ applications, respectively.
+- Machida or Machida3, our programs for running Wallaroo Python 2.7 and Python 3.5+ applications, respectively.
 
 You're going to set up our "Celsius to Fahrenheit" example application. Giles sender will be used to pump data into the application. Data receiver will receive the output, and our Metrics UI will be running so you can observe the overall performance.
 

--- a/book/getting-started/vagrant-setup.md
+++ b/book/getting-started/vagrant-setup.md
@@ -77,7 +77,9 @@ vagrant up
 
 ## What's Included in the Wallaroo Vagrant Box
 
-* **Machida**: runs Wallaroo Python applications.
+* **Machida**: runs Wallaroo Python applications for Python 2.7.
+
+* **Machida3**: runs Wallaroo Python applications for Python 3.x.
 
 * **Giles Sender**: supplies data to Wallaroo applications over TCP.
 

--- a/book/getting-started/vagrant-setup.md
+++ b/book/getting-started/vagrant-setup.md
@@ -79,7 +79,7 @@ vagrant up
 
 * **Machida**: runs Wallaroo Python applications for Python 2.7.
 
-* **Machida3**: runs Wallaroo Python applications for Python 3.x.
+* **Machida3**: runs Wallaroo Python applications for Python 3.6+.
 
 * **Giles Sender**: supplies data to Wallaroo applications over TCP.
 

--- a/book/getting-started/vagrant-setup.md
+++ b/book/getting-started/vagrant-setup.md
@@ -79,7 +79,7 @@ vagrant up
 
 * **Machida**: runs Wallaroo Python applications for Python 2.7.
 
-* **Machida3**: runs Wallaroo Python applications for Python 3.6+.
+* **Machida3**: runs Wallaroo Python applications for Python 3.5+.
 
 * **Giles Sender**: supplies data to Wallaroo applications over TCP.
 

--- a/book/language_support.md
+++ b/book/language_support.md
@@ -1,6 +1,6 @@
 # Wallaroo Languages Supported
 
-Wallaroo currently supports the Python and Go programming languages on 64-bit platforms.
+Wallaroo currently supports the Python 2, Python 3, and Go programming languages on 64-bit platforms.
 
 * Learn more about how to use [Wallaroo with Python](python/intro.md).
 * Learn more about how to use [Wallaroo with Go](go/intro.md).

--- a/book/language_support.md
+++ b/book/language_support.md
@@ -1,6 +1,6 @@
 # Wallaroo Languages Supported
 
-Wallaroo currently supports the Python (2.7, 3.6+) and Go programming languages on 64-bit platforms.
+Wallaroo currently supports the Python (2.7, 3.5+) and Go programming languages on 64-bit platforms.
 
 * Learn more about how to use [Wallaroo with Python](python/intro.md).
 * Learn more about how to use [Wallaroo with Go](go/intro.md).

--- a/book/language_support.md
+++ b/book/language_support.md
@@ -1,6 +1,6 @@
 # Wallaroo Languages Supported
 
-Wallaroo currently supports the Python 2, Python 3, and Go programming languages on 64-bit platforms.
+Wallaroo currently supports the Python (2.7, 3.6+) and Go programming languages on 64-bit platforms.
 
 * Learn more about how to use [Wallaroo with Python](python/intro.md).
 * Learn more about how to use [Wallaroo with Go](go/intro.md).

--- a/book/python/debugging.md
+++ b/book/python/debugging.md
@@ -8,7 +8,7 @@ The simplest way to do some debugging would be to include a `print` statement in
 
 ```python
 def compute(self, data):
-    print "compute", data
+    print("compute", data)
     return data[::-1]
 ```
 
@@ -22,7 +22,7 @@ Using `print` in Python is not without risks. If you try to print a Unicode stri
 
 ```python
 >>> u = u'\ua000abcd\u07b4'
->>> print u
+>>> print(u)
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
 UnicodeEncodeError: 'ascii' codec can't encode character u'\ua000' in position 0: ordinal not in range(128)

--- a/book/python/intro.md
+++ b/book/python/intro.md
@@ -1,6 +1,6 @@
 # Python API Introduction
 
-The Wallaroo Python API can be used to write Wallaroo applications entirely in Python without needing Java or a JVM. This lets developers quickly get started with Wallaroo by leveraging their existing Python knowledge. There are two different version of Machida, one for Python 2.7 on 64-bit platforms called `machida` and one for Python 3.6+ on 64-bit platforms called `machida3`. If you are using Python 3.6+ then you should substitute `machida3` for `machida` as you follow the instructions in the documentation.
+The Wallaroo Python API can be used to write Wallaroo applications entirely in Python without needing Java or a JVM. This lets developers quickly get started with Wallaroo by leveraging their existing Python knowledge. There are two different version of Machida, one for Python 2.7 on 64-bit platforms called `machida` and one for Python 3.5+ on 64-bit platforms called `machida3`. If you are using Python 3.5+ then you should substitute `machida3` for `machida` as you follow the instructions in the documentation.
 
 In order to write a Wallaroo application in Python, the developer creates the functions (decorated with [the Wallaroo API](api.md)) to be run at each step of their application, along with an entry point function that uses the Wallaroo `ApplicationBuilder` that defines the layout of their application.
 

--- a/book/python/intro.md
+++ b/book/python/intro.md
@@ -1,6 +1,6 @@
 # Python API Introduction
 
-The Wallaroo Python API can be used to write Wallaroo applications entirely in Python without needing Java or a JVM. This lets developers quickly get started with Wallaroo by leveraging their existing Python knowledge. There are two different version of Machida, one for Python 2.7 on 64-bit platforms called `machida` and one for Python 3.X on 64-bit platforms called `machida3`. If you are using Python 3.X then you should substitute `machida3` for `machida` as you follow the instructions in the documentation.
+The Wallaroo Python API can be used to write Wallaroo applications entirely in Python without needing Java or a JVM. This lets developers quickly get started with Wallaroo by leveraging their existing Python knowledge. There are two different version of Machida, one for Python 2.7 on 64-bit platforms called `machida` and one for Python 3.6+ on 64-bit platforms called `machida3`. If you are using Python 3.6+ then you should substitute `machida3` for `machida` as you follow the instructions in the documentation.
 
 In order to write a Wallaroo application in Python, the developer creates the functions (decorated with [the Wallaroo API](api.md)) to be run at each step of their application, along with an entry point function that uses the Wallaroo `ApplicationBuilder` that defines the layout of their application.
 

--- a/book/python/running-a-wallaroo-python-application.md
+++ b/book/python/running-a-wallaroo-python-application.md
@@ -6,11 +6,11 @@ You should have already completed the [setup instructions](/book/getting-started
 
 ## Running the Application
 
-Wallaroo uses an embedded Python runtime wrapped with a C API around it that lets Wallaroo execute Python code and read Python variables. So when `machida --application-module my_application` is run, `machida` (the binary we previously compiled), loads up the `my_application.py` module inside of its embedded Python runtime and executes its `application_setup()` function to retrieve the application topology it needs to construct in order to run the application.
+Wallaroo uses an embedded Python runtime wrapped with a C API around it that lets Wallaroo execute Python code and read Python variables. So when `machida --application-module my_application` is run, `machida` (the binary we previously compiled), loads up the `my_application.py` module inside of its embedded Python runtime and executes its `application_setup()` function to retrieve the application topology it needs to construct in order to run the application. `machida3` does the same, but with an embedded Python 3 runtime instead of Python 2.7.
 
 Generally, in order to build a Wallaroo Python application, the following steps should be followed:
 
-* Build the machida binary (this only needs to be done once)
+* Build the machida or machida3 binary (this only needs to be done once)
 * `import wallaroo` in the Python application's `.py` file
 * Create classes that provide the correct Wallaroo Python interfaces (more on this later)
 * Define an `application_setup` function that uses the `ApplicationBuilder` from the `wallaroo` module to construct the application topology.
@@ -20,7 +20,7 @@ Once loaded, Wallaroo executes `application_setup()`, constructs the appropriate
 
 ### A Note About PYTHONPATH
 
-Machida uses the `PYTHONPATH` environment variable to find modules that are imported by the application. You will have at least two modules in your `PYTHONPATH`: the application module and the `wallaroo` module. For example, if you have followed the directions for setting up the tutorial then the Wallaroo Python module is in `$HOME/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/machida/wallaroo.py` and the "Celsius to Fahrenheit" application module is in `$HOME/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/examples/python/celsius/celsius.py`, so you would export `PYTHONPATH` like this:
+Machida uses the `PYTHONPATH` environment variable to find modules that are imported by the application. You will have at least two modules in your `PYTHONPATH`: the application module and the `wallaroo` module. For example, if you have followed the directions for setting up the tutorial then the Wallaroo Python module is in `$HOME/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/machida/lib/` and the "Celsius to Fahrenheit" application module is in `$HOME/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/examples/python/celsius/celsius.py`, you would export `PYTHONPATH` like this:
 
 ```bash
 export PYTHONPATH="$PYTHONPATH:$HOME/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/machida/lib:$HOME/wallaroo-tutorial/wallaroo-{{ book.wallaroo_version }}/examples/python/celsius"

--- a/book/python/running-a-wallaroo-python-application.md
+++ b/book/python/running-a-wallaroo-python-application.md
@@ -10,7 +10,7 @@ Wallaroo uses an embedded Python runtime wrapped with a C API around it that let
 
 Generally, in order to build a Wallaroo Python application, the following steps should be followed:
 
-* Build the machida or machida3 binary (this only needs to be done once)
+* Build the `machida` or `machida3` binary (this only needs to be done once)
 * `import wallaroo` in the Python application's `.py` file
 * Create classes that provide the correct Wallaroo Python interfaces (more on this later)
 * Define an `application_setup` function that uses the `ApplicationBuilder` from the `wallaroo` module to construct the application topology.

--- a/book/python/using-connectors.md
+++ b/book/python/using-connectors.md
@@ -1,5 +1,7 @@
 # Using Connectors as Sources & Sinks
 
+_Python 3: At this point, Connectors are not supported in our Python3 API. We expect support will be added in the next release._
+
 This is a preview release of Wallaroo's connectors feature that allows full customization of sources and sinks. These sources and sinks can be integrated into Wallaroo using libraries you're already familiar with in Python. A number of built-in connectors offer a quick way to get started and hook up common stream types and they're all available for easy customization.
 
 Care has been taken to keep the API simple and the runtime assumptions unobtrusive so it's easy to hook up the library to existing code. Read down below for more information on how this works. As this is still a preview release, we are looking for early feedback and would love to hear from you. You can connect with us by emailing [hello@wallaroolabs.com](mailto:hello@wallaroolabs.com).

--- a/book/python/writing-your-own-application.md
+++ b/book/python/writing-your-own-application.md
@@ -17,7 +17,7 @@ Let's start with the computation, because that's the purpose of the application:
 ```python
 @wallaroo.computation(name='reverse'):
 def reverse(data):
-    print "compute", data
+    print("compute", data)
     return data[::-1]
 ```
 
@@ -27,14 +27,14 @@ Note that there is a `print` statement in the `compute` method (and in other met
 
 ### Sink Encoder
 
-Next, we are going to define how the output gets constructed for the sink. It is important to remember that Wallaroo sends its output over the network, so data going through the sink needs to be of type `bytes`. In Python2, this is the same as `str`.
+Next, we are going to define how the output gets constructed for the sink. It is important to remember that Wallaroo sends its output over the network, so data going through the sink needs to be of type `bytes`. In Python2, this is the same as `str`, but in Python3, strings are Unicode, and need to be converted to `bytes`. Luckily, we can use `encode()` to get a `bytes` from a string in both versions:
 
 ```python
 @wallaroo.encoder
 def encode(data):
     # data is a string
-    print "encode", data
-    return data + "\n"
+    print("encode", data)
+    return (data + "\n").encode()
 ```
 
 ### SourceDecoder
@@ -44,7 +44,7 @@ Now, we also need to decode the incoming bytes of the source.
 ```python
 @wallaroo.decoder(header_length=4, length_fmt=">I")
 def decode(bs):
-    print "decode", bs
+    print("decode", bs)
     return bs.decode("utf-8")
 ```
 
@@ -123,7 +123,7 @@ Wallaroo provides the convenience functions `tcp_parse_input_addrs` and `tcp_par
 
 ### Miscellaneous
 
-Of course, no Python module is complete without its imports. In this case, only two imports are required:
+Of course, no Python module is complete without its imports. In this case, only one import is required:
 
 ```python
 import wallaroo

--- a/book/python/writing-your-own-partitioned-stateful-application.md
+++ b/book/python/writing-your-own-partitioned-stateful-application.md
@@ -30,7 +30,7 @@ And then we define a partitioning function which returns a key from the above li
 ```python
 @wallaroo.partition
 def partition(data):
-    return data.letter[0]
+    return data.letter
 ```
 
 Later when we build the application topology, we will pass both the keys and the function to the builder.

--- a/book/running-wallaroo/autoscale.md
+++ b/book/running-wallaroo/autoscale.md
@@ -4,14 +4,16 @@ Wallaroo is designed to support scale-independent development. It can adapt to c
 
 With autoscale enabled, you can add or remove workers from a running cluster. We call these “grow to fit” and “shrink to fit”, respectively (referring to the fact that the cluster grows or shrinks to fit your current resource requirements). To enable autoscale, you must build a Wallaroo binary using the `-D autoscale` command line argument. Autoscale is set by default when running `make` for building Machida or the example Wallaroo applications.
 
-Remember to use the `machida3` executable instead of `machida` if you are using Python 3.X.
-
 ## Grow to Fit
 
 While a Wallaroo cluster is running, new workers can join the cluster.  To add workers to a running cluster, you must know the control channel address of one of the workers in the running cluster.  Let’s assume it’s `127.0.0.1:12500`.  The following command would allow us to add one worker to a running cluster for the `alphabet` example app:
 
-{% codetabs name="Python", type="py" -%}
+{% codetabs name="Python 2.7", type="py" -%}
 machida --application-module alphabet --in 127.0.0.1:7010 \
+  --out 127.0.0.1:7002 --join 127.0.0.1:12500 --name w3 \
+  --ponythreads 1
+{% language name="Python 3", type="py" -%}
+machida3 --application-module alphabet --in 127.0.0.1:7010 \
   --out 127.0.0.1:7002 --join 127.0.0.1:12500 --name w3 \
   --ponythreads 1
 {%- language name="Go", type="go" -%}
@@ -23,7 +25,7 @@ The `--in` argument specifies the port that the TCP source will listen on, and t
 
 If you want to add more than 1 new worker at a time, you must have all joining workers contact the same running worker and all must specify the same joining worker total as the `worker_count` command line argument.  For example, if 3 workers are joining, then in our case, they could all use `--join 127.0.0.1:12500` and `--worker-count 3`.  Their command lines might be as follows:
 
-{% codetabs name="Python", type="py" -%}
+{% codetabs name="Python 2.7", type="py" -%}
 machida --application-module alphabet --in 127.0.0.1:7010 \
   --out 127.0.0.1:7002 --join 127.0.0.1:12500 --name w3 --worker-count 3 \
   --ponythreads 1
@@ -33,6 +35,18 @@ machida --application-module alphabet --in 127.0.0.1:7010 \
   --ponythreads 1
 
 machida --application-module alphabet --in 127.0.0.1:7010 \
+  --out 127.0.0.1:7002 --join 127.0.0.1:12500 --name w5 --worker-count 3 \
+  --ponythreads 1
+{% language name="Python 3", type="py" -%}
+machida3 --application-module alphabet --in 127.0.0.1:7010 \
+  --out 127.0.0.1:7002 --join 127.0.0.1:12500 --name w3 --worker-count 3 \
+  --ponythreads 1
+
+machida3 --application-module alphabet --in 127.0.0.1:7010 \
+  --out 127.0.0.1:7002 --join 127.0.0.1:12500 --name w4 --worker-count 3 \
+  --ponythreads 1
+
+machida3 --application-module alphabet --in 127.0.0.1:7010 \
   --out 127.0.0.1:7002 --join 127.0.0.1:12500 --name w5 --worker-count 3 \
   --ponythreads 1
 {%- language name="Go", type="go" -%}

--- a/book/running-wallaroo/resilience.md
+++ b/book/running-wallaroo/resilience.md
@@ -67,8 +67,7 @@ cd examples/python/word_count_with_dynamic_keys
     data_receiver --listen 127.0.0.1:7002 | tee received.txt
     ```
 
-4. Shell 2: Start initializer
-
+4. Shell 2: Start initializer (remember to use `machida3-resilience` if using Python 3)
     ```bash
     machida-resilience --application-module word_count_with_dynamic_keys \
       --in 127.0.0.1:7010 --out 127.0.0.1:7002 \
@@ -80,7 +79,7 @@ cd examples/python/word_count_with_dynamic_keys
       | tee initializer.log
     ```
 
-5. Shell 3: Start worker
+5. Shell 3: Start worker (remember to use `machida3-resilience` if using Python 3)
 
     ```bash
     machida-resilience --application-module word_count_with_dynamic_keys \
@@ -116,7 +115,7 @@ cd examples/python/word_count_with_dynamic_keys
     echo '<<CRASH-and-RECOVER>>' | nc -q1 127.0.0.1 7002
     ```
 
-11. Shell 3: Restart worker1 with the same command we used above, but save its log output to a new file
+11. Shell 3: Restart worker1 with the same command we used above, but save its log output to a new file (remember to use `machida3-resilience` if using Python 3)
 
     ```bash
     machida-resilience --application-module word_count_with_dynamic_keys \

--- a/examples/python/alphabet/README.md
+++ b/examples/python/alphabet/README.md
@@ -27,6 +27,7 @@ The `decoder` function creates a `Votes` object with the letter being voted on a
 ## Running Alphabet
 
 In order to run the application you will need Machida, Giles Sender, Data Receiver, and the Cluster Shutdown tool. We provide instructions for building these tools yourself and we provide prebuilt binaries within a Docker container. Please visit our [setup](https://docs.wallaroolabs.com/book/getting-started/choosing-an-installation-option.html) instructions to choose one of these options if you have not already done so.
+If you are using Python3, replace all instances of `machida` with `machida3` in your commands.
 
 You will need five separate shells to run this application (please see [starting a new shell](https://docs.wallaroolabs.com/book/getting-started/starting-a-new-shell.html) for details depending on your installation choice). Open each shell and go to the `examples/python/alphabet` directory.
 

--- a/examples/python/alphabet_partitioned/README.md
+++ b/examples/python/alphabet_partitioned/README.md
@@ -35,6 +35,7 @@ The `decoder` creates a `Votes` object with the letter being voted on and the nu
 ## Running Alphabet Partitioned
 
 In order to run the application you will need Machida, Giles Sender, Data Receiver, and the Cluster Shutdown tool. We provide instructions for building these tools yourself and we provide prebuilt binaries within a Docker container. Please visit our [setup](https://docs.wallaroolabs.com/book/getting-started/choosing-an-installation-option.html) instructions to choose one of these options if you have not already done so.
+If you are using Python3, replace all instances of `machida` with `machida3` in your commands.
 
 You will need six separate shells to run this application (please see [starting a new shell](https://docs.wallaroolabs.com/book/getting-started/starting-a-new-shell.html) for details depending on your installation choice). Open each shell and go to the `examples/python/alphabet_partitioned` directory.
 

--- a/examples/python/alphabet_partitioned/alphabet_partitioned.py
+++ b/examples/python/alphabet_partitioned/alphabet_partitioned.py
@@ -24,8 +24,6 @@ example, all votes for the letter "A" are handled by the same partition.
 import string
 import struct
 
-import logging
-
 import wallaroo
 
 
@@ -45,7 +43,7 @@ def application_setup(args):
 
 @wallaroo.partition
 def partition(data):
-    return data.letter[0:1]
+    return data.letter
 
 
 class TotalVotes(object):
@@ -71,7 +69,6 @@ class Votes(object):
 def decoder(bs):
     (letter, vote_count) = struct.unpack(">sI", bs)
     letter = letter.decode("utf-8") # For Python3 compatibility
-    print("\ndecoded successfully")
     return Votes(letter, vote_count)
 
 

--- a/examples/python/celsius-kafka/README.md
+++ b/examples/python/celsius-kafka/README.md
@@ -23,6 +23,7 @@ The `decoder` function creates a float from the value represented by the payload
 ## Running Celsius Kafka
 
 In order to run the application you will need Machida, Giles Sender, and the Cluster Shutdown tool. We provide instructions for building these tools yourself and we provide prebuilt binaries within a Docker container. Please visit our [setup](https://docs.wallaroolabs.com/book/getting-started/choosing-an-installation-option.html) instructions to choose one of these options if you have not already done so.
+If you are using Python3, replace all instances of `machida` with `machida3` in your commands.
 
 You will also need access to a Kafka cluster.
 

--- a/examples/python/celsius/README.md
+++ b/examples/python/celsius/README.md
@@ -27,6 +27,7 @@ The `decoder` function creates a float from the value represented by the payload
 ## Running Celsius
 
 In order to run the application you will need Machida, Giles Sender, Data Receiver, and the Cluster Shutdown tool. We provide instructions for building these tools yourself and we provide prebuilt binaries within a Docker container. Please visit our [setup](https://docs.wallaroolabs.com/book/getting-started/choosing-an-installation-option.html) instructions to choose one of these options if you have not already done so.
+If you are using Python3, replace all instances of `machida` with `machida3` in your commands.
 
 You will need five separate shells to run this application (please see [starting a new shell](https://docs.wallaroolabs.com/book/getting-started/starting-a-new-shell.html) for details depending on your installation choice). Open each shell and go to the `examples/python/celsius` directory.
 

--- a/examples/python/celsius_connectors/README.md
+++ b/examples/python/celsius_connectors/README.md
@@ -18,10 +18,13 @@ In order to run the application you will need Machida. We provide instructions f
 
 The script expects machida to be in a specific path so you may need to edit `run_sample` to use the correct path for your machida executable. Also be sure to have the correct PYTHONPATH environment variable (it should include the wallaroo package which is part of machida).
 
-One that is done, you can run the application within this directory using:
+Once that is done, you can run the application within this directory using:
 
 ```bash
 ./run_sample
 ```
 
 See the documentation on [using connectors](https://docs.wallaroolabs.com/book/python/using-connectors.html) for more information on how this example works.
+
+### Python3
+This example is currently not compatible with Python3. Python3 support for the experimental connectors feature is expected to arrive in the next release.

--- a/examples/python/celsius_connectors/celsius.py
+++ b/examples/python/celsius_connectors/celsius.py
@@ -62,7 +62,7 @@ def decode_feed(data):
 
 @wallaroo.experimental.stream_message_encoder
 def encode_conversion(data):
-    return str(data)
+    return str(data).encode()
 
 
 @wallaroo.experimental.stream_message_decoder

--- a/examples/python/celsius_connectors/run_sample
+++ b/examples/python/celsius_connectors/run_sample
@@ -5,15 +5,20 @@ import struct
 import socket
 import SocketServer
 import subprocess
-import sys
 import threading
 import time
+
+
+parser = argparse.ArgumentParser("Celsius Connectors Example")
+parser.add_argument('--command', default='machida')
+pargs, _ = parser.parse_known_args()
+machida = pargs.command
 
 # This is imported to test that wallaroo's python library is reachable.
 try:
     import wallaroo
 except:
-    print("Unable to find wallaroo python library. Has the wallaroo "
+    raise ImportError("Unable to find wallaroo python library. Has the wallaroo "
           "environment been activated? "
           "See https://docs.wallaroolabs.com/book/getting-started/wallaroo-up.html")
 
@@ -22,6 +27,7 @@ class UDPHandler(SocketServer.BaseRequestHandler):
     def handle(self):
         data = self.request[0].strip()
         print(data)
+
 
 def send_feed():
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -32,15 +38,19 @@ def send_feed():
         value += 1
         time.sleep(1)
 
+
 def recv_conv():
     server = server = SocketServer.UDPServer(('127.0.0.1', 8901), UDPHandler)
     server.serve_forever()
 
+
 def terminate(_signal=None, _frame=None):
     print("terminating source")
-    source.terminate()
+    if source:
+        source.terminate()
     print("terminating sink")
-    sink.terminate()
+    if sink:
+        sink.terminate()
     if wallaroo:
         print("terminating wallaroo")
         wallaroo.terminate()
@@ -51,18 +61,22 @@ def terminate(_signal=None, _frame=None):
             subprocess.call(['stty', 'sane'])
         except:
             pass
+    print("Waiting one second for processes to exit cleanly")
     time.sleep(1)
-    source.poll()
-    if source.returncode is not None:
-        source.kill()
-    sink.poll()
-    if sink.returncode is not None:
-        sink.kill()
+    if source:
+        source.poll()
+        if source.returncode is None:
+            source.kill()
+    if sink:
+        sink.poll()
+        if sink.returncode is None:
+            sink.kill()
     if wallaroo:
         wallaroo.poll()
-        if wallaroo.returncode is not None:
+        if wallaroo.returncode is None:
             wallaroo.kill()
-    sys.exit(-1)
+    exit(-1)
+
 
 source = subprocess.Popen([
     "../../../connectors/udp_source",
@@ -91,7 +105,7 @@ thread.start()
 
 try:
     wallaroo = subprocess.Popen([
-        "machida",
+        machida,
         "--application-module", "celsius",
         "--metrics", "127.0.0.1:5001",
         "--control", "127.0.0.1:6000",
@@ -101,9 +115,10 @@ try:
         "--cluster-initializer",
         "--ponythreads=1", "--ponynoblock"])
 except:
-    print("Unable to run machida. Has the wallaroo environment "
+    print("Unable to run %s. Has the wallaroo environment "
           " been activated? "
-          "See https://docs.wallaroolabs.com/book/getting-started/wallaroo-up.html")
+          "See https://docs.wallaroolabs.com/book/getting-started/wallaroo-up.html"
+          % machida)
 
 signal.signal(signal.SIGINT, terminate)
 signal.signal(signal.SIGTERM, terminate)

--- a/examples/python/market_spread/README.md
+++ b/examples/python/market_spread/README.md
@@ -61,6 +61,7 @@ The Order messages are handled by the `order_decoder` function, which takes the 
 ## Running Market Spread
 
 In order to run the application you will need Machida, Giles Sender, and the Cluster Shutdown tool. We provide instructions for building these tools yourself and we provide prebuilt binaries within a Docker container. Please visit our [setup](https://docs.wallaroolabs.com/book/getting-started/choosing-an-installation-option.html) instructions to choose one of these options if you have not already done so.
+If you are using Python3, replace all instances of `machida` with `machida3` in your commands.
 
 You will need six separate shells to run this application (please see [starting a new shell](https://docs.wallaroolabs.com/book/getting-started/starting-a-new-shell.html) for details depending on your installation choice). Open each shell and go to the `examples/python/market_spread` directory.
 

--- a/examples/python/reverse/README.md
+++ b/examples/python/reverse/README.md
@@ -24,11 +24,12 @@ The outputs of the application are strings followed by newlines. Here's an examp
 
 ### Processing
 
-The `decoder` function creates a string from the value represented by the payload. The string is then sent to the `reverse` computation where it is reversed. The reversed string is then sent to the `encoder` function, where a newline is appended to the string before it sent out via the sink.
+The `decoder` function creates a string from the value represented by the payload. The string is then sent to the `reverse` computation where it is reversed. The reversed string is then sent to the `encoder` function, where a newline is appended to the string before it is encoded and sent out via the sink.
 
 ## Running Reverse
 
 In order to run the application you will need Machida, Giles Sender, Data Receiver, and the Cluster Shutdown tool. We provide instructions for building these tools yourself and we provide prebuilt binaries within a Docker container. Please visit our [setup](https://docs.wallaroolabs.com/book/getting-started/choosing-an-installation-option.html) instructions to choose one of these options if you have not already done so.
+If you are using Python3, replace all instances of `machida` with `machida3` in your commands.
 
 You will need five separate shells to run this application (please see [starting a new shell](https://docs.wallaroolabs.com/book/getting-started/starting-a-new-shell.html) for details depending on your installation choice). Open each shell and go to the `examples/python/reverse` directory.
 

--- a/examples/python/word_count/README.md
+++ b/examples/python/word_count/README.md
@@ -27,6 +27,7 @@ The `decoder` function turns the input message into a string. That string is the
 ## Running Word Count
 
 In order to run the application you will need Machida, Giles Sender, and the Cluster Shutdown tool. We provide instructions for building these tools yourself and we provide prebuilt binaries within a Docker container. Please visit our [setup](https://docs.wallaroolabs.com/book/getting-started/choosing-an-installation-option.html) instructions to choose one of these options if you have not already done so.
+If you are using Python3, replace all instances of `machida` with `machida3` in your commands.
 
 You will need five separate shells to run this application (please see [starting a new shell](https://docs.wallaroolabs.com/book/getting-started/starting-a-new-shell.html) for details depending on your installation choice). Open each shell and go to the `examples/python/word_count` directory.
 

--- a/examples/python/word_count/word_count.py
+++ b/examples/python/word_count/word_count.py
@@ -65,10 +65,7 @@ class WordTotals(object):
         self.word_totals = {}
 
     def update(self, word):
-        if word in self.word_totals:
-            self.word_totals[word] = self.word_totals[word] + 1
-        else:
-            self.word_totals[word] = 1
+        self.word_totals[word] = self.word_totals.get(word, 0) + 1
 
     def get_count(self, word):
         return WordCount(word, self.word_totals[word])
@@ -95,5 +92,4 @@ def decoder(bs):
 
 @wallaroo.encoder
 def encoder(data):
-    output = data.word + " => " + str(data.count) + "\n"
-    return output.encode("utf-8")
+    return (data.word + " => " + str(data.count) + "\n").encode('utf-8')

--- a/examples/python/word_count_with_dynamic_keys/README.md
+++ b/examples/python/word_count_with_dynamic_keys/README.md
@@ -27,6 +27,7 @@ The `decoder` function turns the input message into a string. That string is the
 ## Running Word Count With Dynamic Keys
 
 In order to run the application you will need Machida, Giles Sender, Data Receiver, and the Cluster Shutdown tool. We provide instructions for building these tools yourself and we provide prebuilt binaries within a Docker container. Please visit our [setup](https://docs.wallaroolabs.com/book/getting-started/choosing-an-installation-option.html) instructions to choose one of these options if you have not already done so.
+If you are using Python3, replace all instances of `machida` with `machida3` in your commands.
 
 You will need five separate shells to run this application (please see [starting a new shell](https://docs.wallaroolabs.com/book/getting-started/starting-a-new-shell.html) for details depending on your installation choice). Open each shell and go to the `examples/python/word_count_with_dynamic_keys` directory.
 

--- a/intro.md
+++ b/intro.md
@@ -40,7 +40,7 @@ How to develop Wallaroo applications using Python.
 
 The ["Setting Up Your Environment for Wallaroo"](book/getting-started/setup.md) describes setting up your development environment and then compiling and running a Wallaroo application. The tools you will install then are useful when developing a Wallaroo application.
 
-The Wallaroo Python API section takes you through a number of examples applications to teach you the Wallaroo Go API.
+The Wallaroo Python API section takes you through a number of examples applications to teach you the Wallaroo Python API.
 
 ### Wallaroo with Go
 


### PR DESCRIPTION
Second pass on gitbook for Python3

- Update walk through sections with notes on differences between `str`, `bytes`, and `unicode` in python2 and 3.
- Update code snippets to match code in examples.
- Update some sections of code to use language selector blocks between python 2 and 3.
- Add notes on `celsius_connectors` README that it isn't compatible with Python3 until the next release (#2574) 
- Add note on `connectors.md` to the same effect.

closes #2514