### PR TITLE
Fix macOS bug: harness shutdown triggers ECONNABORTED

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
       - run: .circleci/clone_tracker.sh
       - run: |
           ulimit -c unlimited
+          ulimit -a
           make integration-tests debug=true
       - store_artifacts:
           path: /tmp/wallaroo_test_errors
@@ -33,6 +34,7 @@ jobs:
       - run: .circleci/clone_tracker.sh
       - run: |
           ulimit -c unlimited
+          ulimit -a
           make integration-tests-testing-correctness-tests-all resilience=on debug=true
       - store_artifacts:
           path: /tmp/wallaroo_test_errors


### PR DESCRIPTION
In the switch to Python3 in PR #2588 for the test harness, we'd
introduced a bug during harness shutdown that would abort the test
when a socket `accept(2)` got an ECONNABORTED error.  This error
only appears to happen on macOS.


