### PR TITLE
Add synchronous NOTIFY_ACK reply to NOTIFY message

### DIFF
--- a/docs/proposals/connector-protocol-v2.md
+++ b/docs/proposals/connector-protocol-v2.md
@@ -56,19 +56,17 @@ This document uses Erlang code to describe the frame format and content. You don
 
 #### Constants
 
-Frame tags (`$H` = ASCII value of H):
-
 ```erlang
--define(HELLO, $H).
--define(OK, $O).
--define(ERROR, $E).
+-define(HELLO, 0).
+-define(OK, 1).
+-define(ERROR, 2).
 
--define(NOTIFY, $N).
--define(NOTIFY_ACK, $n).
--define(MESSAGE, $M).
+-define(NOTIFY, 3).
+-define(NOTIFY_ACK, 4).
+-define(MESSAGE, 5).
 
--define(ACK, $A).
--define(RESTART, $!).
+-define(ACK, 6).
+-define(RESTART, 7).
 ```
 
 Message bit-flags:

--- a/docs/proposals/connector-protocol-v2.md
+++ b/docs/proposals/connector-protocol-v2.md
@@ -112,6 +112,10 @@ u16(N) ->
 u32(N) ->
     <<N:32/big-unsigned>>.
 
+-spec i64(non_neg_integer()) -> binary().
+i64(N) ->
+    <<N:64/big-signed>>.
+
 -spec u64(non_neg_integer()) -> binary().
 u64(N) ->
     <<N:64/big-unsigned>>.
@@ -255,7 +259,7 @@ message(Flags, StreamId, MessageId, EventTime, Key, Message) ->
             u64(MessageId)
         end,
         if Flags band ?EVENT_TIME /= 0 then
-            u64(EventTime)
+            i64(EventTime)
         else
             <<>>
         end,

--- a/docs/proposals/connector-protocol-v2.md
+++ b/docs/proposals/connector-protocol-v2.md
@@ -164,6 +164,7 @@ ok(InitialCredits, PointsOfReference) ->
         u32(InitialCredits),
         % This encodes each point of reference in sequence using the
         % remaining bytes in the frame.
+        u32(length(PointsOfReference)),
         lists:map(fun ({StreamId, StreamName, Ref}) ->
             [u64(StreamId), short_bytes(StreamName), point_of_reference(Ref)]
         end, PointsOfReference)

--- a/docs/proposals/connector-protocol-v2.md
+++ b/docs/proposals/connector-protocol-v2.md
@@ -441,7 +441,7 @@ In the notify-sent state, the following actions are valid:
     * NOTE: The point of reference in this ACK may differ from the point of reference sent by the connector in the NOTIFY message.  The connector must use the point of reference given in the NOTIFY_ACK message.
     * The connector must not send MESSAGE for any stream id before the connector receives a successful NOTIFY_ACK for the stream id.
 - RESTART: Worker -> Connector (next state is terminated)
-    * worker is requesting that the stream be reprocessed in some way
+    * worker is requesting that all streams be reprocessed
 
 In the open state, the following actions are valid:
 
@@ -450,14 +450,14 @@ In the open state, the following actions are valid:
 - ACK: Worker -> Connector
     * the are not 1-1 with MESSAGE frames
 - RESTART: Worker -> Connector (next state is terminated)
-    * worker is requesting that the stream be reprocessed in some way
+    * worker is requesting that all streams be reprocessed
 
 In the closed state, the following actions are valid:
 
 - NOTIFY: Connector -> Worker (next state is open)
     * reopens the stream
 - RESTART: Worker -> Connector (next state is terminated)
-    * worker is requesting that the stream be reprocessed in some way
+    * worker is requesting that all streams be reprocessed
 - ACK: Worker -> Connector
     * these can arrive asynchronously and should be processed accordingly
 

--- a/docs/proposals/connector-protocol-v2.md
+++ b/docs/proposals/connector-protocol-v2.md
@@ -227,7 +227,7 @@ notify(StreamId, StreamName, PointOfRef) ->
 
 -spec notify_ack(non_neg_integer(), bool(), point_of_reference()) -> frame().
 notify_ack(StreamId, NotifySuccess, PointOfRef) ->
-    framed([
+    frame([
         ?NOTIFY_ACK,
         if NotifySuccess -> <<1>>;
            true          -> <<0>>
@@ -271,7 +271,7 @@ message(Flags, StreamId, MessageId, EventTime, Key, Message) ->
     ]).
 
 ack(Credits, MessageAcks) ->
-    framed([
+    frame([
         ?ACK,
         u32(Credits),
         u32(length(MessageAcks)),


### PR DESCRIPTION
Various protocol spec fixes that we've identified over the last few days.

* `NOTIFY`'s reply needs to be sync: add `NOTIFY_ACK` message to fill the new role
* Change constant naming, fix typos, add explicit length of a variable-length list (I'd fixed one of these earlier but missed a 2nd), change type for event time (see commit logs)