### PR TITLE
Pipe `which` stderr output into /dev/null so as not to spam the console

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -200,7 +200,7 @@ ifeq ($(shell uname -s),Linux)
   extra_xargs_arg := -r
   docker_user_arg := -u `id -u`:`id -g`
   host_ip_src = $(shell ifconfig `route -n | grep '^0.0.0.0' | awk '{print $$8}'` | egrep -o 'inet addr:[^ ]+' | awk -F: '{print $$2}')
-  system_cpus := $(shell which cset > /dev/null && sudo cset set -l -r | grep '/system' | awk '{print $$2}')
+  system_cpus := $(shell which cset > /dev/null 2>&1 && sudo cset set -l -r | grep '/system' | awk '{print $$2}')
   ifneq (,$(system_cpus))
     docker_cpu_arg := --cpuset-cpus $(system_cpus)
   endif


### PR DESCRIPTION
A small visual/usability improvement for casual wallaroo users and developers.

If you don't have `cset` installed on your machine, you get a warning message similar to the following every time you run a test:

#### before

```
multi_sink$ make test
which: no cset in (<MY_HOMEDIR>.rbenv/shims:<MY_HOMEDIR>.kiex/elixirs/elixir-1.6.0/bin:<MY_HOMEDIR>.kiex/bin:<MY_HOMEDIR>.erlangs/20/bin:/opt/texlive/2017/bin/x86_64-linux:<MY_HOMEDIR>.local/
bin:/home/p:<MY_HOMEDIR>src/go/bin:<MY_HOMEDIR>.rbenv/bin:/usr/local/openresty/bin:/usr/local/openresty/nginx/sbin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin:/us
r/share/apache-maven/bin:/usr/lib/plan9/bin:/opt/texlive/2018/bin/x86_64-linux:<MY_HOMEDIR>.pulumi/bin)
Building builtin -> /usr/local/lib/pony/0.25.0-232a0abe/packages/builtin
Building . -> /home/p/w/wallaroo/testing/correctness/apps/multi_sink
Building buffered -> /usr/local/lib/pony/0.25.0-232a0abe/packages/buffered
Building collections -> /usr/local/lib/pony/0.25.0-232a0abe/packages/collections
```

This might be confusing as the person running the test can't really tell whether `cset` is a hard requirement for test correctness or not. I think we shouldn't burden the causal user with this information, so let's just hide the verbose stderr message from `which`. 

#### after

```
multi_sink$ make test
Building builtin -> /usr/local/lib/pony/0.25.0-232a0abe/packages/builtin
Building . -> /home/p/w/wallaroo/testing/correctness/apps/multi_sink
Building buffered -> /usr/local/lib/pony/0.25.0-232a0abe/packages/buffered
Building collections -> /usr/local/lib/pony/0.25.0-232a0abe/packages/collections
Building ponytest -> /usr/local/lib/pony/0.25.0-232a0abe/packages/ponytest
```

