### PR TITLE
Add python3 to cli_tests

### DIFF
--- a/machida3/machida.pony
+++ b/machida3/machida.pony
@@ -552,7 +552,6 @@ primitive Machida
     recover val
       let pipeline_tree = PyPipelineTree(application_setup_data, env)
       let pipeline = pipeline_tree.build()?
-      Machida.dec_ref(application_setup_data)
       (pipeline_tree.app_name, pipeline)
     end
 

--- a/testing/correctness/tests/cli_tests/Makefile
+++ b/testing/correctness/tests/cli_tests/Makefile
@@ -40,6 +40,7 @@ cli_tests: CUSTOM_PYTHONPATH = $(CLI_PATH):$(DUMMY_PYTHON_PATH)
 include $(rules_mk_path)
 
 build-testing-correctness-tests-cli_tests: build-machida
+build-testing-correctness-tests-cli_tests: build-machida3
 integration-tests-testing-correctness-tests-cli_tests: cli_tests
 
 cli_tests:

--- a/testing/correctness/tests/cli_tests/conftest.py
+++ b/testing/correctness/tests/cli_tests/conftest.py
@@ -1,0 +1,3 @@
+# Sort the tests alphabetically
+def pytest_collection_modifyitems(session, config, items):
+    items.sort(key=lambda i: i.name)


### PR DESCRIPTION
- refactor cli_tests to take `command` arg
- use test_creator pattern to generate a test per API
- Implement segfault fix from machida in machida3
- Add machida3 tests

closes #2693 