### PR TITLE
Remove support for Fedora 26

### DIFF
--- a/book/getting-started/wallaroo-up.md
+++ b/book/getting-started/wallaroo-up.md
@@ -1,6 +1,6 @@
 # Setting Up Your Wallaroo Development Environment using Wallaroo Up
 
-Wallaroo Up has been tested on Ubuntu Artful/Bionic/Trusty/Xenial, Fedora 26/27/28, CentOS 7, Debian Jessie/Stretch/Buster (Testing), Oracle Linux 7, and Amazon Linux 2 releases. It should also work on Red Hat Enterprise Linux 7.
+Wallaroo Up has been tested on Ubuntu Artful/Bionic/Trusty/Xenial, Fedora 27/28, CentOS 7, Debian Jessie/Stretch/Buster (Testing), Oracle Linux 7, and Amazon Linux 2 releases. It should also work on Red Hat Enterprise Linux 7.
 
 ## Memory requirements
 

--- a/book/go/getting-started/wallaroo-up.md
+++ b/book/go/getting-started/wallaroo-up.md
@@ -1,6 +1,6 @@
 # Setting Up Your Wallaroo Development Environment using Wallaroo Up
 
-Wallaroo Up has been tested on Ubuntu Artful/Bionic/Trusty/Xenial, Fedora 26/27/28, CentOS 7, Debian Jessie/Stretch/Buster (Testing), Oracle Linux 7, and Amazon Linux 2 releases. It should also work on Red Hat Enterprise Linux 7.
+Wallaroo Up has been tested on Ubuntu Artful/Bionic/Trusty/Xenial, Fedora 27/28, CentOS 7, Debian Jessie/Stretch/Buster (Testing), Oracle Linux 7, and Amazon Linux 2 releases. It should also work on Red Hat Enterprise Linux 7.
 
 ## Memory requirements
 

--- a/misc/wallaroo-up-tester.bash
+++ b/misc/wallaroo-up-tester.bash
@@ -83,7 +83,6 @@ declare -a DISTROS_TO_TEST=(
 "ubuntu:bionic,ubuntu/bionic64"
 "ubuntu:artful,ubuntu/artful64"
 "centos:7,centos/7"
-"fedora:26,fedora/26-cloud-base"
 "fedora:27,fedora/27-cloud-base"
 "fedora:28,fedora/28-cloud-base"
 "amazonlinux:2,gbailey/amzn2"
@@ -249,7 +248,7 @@ do
   if [[ "${DOCKER_TEST}" == "true" ]]; then
     # set and create tmp directory for this test run
     tmp_for_run="${TESTING_TMP}/docker/${docker_distro/:/-}"
-    mkdir -p "${tmp_for_run}" 
+    mkdir -p "${tmp_for_run}"
     ${SUDO_COMMAND} rm -rf "${tmp_for_run}/"*
     pushd "${tmp_for_run}"
     LOG_FILE="${tmp_for_run}/docker.log"
@@ -280,7 +279,7 @@ do
     # set and create tmp directory for this test run
     echo "vagrant: $vagrant_distro"
     tmp_for_run="${TESTING_TMP}/vagrant/${vagrant_distro/\//-}"
-    mkdir -p "${tmp_for_run}" 
+    mkdir -p "${tmp_for_run}"
     ${SUDO_COMMAND} rm -rf "${tmp_for_run}/"*
     pushd "${tmp_for_run}"
     LOG_FILE="${tmp_for_run}/vagrant.log"

--- a/misc/wallaroo-up.sh
+++ b/misc/wallaroo-up.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # md5 for validatiing script checksum
-MD5="2652f12abccbccfde0fc2a46627a4d4c  -"
+MD5="150361a08d2319097bdf054a4e8103fb  -"
 
 set -eEuo pipefail
 
@@ -62,7 +62,6 @@ centos-7
 rhel-7
 ol-7
 amzn-2
-fedora-26
 fedora-27
 fedora-28
 ubuntu-trusty


### PR DESCRIPTION
Due to Fedora 26 not being supported by ponyc 0.25.0, we have
dropped support for it. This change updates wally up and the example
tester scripts from installing and running on Fedora 26. We also
remove references to Fedora 26 as a supported distro within the
documentation.

Closes #2590

<!--
Make sure you've read the [Contributors Guide](https://github.com/WallarooLabs/wallaroo/blob/master/CONTRIBUTING.md). You'll need to sign our CLA before your issue can be accepted.

Reference the issue your code change relates to if possible
-->
ref #2583 

<!--
Include any other necessary information below. If you have any questions don't hesitate to reach out on the mailing list or on IRC.
-->
