### PR TITLE
Add RELEASE_MUTABLE_DIR to Metrics UI AppImage HereDoc

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -556,6 +556,7 @@ endef
 
 define APPRUN_HEREDOC
 #!/bin/sh
+export RELEASE_MUTABLE_DIR="/tmp/.local/share/wallaroo"
 HERE=$$(dirname "$$(readlink -f "$${0}")")
 "$${HERE}"/usr/bin/metrics_reporter_ui $$@
 if [ "$$1" = "start" ]; then


### PR DESCRIPTION
Sets the RELEASE_MUTABLE_DIR var under the /tmp directory as opposed
to the default /usr/var directory so that the Metrics UI Image does not
raise an error because it is trying to write within the AppImage.

Closes #2701

<!--
Make sure you've read the [Contributors Guide](https://github.com/WallarooLabs/wallaroo/blob/master/CONTRIBUTING.md). You'll need to sign our CLA before your issue can be accepted.

Reference the issue your code change relates to if possible
-->


<!--
Include any other necessary information below. If you have any questions don't hesitate to reach out on the mailing list or on IRC.
-->
