### PR TITLE
Update kafkacat commands to use unbuffered I/O

### DIFF
--- a/examples/go/kafka_reverse/README.md
+++ b/examples/go/kafka_reverse/README.md
@@ -122,7 +122,7 @@ export KAFKA_IP=$(docker inspect local_kafka_1_1 | grep kafka_ip | grep -Eo '[0-
 To run `kafkacat` to listen to the `test-out` topic via Docker:
 
 ```bash
-docker run --rm -i --name kafkacatconsumer ryane/kafkacat -C -b ${KAFKA_IP}:9092 -t test-out -q
+docker run --rm -i --name kafkacatconsumer ryane/kafkacat -C -b ${KAFKA_IP}:9092 -t test-out -q -u
 ```
 
 ### Shell 3: Kafka Reverse

--- a/examples/pony/celsius-kafka/README.md
+++ b/examples/pony/celsius-kafka/README.md
@@ -115,7 +115,7 @@ export KAFKA_IP=$(docker inspect local_kafka_1_1 | grep kafka_ip | grep -Eo '[0-
 To run `kafkacat` to listen to the `test-out` topic via Docker:
 
 ```bash
-docker run --rm -i --name kafkacatconsumer ryane/kafkacat -C -b ${KAFKA_IP}:9092 -t test-out -q
+docker run --rm -i --name kafkacatconsumer ryane/kafkacat -C -b ${KAFKA_IP}:9092 -t test-out -q -u
 ```
 
 ### Shell 3: Celsius-kafka

--- a/examples/python/celsius-kafka/README.md
+++ b/examples/python/celsius-kafka/README.md
@@ -118,7 +118,7 @@ export KAFKA_IP=$(docker inspect local_kafka_1_1 | grep kafka_ip | grep -Eo '[0-
 To run `kafkacat` to listen to the `test-out` topic via Docker:
 
 ```bash
-docker run --rm -i --name kafkacatconsumer ryane/kafkacat -C -b ${KAFKA_IP}:9092 -t test-out -q
+docker run --rm -i --name kafkacatconsumer ryane/kafkacat -C -b ${KAFKA_IP}:9092 -t test-out -q -u
 ```
 
 ### Shell 3: Celsius-kafka


### PR DESCRIPTION
This change allows the celsius-kafka examples that use kafkacat
to immediately see output when it arrives to kafkacat. Prior to this
change, the results would buffer and not show immediately, at times
leaving users to wonder if Wallaroo was sending messages correctly.

[skip ci]

<!--
Make sure you've read the [Contributors Guide](https://github.com/WallarooLabs/wallaroo/blob/master/CONTRIBUTING.md). You'll need to sign our CLA before your issue can be accepted.

Reference the issue your code change relates to if possible
-->


<!--
Include any other necessary information below. If you have any questions don't hesitate to reach out on the mailing list or on IRC.
-->
