### PR TITLE
Upgrade test harness and tests to python3

### DIFF
--- a/examples/go/alphabet/_test/gen.py
+++ b/examples/go/alphabet/_test/gen.py
@@ -21,7 +21,7 @@ from struct import pack
 # Construct input data list, and total votes as a dict
 expected = {}
 data = []
-for x in xrange(1000):
+for x in range(1000):
     c = choice(lowercase)
     v = randrange(1,10000)
     data.append(pack('>IsI',5, c, v))

--- a/examples/pony/alphabet/_test/gen.py
+++ b/examples/pony/alphabet/_test/gen.py
@@ -21,7 +21,7 @@ from struct import pack
 # Construct input data list, and total votes as a dict
 expected = {}
 data = []
-for x in xrange(1000):
+for x in range(1000):
     c = choice(lowercase)
     v = randrange(1,10000)
     data.append(pack('>IsI',5, c, v))

--- a/examples/python/alphabet/_test/gen.py
+++ b/examples/python/alphabet/_test/gen.py
@@ -21,7 +21,7 @@ from struct import pack
 # Construct input data list, and total votes as a dict
 expected = {}
 data = []
-for x in xrange(1000):
+for x in range(1000):
     c = choice(lowercase)
     v = randrange(1,10000)
     data.append(pack(">IsI",5, c, v))

--- a/examples/python/alphabet_partitioned/_test/gen.py
+++ b/examples/python/alphabet_partitioned/_test/gen.py
@@ -21,7 +21,7 @@ from struct import pack
 # Construct input data list, and total votes as a dict
 expected = {}
 data = []
-for x in xrange(1000):
+for x in range(1000):
     c = choice(lowercase)
     v = randrange(1,10000)
     data.append(pack(">IsI",5, c, v))

--- a/examples/python/celsius/_test/data_gen.py
+++ b/examples/python/celsius/_test/data_gen.py
@@ -20,7 +20,7 @@ import struct
 
 def generate_messages(num_messages):
     with open("celsius.msg", "wb") as f:
-        for x in xrange(num_messages):
+        for x in range(num_messages):
             f.write(struct.pack(">If", 4, random.uniform(0, 10000)))
 
 

--- a/testing/correctness/apps/alphabet/gen.py
+++ b/testing/correctness/apps/alphabet/gen.py
@@ -6,7 +6,7 @@ from struct import pack
 # Construct input data list, and total votes as a dict
 expected = {}
 data = []
-for x in xrange(1000):
+for x in range(1000):
     c = choice(lowercase) + choice(lowercase)
     v = randrange(1,10000)
     data.append(pack('>I2sI',6, c, v))

--- a/testing/correctness/apps/alphabet27/gen.py
+++ b/testing/correctness/apps/alphabet27/gen.py
@@ -6,7 +6,7 @@ from struct import pack
 # Construct input data list, and total votes as a dict
 expected = {}
 data = []
-for x in xrange(1000):
+for x in range(1000):
     c = choice(lowercase)
     v = randrange(1,10000)
     data.append(pack('>IsI',5, c, v))

--- a/testing/correctness/apps/alphabet_python/gen.py
+++ b/testing/correctness/apps/alphabet_python/gen.py
@@ -6,7 +6,7 @@ from struct import pack
 # Construct input data list, and total votes as a dict
 expected = {}
 data = []
-for x in xrange(1000):
+for x in range(1000):
     c = choice(lowercase) + choice(lowercase)
     v = randrange(1,10000)
     data.append(pack(">I2sI",6, c, v))

--- a/testing/correctness/apps/alphabet_python27/gen.py
+++ b/testing/correctness/apps/alphabet_python27/gen.py
@@ -6,7 +6,7 @@ from struct import pack
 # Construct input data list, and total votes as a dict
 expected = {}
 data = []
-for x in xrange(1000):
+for x in range(1000):
     c = choice(lowercase)
     v = randrange(1,10000)
     data.append(pack(">IsI",5, c, v))

--- a/testing/correctness/apps/sequence_window/validator/examples/data_gen.py
+++ b/testing/correctness/apps/sequence_window/validator/examples/data_gen.py
@@ -62,7 +62,7 @@ r1 = Ring()
 timestamp = 0
 file_name = 'pass.txt'
 with open(os.path.join(BASE_PATH, file_name), 'wb') as f:
-    for x in xrange(1,1001):
+    for x in range(1,1001):
         inc_and_write(x,f)
 
 
@@ -72,7 +72,7 @@ r1 = Ring()
 timestamp = 0
 file_name = 'fail_expect_max.txt'
 with open(os.path.join(BASE_PATH, file_name), 'wb') as f:
-    for x in xrange(1,1003):
+    for x in range(1,1003):
         inc_and_write(x,f)
 
 
@@ -82,9 +82,9 @@ r1 = Ring()
 timestamp = 0
 file_name = 'fail_increments.txt'
 with open(os.path.join(BASE_PATH, file_name), 'wb') as f:
-    for x in xrange(1,101):
+    for x in range(1,101):
         inc_and_write(x,f)
-    for x in xrange(81, 1001):
+    for x in range(81, 1001):
         inc_and_write(x,f)
 
 
@@ -94,11 +94,11 @@ r1 = Ring()
 timestamp = 0
 file_name = 'fail_sequentiality.txt'
 with open(os.path.join(BASE_PATH, file_name), 'wb') as f:
-    for x in xrange(1,101):
+    for x in range(1,101):
         inc_and_write(x,f)
-    for x in xrange(101,111):
+    for x in range(101,111):
         inc(x)
-    for x in xrange(111, 1001):
+    for x in range(111, 1001):
         inc_and_write(x,f)
 
 
@@ -108,13 +108,13 @@ r1 = Ring()
 timestamp = 0
 file_name = 'fail_size.txt'
 with open(os.path.join(BASE_PATH, file_name), 'wb') as f:
-    for x in xrange(1,101):
+    for x in range(1,101):
         inc_and_write(x,f)
     r0.r.insert(0, 92)
-    for x in xrange(101,111):
+    for x in range(101,111):
         inc_and_write(x,f)
     r0.r.pop(0)
-    for x in xrange(111,1001):
+    for x in range(111,1001):
         inc_and_write(x,f)
 
 
@@ -124,10 +124,10 @@ r1 = Ring()
 timestamp = 0
 file_name = 'fail_no_nonlead_zeroes.txt'
 with open(os.path.join(BASE_PATH, file_name), 'wb') as f:
-    for x in xrange(1,101):
+    for x in range(1,101):
         inc_and_write(x,f)
     r0.push(0)
-    for x in xrange(101,1001):
+    for x in range(101,1001):
         inc_and_write(x,f)
 
 
@@ -137,10 +137,10 @@ r1 = Ring()
 timestamp = 0
 file_name = 'fail_parity.txt'
 with open(os.path.join(BASE_PATH, file_name), 'wb') as f:
-    for x in xrange(1,101):
+    for x in range(1,101):
         inc_and_write(x,f)
     r0.push(101)  # push 101 to the even partition
-    for x in xrange(102,1001):
+    for x in range(102,1001):
         inc_and_write(x,f)
 
 
@@ -150,7 +150,7 @@ r1 = Ring()
 timestamp = 0
 file_name = 'fail_expected_difference.txt'
 with open(os.path.join(BASE_PATH, file_name), 'wb') as f:
-    for x in xrange(1,999):
+    for x in range(1,999):
         inc_and_write(x,f)
     inc_and_write(1000, f)
 
@@ -161,7 +161,7 @@ r1 = Ring()
 timestamp = 0
 file_name = 'pass_with_atleastonce.txt'
 with open(os.path.join(BASE_PATH, file_name), 'wb') as f:
-    for x in xrange(1,501):
+    for x in range(1,501):
         inc_and_write(x,f)
     r0.r = [394,396,398,400]
     r1.r = [393,395,397,399]

--- a/testing/correctness/tests/autoscale/Makefile
+++ b/testing/correctness/tests/autoscale/Makefile
@@ -49,6 +49,6 @@ integration-tests-testing-correctness-tests-autoscale: autoscale_tests
 
 autoscale_tests:
 	cd $(AUTOSCALE_PATH) && \
-	python2 -m pytest -c $(integration_path)/pytest.ini autoscale_tests.py $(pytest_exp)
+	python3 -m pytest -c $(integration_path)/pytest.ini autoscale_tests.py $(pytest_exp)
 
 endif

--- a/testing/correctness/tests/cli_tests/Makefile
+++ b/testing/correctness/tests/cli_tests/Makefile
@@ -45,6 +45,6 @@ integration-tests-testing-correctness-tests-cli_tests: cli_tests
 
 cli_tests:
 	cd $(CLI_PATH) && \
-	python2 -m pytest -c $(integration_path)/pytest.ini cli_tests.py $(pytest_exp)
+	python3 -m pytest -c $(integration_path)/pytest.ini cli_tests.py $(pytest_exp)
 
 endif

--- a/testing/correctness/tests/cli_tests/cli_tests.py
+++ b/testing/correctness/tests/cli_tests/cli_tests.py
@@ -33,34 +33,42 @@ CMD='machida --application-module dummy'
 if os.environ.get("resilience") == 'on':
     CMD += ' --run-with-resilience'
 
+
 def test_partition_query():
     with Cluster(command=CMD,workers=3) as cluster:
         q = Query(cluster, "partition-query")
         got = q.result()
-        assert sorted(["state_partitions","stateless_partitions"]) == sorted(got.keys())
-        assert got["state_partitions"]["DummyState"].has_key("initializer")
+
+    assert(sorted(["state_partitions","stateless_partitions"]) ==
+           sorted(got.keys()))
+    assert("initializer" in got["state_partitions"]["DummyState"])
+
 
 def test_partition_count_query():
     with Cluster(command=CMD,) as cluster:
         given_data_sent(cluster)
         got = Query(cluster, "partition-count-query").result()
-        assert sorted(got.keys()) == [
-            "state_partitions", "stateless_partitions"]
-        assert got["state_partitions"] == {
-            u"DummyState": {u"initializer": 1},
-            u"PartitionedDummyState": {u"initializer": INPUT_ITEMS}}
-        for (k, v) in got["stateless_partitions"].items():
-            assert int(k)
-            assert v == {u"initializer":1}
+
+    assert(sorted(got.keys()) ==
+           ["state_partitions", "stateless_partitions"])
+    assert(got["state_partitions"] ==
+           {u"DummyState": {u"initializer": 1},
+            u"PartitionedDummyState": {u"initializer": INPUT_ITEMS}})
+    for (k, v) in got["stateless_partitions"].items():
+        assert(int(k))
+        assert(v == {u"initializer": 1})
+
 
 def test_cluster_status_query():
     with Cluster(command=CMD,workers=2) as cluster:
-
         q = Query(cluster, "cluster-status-query")
-        assert q.result() == {
-            u"processing_messages": True,
+        got = q.result()
+
+    assert(got ==
+           {u"processing_messages": True,
             u"worker_names": [u"initializer", u"worker1"],
-            u"worker_count": 2}
+            u"worker_count": 2})
+
 
 def test_source_ids_query():
     HARDCODED_NO_OF_SOURCE_IDS = 10
@@ -68,55 +76,66 @@ def test_source_ids_query():
         given_data_sent(cluster)
         q = Query(cluster, "source-ids-query")
         got = q.result()
-        assert got.keys() == ["source_ids"]
-        assert len(got["source_ids"]) == HARDCODED_NO_OF_SOURCE_IDS
+
+    assert(list(got.keys()) == ["source_ids"])
+    assert(len(got["source_ids"]) == HARDCODED_NO_OF_SOURCE_IDS)
+
 
 def test_state_entity_query():
     with Cluster(command=CMD,workers=2) as cluster:
         given_data_sent(cluster)
         got = Query(cluster, "state-entity-query").result()
-        assert sorted(got.keys()) == [u'DummyState', u'PartitionedDummyState']
-        assert got[u'DummyState'] == [u'key']
-        assert len(got[u'PartitionedDummyState']) == 7
+
+    assert(sorted(got.keys()) == [u'DummyState', u'PartitionedDummyState'])
+    assert(got[u'DummyState'] == [u'key'])
+    assert(len(got[u'PartitionedDummyState']) == 7)
+
 
 def test_state_entity_count_query():
     with Cluster(command=CMD,workers=2) as cluster:
         given_data_sent(cluster)
         q = Query(cluster, "state-entity-count-query")
-        assert q.result() == {u'DummyState':1,
-                              u'PartitionedDummyState':7}
+        got = q.result()
+
+    assert(got == {u'DummyState':1,
+                          u'PartitionedDummyState':7})
+
 
 def test_stateless_partition_query():
     with Cluster(command=CMD,workers=2) as cluster:
         got = Query(cluster, "stateless-partition-query").result()
-        for (k,v) in got.items():
-            assert int(k)
-            assert sorted(v.keys()) == [u"initializer", u"worker1"]
-            assert len(v[u"initializer"]) == 1
-            assert int((v[u"initializer"])[0])
-            assert len(v[u"worker1"]) == 1
-            assert int((v[u"worker1"])[0])
+
+    for (k,v) in got.items():
+        assert(int(k))
+        assert(sorted(v.keys()) == [u"initializer", u"worker1"])
+        assert(len(v[u"initializer"]) == 1)
+        assert(int((v[u"initializer"])[0]))
+        assert(len(v[u"worker1"]) == 1)
+        assert(int((v[u"worker1"])[0]))
+
 
 def test_stateless_partition_count_query():
     with Cluster(command=CMD, workers=2) as cluster:
         got = Query(cluster, "stateless-partition-count-query").result()
-        for (k,v) in got.items():
-            assert int(k)
-            assert v == {u"initializer" : 1, u"worker1": 1}
+
+    for (k,v) in got.items():
+        assert(int(k))
+        assert(v == {u"initializer" : 1, u"worker1": 1})
 
     # def __init__(self, host='127.0.0.1', sources=1, n_workers=1,
     #              command='machida --application-module dummy'):
 
+
 def given_data_sent(cluster):
-    reader = Reader(iter_generator(
-        items=[chr(x+65) for x in range(INPUT_ITEMS)],
-        to_string=lambda s: pack('>2sI', s, 1),
-        on_next=lambda s: s))
+    reader = Reader(iter_generator(items=[chr(x+65).encode()
+                                          for x in range(INPUT_ITEMS)],
+                                   to_bytes=lambda s: pack('>2sI', s, 1)))
     sender = Sender(cluster.source_addrs[0],
                     reader,
                     batch_size=50, interval=0.05, reconnect=True)
     cluster.add_sender(sender, start=True)
     time.sleep(0.5)
+
 
 class Query(object):
     def __init__(self, cluster, type):

--- a/testing/correctness/tests/log_rotation/log_rotation.py
+++ b/testing/correctness/tests/log_rotation/log_rotation.py
@@ -106,7 +106,7 @@ def _test_log_rotation_external_trigger_no_recovery(command):
         ports = get_port_values(num=num_ports, host=host)
         (input_ports, worker_ports) = (
             ports[:sources],
-            [ports[sources:][i:i+3] for i in xrange(0,
+            [ports[sources:][i:i+3] for i in range(0,
                 len(ports[sources:]), 3)])
         inputs = ','.join(['{}:{}'.format(host, p) for p in
                            input_ports])
@@ -446,7 +446,7 @@ def _test_log_rotation_file_size_trigger_no_recovery(command):
         ports = get_port_values(num=num_ports, host=host)
         (input_ports, worker_ports) = (
             ports[:sources],
-            [ports[sources:][i:i+3] for i in xrange(0,
+            [ports[sources:][i:i+3] for i in range(0,
                 len(ports[sources:]), 3)])
         inputs = ','.join(['{}:{}'.format(host, p) for p in
                            input_ports])
@@ -588,7 +588,7 @@ def _test_log_rotation_file_size_trigger_recovery(command):
         ports = get_port_values(num=num_ports, host=host)
         (input_ports, worker_ports) = (
             ports[:sources],
-            [ports[sources:][i:i+3] for i in xrange(0,
+            [ports[sources:][i:i+3] for i in range(0,
                 len(ports[sources:]), 3)])
         inputs = ','.join(['{}:{}'.format(host, p) for p in
                            input_ports])

--- a/testing/correctness/tests/resilience/Makefile
+++ b/testing/correctness/tests/resilience/Makefile
@@ -50,7 +50,7 @@ integration-tests-testing-correctness-tests-resilience: resilience_tests
 ifeq ($(resilience),on)
 resilience_tests:
 	cd $(RESILIENCE_PATH) && \
-	python2 -m pytest -c $(integration_path)/pytest.ini resilience_tests.py $(pytest_exp)
+	python3 -m pytest -c $(integration_path)/pytest.ini resilience_tests.py $(pytest_exp)
 else
 resilience_tests:
 	$(QUIET)printf "reseilience tests not run.\nRun make with 'resilience=on' to run this test.\n"

--- a/testing/correctness/tests/resilience/resilience.py
+++ b/testing/correctness/tests/resilience/resilience.py
@@ -54,8 +54,8 @@ FROM_TAIL = int(os.environ.get("FROM_TAIL", 10))
 # Keep only the key as a string, and the final output tuple as a
 # string
 def parse_sink_value(s):
-    return (s[4:].strip("()").split(',',1)[0].split(".",1)[0],
-        s[4:].strip("()").split(",",1)[1])
+    return (s[4:].strip(b"()").split(b',',1)[0].split(b".",1)[0],
+        s[4:].strip(b"()").split(b",",1)[1])
 
 
 # TODO: refactor and move to control.py
@@ -73,8 +73,8 @@ def pause_senders_and_sink_await(cluster, timeout=10):
     msg = cluster.senders[0].reader.gen
     await_values = []
     for part, val in enumerate(msg.seqs):
-        key = '{:07d}'.format(part)
-        data = '[{},{},{},{}]'.format(*[val-x for x in range(3,-1,-1)])
+        key = '{:07d}'.format(part).encode()
+        data = '[{},{},{},{}]'.format(*[val-x for x in range(3,-1,-1)]).encode()
         await_values.append((key, data))
     cluster.sink_await(values=await_values, func=parse_sink_value)
     # Since snapshots happen at a 1 second frequency, we need to wait
@@ -457,8 +457,8 @@ def _run(persistent_data, res_ops, command, ops=[], initial=None, sources=1,
             # the multi sequence generator
             await_values = []
             for part, val in enumerate(msg.seqs):
-                key = '{:07d}'.format(part)
-                data = '[{},{},{},{}]'.format(*[val-x for x in range(3,-1,-1)])
+                key = '{:07d}'.format(part).encode()
+                data = '[{},{},{},{}]'.format(*[val-x for x in range(3,-1,-1)]).encode()
                 await_values.append((key, data))
             cluster.sink_await(values=await_values, func=parse_sink_value)
 

--- a/testing/correctness/tests/resilience/test_creator.py
+++ b/testing/correctness/tests/resilience/test_creator.py
@@ -29,5 +29,5 @@ class Creator(object):
             _test_resilience(cmd, ops=ops, cycles=cycles, initial=initial,
                              validate_output=validate_output, sources=sources,
                              api=api)
-        f.func_name = test_name
+        f.__name__ = test_name
         setattr(self.module, test_name, f)

--- a/testing/correctness/tests/restart_without_resilience/Makefile
+++ b/testing/correctness/tests/restart_without_resilience/Makefile
@@ -53,7 +53,7 @@ restart_without_resilience_tests:
 else
 restart_without_resilience_tests:
 	cd $(RESTART_WITHOUT_RESILIENCE_PATH) && \
-	python2 -m pytest -c $(integration_path)/pytest.ini restart_without_resilience.py $(pytest_exp)
+	python3 -m pytest -c $(integration_path)/pytest.ini restart_without_resilience.py $(pytest_exp)
 endif
 
 endif

--- a/testing/correctness/tests/restart_without_resilience/restart_without_resilience.py
+++ b/testing/correctness/tests/restart_without_resilience/restart_without_resilience.py
@@ -46,7 +46,7 @@ def test_restart_machida():
     _test_restart(command)
 
 
-def test_restart_machida():
+def test_restart_machida3():
     command = 'machida3 --application-module sequence_window'
     _test_restart(command)
 
@@ -101,8 +101,8 @@ def _run(command, persistent_data):
     sink_mode = 'framed'
     workers = 2
     expect = 200
-    last_value_0 = '[{}]'.format(','.join((str(expect-v) for v in range(6,-2,-2))))
-    last_value_1 = '[{}]'.format(','.join((str(expect-1-v) for v in range(6,-2,-2))))
+    last_value_0 = '[{}]'.format(','.join((str(expect-v) for v in range(6,-2,-2)))).encode()
+    last_value_1 = '[{}]'.format(','.join((str(expect-1-v) for v in range(6,-2,-2)))).encode()
     await_values = (struct.pack('>I', len(last_value_0)) + last_value_0,
                    struct.pack('>I', len(last_value_1)) + last_value_1)
 

--- a/testing/correctness/tests/topology/Makefile
+++ b/testing/correctness/tests/topology/Makefile
@@ -48,12 +48,12 @@ integration-tests-testing-correctness-tests-topology: topology_tests
 
 topology_python_unit_tests:
 	cd $(TOPOLOGY_TESTS_PATH) && \
-		python2 -m pytest -c $(integration_path)/pytest.ini components.py $(pytest_exp) && \
-		python3 -m pytest -c $(integration_path)/pytest.ini components.py $(pytest_exp)
+		python2 -m pytest -c $(integration_path)/pytest.ini components.py && \
+		python3 -m pytest -c $(integration_path)/pytest.ini components.py
 
 topology_tests:
 	cd $(TOPOLOGY_TESTS_PATH) && \
-		python2 -m pytest -c $(integration_path)/pytest.ini topology_tests.py $(pytest_exp)
+		python3 -m pytest -c $(integration_path)/pytest.ini topology_tests.py $(pytest_exp)
 
 # end of prevent rules from being evaluated/included multiple times
 endif

--- a/testing/correctness/tests/topology/topology_tests.py
+++ b/testing/correctness/tests/topology/topology_tests.py
@@ -66,7 +66,7 @@ def run_test(api, cmd, validation_cmd, topology, workers=1):
             try:
                 # clean up data collection before each attempt
                 persistent_data.clear()
-                log_stream.reset()
+                log_stream.seek(0)
                 log_stream.truncate()
 
                 # start test attempt
@@ -159,8 +159,8 @@ def create_test(api, cmd, validation_cmd, steps, workers=1):
         workers=workers,
         topo='_'.join(steps)))
     def f():
-        run_test(api, cmd, validation_cmd, steps)
-    f.func_name = test_name
+        run_test(api, cmd, validation_cmd, steps, workers)
+    f.__name__ = test_name
     globals()[test_name] = f
 
 # Create tests!

--- a/testing/performance/apps/python/sleepy_python/sleepy.py
+++ b/testing/performance/apps/python/sleepy_python/sleepy.py
@@ -95,7 +95,7 @@ class TuplePartitioner(object):
         assignment).
         """
         self.slot = slot
-        self.partitions = [str(x) for x in xrange(0, size)]
+        self.partitions = [str(x) for x in range(0, size)]
 
     def partition(self, tuple):
         return str(self.partitions[tuple[self.slot] % len(self.partitions)])

--- a/testing/tools/integration/control.py
+++ b/testing/tools/integration/control.py
@@ -224,13 +224,14 @@ class CrashChecker(StoppableThread):
         super(CrashChecker, self).__init__()
         self.cluster = cluster
         self.func = func
+        logging.debug('Crash Checker: {!r}, {!r}'.format(cluster, func))
 
     def run(self):
         while not self.stopped():
             if self.func:
-                crashed = self.cluster.get_crashed_workers(self.func)
+                crashed = list(self.cluster.get_crashed_workers(self.func))
             else:
-                crashed = self.cluster.get_crashed_workers()
+                crashed = list(self.cluster.get_crashed_workers())
             if crashed:
                 logging.debug("CrashChecker, results: {}".format(crashed))
                 err = ClusterError("A crash was detected in the workers: {}"

--- a/testing/tools/integration/external.py
+++ b/testing/tools/integration/external.py
@@ -42,7 +42,7 @@ def run_shell_cmd(cmd):
             return ShellCmdResult(False, str(err), 2, cmd)
         else:
             raise
-    return ShellCmdResult(True, out, 0, shlex.split(cmd))
+    return ShellCmdResult(True, out.decode(), 0, shlex.split(cmd))
 
 
 def setup_resilience_path(res_dir):
@@ -160,7 +160,7 @@ def save_logs_to_file(base_dir, log_stream=None, persistent_data={}):
     try:
         makedirs_if_not_exists(base_dir)
         if log_stream:
-            with open(os.path.join(base_dir, 'test.error.log'), 'wb') as f:
+            with open(os.path.join(base_dir, 'test.error.log'), 'w') as f:
                 f.write(log_stream.getvalue())
         runner_data = persistent_data.get('runner_data', [])
 
@@ -171,7 +171,7 @@ def save_logs_to_file(base_dir, log_stream=None, persistent_data={}):
                 code=rd.returncode,
                 pid=rd.pid,
                 time=strftime(rd.start_time, STRFTIME_FMT))
-            with open(os.path.join(base_dir, worker_log_name), 'wb') as f:
+            with open(os.path.join(base_dir, worker_log_name), 'w') as f:
                 f.write('{identifier} ->\n\n{stdout}\n\n{identifier} <-'
                     .format(identifier="--- {name} (pid: {pid}, rc: {rc})"
                         .format(name=rd.name, pid=rd.pid,
@@ -189,7 +189,8 @@ def save_logs_to_file(base_dir, log_stream=None, persistent_data={}):
                 port=sd.port,
                 time=strftime(sd.start_time, STRFTIME_FMT))
             with open(os.path.join(base_dir, sender_log_name), 'wb') as f:
-                f.write(''.join(sd.data))
+                for d in sd.data:
+                    f.write(d)
 
         # save sinks data to files
         sink_data = persistent_data.get('sink_data', [])
@@ -202,7 +203,8 @@ def save_logs_to_file(base_dir, log_stream=None, persistent_data={}):
                 port=sk.port,
                 time=strftime(sk.start_time, STRFTIME_FMT))
             with open(os.path.join(base_dir, sink_log_name), 'wb') as f:
-                f.write(''.join(sk.data))
+                for d in sk.data:
+                    f.write(d)
         logging.warn("Error logs saved to {}".format(base_dir))
 
         # save core files if they exist

--- a/testing/tools/integration/integration.py
+++ b/testing/tools/integration/integration.py
@@ -30,6 +30,10 @@ from .end_points import (Sender,
 from .errors import PipelineTestError
 from .logger import INFO2
 
+try:
+    basestring
+except NameError:
+    basestring = (str, bytes)
 
 
 DEFAULT_SINK_STOP_TIMEOUT = 30
@@ -232,7 +236,7 @@ def pipeline_test(generator, expected, command, workers=1, sources=1,
                 # Validate captured output against expected output
                 if isinstance(expected, basestring):
                     expected = io.BufferedReader(io.BytesIO(expected))
-                if isinstance(expected, (file, io.BufferedReader)):
+                if hasattr(expected, 'read') and hasattr(expected, 'tell'):
                     if isinstance(processed, list):
                         bytesio = io.BytesIO()
                         for part in processed:
@@ -263,7 +267,7 @@ def pipeline_test(generator, expected, command, workers=1, sources=1,
                     flattened = list(itertools.chain.from_iterable(processed))
                     if mode == 'newlines':
                         # add newlines to expected
-                        expected = ['{}\n'.format(e) for e in expected]
+                        expected = [e + b'\n' for e in expected]
                     try:
                         assert(expected == flattened)
                     except:

--- a/testing/tools/integration/metrics_parser.py
+++ b/testing/tools/integration/metrics_parser.py
@@ -58,32 +58,32 @@ class MetricsParser(object):
     def parse_join(cls, payload=''):
         buf = BufferedReader(BytesIO(payload))
         topic_size = unpack('>I', buf.read(4))[0]
-        topic = unpack(_s(topic_size), buf.read(topic_size))[0]
+        topic = unpack(_s(topic_size), buf.read(topic_size))[0].decode()
         worker_name_size = unpack('>I', buf.read(4))[0]
         worker_name = unpack(_s(worker_name_size),
-                             buf.read(worker_name_size))[0]
+                             buf.read(worker_name_size))[0].decode()
         return {'type': 'join', 'topic': topic, 'worker_name': worker_name}
 
     def parse_metrics(cls, payload):
         buf = BufferedReader(BytesIO(payload))
         event_size = unpack('>I', buf.read(4))[0]
-        event = unpack(_s(event_size), buf.read(event_size))[0]
+        event = unpack(_s(event_size), buf.read(event_size))[0].decode()
         topic_size = unpack('>I', buf.read(4))[0]
-        topic = unpack(_s(topic_size), buf.read(topic_size))[0]
+        topic = unpack(_s(topic_size), buf.read(topic_size))[0].decode()
         payload_size = unpack('>I', buf.read(4))[0]
         payload_header = unpack('>I', buf.read(4))[0]
         metric_name_size = unpack('>I', buf.read(4))[0]
         metric_name = unpack(_s(metric_name_size),
-                             buf.read(metric_name_size))[0]
+                             buf.read(metric_name_size))[0].decode()
         metric_category_size = unpack('>I', buf.read(4))[0]
         metric_category = unpack(_s(metric_category_size),
-                                 buf.read(metric_category_size))[0]
+                                 buf.read(metric_category_size))[0].decode()
         worker_name_size = unpack('>I', buf.read(4))[0]
         worker_name = unpack(_s(worker_name_size),
-                             buf.read(worker_name_size))[0]
+                             buf.read(worker_name_size))[0].decode()
         pipeline_name_size = unpack('>I', buf.read(4))[0]
         pipeline_name = unpack(_s(pipeline_name_size),
-                               buf.read(pipeline_name_size))[0]
+                               buf.read(pipeline_name_size))[0].decode()
         ID = unpack('>H', buf.read(2))[0]
         latency_histogram = [unpack('>Q', buf.read(8))[0] for x in range(65)]
         max_latency = unpack('>Q', buf.read(8))[0]
@@ -144,7 +144,7 @@ class MetricsData(MetricsParser):
             if header:
                 payload = buf.read(header-1)
             else:
-                payload = ''
+                payload = b''
             self.records.append({'type': MSG_TYPES.get(msg_type, None),
                                  'payload': payload,
                                  'raw_type': msg_type})

--- a/testing/tools/integration/observability.py
+++ b/testing/tools/integration/observability.py
@@ -164,7 +164,7 @@ def get_func_name(f):
     functions created with `functools.partial`.
     """
     if isinstance(f, FunctionType):
-        return f.func_name
+        return f.__name__
     elif isinstance(f, partial):
         return get_func_name(f.func)
     raise ValueError("Can't get func_name of provided function {}".format(f))
@@ -311,7 +311,7 @@ class RunnerReadyChecker(StoppableThread):
         self.error = None
 
     def run(self):
-        with open(self._path, 'rb') as r:
+        with open(self._path, 'r') as r:
             started = time.time()
             while not self.stopped():
                 r.seek(0)
@@ -353,7 +353,7 @@ class RunnerChecker(StoppableThread):
         self.compiled = [re.compile(p) for p in patterns]
 
     def run(self):
-        with open(self._path, 'rb') as r:
+        with open(self._path, 'r') as r:
             last_match = self.start_from
             started = time.time()
             while not self.stopped():

--- a/testing/tools/integration_test
+++ b/testing/tools/integration_test
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 import argparse
 from collections import namedtuple
@@ -223,10 +223,12 @@ class CSVStringAction(argparse.Action):
         if not isinstance(values, list):
             values = [values]
         if len(values) == 1:
-            setattr(namespace, self.dest, values[0].split(','))
+            setattr(namespace, self.dest, map(lambda s: s.encode(),
+                                              values[0].split(',')))
         elif len(values) == 2:
             if values[1] == 'string':
-                setattr(namespace, self.dest, values[0].split(','))
+                setattr(namespace, self.dest, map(lambda s: s.encode(),
+                                                  values[0].split(',')))
             elif values[1] == 'int':
                 setattr(namespace, self.dest, map(int, values[0].split(',')))
             elif values[1] == 'float':
@@ -481,6 +483,10 @@ def CLI():
                             help=("Timeout in seconds before killing any "
                                   "remaining live workers and raising an "
                                   "error."))
+    term_group.add_argument('--max-retries', type=int, default=5,
+                            help=("Max number of times to attempt the test"
+                                  " if it fails due a "
+                                  "RunnerHasntStartedError"))
 
     args = parser.parse_args()
     log_level = get_log_level(args.log_level)
@@ -520,7 +526,7 @@ def CLI():
             try:
                 # clean up data collection before each attempt
                 persistent_data.clear()
-                log_stream.reset()
+                log_stream.seek(0)
                 log_stream.truncate()
 
                 # start test attempt

--- a/testing/tools/integration_test
+++ b/testing/tools/integration_test
@@ -301,7 +301,7 @@ class SinkAwaitAction(argparse.Action):
         if len(values) == 1:
             values.append('>I')
         elif len(values) != 2:
-            msg = ('Argumet "{f}" requires 1 or 2 arguments specifying '
+            msg = ('Argument "{f}" requires 1 or 2 arguments specifying '
                    'value [header]'.format(f=self.dest))
             raise argparse.ArgumentTypeError(msg)
         dest = getattr(namespace, self.dest)
@@ -309,7 +309,7 @@ class SinkAwaitAction(argparse.Action):
             dest = []
             setattr(namespace, self.dest, dest)
         if values[1]:
-            dest.append(struct.pack(values[1], len(values[0])) + values[0])
+            dest.append(struct.pack(values[1], len(values[0])) + values[0].encode())
         else:
             dest.append(values[0])
 


### PR DESCRIPTION
This PR upgrades the test harness to use python3 instead of python2.
This includes:
- `integration_test` CLI.
- updating the test scripts in `testing/correctness/tests/` to python3 (the ones that are being used, anyway, I left `log_rotation` untouched).
- fixing a bug in the topology tests that meant they were only testing 1 worker topologies.
- fixing the leaking file descriptor bug, which was causing some test failure.
- fixing the intermittent failure to start workers due to https://bugs.python.org/issue20318


Below is the full laundry list of changes:

- Update Runner class to clean up forked process handles as soon as the
  child process exits. This prevents a file descriptor leak we've been
  seeing and which was causing some tests to fail due to running into
  the systems' ulimit.
  This also means /tmp doesn't get filled up with `tmpXXXXXXX` files
  anymore, as they get properly cleaned up now that their fd's don't
  leak past GC.
- Update testing harness to be python3 compatible
- prefer bytestrings everywhere tests interact with external data
  (files, network, generators, etc)
- Add `--max-retires` parameter to integration_test CLI
- update integration_test CLI to use python3 instead of 2
- update resilience/Makefile to use `python3 -m pytest` instead of
`python2`
- update autoscale/Makefile to use python3 for pytest
- update resilience/Makefile to use python3 for pytest
- update topology/Makefile to use python3 for pytest
- update various python files to be python3 compatible
  - replace `dict.has_key(key)` with `key in dict`
  - bytes vs strings vs unicode where relevant
  - assertions as function rather than magic word
  - print as function rather than magic word
- Fix worker argument to topology test
  - Before this, they were always running with `workers=1` because the
    test creator function never used the `size` paramter in the `run_test`
    function.

closes #2568
