### PR TITLE
Fix failing command in release script

### DIFF
--- a/.release/release.sh
+++ b/.release/release.sh
@@ -125,8 +125,8 @@ checkout_and_pull_release_branch() {
 
 merge_rc_branch_into_release() {
   echo "Merging $rc_branch_name with release branch..."
-  merge_result=$(git merge "origin/$rc_branch_name")
-  if ! $merge_result; then
+  git merge "origin/$rc_branch_name"
+  if ! git status | grep -q "working directory clean"; then
     printf "There was a merge conflict, please resolve manually and push to"
     printf "the \`release\` branch once resolved."
     exit 1


### PR DESCRIPTION
Previously, the script would fail even on a clean merge. This change
updates the script to verify the git status before continuing.
<!--
Make sure you've read the [Contributors Guide](https://github.com/WallarooLabs/wallaroo/blob/master/CONTRIBUTING.md). You'll need to sign our CLA before your issue can be accepted.

Reference the issue your code change relates to if possible
-->
ref #2618

<!--
Include any other necessary information below. If you have any questions don't hesitate to reach out on the mailing list or on IRC.
-->
