### PR TITLE
Pass implicit key through unless explicitly overriden

### DIFF
--- a/lib/wallaroo/application.pony
+++ b/lib/wallaroo/application.pony
@@ -198,6 +198,10 @@ class Pipeline[Out: Any val] is BasicPipeline
       Pipeline[Out](_stages, _dag_sink_ids)
     end
 
+  fun ref collect(): Pipeline[Out] =>
+    let collect_key = CollectKeyGenerator()
+    key_by(CollectKeyExtractor[Out](collect_key))
+
   fun graph(): this->Dag[Stage] => _stages
 
   fun size(): USize => _stages.size()

--- a/lib/wallaroo/core/common/key.pony
+++ b/lib/wallaroo/core/common/key.pony
@@ -17,3 +17,7 @@ Copyright 2018 The Wallaroo Authors.
 */
 
 type Key is String
+
+primitive CollectKeyGenerator
+  fun apply(): Key =>
+    "collect-key-" + RoutingIdGenerator().string()

--- a/lib/wallaroo/core/partitioning/partitioning.pony
+++ b/lib/wallaroo/core/partitioning/partitioning.pony
@@ -27,6 +27,15 @@ use "wallaroo_labs/mort"
 interface val KeyExtractor[In: Any val]
   fun apply(input: In): Key
 
+class val CollectKeyExtractor[In: Any val]
+  let _constant_key: Key
+
+  new val create(c_key: Key) =>
+    _constant_key = c_key
+
+  fun apply(input: In): Key =>
+    _constant_key
+
 trait Partitioner
   // Takes an input and the current key associated with that input.
   // Based on a new partitioning scheme, it might replace this old key with

--- a/machida/lib/wallaroo/__init__.py
+++ b/machida/lib/wallaroo/__init__.py
@@ -63,7 +63,7 @@ def source(name, source_config):
 
 
 def build_application(app_name, pipeline):
-    if not pipeline.__is_closed__():
+    if not pipeline._is_closed():
         print("\nAPI_Error: An application must end with to_sink/s.")
         raise WallarooParameterError()
     return pipeline.__to_tuple__(app_name)
@@ -81,13 +81,13 @@ class Pipeline(object):
     def __to_tuple__(self, app_name):
         return self._pipeline_tree.to_tuple(app_name)
 
-    def __is_closed__(self):
+    def _is_closed(self):
         return self._pipeline_tree.is_closed
 
     def to(self, computation):
-        return self.clone().__to__(computation)
+        return self.clone()._to(computation)
 
-    def __to__(self, computation):
+    def _to(self, computation):
         if isinstance(computation, StateComputation):
             self._pipeline_tree.add_stage(("to_state", computation))
         else:
@@ -95,16 +95,16 @@ class Pipeline(object):
         return self
 
     def to_sink(self, sink_config):
-        return self.clone().__to_sink__(sink_config)
+        return self.clone()._to_sink(sink_config)
 
-    def __to_sink__(self, sink_config):
+    def _to_sink(self, sink_config):
         self._pipeline_tree.add_stage(("to_sink", sink_config.to_tuple()))
         return self
 
     def to_sinks(self, sink_configs):
-        return self.clone().__to_sinks__(sink_configs)
+        return self.clone()._to_sinks(sink_configs)
 
-    def __to_sinks__(self, sink_configs):
+    def _to_sinks(self, sink_configs):
         sinks = []
         for sc in sink_configs:
             sinks.append(sc.to_tuple())
@@ -112,16 +112,23 @@ class Pipeline(object):
         return self
 
     def key_by(self, key_extractor):
-        return self.clone().__key_by__(key_extractor)
+        return self.clone()._key_by(key_extractor)
 
-    def __key_by__(self, key_extractor):
+    def _key_by(self, key_extractor):
         self._pipeline_tree.add_stage(("key_by", key_extractor))
         return self
 
-    def merge(self, pipeline):
-        return self.clone().__merge__(pipeline.clone())
+    def collect(self):
+        return self.clone()._collect()
 
-    def __merge__(self, pipeline):
+    def _collect(self):
+        self._pipeline_tree.add_stage(("collect", ""))
+        return self
+
+    def merge(self, pipeline):
+        return self.clone()._merge(pipeline.clone())
+
+    def _merge(self, pipeline):
         self._pipeline_tree.merge(pipeline._pipeline_tree)
         return self
 

--- a/machida/machida.pony
+++ b/machida/machida.pony
@@ -1127,6 +1127,8 @@ class val PyPipelineTree
       let key_extractor = PyKeyExtractor(raw_key_extractor)
       Machida.inc_ref(raw_key_extractor)
       pipeline = pipeline.key_by(key_extractor)
+    | "collect" =>
+      pipeline = pipeline.collect()
     | "to_sink" =>
       pipeline = pipeline.to_sink(
         _SinkConfig.from_tuple(@PyTuple_GetItem(stage, 1), env)?)

--- a/machida3/machida.pony
+++ b/machida3/machida.pony
@@ -1170,6 +1170,8 @@ primitive _SinkConfig
         let key_extractor = PyKeyExtractor(raw_key_extractor)
         Machida.inc_ref(raw_key_extractor)
         pipeline = pipeline.key_by(key_extractor)
+      | "collect" =>
+        pipeline = pipeline.collect()
       | "to_sink" =>
         pipeline = pipeline.to_sink(
           _SinkConfig.from_tuple(@PyTuple_GetItem(stage, 1), env)?)

--- a/testing/correctness/apps/dummy_python/dummy.py
+++ b/testing/correctness/apps/dummy_python/dummy.py
@@ -25,6 +25,7 @@ def application_setup(args):
                     wallaroo.TCPSourceConfig(in_host, in_port, decoder,
                                              parallelism=13))
       .to(pass_through)
+      .collect()
       .to(count)
       .key_by(partition)
       .to(count_partitioned)

--- a/testing/correctness/apps/multi_partition_detector/multi_partition_detector.pony
+++ b/testing/correctness/apps/multi_partition_detector/multi_partition_detector.pony
@@ -92,7 +92,6 @@ actor Main
           env.out.print("Adding level " + x.string())
           p = p.key_by(WindowPartitionFunction)
           p = p.to[t.Message](TraceID(x.string()))
-          p = p.key_by(WindowPartitionFunction)
           p = p.to[t.Message](TraceWindow(x.string()))
         end
         p.to_sink(TCPSinkConfig[t.Message].from_options(MessageEncoder,

--- a/testing/correctness/apps/multi_pipeline/multi_pipeline.pony
+++ b/testing/correctness/apps/multi_pipeline/multi_pipeline.pony
@@ -33,17 +33,15 @@ actor Main
         let inputs1 = Wallaroo.source[F32]("Celsius Conversion",
             TCPSourceConfig[F32].from_options(CelsiusDecoder,
               TCPSourceConfigCLIParser(env.args)?(0)?))
-            .key_by(Constant)
+            .collect()
             .to[F32](Multiply)
-            .key_by(Constant)
             .to[F32](Add)
 
         let inputs2 = Wallaroo.source[F32]("Celsius Conversion",
             TCPSourceConfig[F32].from_options(CelsiusDecoder,
               TCPSourceConfigCLIParser(env.args)?(1)?))
-            .key_by(Constant)
+            .collect()
             .to[F32](Multiply)
-            .key_by(Constant)
             .to[F32](Add)
 
         inputs1.merge[F32](inputs2)
@@ -54,10 +52,6 @@ actor Main
     else
       @printf[I32]("Couldn't build topology\n".cstring())
     end
-
-primitive Constant
-  fun apply(f: F32): String =>
-    "constant"
 
 primitive Multiply is StatelessComputation[F32, F32]
   fun apply(input: F32): F32 =>

--- a/testing/correctness/apps/multi_sink/multi_sink.pony
+++ b/testing/correctness/apps/multi_sink/multi_sink.pony
@@ -35,9 +35,8 @@ actor Main
                 TCPSourceConfigCLIParser(env.args)?(0)?))
 
         values
-          .key_by(Constant)
+          .collect()
           .to[F32](Multiply)
-          .key_by(Constant)
           .to[F32](Add)
           .to_sinks([
             TCPSinkConfig[F32 val].from_options(FahrenheitEncoder,
@@ -49,10 +48,6 @@ actor Main
     else
       @printf[I32]("Couldn't build topology\n".cstring())
     end
-
-primitive Constant
-  fun apply(f: F32): String =>
-    "constant"
 
 primitive Multiply is StatelessComputation[F32, F32]
   fun apply(input: F32): F32 =>

--- a/testing/correctness/apps/sequence_window/main.pony
+++ b/testing/correctness/apps/sequence_window/main.pony
@@ -98,7 +98,7 @@ actor Main
               TCPSourceConfigCLIParser(env.args)?(0)?))
 
         inputs
-          .key_by(Constant)
+          .collect()
           .to[U64](MaybeOneToMany)
           .key_by(ExtractWindow)
           .to[String val](ObserveNewValue)
@@ -110,10 +110,6 @@ actor Main
     else
       @printf[I32]("Couldn't build topology\n".cstring())
     end
-
-primitive Constant
-  fun apply(u: U64): Key =>
-    "constant"
 
 primitive ExtractWindow
   fun apply(u: U64 val): Key =>

--- a/testing/correctness/apps/sequence_window_python/sequence_window.py
+++ b/testing/correctness/apps/sequence_window_python/sequence_window.py
@@ -27,18 +27,13 @@ def application_setup(args):
                     wallaroo.TCPSourceConfig(in_host, in_port, decoder))
 
     pipeline = (inputs
-        .key_by(constant)
+        .collect()
         .to(maybe_one_to_many)
         .key_by(extract_window)
         .to(observe_new_value)
         .to_sink(wallaroo.TCPSinkConfig(out_host, out_port, encoder)))
 
     return wallaroo.build_application("Sequence Window", pipeline)
-
-
-@wallaroo.key_extractor
-def constant(data):
-    return "constant"
 
 
 @wallaroo.key_extractor

--- a/testing/correctness/tests/cli_tests/cli_tests.py
+++ b/testing/correctness/tests/cli_tests/cli_tests.py
@@ -113,7 +113,7 @@ def _test_state_entity_query(command):
                     continue
         # Check we have as many state keys as input items
         assert(len(part_ids) == INPUT_ITEMS)
-        assert(single_part_id == 'single-partition-key')
+        assert(single_part_id.split("-")[0] == 'collect')
         # check that there are two computation ids
         comp_ids = set()
         for w in got.values():


### PR DESCRIPTION
We were already passing the implicit key through, but treated a
state computation as a special case. This commit removes this
special case treatment, and adds a new API call ".collect()" for
the case where you want all messages after a certain stage to be
assigned the same routing key.
