### PR TITLE
Assign routing keys to messages based on source-specific policies

### DIFF
--- a/lib/wallaroo/core/source/connector_source/connector_framed_source_notify.pony
+++ b/lib/wallaroo/core/source/connector_source/connector_framed_source_notify.pony
@@ -109,10 +109,18 @@ class ConnectorSourceNotify[In: Any val]
             @printf[I32](("Msg decoded at " + _pipeline_name +
               " source\n").cstring())
           end
+
+          let msg_uid = _msg_id_gen()
+
+          // TODO: We need a way to determine the key based on the policy
+          // for any particular connector. For example, the Kafka connector
+          // needs a way to provide the Kafka key here.
+          let initial_key = msg_uid.string()
+
           if decoded isnt None then
             _runner.run[In](_pipeline_name, pipeline_time_spent, decoded,
-              "connector-source-key", _source_id, source, _router,
-              _msg_id_gen(), None, decode_end_ts,
+              consume initial_key, _source_id, source, _router,
+              msg_uid, None, decode_end_ts,
               latest_metrics_id, ingest_ts, _metrics_reporter)
           else
             (true, ingest_ts)

--- a/lib/wallaroo/core/source/connector_source/connector_source_config.pony
+++ b/lib/wallaroo/core/source/connector_source/connector_source_config.pony
@@ -18,6 +18,7 @@ Copyright 2017 The Wallaroo Authors.
 
 use "options"
 use "wallaroo"
+use "wallaroo/core/partitioning"
 use "wallaroo/core/source"
 
 primitive ConnectorSourceConfigCLIParser
@@ -84,3 +85,6 @@ class val ConnectorSourceConfig[In: Any val]
   fun source_listener_builder_builder(): ConnectorSourceListenerBuilderBuilder[In] =>
     ConnectorSourceListenerBuilderBuilder[In](_host, _service, _parallelism,
       _handler)
+
+  fun default_partitioner_builder(): PartitionerBuilder =>
+    PassthroughPartitionerBuilder

--- a/lib/wallaroo/core/source/gen_source/gen_source_config.pony
+++ b/lib/wallaroo/core/source/gen_source/gen_source_config.pony
@@ -18,6 +18,7 @@ Copyright 2017 The Wallaroo Authors.
 
 use "options"
 use "wallaroo"
+use "wallaroo/core/partitioning"
 use "wallaroo/core/source"
 
 class val GenSourceConfig[In: Any val]
@@ -28,3 +29,6 @@ class val GenSourceConfig[In: Any val]
 
   fun source_listener_builder_builder(): GenSourceListenerBuilderBuilder[In] =>
     GenSourceListenerBuilderBuilder[In](_gen)
+
+  fun default_partitioner_builder(): PartitionerBuilder =>
+    RandomPartitionerBuilder

--- a/lib/wallaroo/core/source/kafka_source/kafka_source_config.pony
+++ b/lib/wallaroo/core/source/kafka_source/kafka_source_config.pony
@@ -20,6 +20,7 @@ use "net"
 use "options"
 use "pony-kafka"
 use "pony-kafka/customlogger"
+use "wallaroo/core/partitioning"
 use "wallaroo/core/source"
 
 
@@ -43,3 +44,6 @@ class val KafkaSourceConfig[In: Any val] is SourceConfig
   fun source_listener_builder_builder(): KafkaSourceListenerBuilderBuilder[In]
   =>
     KafkaSourceListenerBuilderBuilder[In](_ksco, _handler, _auth)
+
+  fun default_partitioner_builder(): PartitionerBuilder =>
+    PassthroughPartitionerBuilder

--- a/lib/wallaroo/core/source/kafka_source/kafka_source_notify.pony
+++ b/lib/wallaroo/core/source/kafka_source/kafka_source_notify.pony
@@ -116,9 +116,17 @@ class KafkaSourceNotify[In: Any val]
           @printf[I32](("Msg decoded at " + _pipeline_name +
             " source\n").cstring())
         end
+
+        let msg_id = _msg_id_gen()
+
+        let initial_key =
+          match kafka_msg_key
+          | let a: Array[U8] val => String.from_array(a)
+          else msg_id.string() end
+
         _runner.run[In](_pipeline_name, pipeline_time_spent, decoded,
-          "kafka-source-key", _source_id, source, _router,
-          _msg_id_gen(), None, decode_end_ts, latest_metrics_id, ingest_ts,
+          consume initial_key, _source_id, source, _router,
+          msg_id, None, decode_end_ts, latest_metrics_id, ingest_ts,
           _metrics_reporter)
       else
         @printf[I32](("Unable to decode message at " + _pipeline_name +

--- a/lib/wallaroo/core/source/source.pony
+++ b/lib/wallaroo/core/source/source.pony
@@ -31,6 +31,7 @@ use "wallaroo/core/topology"
 
 
 interface val SourceConfig
+  fun default_partitioner_builder(): PartitionerBuilder
   fun source_listener_builder_builder(): SourceListenerBuilderBuilder
 
 interface val TypedSourceConfig[In: Any val] is SourceConfig

--- a/lib/wallaroo/core/source/tcp_source/framed_source_notify.pony
+++ b/lib/wallaroo/core/source/tcp_source/framed_source_notify.pony
@@ -108,6 +108,7 @@ class TCPSourceNotify[In: Any val]
             @printf[I32](("Msg decoded at " + _pipeline_name +
               " source\n").cstring())
           end
+
           if decoded isnt None then
             _runner.run[In](_pipeline_name, pipeline_time_spent, decoded,
               "tcp-source-key", _source_id, source, _router,

--- a/lib/wallaroo/core/source/tcp_source/tcp_source_config.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source_config.pony
@@ -18,6 +18,7 @@ Copyright 2017 The Wallaroo Authors.
 
 use "options"
 use "wallaroo"
+use "wallaroo/core/partitioning"
 use "wallaroo/core/source"
 
 primitive TCPSourceConfigCLIParser
@@ -84,3 +85,6 @@ class val TCPSourceConfig[In: Any val]
   fun source_listener_builder_builder(): TCPSourceListenerBuilderBuilder[In] =>
     TCPSourceListenerBuilderBuilder[In](_host, _service, _parallelism,
       _handler)
+
+  fun default_partitioner_builder(): PartitionerBuilder =>
+    RandomPartitionerBuilder

--- a/lib/wallaroo/core/topology/runner.pony
+++ b/lib/wallaroo/core/topology/runner.pony
@@ -61,7 +61,7 @@ trait val RunnerBuilder
   fun apply(event_log: EventLog, auth: AmbientAuth,
     next_runner: (Runner iso | None) = None,
     router: (Router | None) = None,
-    partitioner_builder: PartitionerBuilder = SinglePartitionerBuilder):
+    partitioner_builder: PartitionerBuilder = PassthroughPartitionerBuilder):
     Runner iso^
 
   fun name(): String
@@ -90,7 +90,7 @@ class val RunnerSequenceBuilder is RunnerBuilder
     auth: AmbientAuth,
     next_runner: (Runner iso | None) = None,
     router: (Router | None) = None,
-    partitioner_builder: PartitionerBuilder = SinglePartitionerBuilder):
+    partitioner_builder: PartitionerBuilder = PassthroughPartitionerBuilder):
     Runner iso^
   =>
     var remaining: USize = _runner_builders.size()
@@ -155,7 +155,7 @@ class val StatelessComputationRunnerBuilder[In: Any val, Out: Any val] is
     auth: AmbientAuth,
     next_runner: (Runner iso | None) = None,
     router: (Router | None) = None,
-    partitioner_builder: PartitionerBuilder = SinglePartitionerBuilder):
+    partitioner_builder: PartitionerBuilder = PassthroughPartitionerBuilder):
     Runner iso^
   =>
     match (consume next_runner)
@@ -187,7 +187,7 @@ class val StateRunnerBuilder[In: Any val, Out: Any val, S: State ref] is
     auth: AmbientAuth,
     next_runner: (Runner iso | None) = None,
     router: (Router | None) = None,
-    partitioner_builder: PartitionerBuilder = SinglePartitionerBuilder):
+    partitioner_builder: PartitionerBuilder = PassthroughPartitionerBuilder):
     Runner iso^
   =>
     match (consume next_runner)
@@ -529,7 +529,7 @@ class iso RouterRunner is Runner
     latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64,
     metrics_reporter: MetricsReporter ref): (Bool, U64)
   =>
-    let new_key = _partitioner[D](data)
+    let new_key = _partitioner[D](data, key)
     router.route[D](metric_name, pipeline_time_spent, data, new_key,
       producer_id, producer, i_msg_uid, frac_ids, latest_ts, metrics_id,
       worker_ingress_ts)


### PR DESCRIPTION
Prior to this change, sources always defaulted to assigning random
routing keys to messages unless overriden by downstream context (e.g.
a `key_by` call). These changes ensure that individual source
implementations can determine their own key assignment strategies.
This will give us flexibility to determine keys for connectors based
on a range of potential policies.