### PR TITLE
s/logging.warn/logging.warning/ in python code

### DIFF
--- a/demos/resilience-demo/lib/cluster.py
+++ b/demos/resilience-demo/lib/cluster.py
@@ -142,7 +142,7 @@ class Runner(threading.Thread):
             self.p.wait()
         except Exception as err:
             self.error = err
-            logging.warn("{}: Stopped running!".format(self.name))
+            logging.warning("{}: Stopped running!".format(self.name))
             raise
 
     def send_signal(self, signal):

--- a/demos/resilience-demo/lib/control.py
+++ b/demos/resilience-demo/lib/control.py
@@ -201,7 +201,7 @@ class TryUntilTimeout(StoppableThread):
             except Exception as err:
                 logging.log(1, "iteration failed...")
                 if time.time() - t0 > self.timeout:
-                    logging.warn("Failed on attempt {} of test: {}..."
+                    logging.warning("Failed on attempt {} of test: {}..."
                           .format(c, get_func_name(self.test)))
                     logging.exception(err)
                     self.stop(err)

--- a/demos/resilience-demo/lib/end_points.py
+++ b/demos/resilience-demo/lib/end_points.py
@@ -347,8 +347,8 @@ class Sender(StoppableThread):
         logging.log(INFO2, "Sender received stop instruction.")
         super(Sender, self).stop(error)
         if self.batch:
-            logging.warn("Sender stopped, but send buffer size is {}"
-                         .format(len(self.batch)))
+            logging.warning("Sender stopped, but send buffer size is {}"
+                            .format(len(self.batch)))
 
 
 class NoNonzeroError(ValueError):

--- a/demos/resilience-demo/lib/external.py
+++ b/demos/resilience-demo/lib/external.py
@@ -195,13 +195,13 @@ def save_logs_to_file(base_dir, log_stream=None, persistent_data={}):
                 time=strftime(sk.start_time, STRFTIME_FMT))
             with open(os.path.join(base_dir, sink_log_name), 'wb') as f:
                 f.write(''.join(sk.data))
-        logging.warn("Error logs saved to {}".format(base_dir))
+        logging.warning("Error logs saved to {}".format(base_dir))
 
         # save core files if they exist
         rex = re.compile('core.*')
         cores = list(filter(lambda s: rex.match(s), os.listdir(os.getcwd())))
         if cores:
-            logging.warn("Core files detected: {}".format(cores))
+            logging.warning("Core files detected: {}".format(cores))
         for core in cores:
             logging.info("Moving core {} to {}".format(core, base_dir))
             shutil.move(core, os.path.join(base_dir, core))

--- a/testing/correctness/tests/resilience/resilience.py
+++ b/testing/correctness/tests/resilience/resilience.py
@@ -303,7 +303,7 @@ def _test_resilience(command, ops=[], initial=None, sources=1,
             try:
                 raise
             except RunnerHasntStartedError as err:
-                logging.warn("Runner failed to start properly.")
+                logging.warning("Runner failed to start properly.")
                 if retry_count > 0:
                     logging.info("Restarting the test!")
                     _test_resilience(
@@ -350,7 +350,7 @@ def _test_resilience(command, ops=[], initial=None, sources=1,
             save_logs_to_file(base_dir, log_stream, persistent_data)
         except Exception as err_inner:
             logging.exception(err_inner)
-            logging.warn("Encountered an error when saving logs files to {}"
+            logging.warning("Encountered an error when saving logs files to {}"
                          .format(base_dir))
         logging.exception(err)
         raise

--- a/testing/correctness/tests/restart_without_resilience/restart_without_resilience.py
+++ b/testing/correctness/tests/restart_without_resilience/restart_without_resilience.py
@@ -88,8 +88,8 @@ def _test_restart(command):
             save_logs_to_file(base_dir, log_stream, persistent_data)
         except Exception as err_inner:
             logging.exception(err_inner)
-            logging.warn("Encountered an error when saving logs files to {}"
-                         .format(base_dir))
+            logging.warning("Encountered an error when saving logs files to {}"
+                            .format(base_dir))
         logging.exception(err)
         raise
 

--- a/testing/correctness/tests/topology/topology_tests.py
+++ b/testing/correctness/tests/topology/topology_tests.py
@@ -135,7 +135,7 @@ def run_test(api, cmd, validation_cmd, topology, workers=1):
                 logging.info("Run phase complete. Proceeding to validation.")
                 break
             except RunnerHasntStartedError:
-                logging.warn("Runner failed to start properly.")
+                logging.warning("Runner failed to start properly.")
                 if attempt < max_retries:
                     logging.info("Restarting the test!")
                     time.sleep(0.5)
@@ -164,7 +164,7 @@ def run_test(api, cmd, validation_cmd, topology, workers=1):
         try:
             save_logs_to_file(base_dir, log_stream, persistent_data)
         except Exception as err:
-            logging.warn("failed to save logs to file")
+            logging.warning("failed to save logs to file")
             logging.exception(err)
         raise
 

--- a/testing/tools/integration/cluster.py
+++ b/testing/tools/integration/cluster.py
@@ -148,7 +148,7 @@ class Runner(threading.Thread):
             self._file = None
         except Exception as err:
             self.error = err
-            logging.warn("{}: Stopped running!".format(self.name))
+            logging.warning("{}: Stopped running!".format(self.name))
             raise
 
     def send_signal(self, signal):

--- a/testing/tools/integration/control.py
+++ b/testing/tools/integration/control.py
@@ -204,7 +204,7 @@ class TryUntilTimeout(StoppableThread):
             except Exception as err:
                 logging.log(1, "iteration failed...")
                 if time.time() - t0 > self.timeout:
-                    logging.warn("Failed on attempt {} of test: {}..."
+                    logging.warning("Failed on attempt {} of test: {}..."
                           .format(c, get_func_name(self.test)))
                     logging.exception(err)
                     self.stop(err)

--- a/testing/tools/integration/end_points.py
+++ b/testing/tools/integration/end_points.py
@@ -383,8 +383,8 @@ class Sender(StoppableThread):
             logging.log(INFO2, "Sender received stop instruction.")
         super(Sender, self).stop(*args, **kwargs)
         if self.batch:
-            logging.warn("Sender stopped, but send buffer size is {}"
-                         .format(len(self.batch)))
+            logging.warning("Sender stopped, but send buffer size is {}"
+                            .format(len(self.batch)))
 
 
 class NoNonzeroError(ValueError):

--- a/testing/tools/integration/external.py
+++ b/testing/tools/integration/external.py
@@ -207,13 +207,13 @@ def save_logs_to_file(base_dir, log_stream=None, persistent_data={}):
             with open(os.path.join(base_dir, sink_log_name), 'wb') as f:
                 for d in sk.data:
                     f.write(d)
-        logging.warn("Error logs saved to {}".format(base_dir))
+        logging.warning("Error logs saved to {}".format(base_dir))
 
         # save core files if they exist
         rex = re.compile('core.*')
         cores = list(filter(lambda s: rex.match(s), os.listdir(os.getcwd())))
         if cores:
-            logging.warn("Core files detected: {}".format(cores))
+            logging.warning("Core files detected: {}".format(cores))
         for core in cores:
             logging.info("Moving core {} to {}".format(core, base_dir))
             shutil.move(core, os.path.join(base_dir, core))

--- a/testing/tools/integration_test
+++ b/testing/tools/integration_test
@@ -562,7 +562,7 @@ def CLI():
                 logging.info("Run phase complete. Proceeding to validation.")
                 break
             except RunnerHasntStartedError:
-                logging.warn("Runner failed to start properly.")
+                logging.warning("Runner failed to start properly.")
                 if attempt < args.max_retries:
                     logging.info("Restarting the test!")
                     time.sleep(0.5)
@@ -579,7 +579,7 @@ def CLI():
         try:
             save_logs_to_file(base_dir, log_stream, persistent_data)
         except Exception as err:
-            logging.warn("failed to save logs to file")
+            logging.warning("failed to save logs to file")
             logging.exception(err)
         parser.exit(1)
 


### PR DESCRIPTION
`logging.warn` is deprecated in favour of `logging.warning` in Python3,
which results in deprecation warning messages polluting our test logs.
This commit updates the usage to the new style.

I noticed this in the logs referenced in #2589 
