### PR TITLE
Support key and timestamp assignment in connectors

### DIFF
--- a/lib/wallaroo/core/source/connector_source/connector_framed_source_notify.pony
+++ b/lib/wallaroo/core/source/connector_source/connector_framed_source_notify.pony
@@ -19,6 +19,7 @@ Copyright 2017 The Wallaroo Authors.
 use "collections"
 use "time"
 use "wallaroo_labs/time"
+use "wallaroo_labs/bytes"
 use "wallaroo/core/boundary"
 use "wallaroo/core/common"
 use "wallaroo/core/partitioning"
@@ -90,15 +91,31 @@ class ConnectorSourceNotify[In: Any val]
 
       (let is_finished, let last_ts) =
         try
-          let decoded =
-            try
-              _handler.decode(consume data)?
+          let data': Array[U8] val = consume data
+          // TODO: John use this variable
+          let event_timestamp: U64 = try
+              Bytes.to_u64(data'(0)?, data'(1)?, data'(2)?, data'(3)?, data'(4)?,
+                  data'(5)?, data'(6)?, data'(7)?)
             else
-              ifdef debug then
-                @printf[I32]("Error decoding message at source\n".cstring())
-              end
-              error
+              0
             end
+          let key_length: U32 = try
+              Bytes.to_u32(data'(8)?, data'(9)?, data'(10)?, data'(11)?)
+            else
+              0
+            end
+          let key_bytes = recover val data'.slice(12, 12+key_length.usize()) end
+          let key_string = String.from_array(key_bytes)
+          let decoder_data = recover val data'.slice(8+4+key_length.usize()) end
+          let decoded = try
+            _handler.decode(decoder_data)?
+          else
+            ifdef debug then
+              @printf[I32]("Error decoding message at source\n".cstring())
+            end
+            error
+          end
+
           let decode_end_ts = Time.nanos()
           _metrics_reporter.step_metric(_pipeline_name,
             "Decode Time in Connector Source", latest_metrics_id, ingest_ts,
@@ -115,9 +132,17 @@ class ConnectorSourceNotify[In: Any val]
           // TODO: We need a way to determine the key based on the policy
           // for any particular connector. For example, the Kafka connector
           // needs a way to provide the Kafka key here.
-          let initial_key = msg_uid.string()
 
-          if decoded isnt None then
+          // TODO: Match to see if key exists and if it does use that for initial key instead
+          let initial_key =
+            if key_string isnt None then
+              key_string.string()
+            else
+              msg_uid.string()
+            end
+
+
+          if decoder_data isnt None then
             _runner.run[In](_pipeline_name, pipeline_time_spent, decoded,
               consume initial_key, _source_id, source, _router,
               msg_uid, None, decode_end_ts,

--- a/lib/wallaroo/core/source/connector_source/connector_framed_source_notify.pony
+++ b/lib/wallaroo/core/source/connector_source/connector_framed_source_notify.pony
@@ -133,7 +133,6 @@ class ConnectorSourceNotify[In: Any val]
           // for any particular connector. For example, the Kafka connector
           // needs a way to provide the Kafka key here.
 
-          // TODO: Match to see if key exists and if it does use that for initial key instead
           let initial_key =
             if key_string isnt None then
               key_string.string()

--- a/lib/wallaroo/core/source/connector_source/connector_framed_source_notify.pony
+++ b/lib/wallaroo/core/source/connector_source/connector_framed_source_notify.pony
@@ -106,7 +106,7 @@ class ConnectorSourceNotify[In: Any val]
             end
           let key_bytes = recover val data'.slice(12, 12+key_length.usize()) end
           let key_string = String.from_array(key_bytes)
-          let decoder_data = recover val data'.slice(8+4+key_length.usize()) end
+          let decoder_data = recover val data'.slice(12+key_length.usize()) end
           let decoded = try
             _handler.decode(decoder_data)?
           else
@@ -135,7 +135,7 @@ class ConnectorSourceNotify[In: Any val]
 
           let initial_key =
             if key_string isnt None then
-              key_string.string()
+              key_string
             else
               msg_uid.string()
             end

--- a/machida/lib/wallaroo/__init__.py
+++ b/machida/lib/wallaroo/__init__.py
@@ -287,8 +287,6 @@ def _wallaroo_wrap(name, func, base_cls, **kwargs):
                 def payload_length(self, bs):
                     return struct.unpack(">I", bs)[0]
                 def decode(self, bs):
-                    # We're dropping event_time for now. Pony will pick this up
-                    # itself. Slice bytes off the front: struct.calcsize('<q') = 8
                     return func(bs)
                 def decoder(self):
                     return func

--- a/machida/lib/wallaroo/__init__.py
+++ b/machida/lib/wallaroo/__init__.py
@@ -251,7 +251,7 @@ def _wallaroo_wrap(name, func, base_cls, **kwargs):
                         event_time = int(event_time.timestamp() * 1000)
                     encoded_key = key.encode() if key else ''.encode()
                     return struct.pack(
-                        '<IqI{}s{}s'.format(len(encoded_key), len(encoded)),
+                        '>IqI{}s{}s'.format(len(encoded_key), len(encoded)),
                         len(encoded) + 8 + len(encoded_key) + 8, # total frame size
                         event_time, # 64bit event_time
                         len(encoded_key),
@@ -285,7 +285,7 @@ def _wallaroo_wrap(name, func, base_cls, **kwargs):
                     # struct.calcsize('<I')
                     return 4
                 def payload_length(self, bs):
-                    return struct.unpack("<I", bs)[0]
+                    return struct.unpack(">I", bs)[0]
                 def decode(self, bs):
                     # We're dropping event_time for now. Pony will pick this up
                     # itself. Slice bytes off the front: struct.calcsize('<q') = 8

--- a/machida/lib/wallaroo/__init__.py
+++ b/machida/lib/wallaroo/__init__.py
@@ -236,7 +236,7 @@ def _wallaroo_wrap(name, func, base_cls, **kwargs):
         # ConnectorEncoder
         if issubclass(base_cls, ConnectorEncoder):
             class C(base_cls):
-                def encode(self, data, event_time=0):
+                def encode(self, data, event_time=0, key=None):
                     encoded = func(data)
                     if isinstance(event_time, dt.datetime):
                         # We'll assume naive datetime values should be treated as
@@ -249,10 +249,13 @@ def _wallaroo_wrap(name, func, base_cls, **kwargs):
                         # Convert to an integer number of ms from the floating
                         # point seconds that Python uses.
                         event_time = int(event_time.timestamp() * 1000)
+                    encoded_key = key.encode() if key else ''.encode()
                     return struct.pack(
-                        '<Iq{}s'.format(len(encoded)),
-                        len(encoded) + 8, # total frame size
+                        '<IqI{}s{}s'.format(len(encoded_key), len(encoded)),
+                        len(encoded) + 8 + len(encoded_key) + 8, # total frame size
                         event_time, # 64bit event_time
+                        len(encoded_key),
+                        encoded_key,
                         encoded) # final payload, variable size as formatted above
 
         # OctetEncoder
@@ -286,8 +289,7 @@ def _wallaroo_wrap(name, func, base_cls, **kwargs):
                 def decode(self, bs):
                     # We're dropping event_time for now. Pony will pick this up
                     # itself. Slice bytes off the front: struct.calcsize('<q') = 8
-                    message_data = bs[8:]
-                    return func(message_data)
+                    return func(bs)
                 def decoder(self):
                     return func
 

--- a/machida/lib/wallaroo/experimental/__init__.py
+++ b/machida/lib/wallaroo/experimental/__init__.py
@@ -93,10 +93,10 @@ class SourceConnector(object):
                 else:
                     raise
 
-    def write(self, message, key=None, event_time=0):
+    def write(self, message, event_time=0, key=None):
         if self._conn == None:
             raise RuntimeError("Please call connect before writing")
-        payload = self._encoder.encode(message, key, event_time)
+        payload = self._encoder.encode(message, event_time, key)
         self._conn.sendall(payload)
 
 

--- a/machida/lib/wallaroo/experimental/__init__.py
+++ b/machida/lib/wallaroo/experimental/__init__.py
@@ -93,10 +93,10 @@ class SourceConnector(object):
                 else:
                     raise
 
-    def write(self, message, event_time=0):
+    def write(self, message, key=None, event_time=0):
         if self._conn == None:
             raise RuntimeError("Please call connect before writing")
-        payload = self._encoder.encode(message, event_time)
+        payload = self._encoder.encode(message, key, event_time)
         self._conn.sendall(payload)
 
 


### PR DESCRIPTION
ref #2717 

Initial pony and python changes so connectors can provide a key and timestamp to wallaroo.