### PR TITLE
Fix docker-release script

### DIFF
--- a/.release/docker-release.sh
+++ b/.release/docker-release.sh
@@ -160,7 +160,7 @@ push_release_latest_docker_images() {
   then
     ## Conditional check for whether the Wallaroo latest Docker path has been set, does not
     ## upload image if it hasn't. Otherwise uploads to Bintray.
-    if [ -n "$wallaroo_docker_image_latest_path"]
+    if [ -n "$wallaroo_docker_image_latest_path" ]
     then
       # push the image
       if docker push "$wallaroo_docker_image_latest_path"


### PR DESCRIPTION
Spaces are required around `[` and `]`.

Fixes #2617

Signed-off-by: Christian Witts <cwitts@gmail.com>

<!--
Make sure you've read the [Contributors Guide](https://github.com/WallarooLabs/wallaroo/blob/master/CONTRIBUTING.md). You'll need to sign our CLA before your issue can be accepted.

Reference the issue your code change relates to if possible
-->
ref #

<!--
Include any other necessary information below. If you have any questions don't hesitate to reach out on the mailing list or on IRC.
-->
