### PR TITLE
integration Sender: Add try/except wrapper around socket.sendall()

### DIFF
--- a/testing/tools/integration/end_points.py
+++ b/testing/tools/integration/end_points.py
@@ -296,7 +296,16 @@ class Sender(StoppableThread):
         self.pause_event.clear()
 
     def send(self, bs):
-        self.sock.sendall(bs)
+        try:
+            self.sock.sendall(bs)
+        except OSError as err:
+            if err.errno == 104 or err.errno == 54:
+                # ECONNRESET on Linux or macOS, respectively
+                is_econnreset = true
+            else:
+                is_econnreset = false
+            logging.info("socket errno {} ECONNRESET {} stopped {}"
+                .format(err.errno, is_econnreset, self.stopped()))
         self.data.append(bs)
         self._bytes_sent += len(bs)
 

--- a/testing/tools/integration/end_points.py
+++ b/testing/tools/integration/end_points.py
@@ -301,9 +301,9 @@ class Sender(StoppableThread):
         except OSError as err:
             if err.errno == 104 or err.errno == 54:
                 # ECONNRESET on Linux or macOS, respectively
-                is_econnreset = true
+                is_econnreset = True
             else:
-                is_econnreset = false
+                is_econnreset = False
             logging.info("socket errno {} ECONNRESET {} stopped {}"
                 .format(err.errno, is_econnreset, self.stopped()))
             raise err

--- a/testing/tools/integration/end_points.py
+++ b/testing/tools/integration/end_points.py
@@ -306,6 +306,7 @@ class Sender(StoppableThread):
                 is_econnreset = false
             logging.info("socket errno {} ECONNRESET {} stopped {}"
                 .format(err.errno, is_econnreset, self.stopped()))
+            raise err
         self.data.append(bs)
         self._bytes_sent += len(bs)
 

--- a/testing/tools/integration/end_points.py
+++ b/testing/tools/integration/end_points.py
@@ -306,7 +306,6 @@ class Sender(StoppableThread):
                 is_econnreset = False
             logging.info("socket errno {} ECONNRESET {} stopped {}"
                 .format(err.errno, is_econnreset, self.stopped()))
-            raise err
         self.data.append(bs)
         self._bytes_sent += len(bs)
 


### PR DESCRIPTION
Fixes #2628.

Avoids throwing an exception that rises to top of integration test script.  I'm not 100% sure that this is the right thing to do, so I've added a 2nd commit to raise the error anyway to give some details in the CI error report.