### PR TITLE
Python 3 connectors

### DIFF
--- a/book/python/using-connectors.md
+++ b/book/python/using-connectors.md
@@ -1,7 +1,5 @@
 # Using Connectors as Sources & Sinks
 
-_Python 3: At this point, Connectors are not supported in our Python 3 API. We expect support will be added in the next release._
-
 This is a preview release of Wallaroo's connectors feature that allows full customization of sources and sinks. These sources and sinks can be integrated into Wallaroo using libraries you're already familiar with in Python. A number of built-in connectors offer a quick way to get started and hook up common stream types and they're all available for easy customization.
 
 Care has been taken to keep the API simple and the runtime assumptions unobtrusive so it's easy to hook up the library to existing code. Read down below for more information on how this works. As this is still a preview release, we are looking for early feedback and would love to hear from you. You can connect with us by emailing [hello@wallaroolabs.com](mailto:hello@wallaroolabs.com).

--- a/connectors/kafka_sink
+++ b/connectors/kafka_sink
@@ -13,4 +13,5 @@ topic = connector.params.topic
 
 while True:
     key, value = connector.read()
-    producer.send(topic, key=str(key), value=str(value))
+    producer.send(topic, key=str(key).encode('utf-8'),
+                  value=str(value).encode('utf-8'))

--- a/connectors/rabbitmq_source
+++ b/connectors/rabbitmq_source
@@ -54,6 +54,8 @@ class AsyncConsumer(object):
         self.add_on_channel_close_callback()
         if self._exchange:
             self.setup_exchange(self._exchange)
+        else:
+            self.start_consuming()
 
     def add_on_channel_close_callback(self):
         self._channel.add_on_close_callback(self.on_channel_closed)
@@ -99,7 +101,7 @@ class AsyncConsumer(object):
 
     def on_message(self, unused_channel, basic_deliver, properties, body):
         self.acknowledge_message(basic_deliver.delivery_tag)
-        self.handle_message(body)
+        self._handle_message(body)
 
     def acknowledge_message(self, delivery_tag):
         self._channel.basic_ack(delivery_tag)

--- a/connectors/redis_hash_sink
+++ b/connectors/redis_hash_sink
@@ -10,5 +10,5 @@ redis = Redis(connector.params.host, int(connector.params.port), connector.param
 hkey = connector.params.key
 
 while True:
-    k, v  = conncetor.read()
+    k, v  = connector.read()
     redis.hset(hkey, k, v)

--- a/examples/python/celsius_connectors/README.md
+++ b/examples/python/celsius_connectors/README.md
@@ -25,6 +25,3 @@ Once that is done, you can run the application within this directory using:
 ```
 
 See the documentation on [using connectors](https://docs.wallaroolabs.com/book/python/using-connectors.html) for more information on how this example works.
-
-### Python 3
-This example is currently not compatible with Python 3. Python 3 support for the experimental connectors feature is expected to arrive in the next release.


### PR DESCRIPTION
This PR fixes issues that prevented our connector examples from running in Python 3 and updates the documentation to remove the notes about connectors not working with Python 3.

closes #2648
closes #2657