### PR TITLE
Increase boundary reconnect pause threshold

### DIFF
--- a/lib/wallaroo/core/boundary/boundary.pony
+++ b/lib/wallaroo/core/boundary/boundary.pony
@@ -725,7 +725,7 @@ actor OutgoingBoundary is Consumer
 
   fun ref _schedule_reconnect() =>
     // Gradually back off
-    if _reconnect_pause < 8_000_000 then
+    if _reconnect_pause < 8_000_000_000 then
       _reconnect_pause = _reconnect_pause * 2
     end
 


### PR DESCRIPTION
The old threshold for boundary reconnect pauses was entered in
microseconds when it should have been in nanoseconds. This meant that
reconnect back off never actually happened and we simply continued to
retry every second.
