### PR TITLE
Expose TCP Source parallelism in Machida (2&3)

### DIFF
--- a/machida/lib/wallaroo/__init__.py
+++ b/machida/lib/wallaroo/__init__.py
@@ -391,13 +391,14 @@ def encoder(func):
     return C()
 
 class TCPSourceConfig(object):
-    def __init__(self, host, port, decoder):
+    def __init__(self, host, port, decoder, parallelism=10):
         self._host = host
         self._port = port
         self._decoder = decoder
+        self._parallelism = parallelism
 
     def to_tuple(self):
-        return ("tcp", self._host, self._port, self._decoder)
+        return ("tcp", self._host, self._port, self._decoder, self._parallelism)
 
 class GenSourceConfig(object):
     def __init__(self, gen_instance):

--- a/machida/machida.pony
+++ b/machida/machida.pony
@@ -801,7 +801,11 @@ primitive _SourceConfig
         PyFramedSourceHandler(d)?
       end
 
-      TCPSourceConfig[(PyData val | None)](decoder, host, port)
+      let parallelism = recover val
+        USize.from[I64](@PyInt_AsLong(@PyTuple_GetItem(source_config_tuple, 4)))
+      end
+
+      TCPSourceConfig[(PyData val | None)](decoder, host, port, parallelism)
     | "kafka-internal" =>
       let kafka_source_name = recover val
         String.copy_cstring(@PyString_AsString(@PyTuple_GetItem(source_config_tuple, 1)))

--- a/machida3/machida.pony
+++ b/machida3/machida.pony
@@ -840,7 +840,11 @@ primitive _SourceConfig
         PyFramedSourceHandler(d)?
       end
 
-      TCPSourceConfig[(PyData val | None)](decoder, host, port)
+      let parallelism = recover val
+        USize.from[I64](@PyLong_AsLong(@PyTuple_GetItem(source_config_tuple, 4)))
+      end
+
+      TCPSourceConfig[(PyData val | None)](decoder, host, port, parallelism)
     | "kafka-internal" =>
       let kafka_source_name = recover val
         Machida.py_bytes_or_unicode_to_pony_string(@PyTuple_GetItem(source_config_tuple, 1))

--- a/testing/correctness/apps/dummy_python/dummy.py
+++ b/testing/correctness/apps/dummy_python/dummy.py
@@ -22,7 +22,8 @@ def application_setup(args):
     out_host, out_port = wallaroo.tcp_parse_output_addrs(args)[0]
 
     pipeline = (wallaroo.source("Dummy",
-                    wallaroo.TCPSourceConfig(in_host, in_port, decoder))
+                    wallaroo.TCPSourceConfig(in_host, in_port, decoder,
+                                             parallelism=13))
       .to(pass_through)
       .to(count)
       .key_by(partition)

--- a/testing/correctness/tests/cli_tests/cli_tests.py
+++ b/testing/correctness/tests/cli_tests/cli_tests.py
@@ -78,7 +78,7 @@ def _test_cluster_status_query(command):
 
 
 def _test_source_ids_query(command):
-    HARDCODED_NO_OF_SOURCE_IDS = 10
+    defined_source_parallelism = 13 # see dummy.py TCPSourceconfig
     with LoggingTestContext() as ctx:
         with ctx.Cluster(command=command, sources=1) as cluster:
             given_data_sent(cluster)
@@ -86,7 +86,7 @@ def _test_source_ids_query(command):
             got = q.result()['initializer']
 
         assert(list(got.keys()) == ["source_ids"])
-        assert(len(got["source_ids"]) == HARDCODED_NO_OF_SOURCE_IDS)
+        assert(len(got["source_ids"]) == defined_source_parallelism)
 
 
 def _test_state_entity_query(command):


### PR DESCRIPTION
Some users might want to connect more that 10 sockets
to a Python Wallaroo app. Without the option to increase
the number of TCP Source listeners, the app cannot support
more that 10 concurrent source connections.

This change allows users to specify `parallelism`,
as an optional keyword argument:

```
 wallaroo.TCPSourceConfig(in_host, in_port, decoder,
                                             parallelism=13))

```

The previous API still works as usual, and uses the default
of 10, defined in `machida.pony`.

```
 wallaroo.TCPSourceConfig(in_host, in_port, decoder)
```