### PR TITLE
Add support for python3 in the Wallaroo Docker image's virtualenv

### DIFF
--- a/book/getting-started/run-a-wallaroo-application-docker.md
+++ b/book/getting-started/run-a-wallaroo-application-docker.md
@@ -19,26 +19,48 @@ Let's get started!
 
 Since Wallaroo is a distributed application, its components need to run separately, and concurrently, so that they may connect to one another to form the application cluster. For this example, you will need 6 separate terminal shells to start the docker container, run the metrics UI, run a source, run a sink, run the Celsius application, and eventually, to send a cluster shutdown command.
 
-## Shell 1: Start the Wallaroo Docker container
+## Shell 1: Start the Wallaroo Docker container for Machida
 
 {% codetabs name="UNIX Bash", type="bash" -%}
 docker run --rm -it --privileged -p 4000:4000 \
 -v /tmp/wallaroo-docker/wallaroo-{{ book.wallaroo_version }}/wallaroo-src:/src/wallaroo \
--v /tmp/wallaroo-docker/wallaroo-{{ book.wallaroo_version }}/python-virtualenv:/src/python-virtualenv \
+-v /tmp/wallaroo-docker/wallaroo-{{ book.wallaroo_version }}/python-virtualenv-machida:/src/python-virtualenv \
 --name wally \
 wallaroo-labs-docker-wallaroolabs.bintray.io/{{ docker_version_url }}
 {%- language name="Windows Powershell", type="bash" -%}
 docker run --rm -it --privileged -p 4000:4000 `
 -v c:/wallaroo-docker/wallaroo--{{ book.wallaroo_version }}/wallaroo-src:/src/wallaroo `
--v c:/wallaroo-docker/wallaroo-{{ book.wallaroo_version }}/python-virtualenv:/src/python-virtualenv `
+-v c:/wallaroo-docker/wallaroo-{{ book.wallaroo_version }}/python-virtualenv-machida:/src/python-virtualenv `
 --name wally `
 wallaroo-labs-docker-wallaroolabs.bintray.io/{{ docker_version_url }}
 {%- language name="Windows Command Prompt", type="bash" -%}
 docker run --rm -it --privileged -p 4000:4000 ^
 -v c:/wallaroo-docker/wallaroo-{{ book.wallaroo_version }}/wallaroo-src:/src/wallaroo ^
--v c:/wallaroo-docker/wallaroo-{{ book.wallaroo_version }}/python-virtualenv:/src/python-virtualenv ^
+-v c:/wallaroo-docker/wallaroo-{{ book.wallaroo_version }}/python-virtualenv-machida:/src/python-virtualenv ^
 --name wally ^
 wallaroo-labs-docker-wallaroolabs.bintray.io/{{ docker_version_url }}
+{%- endcodetabs %}
+
+## Shell 1: Start the Wallaroo Docker container for Machida3
+
+{% codetabs name="UNIX Bash", type="bash" -%}
+docker run --rm -it --privileged -p 4000:4000 \
+-v /tmp/wallaroo-docker/wallaroo-{{ book.wallaroo_version }}/wallaroo-src:/src/wallaroo \
+-v /tmp/wallaroo-docker/wallaroo-{{ book.wallaroo_version }}/python-virtualenv-machida3:/src/python-virtualenv \
+--name wally \
+wallaroo-labs-docker-wallaroolabs.bintray.io/{{ docker_version_url }} -p python3
+{%- language name="Windows Powershell", type="bash" -%}
+docker run --rm -it --privileged -p 4000:4000 `
+-v c:/wallaroo-docker/wallaroo--{{ book.wallaroo_version }}/wallaroo-src:/src/wallaroo `
+-v c:/wallaroo-docker/wallaroo-{{ book.wallaroo_version }}/python-virtualenv-machida3:/src/python-virtualenv `
+--name wally `
+wallaroo-labs-docker-wallaroolabs.bintray.io/{{ docker_version_url }} -p python3
+{%- language name="Windows Command Prompt", type="bash" -%}
+docker run --rm -it --privileged -p 4000:4000 ^
+-v c:/wallaroo-docker/wallaroo-{{ book.wallaroo_version }}/wallaroo-src:/src/wallaroo ^
+-v c:/wallaroo-docker/wallaroo-{{ book.wallaroo_version }}/python-virtualenv-machida3:/src/python-virtualenv ^
+--name wally ^
+wallaroo-labs-docker-wallaroolabs.bintray.io/{{ docker_version_url }} -p python3
 {%- endcodetabs %}
 
 ### Breaking down the Docker command
@@ -55,9 +77,11 @@ wallaroo-labs-docker-wallaroolabs.bintray.io/{{ docker_version_url }}
 
 * `-v /tmp/wallaroo-docker/wallaroo-{{ book.wallaroo_version }}/wallaroo-src:/src/wallaroo`: Mounts a host directory as a data volume within the container. The first time you run this, an empty directory needs to be used in order for the Docker container to copy the Wallaroo source code to your host. If an empty directory is not used, we are assuming it is prepopulated with the Wallaroo source code from this point forward. This allows you to open and modify the Wallaroo source code with the editor of your choice on your host. The Wallaroo source code will persist on your machine after the container is stopped or deleted. This setting is optional, but without it you would need to use an editor within the container to view or modify the Wallaroo source code.
 
-* `-v /tmp/wallaroo-docker/wallaroo-{{ book.wallaroo_version }}/python-virtualenv:/src/python-virtualenv`: Mounts a host directory as a data volume within the container. The first time this is run for the provided directory, this command will setup a persistent Python virtual environment using [virtualenv](https://virtualenv.pypa.io/en/stable/) for the container on your host. Thus, if you need to install any python modules using `pip` or `easy_install` they will persist after the container is stopped or deleted. This setting is optional, but without it, you will not have a persistent `virtualenv` for the container.
+* `-v /tmp/wallaroo-docker/wallaroo-{{ book.wallaroo_version }}/python-virtualenv-machida(machida3):/src/python-virtualenv`: Mounts a host directory as a data volume within the container. The first time this is run for the provided directory, this command will setup a persistent Python virtual environment using [virtualenv](https://virtualenv.pypa.io/en/stable/) for the container on your host. Thus, if you need to install any python modules using `pip` or `easy_install` they will persist after the container is stopped or deleted. This setting is optional, but without it, you will not have a persistent `virtualenv` for the container. We ask you to mount to `/tmp/wallaroo-docker/wallaroo-{{ book.wallaroo_version }}/python-virtualenv-machida` when using `machida` and `/tmp/wallaroo-docker/wallaroo-{{ book.wallaroo_version }}/python-virtualenv-machida3` when using `machida3` to avoid having conflicting `virtualenv` environments.
 
 * `--name wally`: The name for the container. This setting is optional but makes it easier to reference the container in later commands.
+
+* `-p python3`: This is a required argument if you will be running `machida3`. This argument allows us to set the python interpreter for the `virtualenv` environment to `python3` instead of the default `python2`. If you plan to run `machida`, this argument is not needed.
 
 ## Starting new shells
 
@@ -65,9 +89,11 @@ For each Shell you're expected to setup, you'd have to run the following to ente
 
 Enter the Wallaroo Docker container:
 
-```bash
+{% codetabs name="Machida", type="bash" -%}
 docker exec -it wally env-setup
-```
+{%- language name="Machida3", type="bash" -%}
+docker exec -it wally env-setup -p python3
+{%- endcodetabs %}
 
 This command will start a new Bash shell within the container, which will run the `env-setup` script to ensure our persistent Python `virtualenv` is set up.
 

--- a/book/getting-started/starting-a-new-shell.md
+++ b/book/getting-started/starting-a-new-shell.md
@@ -8,9 +8,11 @@ For each Shell you're expected to setup, you'd have to run the following to ente
 
 Enter the Wallaroo Docker container:
 
-```bash
+{% codetabs name="Machida", type="bash" -%}
 docker exec -it wally env-setup
-```
+{%- language name="Machida3", type="bash" -%}
+docker exec -it wally env-setup -p python3
+{%- endcodetabs %}
 
 This command will start a new Bash shell within the container, which will run the `env-setup` script to ensure our persistent Python `virtualenv` is set up.
 

--- a/docker/env-setup
+++ b/docker/env-setup
@@ -1,22 +1,109 @@
-#!/bin/sh
+#!/bin/bash
 
+# default python interpreter arguments
+VALID_PYTHON_INTERPRETER_ARGS="
+python2
+python3
+"
+
+# sets default python interpreter to python2
+PYTHON_INTERPRETER="python2"
+
+# sets the wallaroo source directory within the Docker container
 WALLAROO_DIR="/src/wallaroo"
+
+# function to output usage instructions for this script
+usage() {
+  cat 1>&2 <<EOF
+  The environment setup script for Wallaroo in Docker development
+  USAGE:
+    env_setup [FLAGS ][OPTIONS]
+
+  FLAGS:
+    -h        Prints help information
+
+  OPTIONS:
+    -p <python interpreter> Choose the python interpreter to use for the virtualenv (python2/python3)
+EOF
+}
+
+# function to output errors and exit
+error() {
+    echo -e "ERROR: $1" >&2
+    exit 1
+}
+
+# parse command line options
+while getopts 'h:p:' OPTION; do
+  case "$OPTION" in
+    h)
+      usage
+      exit 1
+      ;;
+    p)
+      WALLAROO_PYTHON_ARG="$(echo "$OPTARG" | tr '[:upper:]' '[:lower:]')"
+      ;;
+    ?)
+      usage
+      exit 1
+      ;;
+  esac
+done
+shift "$((OPTIND -1))"
+
+# validate arguments and set variables
+if ! echo "$VALID_PYTHON_INTERPRETER_ARGS" | grep "^$WALLAROO_PYTHON_ARG\$" > /dev/null; then
+  usage
+  echo
+  error "Invalid Python interpreter arg: '$WALLAROO_PYTHON_ARG'"
+else
+  case "$WALLAROO_PYTHON_ARG" in
+    python2)
+      PYTHON_INTERPRETER="python2"
+      ;;
+    python3)
+      PYTHON_INTERPRETER="python3"
+      ;;
+  esac
+fi
+
+# copies wallaroo source code to the source directory if it is empty
 cd $WALLAROO_DIR
 if [ ! "$(ls -A $WALLAROO_DIR)" ]; then
   echo "====== Copying Wallaroo Source Code to Working Directory (/src/wallaroo) ======"
   cp -r /wallaroo-src/* /src/wallaroo
 fi
+
+# create a virtualenv only if the user mounted a directory to /src/python-virtualenv
 if [ -d /src/python-virtualenv ]; then
   cd /src/python-virtualenv
+  # setup virtualenv if bin/activate is not present in the mounted directory
   if [ ! -f bin/activate ]; then
     echo "====== Setting up Persistent Python Virtual Environment ======"
-    virtualenv .
+    if [ "$PYTHON_INTERPRETER" = "python2" ]; then
+      virtualenv .
+    elif [ "$PYTHON_INTERPRETER" = "python3" ]; then
+      virtualenv -p "python3" .
+    fi
     echo "====== Done Setting up Persistent Python Virtual Environment ======"
   fi
   echo "====== Activating Persistent Python Virtual Environment ======"
   echo "====== WARNING: Any software installed via apt-get will not be persistent ======"
   echo "====== WARNING: Please make sure to use pip/easy_install instead ======"
   . bin/activate
+  PYTHON_VERSION=$(python --version 2>&1)
+  case "$PYTHON_INTERPRETER" in
+    python2)
+      PYTHON_INTERPRETER_NUM="Python 2."
+      ;;
+    python3)
+      PYTHON_INTERPRETER_NUM="Python 3."
+      ;;
+      esac
+  # verify the user provided interpreter matches the interpreter in the exisiting virtualenv, error out if it does not
+  if [[ $PYTHON_VERSION != *"${PYTHON_INTERPRETER_NUM}"* ]]; then
+    error "The Python interpreter provided: '$PYTHON_INTERPRETER' does not match the python interpreter in the current virtualenv: '$PYTHON_VERSION'.\nPlease provide the matching interpreter or map a different directory from your local machine to the Docker container."
+  fi
 else
   echo "====== WARNING: Any software installed via apt-get will not be persistent ======"
 fi


### PR DESCRIPTION
Users can now pass -p <python2/python3> to the `docker run` command
for Wallaroo's Docker image in order to select the python interpreter.
If no argument is passed, the virtualenv defaults to python2.



<!--
Make sure you've read the [Contributors Guide](https://github.com/WallarooLabs/wallaroo/blob/master/CONTRIBUTING.md). You'll need to sign our CLA before your issue can be accepted.

Reference the issue your code change relates to if possible
-->
ref #2552

<!--
Include any other necessary information below. If you have any questions don't hesitate to reach out on the mailing list or on IRC.
-->

**To test new `virtualenv` functionality**

replace the `docker run`'s image with: `jonbrwn/wallaroo-docker-py3-tester:latest`

**NOTE:** The above docker image **DOES NOT** have `machida3` and is intended solely to test the `python2` and `python3` virtualenv support
