### PR TITLE
Add connector_wire_messages codecs package

### DIFF
--- a/lib/wallaroo_labs/_test.pony
+++ b/lib/wallaroo_labs/_test.pony
@@ -35,6 +35,7 @@ use options = "options"
 use queue = "queue"
 use weighted = "weighted"
 use query = "query"
+use cwm = "connector_wire_messages"
 
 actor Main is TestList
   new create(env: Env) =>
@@ -53,3 +54,4 @@ actor Main is TestList
     queue.Main.make().tests(test)
     weighted.Main.make().tests(test)
     query.Main.make().tests(test)
+    cwm.Main.make().tests(test)

--- a/lib/wallaroo_labs/connector_wire_messages/.gitignore
+++ b/lib/wallaroo_labs/connector_wire_messages/.gitignore
@@ -1,0 +1,1 @@
+connector_wire_messages

--- a/lib/wallaroo_labs/connector_wire_messages/_test.pony
+++ b/lib/wallaroo_labs/connector_wire_messages/_test.pony
@@ -1,0 +1,341 @@
+/*
+
+Copyright 2017 The Wallaroo Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing
+ permissions and limitations under the License.
+
+*/
+
+use "buffered"
+use "ponytest"
+
+actor Main is TestList
+  new create(env: Env) =>
+    PonyTest(env, this)
+
+  new make() => None
+
+  fun tag tests(test: PonyTest) =>
+    test(_TestBitFlags)
+    test(_TestHelloMsg)
+    test(_TestOkMsg)
+    test(_TestErrorMsg)
+    test(_TestNotifyMsg)
+    test(_TestNotifyAckMsg)
+    test(_TestMessageMsg)
+    test(_TestAckMsg)
+    test(_TestRestartMsg)
+
+class iso _TestBitFlags is UnitTest
+  fun name(): String => "connector_wire_messages/_TestBitFlags"
+
+  fun apply(h: TestHelper) =>
+    // Test Ephemeral: value 1
+    h.assert_eq[U8](Ephemeral(), 1)
+    h.assert_eq[U8](Ephemeral(2), 3)
+    h.assert_eq[U8](Ephemeral.clear(3), 2)
+    h.assert_true(Ephemeral.eq(1))
+    h.assert_false(Ephemeral.eq(2))
+    h.assert_true(Ephemeral == 1)
+    h.assert_false(Ephemeral == 2)
+    h.assert_true(Ephemeral.is_set(3))
+    h.assert_false(Ephemeral.is_set(2))
+
+    // test Boundary: Value 2
+    h.assert_eq[U8](Boundary(), 2)
+    h.assert_eq[U8](Boundary(2), 2)
+    h.assert_eq[U8](Boundary.clear(3), 1)
+    h.assert_true(Boundary.eq(2))
+    h.assert_false(Boundary.eq(3))
+    h.assert_true(Boundary == 2)
+    h.assert_false(Boundary == 1)
+    h.assert_true(Boundary.is_set(3))
+    h.assert_false(Boundary.is_set(4))
+
+    // test Eos: Value 4
+    h.assert_eq[U8](Eos(), 4)
+    h.assert_eq[U8](Eos(4), 4)
+    h.assert_eq[U8](Eos.clear(5), 1)
+    h.assert_true(Eos.eq(4))
+    h.assert_false(Eos.eq(5))
+    h.assert_true(Eos == 4)
+    h.assert_false(Eos == 1)
+    h.assert_true(Eos.is_set(5))
+    h.assert_false(Eos.is_set(3))
+
+   // test UnstableReference: Value 8
+    h.assert_eq[U8](UnstableReference(), 8)
+    h.assert_eq[U8](UnstableReference(8), 8)
+    h.assert_eq[U8](UnstableReference.clear(9), 1)
+    h.assert_true(UnstableReference.eq(8))
+    h.assert_false(UnstableReference.eq(9))
+    h.assert_true(UnstableReference == 8)
+    h.assert_false(UnstableReference == 9)
+    h.assert_true(UnstableReference.is_set(9))
+    h.assert_false(UnstableReference.is_set(3))
+
+   // test EventTime: Value 16
+    h.assert_eq[U8](EventTime(), 16)
+    h.assert_eq[U8](EventTime(16), 16)
+    h.assert_eq[U8](EventTime.clear(17), 1)
+    h.assert_true(EventTime.eq(16))
+    h.assert_false(EventTime.eq(17))
+    h.assert_true(EventTime == 16)
+    h.assert_false(EventTime == 17)
+    h.assert_true(EventTime.is_set(17))
+    h.assert_false(EventTime.is_set(15))
+
+   // test Key: Value 32
+    h.assert_eq[U8](Key(), 32)
+    h.assert_eq[U8](Key(32), 32)
+    h.assert_eq[U8](Key.clear(33), 1)
+    h.assert_true(Key.eq(32))
+    h.assert_false(Key.eq(33))
+    h.assert_true(Key == 32)
+    h.assert_false(Key == 33)
+    h.assert_true(Key.is_set(33))
+    h.assert_false(Key.is_set(31))
+
+class iso _TestHelloMsg is UnitTest
+  fun name(): String => "connector_wire_messages/_TestHelloMsg"
+
+  fun apply(h: TestHelper) ? =>
+    let a = HelloMsg("version", "cookie", "program", "instance")
+    let encoded = Frame.encode(a)
+    let m = Frame.decode(encoded)?
+    let b = m as HelloMsg
+    h.assert_eq[String](a.version, b.version)
+    h.assert_eq[String](a.cookie, b.cookie)
+    h.assert_eq[String](a.program_name, b.program_name)
+    h.assert_eq[String](a.instance_name, b.instance_name)
+
+class iso _TestOkMsg is UnitTest
+  fun name(): String => "connector_wire_messages/_TestOkMsg"
+
+  fun apply(h: TestHelper) ? =>
+    let ic: U32 = 100
+    let cl: Array[Credit] val = [(1, "1", 0); (2, "2", 1); (3, "3", 2)]
+    let a = OkMsg(ic, cl)
+    let encoded = Frame.encode(a)
+    let m = Frame.decode(encoded)?
+    let b = m as OkMsg
+    h.assert_eq[U32](a.initial_credits, ic)
+    h.assert_eq[U32](b.initial_credits, ic)
+    for (i, cr) in a.credit_list.pairs() do
+      h.assert_eq[StreamId](cr._1, cl(i)?._1)
+      h.assert_eq[StreamName](cr._2, cl(i)?._2)
+      h.assert_eq[PointOfRef](cr._3, cl(i)?._3)
+    end
+    for (i, cr) in b.credit_list.pairs() do
+      h.assert_eq[StreamId](cr._1, cl(i)?._1)
+      h.assert_eq[StreamName](cr._2, cl(i)?._2)
+      h.assert_eq[PointOfRef](cr._3, cl(i)?._3)
+    end
+
+class iso _TestErrorMsg is UnitTest
+  fun name(): String => "connector_wire_messages/_TestErrorMsg"
+
+  fun apply(h: TestHelper) ? =>
+    let msg: String = "some error"
+    let a = ErrorMsg(msg)
+    let encoded = Frame.encode(a)
+    let m = Frame.decode(encoded)?
+    let b = m as ErrorMsg
+    h.assert_eq[String](b.message, msg)
+    h.assert_eq[String](b.message, msg)
+
+class iso _TestNotifyMsg is UnitTest
+  fun name(): String => "connector_wire_messages/_TestNotifyMsg"
+
+  fun apply(h: TestHelper) ? =>
+    let cr: Credit = (1, "2", 3)
+    let a = NotifyMsg(cr._1, cr._2, cr._3)
+    let encoded = Frame.encode(a)
+    let m = Frame.decode(encoded)?
+    let b = m as NotifyMsg
+    h.assert_eq[StreamId](a.stream_id, cr._1)
+    h.assert_eq[StreamName](a.stream_name, cr._2)
+    h.assert_eq[PointOfRef](a.point_of_ref, cr._3)
+    h.assert_eq[StreamId](b.stream_id, cr._1)
+    h.assert_eq[StreamName](b.stream_name, cr._2)
+    h.assert_eq[PointOfRef](b.point_of_ref, cr._3)
+
+class iso _TestNotifyAckMsg is UnitTest
+  fun name(): String => "connector_wire_messages/_TestNotifyAckMsg"
+
+  fun apply(h: TestHelper) ? =>
+    let success = true
+    let sid: StreamId = 1
+    let por: PointOfRef = 12
+    let a = NotifyAckMsg(success, sid, por)
+    let encoded = Frame.encode(a)
+    let m = Frame.decode(encoded)?
+    let b = m as NotifyAckMsg
+    h.assert_eq[Bool](a.success, success)
+    h.assert_eq[StreamId](a.stream_id, sid)
+    h.assert_eq[PointOfRef](a.point_of_ref, por)
+    h.assert_eq[Bool](b.success, success)
+    h.assert_eq[StreamId](b.stream_id, sid)
+    h.assert_eq[PointOfRef](b.point_of_ref, por)
+
+class iso _TestMessageMsg is UnitTest
+  fun name(): String => "connector_wire_messages/_TestMessageMsg"
+
+  fun apply(h: TestHelper) ? =>
+    """
+    Allowed flag combinations
+        1 2 4   8   16  32
+        E B Eo  Un  Et  K
+    E   x   x       x   x
+    B     x x       x
+    Eo      x   x   x   x
+    Un          x   x   x
+    Et              x   x
+    K                   x
+    """
+    let sid: StreamId = 1
+    let mid: MessageId = 10
+    let kb = "key"
+    let et: EventTimeType val = 123456789
+    let mb = "this is a message"
+    let all_flags: Array[U8] val =
+      recover
+        [
+          // Ephemeral
+          1
+          1 or 4
+          1 or 16
+          1 or 32
+          1 or 4 or 16
+          1 or 4 or 32
+          1 or 4 or 16 or 32
+          // Boundary
+          2
+          2 or 4
+          2 or 16
+          2 or 4 or 16
+          // EOS
+          4
+          4 or 8
+          4 or 16
+          4 or 32
+          4 or 8 or 16
+          4 or 8 or 32
+          4 or 8 or 16 or 32
+          // UnstableReference
+          8
+          8 or 16
+          8 or 32
+          8 or 16 or 32
+          // EventTime
+          16
+          16 or 32
+          // Key
+          32
+        ]
+      end
+
+    for fl in all_flags.values() do
+      let a = MessageMsg(
+        sid,
+        fl,
+        if Ephemeral.is_set(fl) then None else mid end,
+        if EventTime.is_set(fl) then et else None end,
+        if Key.is_set(fl) then kb else None end,
+        if Boundary.is_set(fl) then None else mb end)?
+
+
+      let encoded = Frame.encode(a)
+      let m = Frame.decode(encoded)?
+      let b = m as MessageMsg
+      if not Ephemeral.is_set(fl) then
+        match a.message_id
+        | let mid': U64 => h.assert_eq[MessageId](mid', mid)
+        end
+        match b.message_id
+        | let mid': U64 => h.assert_eq[MessageId](mid', mid)
+        end
+      else
+        h.assert_true(a.message_id is None)
+        h.assert_true(b.message_id is None)
+      end
+      if EventTime.is_set(fl) then
+        match a.event_time
+        | let et': I64 =>
+          h.assert_eq[EventTimeType](et', et)
+        end
+        match b.event_time
+        | let et': I64 =>
+          h.assert_eq[EventTimeType](et', et)
+        end
+      else
+        h.assert_true(a.event_time is None)
+        h.assert_true(b.event_time is None)
+      end
+      if Key.is_set(fl) then
+        match a.key
+        | let kb': String =>
+          h.assert_eq[String](kb', kb)
+        end
+        match b.key
+        | let kb': String =>
+          h.assert_eq[String](kb', kb)
+        end
+      else
+        h.assert_true(a.key is None)
+        h.assert_true(b.key is None)
+      end
+      if not Boundary.is_set(fl) then
+        match a.message
+        | let mb': String =>
+          h.assert_eq[String](mb', mb)
+        end
+        match b.message
+        | let mb': String =>
+          h.assert_eq[String](mb', mb)
+        end
+      else
+        h.assert_true(a.message is None)
+        h.assert_true(b.message is None)
+      end
+    end
+
+class iso _TestAckMsg is UnitTest
+  fun name(): String => "connector_wire_messages/_TestAckMsg"
+
+  fun apply(h: TestHelper) ? =>
+    let credits: U32 = 100
+    let cl: Array[(StreamId, PointOfRef)] val = [(1, 1) ; (2, 2) ; (3, 3)]
+    let a = AckMsg(credits, cl)
+    let encoded = Frame.encode(a)
+    let m = Frame.decode(encoded)?
+    let b = m as AckMsg
+    h.assert_eq[U32](a.credits, credits)
+    for (i, p) in a.credit_list.pairs() do
+      h.assert_eq[StreamId](p._1, cl(i)?._1)
+      h.assert_eq[PointOfRef](p._2, cl(i)?._2)
+    end
+    h.assert_eq[U32](b.credits, credits)
+    for (i, p) in b.credit_list.pairs() do
+      h.assert_eq[StreamId](p._1, cl(i)?._1)
+      h.assert_eq[PointOfRef](p._2, cl(i)?._2)
+    end
+
+class iso _TestRestartMsg is UnitTest
+  fun name(): String => "connector_wire_messages/_TestRestartMsg"
+
+  fun apply(h: TestHelper) ? =>
+    let a = RestartMsg
+    let encoded = Frame.encode(a)
+    let m = Frame.decode(encoded)?
+    let b = m as RestartMsg

--- a/lib/wallaroo_labs/connector_wire_messages/_test.pony
+++ b/lib/wallaroo_labs/connector_wire_messages/_test.pony
@@ -1,6 +1,6 @@
 /*
 
-Copyright 2017 The Wallaroo Authors.
+Copyright 2018 The Wallaroo Authors.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -151,7 +151,7 @@ class iso _TestErrorMsg is UnitTest
     let encoded = Frame.encode(a)
     let m = Frame.decode(encoded)?
     let b = m as ErrorMsg
-    h.assert_eq[String](b.message, msg)
+    h.assert_eq[String](a.message, msg)
     h.assert_eq[String](b.message, msg)
 
 class iso _TestNotifyMsg is UnitTest

--- a/lib/wallaroo_labs/connector_wire_messages/connector_wire_messages.pony
+++ b/lib/wallaroo_labs/connector_wire_messages/connector_wire_messages.pony
@@ -1,0 +1,435 @@
+/*
+
+Copyright 2018 The Wallaroo Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing
+ permissions and limitations under the License.
+
+*/
+
+use "buffered"
+use col = "collections"
+
+// Message bit flags
+
+type Flags is U8
+
+trait val BitFlags
+  fun apply(value: Flags): Flags      // set the mask's bit
+  fun clear(other: Flags): Flags      // unset the mask's bit
+  fun eq(y: Flags): Bool              // is this mask the only one set?
+  fun is_set(other: Flags): Bool      // is the mask's bit set?
+
+
+primitive Ephemeral is BitFlags
+  fun apply(value: Flags = 0): Flags => value.op_or(1)
+  fun clear(other: Flags): Flags => other.op_and(Flags(1).op_not())
+  fun eq(other: Flags): Bool => other == 1
+  fun is_set(other: Flags): Bool => other.op_and(1) == 1
+
+primitive Boundary is BitFlags
+  fun apply(value: Flags = 0): Flags => value.op_or(2)
+  fun clear(other: Flags): Flags => other.op_and(Flags(2).op_not())
+  fun eq(other: Flags): Bool => other == 2
+  fun is_set(other: Flags): Bool => other.op_and(2) == 2
+
+primitive Eos is BitFlags
+  fun apply(value: Flags = 0): Flags => value.op_or(4)
+  fun clear(other: Flags): Flags => other.op_and(Flags(4).op_not())
+  fun eq(other: Flags): Bool => other == 4
+  fun is_set(other: Flags): Bool => other.op_and(4) == 4
+
+primitive UnstableReference is BitFlags
+  fun apply(value: Flags = 0): Flags => value.op_or(8)
+  fun clear(other: Flags): Flags => other.op_and(Flags(8).op_not())
+  fun eq(other: Flags): Bool => other == 8
+  fun is_set(other: Flags): Bool => other.op_and(8) == 8
+
+primitive EventTime is BitFlags
+  fun apply(value: Flags = 0): Flags => value.op_or(16)
+  fun clear(other: Flags): Flags => other.op_and(Flags(16).op_not())
+  fun eq(other: Flags): Bool => other == 16
+  fun is_set(other: Flags): Bool => other.op_and(16) == 16
+
+primitive Key is BitFlags
+  fun apply(value: Flags = 0): Flags => value.op_or(32)
+  fun clear(other: Flags): Flags => other.op_and(Flags(32).op_not())
+  fun eq(other: Flags): Bool => other == 32
+  fun is_set(other: Flags): Bool => other.op_and(32) == 32
+
+primitive FlagsAllowed
+  fun apply(f: Flags): Bool =>
+  """
+  Allowed flag combinations
+      E B Eo  Un  Et  K
+  E   x   x       x   x
+  B     x x       x
+  Eo      x   x   x   x
+  Un          x   x   x
+  Et              x   x
+  K                   x
+  """
+  if Ephemeral.is_set(f) then
+    if Boundary.is_set(f) or UnstableReference.is_set(f) then
+      false
+    else
+      true
+    end
+  elseif Boundary.is_set(f) then
+    if UnstableReference.is_set(f) or Key.is_set(f) then
+      false
+    else
+      true
+    end
+  else
+    true
+  end
+
+// Frame types
+
+primitive FrameTag
+  fun decode(rb: Reader): Message ? =>
+    let frame_tag = rb.u8()?
+    match frame_tag
+    | 0 => HelloMsg.decode(rb)?
+    | 1 => OkMsg.decode(consume rb)?
+    | 2 => ErrorMsg.decode(consume rb)?
+    | 3 => NotifyMsg.decode(consume rb)?
+    | 4 => NotifyAckMsg.decode(consume rb)?
+    | 5 => MessageMsg.decode(consume rb)?
+    | 6 => AckMsg.decode(consume rb)?
+    | 7 => RestartMsg.decode(consume rb)
+    else
+      error
+    end
+
+  fun apply(msg: Message): U8 =>
+    match msg
+    | let m: HelloMsg => 0
+    | let m: OkMsg => 1
+    | let m: ErrorMsg => 2
+    | let m: NotifyMsg => 3
+    | let m: NotifyAckMsg => 4
+    | let m: MessageMsg => 5
+    | let m: AckMsg => 6
+    | let m: RestartMsg => 7
+    end
+
+// Framing
+type StreamId is U64
+type StreamName is String
+type PointOfRef is U64
+type Credit is (StreamId, StreamName, PointOfRef)
+type EventTimeType is I64
+type MessageId is U64
+type MessageBytes is ByteSeq
+type KeyBytes is ByteSeq
+
+
+type Message is ( HelloMsg |
+                  OkMsg |
+                  ErrorMsg |
+                  NotifyMsg |
+                  NotifyAckMsg |
+                  MessageMsg |
+                  AckMsg |
+                  RestartMsg )
+
+trait MessageTrait
+  fun encode(wb: Writer = Writer): Writer ?
+  new decode(rb: Reader) ?
+
+primitive Frame
+  fun encode(msg: Message, wb: Writer = Writer): Array[U8] val =>
+    let encoded = msg.encode()
+    wb.u8(FrameTag(msg))
+    wb.writev(encoded.done())
+    let bs: Array[ByteSeq val] val = wb.done()
+    recover
+      let a = Array[U8]
+      for b in bs.values() do
+        a.append(b)
+      end
+      a
+    end
+
+  fun decode(data: Array[U8] val): Message ? =>
+    // read length
+    let rb = Reader
+    rb.append(data)
+    FrameTag.decode(consume rb)?
+
+
+class HelloMsg is MessageTrait
+  let version: String
+  let cookie: String
+  let program_name: String
+  let instance_name: String
+
+  new create(version': String, cookie': String, program_name': String,
+    instance_name': String)
+  =>
+    version = version'
+    cookie = cookie'
+    program_name = program_name'
+    instance_name = instance_name'
+
+  new decode(rb: Reader) ? =>
+    var length = rb.u16_be()?.usize()
+    version = String.from_array(rb.block(length)?)
+    length = rb.u16_be()?.usize()
+    cookie = String.from_array(rb.block(length)?)
+    length = rb.u16_be()?.usize()
+    program_name = String.from_array(rb.block(length)?)
+    length = rb.u16_be()?.usize()
+    instance_name = String.from_array(rb.block(length)?)
+
+  fun encode(wb: Writer = Writer): Writer =>
+    wb.u16_be(version.size().u16())
+    wb.write(version)
+    wb.u16_be(cookie.size().u16())
+    wb.write(cookie)
+    wb.u16_be(program_name.size().u16())
+    wb.write(program_name)
+    wb.u16_be(instance_name.size().u16())
+    wb.write(instance_name)
+    wb
+
+class OkMsg is MessageTrait
+  let initial_credits: U32
+  let credit_list: Array[Credit] val
+
+  new create(initial_credits': U32, credit_list': Array[Credit] val) =>
+    initial_credits = initial_credits'
+    credit_list = credit_list'
+
+  new decode(rb: Reader) ? =>
+    initial_credits = rb.u32_be()?
+    let cl = recover iso Array[Credit] end
+    let cl_size = rb.u32_be()?.usize()
+    for x in col.Range(0, cl_size) do
+      let sid = rb.u64_be()?
+      let snl = rb.u16_be()?.usize()
+      let sn = String.from_array(rb.block(snl)?)
+      let por = rb.u64_be()?
+      cl.push((sid, sn, por))
+    end
+    credit_list = consume cl
+
+  fun encode(wb: Writer = Writer): Writer =>
+    wb.u32_be(initial_credits)
+    wb.u32_be(credit_list.size().u32())
+    for v in credit_list.values() do
+      wb.u64_be(v._1)
+      wb.u16_be(v._2.size().u16())
+      wb.write(v._2)
+      wb.u64_be(v._3)
+    end
+    wb
+
+class ErrorMsg is MessageTrait
+  let message: String
+
+  new create(message': String) =>
+    message = message'
+
+  new decode(rb: Reader)? =>
+    let length = rb.u16_be()?.usize()
+    message = String.from_array(rb.block(length)?)
+
+  fun encode(wb: Writer = Writer): Writer =>
+    wb.u16_be(message.size().u16())
+    wb.write(message)
+    wb
+
+class NotifyMsg is MessageTrait
+  let stream_id: StreamId
+  let stream_name: StreamName
+  let point_of_ref: PointOfRef
+
+  new create(stream_id': StreamId, stream_name': StreamName,
+    point_of_ref': PointOfRef)
+  =>
+    stream_id = stream_id'
+    stream_name = stream_name'
+    point_of_ref = point_of_ref'
+
+  new decode(rb: Reader) ? =>
+    stream_id = rb.u64_be()?
+    let length = rb.u16_be()?.usize()
+    stream_name = String.from_array(rb.block(length)?)
+    point_of_ref = rb.u64_be()?
+
+  fun encode(wb: Writer = Writer): Writer =>
+    wb.u64_be(stream_id)
+    wb.u16_be(stream_name.size().u16())
+    wb.write(stream_name)
+    wb.u64_be(point_of_ref)
+    wb
+
+class NotifyAckMsg is MessageTrait
+  let success: Bool
+  let stream_id: StreamId
+  let point_of_ref: PointOfRef
+
+  new create(success': Bool, stream_id': StreamId, point_of_ref': PointOfRef) =>
+    success = success'
+    stream_id = stream_id'
+    point_of_ref = point_of_ref'
+
+  new decode(rb: Reader) ? =>
+    success = if rb.u8()? == 1 then true else false end
+    stream_id = rb.u64_be()?
+    point_of_ref = rb.u64_be()?
+
+  fun encode(wb: Writer = Writer): Writer =>
+    if success then wb.u8(1) else wb.u8(0) end
+    wb.u64_be(stream_id)
+    wb.u64_be(point_of_ref)
+    wb
+
+class MessageMsg is MessageTrait
+  let stream_id: StreamId
+  let flags: Flags
+  let message_id: (MessageId | None)
+  let event_time: (EventTimeType | None)
+  let key: (KeyBytes | None)
+  let message: (MessageBytes | None)
+
+  new create(
+    stream_id': StreamId,
+    flags': Flags,
+    message_id': (MessageId | None) = None,
+    event_time': (EventTimeType | None) = None,
+    key': (KeyBytes | None) = None,
+    message': (MessageBytes | None) = None) ?
+  =>
+    stream_id = stream_id'
+    flags = flags'
+    message_id = message_id'
+    event_time = event_time'
+    key = key'
+    message = message'
+
+    if not FlagsAllowed(flags) then
+      @printf[I32]("Illegal flags combination: %s\n".cstring(),
+        flags'.string().cstring())
+      error
+    end
+
+  new decode(rb: Reader) ? =>
+    stream_id = rb.u64_be()?
+    flags = rb.u8()?
+    if not FlagsAllowed(flags) then
+      @printf[I32]("Illegal flags combination: %s\n".cstring(),
+        flags.string().cstring())
+      error
+    end
+
+    message_id =
+      if not Ephemeral.is_set(flags) then
+        rb.u64_be()?
+      else
+        None
+      end
+
+    event_time =
+      if EventTime.is_set(flags) then
+        rb.i64_be()?
+      else
+        None
+      end
+
+    key =
+      if (Key.is_set(flags)) and (not Boundary.is_set(flags))  then
+        let length = rb.u16_be()?.usize()
+        rb.block(length)?
+      else
+        None
+      end
+
+    message =
+      if not Boundary.is_set(flags) then
+        rb.block(rb.size())?
+      else
+        None
+      end
+
+  fun encode(wb: Writer = Writer): Writer =>
+    wb.u64_be(stream_id)
+    wb.u8(flags)
+
+    if not Ephemeral.is_set(flags) then
+      match message_id
+      | let mid: MessageId => wb.u64_be(mid)
+      end
+    end
+
+    if EventTime.is_set(flags) then
+      match event_time
+      | let et: EventTimeType => wb.i64_be(et)
+      end
+    end
+
+    if Key.is_set(flags) then
+      match key
+      | let kb: KeyBytes =>
+        wb.u16_be(kb.size().u16())
+        wb.write(kb)
+      end
+    end
+
+    if not Boundary.is_set(flags) then
+      match message
+      | let mb: MessageBytes => wb.write(mb)
+      end
+    end
+    wb
+
+class AckMsg is MessageTrait
+  let credits: U32
+  let credit_list: Array[(StreamId, PointOfRef)] val
+
+  new create(credits': U32, credit_list': Array[(StreamId, PointOfRef)] val) =>
+    credits = credits'
+    credit_list = credit_list'
+
+  new decode(rb: Reader) ? =>
+    credits = rb.u32_be()?
+    let cl_size = rb.u32_be()?.usize()
+    let cl = recover iso Array[(StreamId, PointOfRef)] end
+    for x in col.Range(0, cl_size) do
+      cl.push((rb.u64_be()?, rb.u64_be()?))
+    end
+    credit_list = consume cl
+
+
+  fun encode(wb: Writer = Writer): Writer =>
+    wb.u32_be(credits)
+    wb.u32_be(credit_list.size().u32())
+    for cr in credit_list.values() do
+      wb.u64_be(cr._1)
+      wb.u64_be(cr._2)
+    end
+    wb
+
+class RestartMsg is MessageTrait
+  new create() =>
+    """
+    """
+
+  fun encode(wb: Writer = Writer): Writer =>
+    wb
+
+  new  decode(rb: Reader) =>
+    """
+    """


### PR DESCRIPTION
- Primitives for creating and testing bit flags
- Primitives for converting message types to frame tags and vice versa
- Classes for each message time
- `Frame` primitive for handling encoding and decoding of messages
- Tests for everything

closes #2715 


## Usage
Note that the frames do not include the `U32` length header, as it is stripped by the pony `FramedSourceHandler`.
```pony
try
  let msg = Framed.decode(data)?
  match msg
  | let m: MessageMsg =>
    // use the normal `let decoded =...` code block here
  | let m: HelloMsg =>
    // got hello, respond with OkMsg!
    let ok = OkMsg(where initial_credits = 1_000_000,
      credit_list = [(0, "stream1", 0); (1, "stream2", 0)])
    let encoded = Frame.encode(ok)
    // send the message back... don't forget to length encode!
    send(Bytes.length_encode(encoded))
  // ... rest of the match goes here
else
  ...
end
```

## Notes
1. This is a "complete" codec package, in that it can both encode and decode all message types, including the ones that the source connector is only expected to receive.