### PR TITLE
Force Travis/Vagrant release box to use node 10.9.0

### DIFF
--- a/.release/bootstrap.sh
+++ b/.release/bootstrap.sh
@@ -72,8 +72,8 @@ install_monitoring_hub_dependencies() {
   curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | NVM_DIR="/home/vagrant/.nvm" PROFILE="vagrant" bash
   NVM_DIR="/home/vagrant/.nvm"
   [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-  nvm install node
-  nvm alias default node
+  nvm install 10.9.0
+  nvm alias default 10.9.0
 
   echo "** Monitoring hub dependencies installed"
 }

--- a/rules.mk
+++ b/rules.mk
@@ -619,7 +619,7 @@ build-metrics-ui-appimage:
           -v /etc/passwd:/etc/passwd:ro \
           -w $(abs_wallaroo_dir) \
           wallaroolabs/metrics_ui-centos-builder:2018.08.03.1 \
-          sh -c 'export HOME=/tmp && mkdir /tmp/.nvm && curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | NVM_DIR="/tmp/.nvm" bash && export NVM_DIR="/tmp/.nvm" && [ -s "$$NVM_DIR/nvm.sh" ] && . "$$NVM_DIR/nvm.sh" && nvm install node && nvm alias default node && make release-monitoring_hub-apps-metrics_reporter_ui'
+          sh -c 'export HOME=/tmp && mkdir /tmp/.nvm && curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.sh | NVM_DIR="/tmp/.nvm" bash && export NVM_DIR="/tmp/.nvm" && [ -s "$$NVM_DIR/nvm.sh" ] && . "$$NVM_DIR/nvm.sh" && nvm install 10.9.0 && nvm alias default 10.9.0 && make release-monitoring_hub-apps-metrics_reporter_ui'
 
 # put files into AppDir
 	$(QUIET)docker run --rm -i $(docker_user_arg) -v \


### PR DESCRIPTION
This is due to an issue with node 11.0.0 and node-sass which causes
node-sass to not install.

<!--
Make sure you've read the [Contributors Guide](https://github.com/WallarooLabs/wallaroo/blob/master/CONTRIBUTING.md). You'll need to sign our CLA before your issue can be accepted.

Reference the issue your code change relates to if possible
-->
ref #

<!--
Include any other necessary information below. If you have any questions don't hesitate to reach out on the mailing list or on IRC.
-->
