### PR TITLE
Update Wallaroo AMI to use machida3

### DIFF
--- a/.for_maintainers/release/AMI_RELEASE.md
+++ b/.for_maintainers/release/AMI_RELEASE.md
@@ -49,7 +49,7 @@ This will `ssh` you into the running Wallaroo box.
 This will do the following:
 
 1. Check out Wallaroo at `<BRANCH>`
-2. Clean up and then build: `machida`,`cluster_shutdown`,
+2. Clean up and then build: `machida3`,`cluster_shutdown`,
   `data_receiver`, and `sender`.
 3. Launch an EC2 instance of Ubuntu 16.04 and install the
    minimum necessary set of packages to run Wallaroo apps
@@ -94,7 +94,7 @@ The build process comprises the following files:
 * [`template.json`](../../.release/ami/template.json): The [Packer template][packer_template] for the AMI
 * [`ami/initial_system_setup.sh`](../../.release/ami/initial_system_setup.sh):
   This script is run on the EC2 instance. It is responsible for installing the
-  runtime dependencies for `machida`, and setting up an `/etc/rc.local` script to run
+  runtime dependencies for `machida3`, and setting up an `/etc/rc.local` script to run
   on system startup.
 * [`regions`](../../.release/ami/regions): A text file listing the AWS regions
   where the public AMI will be available.

--- a/.release/ami-release.sh
+++ b/.release/ami-release.sh
@@ -32,18 +32,18 @@ compile_for_sandy_bridge() {
   git checkout "$RC_BRANCH_NAME"
   make clean
 
-  make build-machida "$PONYC_OPTS" resilience=on
-  mv machida/build/machida machida-resilience
-  make clean-machida
-  make build-machida "$PONYC_OPTS" resilience=off
+  make build-machida3 "$PONYC_OPTS" resilience=on
+  mv machida3/build/machida3 machida3-resilience
+  make clean-machida3
+  make build-machida3 "$PONYC_OPTS" resilience=off
   (cd utils/data_receiver && make "$PONYC_OPTS")
   (cd utils/cluster_shutdown && make "$PONYC_OPTS")
   (cd utils/cluster_shrinker && make "$PONYC_OPTS")
   (cd giles/sender && make "$PONYC_OPTS")
 
   zip -j9 .release/wallaroo_bin.zip \
-      machida/build/machida \
-      machida-resilience \
+      machida3/build/machida3 \
+      machida3-resilience \
       utils/data_receiver/data_receiver \
       utils/cluster_shutdown/cluster_shutdown \
       utils/cluster_shrinker/cluster_shrinker \

--- a/.release/ami/initial_system_setup.sh
+++ b/.release/ami/initial_system_setup.sh
@@ -1,7 +1,14 @@
 #!/bin/sh
+set -x #echo on
+export DEBIAN_FRONTEND=noninteractive
+export TERM=linux
 
+# grub-pc currently causes apt-get upgrade to pause indefinitely
+# holding so it does not get upgraded
+sudo apt-mark hold grub-pc
 # Install common tools
-sudo apt-get update && sudo apt-get -y upgrade
+sudo apt-get -y update
+sudo apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
 sudo apt-get install -y python3-dev build-essential python3-pip unzip zip curl \
                         libsnappy-dev liblz4-dev libz-dev libssl-dev \
                         cpuset numactl

--- a/.release/ami/initial_system_setup.sh
+++ b/.release/ami/initial_system_setup.sh
@@ -2,7 +2,7 @@
 
 # Install common tools
 sudo apt-get update && sudo apt-get -y upgrade
-sudo apt-get install -y python-dev build-essential python-pip unzip zip curl \
+sudo apt-get install -y python3-dev build-essential python3-pip unzip zip curl \
                         libsnappy-dev liblz4-dev libz-dev libssl-dev \
                         cpuset numactl
 sudo -H python -m pip install pytest==3.2.2

--- a/.release/ami/regions
+++ b/.release/ami/regions
@@ -1,6 +1,5 @@
 ap-northeast-1
 ap-northeast-2
-ap-south-1
 ap-southeast-1
 ap-southeast-2
 ca-central-1


### PR DESCRIPTION
<!--
Make sure you've read the [Contributors Guide](https://github.com/WallarooLabs/wallaroo/blob/master/CONTRIBUTING.md). You'll need to sign our CLA before your issue can be accepted.

Reference the issue your code change relates to if possible
-->
Updates Wallaroo AMI to use machida3 instead of machida

- makes various fixes to the initial system setup script that was causing indefinite pauses which would lead to the AMI never being created.

ref #2728 
<!--
Include any other necessary information below. If you have any questions don't hesitate to reach out on the mailing list or on IRC.
-->
