### PR TITLE
Change "stateless" to "stateful" in alerts_stateful README

### DIFF
--- a/examples/python/alerts_stateful/README.md
+++ b/examples/python/alerts_stateful/README.md
@@ -1,4 +1,4 @@
-# Alerts (stateless)
+# Alerts (stateful)
 
 ## About The Application
 
@@ -11,19 +11,19 @@ objects.
 
 ### Processing
 
-We add the total of each transaction to a running total at a state computation. If that running total is higher than a certain positive threshold, we create a deposit alert. If it's lower than a certain negative threshold, we create a withdrawal alert. 
+We add the total of each transaction to a running total at a state computation. If that running total is higher than a certain positive threshold, we create a deposit alert. If it's lower than a certain negative threshold, we create a withdrawal alert.
 
 ### Output
 
 Alerts will output messages that are string representations of triggered
-alerts. 
+alerts.
 
 ## Running Alerts
 
 In order to run the application you will need Machida, Data Receiver, and the Cluster Shutdown tool. We provide instructions for building these tools yourself and we provide prebuilt binaries within a Docker container. Please visit our [setup](https://docs.wallaroolabs.com/book/getting-started/choosing-an-installation-option.html) instructions to choose one of these options if you have not already done so.
 If you are using Python 3, replace all instances of `machida` with `machida3` in your commands.
 
-You will need four separate shells to run this application (please see [starting a new shell](https://docs.wallaroolabs.com/book/getting-started/starting-a-new-shell.html) for details depending on your installation choice). Open each shell and go to the `examples/python/alerts_stateless` directory.
+You will need four separate shells to run this application (please see [starting a new shell](https://docs.wallaroolabs.com/book/getting-started/starting-a-new-shell.html) for details depending on your installation choice). Open each shell and go to the `examples/python/alerts_stateful` directory.
 
 ### Shell 1: Metrics
 


### PR DESCRIPTION
The README file for alerts_stateful had references to
"stateless". These references have been changed to correctly refer to
"stateful".

Fixes #2677
