### PR TITLE
Sources on Multiple Workers - Intermediate Version

### DIFF
--- a/examples/pony/alphabet/Makefile
+++ b/examples/pony/alphabet/Makefile
@@ -45,7 +45,7 @@ integration-tests-examples-pony-alphabet: alphabet_pony_test
 alphabet_pony_test:
 	cd $(ALPHABET_PONY_PATH) && \
 	python _test/gen.py && \
-	integration_test --framed-file-sender _test.txt \
+	integration_test --framed-file-sender _test.txt '"Alphabet Votes"' \
 		--validation-cmd 'python _test/validate.py --expected _expected.json --output' \
 		--log-level error \
 		--batch-size 10 \

--- a/examples/pony/alphabet/README.md
+++ b/examples/pony/alphabet/README.md
@@ -75,7 +75,7 @@ data_receiver --listen 127.0.0.1:7002 --no-write \
 Start the application
 
 ```bash
-./alphabet --in 127.0.0.1:7010 --out 127.0.0.1:7002 --metrics 127.0.0.1:5001 \
+./alphabet --in "Alphabet Votes"@127.0.0.1:7010 --out 127.0.0.1:7002 --metrics 127.0.0.1:5001 \
   --control 127.0.0.1:12500 --data 127.0.0.1:12501 --external 127.0.0.1:5050 \
   --cluster-initializer --ponynoblock --ponythreads=1
 ```

--- a/examples/pony/alphabet/alphabet.pony
+++ b/examples/pony/alphabet/alphabet.pony
@@ -36,7 +36,7 @@ actor Main
       let pipeline = recover val
           let votes = Wallaroo.source[Votes]("Alphabet Votes",
                 TCPSourceConfig[Votes].from_options(VotesDecoder,
-                  TCPSourceConfigCLIParser(env.args)?(0)?))
+                  TCPSourceConfigCLIParser(env.args)?("Alphabet Votes")?))
 
           votes
             .key_by(ExtractFirstLetter)

--- a/lib/wallaroo/application.pony
+++ b/lib/wallaroo/application.pony
@@ -61,6 +61,7 @@ trait BasicPipeline
   fun graph(): this->Dag[Stage]
   fun is_finished(): Bool
   fun size(): USize
+  fun worker_source_configs(): this->Map[String, WorkerSourceConfig]
 
 type Stage is (RunnerBuilder | SinkBuilder | Array[SinkBuilder] val |
   SourceConfigWrapper | RandomPartitionerBuilder | KeyPartitionerBuilder)
@@ -68,7 +69,11 @@ type Stage is (RunnerBuilder | SinkBuilder | Array[SinkBuilder] val |
 class Pipeline[Out: Any val] is BasicPipeline
   let _stages: Dag[Stage]
   let _dag_sink_ids: Array[RoutingId]
+  // map from source name to worker specific source config
+  var _worker_source_configs: Map[String, WorkerSourceConfig] =
+    _worker_source_configs.create()
   var _finished: Bool
+
 
   var _last_is_shuffle: Bool
   var _last_is_key_by: Bool
@@ -82,15 +87,19 @@ class Pipeline[Out: Any val] is BasicPipeline
     let sc_wrapper = SourceConfigWrapper(n, source_config)
     let source_id' = _stages.add_node(sc_wrapper)
     _dag_sink_ids.push(source_id')
+    _worker_source_configs.update(sc_wrapper.name(),
+      source_config.worker_source_config())
 
   new create(stages: Dag[Stage] = Dag[Stage],
     dag_sink_ids: Array[RoutingId] = Array[RoutingId],
+    worker_source_configs': Map[String, WorkerSourceConfig],
     finished: Bool = false,
     last_is_shuffle: Bool = false,
     last_is_key_by: Bool = false)
   =>
     _stages = stages
     _dag_sink_ids = dag_sink_ids
+    _worker_source_configs = worker_source_configs'
     _finished = finished
     _last_is_shuffle = last_is_shuffle
     _last_is_key_by = last_is_key_by
@@ -114,16 +123,18 @@ class Pipeline[Out: Any val] is BasicPipeline
       // Successful merge
       try
         _stages.merge(pipeline._stages)?
+        _worker_source_configs.concat(pipeline.worker_source_configs().pairs())
       else
         // We should have ruled this out through the if branches
         Unreachable()
       end
       _dag_sink_ids.append(pipeline._dag_sink_ids)
-      return Pipeline[(Out | MergeOut)](_stages, _dag_sink_ids
+      return Pipeline[(Out | MergeOut)](_stages, _dag_sink_ids,
+        _worker_source_configs
         where last_is_shuffle = _last_is_shuffle,
         last_is_key_by = _last_is_key_by)
     end
-    Pipeline[(Out | MergeOut)](_stages, _dag_sink_ids)
+    Pipeline[(Out | MergeOut)](_stages, _dag_sink_ids, _worker_source_configs)
 
   fun ref to[Next: Any val](comp: Computation[Out, Next],
     parallelization: USize = 10): Pipeline[Next]
@@ -139,10 +150,10 @@ class Pipeline[Out: Any val] is BasicPipeline
       else
         Fail()
       end
-      Pipeline[Next](_stages, [node_id])
+      Pipeline[Next](_stages, [node_id], _worker_source_configs)
     else
       _try_add_to_finished_pipeline()
-      Pipeline[Next](_stages, _dag_sink_ids)
+      Pipeline[Next](_stages, _dag_sink_ids, _worker_source_configs)
     end
 
   fun ref to_sink(sink_information: SinkConfig[Out]): Pipeline[Out] =>
@@ -156,11 +167,11 @@ class Pipeline[Out: Any val] is BasicPipeline
       else
         Fail()
       end
-      Pipeline[Out](_stages, [node_id]
+      Pipeline[Out](_stages, [node_id], _worker_source_configs
         where finished = true)
     else
       _try_add_to_finished_pipeline()
-      Pipeline[Out](_stages, _dag_sink_ids)
+      Pipeline[Out](_stages, _dag_sink_ids, _worker_source_configs)
     end
 
   fun ref to_sinks(sink_configs: Array[SinkConfig[Out]] box): Pipeline[Out] =>
@@ -181,11 +192,11 @@ class Pipeline[Out: Any val] is BasicPipeline
       else
         Fail()
       end
-      Pipeline[Out](_stages, [node_id]
+      Pipeline[Out](_stages, [node_id], _worker_source_configs
         where finished = true)
     else
       _try_add_to_finished_pipeline()
-      Pipeline[Out](_stages, _dag_sink_ids)
+      Pipeline[Out](_stages, _dag_sink_ids, _worker_source_configs)
     end
 
   fun ref key_by(pf: KeyExtractor[Out]): Pipeline[Out] =>
@@ -198,11 +209,11 @@ class Pipeline[Out: Any val] is BasicPipeline
       else
         Fail()
       end
-      Pipeline[Out](_stages, [node_id]
+      Pipeline[Out](_stages, [node_id], _worker_source_configs
         where last_is_key_by = true)
     else
       _try_add_to_finished_pipeline()
-      Pipeline[Out](_stages, _dag_sink_ids)
+      Pipeline[Out](_stages, _dag_sink_ids, _worker_source_configs)
     end
 
   fun ref collect(): Pipeline[Out] =>
@@ -210,6 +221,9 @@ class Pipeline[Out: Any val] is BasicPipeline
     key_by(CollectKeyExtractor[Out](collect_key))
 
   fun graph(): this->Dag[Stage] => _stages
+
+  fun worker_source_configs(): this->Map[String, WorkerSourceConfig] =>
+    _worker_source_configs
 
   fun size(): USize => _stages.size()
 

--- a/lib/wallaroo/application.pony
+++ b/lib/wallaroo/application.pony
@@ -61,7 +61,7 @@ trait BasicPipeline
   fun graph(): this->Dag[Stage]
   fun is_finished(): Bool
   fun size(): USize
-  fun worker_source_configs(): this->Map[String, WorkerSourceConfig]
+  fun worker_source_configs(): this->Map[SourceName, WorkerSourceConfig]
 
 type Stage is (RunnerBuilder | SinkBuilder | Array[SinkBuilder] val |
   SourceConfigWrapper | RandomPartitionerBuilder | KeyPartitionerBuilder)
@@ -70,7 +70,7 @@ class Pipeline[Out: Any val] is BasicPipeline
   let _stages: Dag[Stage]
   let _dag_sink_ids: Array[RoutingId]
   // map from source name to worker specific source config
-  var _worker_source_configs: Map[String, WorkerSourceConfig] =
+  var _worker_source_configs: Map[SourceName, WorkerSourceConfig] =
     _worker_source_configs.create()
   var _finished: Bool
 
@@ -92,7 +92,7 @@ class Pipeline[Out: Any val] is BasicPipeline
 
   new create(stages: Dag[Stage] = Dag[Stage],
     dag_sink_ids: Array[RoutingId] = Array[RoutingId],
-    worker_source_configs': Map[String, WorkerSourceConfig],
+    worker_source_configs': Map[SourceName, WorkerSourceConfig],
     finished: Bool = false,
     last_is_shuffle: Bool = false,
     last_is_key_by: Bool = false)
@@ -222,7 +222,7 @@ class Pipeline[Out: Any val] is BasicPipeline
 
   fun graph(): this->Dag[Stage] => _stages
 
-  fun worker_source_configs(): this->Map[String, WorkerSourceConfig] =>
+  fun worker_source_configs(): this->Map[SourceName, WorkerSourceConfig] =>
     _worker_source_configs
 
   fun size(): USize => _stages.size()

--- a/lib/wallaroo/application.pony
+++ b/lib/wallaroo/application.pony
@@ -69,11 +69,9 @@ type Stage is (RunnerBuilder | SinkBuilder | Array[SinkBuilder] val |
 class Pipeline[Out: Any val] is BasicPipeline
   let _stages: Dag[Stage]
   let _dag_sink_ids: Array[RoutingId]
-  // map from source name to worker specific source config
   var _worker_source_configs: Map[SourceName, WorkerSourceConfig] =
     _worker_source_configs.create()
   var _finished: Bool
-
 
   var _last_is_shuffle: Bool
   var _last_is_key_by: Bool

--- a/lib/wallaroo/core/initialization/local_topology.pony
+++ b/lib/wallaroo/core/initialization/local_topology.pony
@@ -242,6 +242,7 @@ actor LocalTopologyInitializer is LayoutInitializer
   let _is_joining: Bool
 
   let _routing_id_gen: RoutingIdGenerator = RoutingIdGenerator
+  // Map from the source name to the WorkerSourceConfig
   let _worker_source_configs: Map[SourceName, WorkerSourceConfig] val
 
   // Accumulate all SourceListenerBuilders so we can build them

--- a/lib/wallaroo/core/initialization/local_topology.pony
+++ b/lib/wallaroo/core/initialization/local_topology.pony
@@ -242,10 +242,7 @@ actor LocalTopologyInitializer is LayoutInitializer
   let _is_joining: Bool
 
   let _routing_id_gen: RoutingIdGenerator = RoutingIdGenerator
-  // (String, String) -> WorkerSourceConfig
-  // WorkerSourceConfig
-  // let _input_source_addr_map: Map[String, WorkerSourceConfig] val
-  let _worker_source_configs: Map[String, WorkerSourceConfig] val
+  let _worker_source_configs: Map[SourceName, WorkerSourceConfig] val
 
   // Accumulate all SourceListenerBuilders so we can build them
   // once EventLog signals we're ready
@@ -275,7 +272,7 @@ actor LocalTopologyInitializer is LayoutInitializer
     local_topology_file: String, data_channel_file: String,
     worker_names_file: String, local_keys_filepath: FilePath,
     the_journal: SimpleJournal, do_local_file_io: Bool,
-    worker_source_configs: Map[String, WorkerSourceConfig] val,
+    worker_source_configs: Map[SourceName, WorkerSourceConfig] val,
     cluster_manager: (ClusterManager | None) = None,
     is_joining: Bool = false)
   =>

--- a/lib/wallaroo/core/source/connector_source/connector_framed_source_notify.pony
+++ b/lib/wallaroo/core/source/connector_source/connector_framed_source_notify.pony
@@ -46,7 +46,8 @@ class ConnectorSourceNotify[In: Any val]
   let _metrics_reporter: MetricsReporter
   let _header_size: USize
 
-  // Watermark !@ How do we handle this respecting per-connector-type policies
+  // Watermark !TODO! How do we handle this respecting per-connector-type
+  // policies
   var _watermark_ts: U64 = 0
 
   new iso create(source_id: RoutingId, pipeline_name: String, env: Env,

--- a/lib/wallaroo/core/source/gen_source/gen_source.pony
+++ b/lib/wallaroo/core/source/gen_source/gen_source.pony
@@ -116,7 +116,7 @@ actor GenSource[V: Any val] is Source
   var _next_checkpoint_id: CheckpointId = 1
 
   let _pipeline_name: String
-  let _source_name: String
+  let _source_name: SourceName
   let _runner: Runner
   let _msg_id_gen: MsgIdGenerator = MsgIdGenerator
 

--- a/lib/wallaroo/core/source/gen_source/gen_source.pony
+++ b/lib/wallaroo/core/source/gen_source/gen_source.pony
@@ -64,6 +64,14 @@ interface GenSourceGenerator[V: Any val]
   fun initial_value(): (V | None)
   fun ref apply(v: V): (V | None)
 
+primitive EmptyGenSourceGeneratorBuilder[V: Any val]
+  fun apply(): GenSourceGenerator[V] =>
+    EmptyGenSource[V]
+
+class ref EmptyGenSource[V: Any val]
+  fun initial_value(): None => None
+  fun ref apply(v: V): None => None
+
 actor GenSource[V: Any val] is Source
   """
   # GenSource

--- a/lib/wallaroo/core/source/gen_source/gen_source_config.pony
+++ b/lib/wallaroo/core/source/gen_source/gen_source_config.pony
@@ -22,12 +22,10 @@ use "wallaroo/core/partitioning"
 use "wallaroo/core/source"
 
 class val GenSourceConfig[In: Any val]
-  let _gen: GenSourceGeneratorBuilder[In]
   let _worker_source_config: WorkerGenSourceConfig[In]
 
   new val create(gen: GenSourceGeneratorBuilder[In]) =>
-    _gen = gen
-    _worker_source_config = WorkerGenSourceConfig[In](_gen)
+    _worker_source_config = WorkerGenSourceConfig[In](gen)
 
   fun source_listener_builder_builder(): GenSourceListenerBuilderBuilder[In] =>
     GenSourceListenerBuilderBuilder[In]

--- a/lib/wallaroo/core/source/gen_source/gen_source_config.pony
+++ b/lib/wallaroo/core/source/gen_source/gen_source_config.pony
@@ -21,20 +21,25 @@ use "wallaroo"
 use "wallaroo/core/partitioning"
 use "wallaroo/core/source"
 
-primitive WorkerGenSourceConfig is WorkerSourceConfig
-
 class val GenSourceConfig[In: Any val]
   let _gen: GenSourceGeneratorBuilder[In]
+  let _worker_source_config: WorkerGenSourceConfig[In]
 
   new val create(gen: GenSourceGeneratorBuilder[In]) =>
     _gen = gen
+    _worker_source_config = WorkerGenSourceConfig[In](_gen)
 
   fun source_listener_builder_builder(): GenSourceListenerBuilderBuilder[In] =>
-    GenSourceListenerBuilderBuilder[In](_gen)
+    GenSourceListenerBuilderBuilder[In]
 
   fun default_partitioner_builder(): PartitionerBuilder =>
     RandomPartitionerBuilder
 
   fun worker_source_config(): WorkerSourceConfig =>
-    WorkerGenSourceConfig
+    _worker_source_config
 
+class val WorkerGenSourceConfig[In: Any val] is WorkerSourceConfig
+  let generator: GenSourceGeneratorBuilder[In]
+
+  new val create(generator': GenSourceGeneratorBuilder[In]) =>
+    generator = generator'

--- a/lib/wallaroo/core/source/gen_source/gen_source_config.pony
+++ b/lib/wallaroo/core/source/gen_source/gen_source_config.pony
@@ -21,6 +21,8 @@ use "wallaroo"
 use "wallaroo/core/partitioning"
 use "wallaroo/core/source"
 
+primitive WorkerGenSourceConfig is WorkerSourceConfig
+
 class val GenSourceConfig[In: Any val]
   let _gen: GenSourceGeneratorBuilder[In]
 
@@ -32,3 +34,7 @@ class val GenSourceConfig[In: Any val]
 
   fun default_partitioner_builder(): PartitionerBuilder =>
     RandomPartitionerBuilder
+
+  fun worker_source_config(): WorkerSourceConfig =>
+    WorkerGenSourceConfig
+

--- a/lib/wallaroo/core/source/gen_source/gen_source_listener.pony
+++ b/lib/wallaroo/core/source/gen_source/gen_source_listener.pony
@@ -116,7 +116,7 @@ actor GenSourceListener[In: Any val] is SourceListener
     _create_source()
 
   fun ref _create_source() =>
-    let name = _pipeline_name + " source"
+    let name = _worker_name + ":" + _pipeline_name + " source"
     let temp_id = MD5(name)
     let rb = Reader
     rb.append(temp_id)

--- a/lib/wallaroo/core/source/gen_source/gen_source_listener_builder.pony
+++ b/lib/wallaroo/core/source/gen_source/gen_source_listener_builder.pony
@@ -27,6 +27,7 @@ use "wallaroo/core/metrics"
 use "wallaroo/core/routing"
 use "wallaroo/core/source"
 use "wallaroo/core/topology"
+use "wallaroo_labs/mort"
 
 
 class val GenSourceListenerBuilder[In: Any val]
@@ -79,10 +80,6 @@ class val GenSourceListenerBuilder[In: Any val]
       _layout_initializer, _recovering, _target_router, _generator)
 
 class val GenSourceListenerBuilderBuilder[In: Any val]
-  let _generator: GenSourceGeneratorBuilder[In]
-
-  new val create(generator: GenSourceGeneratorBuilder[In]) =>
-    _generator = generator
 
   fun apply(worker_name: String, pipeline_name: String,
     runner_builder: RunnerBuilder, partitioner_builder: PartitionerBuilder,
@@ -96,7 +93,17 @@ class val GenSourceListenerBuilderBuilder[In: Any val]
     target_router: Router = EmptyRouter):
     GenSourceListenerBuilder[In]
   =>
-    GenSourceListenerBuilder[In](worker_name, pipeline_name, runner_builder,
-      partitioner_builder, router, metrics_conn, consume metrics_reporter,
-      router_registry, outgoing_boundary_builders, event_log, auth,
-      layout_initializer, recovering, target_router, _generator)
+    match worker_source_config
+    | let config: WorkerGenSourceConfig[In] =>
+      GenSourceListenerBuilder[In](worker_name, pipeline_name, runner_builder,
+        partitioner_builder, router, metrics_conn, consume metrics_reporter,
+        router_registry, outgoing_boundary_builders, event_log, auth,
+        layout_initializer, recovering, target_router, config.generator)
+    else
+      Unreachable()
+      GenSourceListenerBuilder[In](worker_name, pipeline_name, runner_builder,
+        partitioner_builder, router, metrics_conn, consume metrics_reporter,
+        router_registry, outgoing_boundary_builders, event_log, auth,
+        layout_initializer, recovering, target_router,
+        EmptyGenSourceGeneratorBuilder[In])
+    end

--- a/lib/wallaroo/core/source/gen_source/gen_source_listener_builder.pony
+++ b/lib/wallaroo/core/source/gen_source/gen_source_listener_builder.pony
@@ -91,7 +91,9 @@ class val GenSourceListenerBuilderBuilder[In: Any val]
     outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val,
     event_log: EventLog, auth: AmbientAuth,
     layout_initializer: LayoutInitializer,
-    recovering: Bool, target_router: Router = EmptyRouter):
+    recovering: Bool,
+    worker_source_config: WorkerSourceConfig,
+    target_router: Router = EmptyRouter):
     GenSourceListenerBuilder[In]
   =>
     GenSourceListenerBuilder[In](worker_name, pipeline_name, runner_builder,

--- a/lib/wallaroo/core/source/source.pony
+++ b/lib/wallaroo/core/source/source.pony
@@ -29,6 +29,8 @@ use "wallaroo/core/metrics"
 use "wallaroo/core/routing"
 use "wallaroo/core/topology"
 
+type SourceName is String
+
 interface val SourceConfig
   fun default_partitioner_builder(): PartitionerBuilder
   fun val source_listener_builder_builder(): SourceListenerBuilderBuilder

--- a/lib/wallaroo/core/source/source.pony
+++ b/lib/wallaroo/core/source/source.pony
@@ -29,10 +29,10 @@ use "wallaroo/core/metrics"
 use "wallaroo/core/routing"
 use "wallaroo/core/topology"
 
-
 interface val SourceConfig
   fun default_partitioner_builder(): PartitionerBuilder
-  fun source_listener_builder_builder(): SourceListenerBuilderBuilder
+  fun val source_listener_builder_builder(): SourceListenerBuilderBuilder
+  fun worker_source_config(): WorkerSourceConfig
 
 interface val TypedSourceConfig[In: Any val] is SourceConfig
 
@@ -46,6 +46,8 @@ class val SourceConfigWrapper
 
   fun name(): String => _name
   fun source_config(): SourceConfig => _source_config
+
+trait val WorkerSourceConfig
 
 trait tag Source is (Producer & DisposableActor & BoundaryUpdatable &
   StatusReporter)

--- a/lib/wallaroo/core/source/source_listener.pony
+++ b/lib/wallaroo/core/source/source_listener.pony
@@ -41,5 +41,7 @@ interface val SourceListenerBuilderBuilder
     outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val,
     event_log: EventLog, auth: AmbientAuth,
     layout_initializer: LayoutInitializer,
-    recovering: Bool, target_router: Router = EmptyRouter):
+    recovering: Bool,
+    worker_source_config: WorkerSourceConfig,
+    target_router: Router = EmptyRouter):
     SourceListenerBuilder

--- a/lib/wallaroo/core/source/tcp_source/tcp_source.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source.pony
@@ -434,8 +434,8 @@ actor TCPSource[In: Any val] is Source
       end
 
       match token
-      | let sbt: CheckpointBarrierToken =>
-        checkpoint_state(sbt.id)
+      | let cpbt: CheckpointBarrierToken =>
+        checkpoint_state(cpbt.id)
       end
       for (o_id, o) in _outputs.pairs() do
         match o

--- a/lib/wallaroo/core/source/tcp_source/tcp_source_config.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source_config.pony
@@ -24,7 +24,7 @@ use "wallaroo/core/source"
 use "wallaroo_labs/mort"
 
 primitive TCPSourceConfigCLIParser
-  fun apply(args: Array[String] val): Map[String, TCPSourceConfigOptions] val ? =>
+  fun apply(args: Array[String] val): Map[SourceName, TCPSourceConfigOptions] val ? =>
     let in_arg = "in"
     let short_in_arg = "i"
 
@@ -45,9 +45,9 @@ primitive TCPSourceConfigCLIParser
     error
 
   fun _from_input_string(inputs: String):
-    Map[String, TCPSourceConfigOptions] val
+    Map[SourceName, TCPSourceConfigOptions] val
   =>
-    let opts = recover trn Map[String, TCPSourceConfigOptions] end
+    let opts = recover trn Map[SourceName, TCPSourceConfigOptions] end
 
     for input in inputs.split(",").values() do
       try

--- a/lib/wallaroo/core/source/tcp_source/tcp_source_config.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source_config.pony
@@ -67,9 +67,9 @@ primitive TCPSourceConfigCLIParser
 class val TCPSourceConfigOptions
   let host: String
   let service: String
-  let source_name: String
+  let source_name: SourceName
 
-  new val create(host': String, service': String, source_name': String) =>
+  new val create(host': String, service': String, source_name': SourceName) =>
     host = host'
     service = service'
     source_name = source_name'
@@ -80,7 +80,7 @@ class val TCPSourceConfig[In: Any val]
   let _worker_source_config: WorkerTCPSourceConfig
 
   new val create(handler': FramedSourceHandler[In] val, host': String,
-    service': String, source_name': String, parallelism': USize = 10)
+    service': String, source_name': SourceName, parallelism': USize = 10)
   =>
     handler = handler'
     parallelism = parallelism'
@@ -106,9 +106,9 @@ class val TCPSourceConfig[In: Any val]
 class val WorkerTCPSourceConfig is WorkerSourceConfig
   let host: String
   let service: String
-  let source_name: String
+  let source_name: SourceName
 
-  new val create(source_name': String, host': String, service': String) =>
+  new val create(source_name': SourceName, host': String, service': String) =>
     host = host'
     service = service'
     source_name = source_name'

--- a/lib/wallaroo/core/source/tcp_source/tcp_source_config.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source_config.pony
@@ -16,13 +16,15 @@ Copyright 2017 The Wallaroo Authors.
 
 */
 
+use "collections"
 use "options"
 use "wallaroo"
 use "wallaroo/core/partitioning"
 use "wallaroo/core/source"
+use "wallaroo_labs/mort"
 
 primitive TCPSourceConfigCLIParser
-  fun apply(args: Array[String] val): Array[TCPSourceConfigOptions] val ? =>
+  fun apply(args: Array[String] val): Map[String, TCPSourceConfigOptions] val ? =>
     let in_arg = "in"
     let short_in_arg = "i"
 
@@ -36,18 +38,28 @@ primitive TCPSourceConfigCLIParser
       | ("help", let arg: None) =>
         StartupHelp()
       | (in_arg, let input: String) =>
-        return _from_input_string(input)?
+        return _from_input_string(input)
       end
     end
 
     error
 
-  fun _from_input_string(inputs: String): Array[TCPSourceConfigOptions] val ? =>
-    let opts = recover trn Array[TCPSourceConfigOptions] end
+  fun _from_input_string(inputs: String):
+    Map[String, TCPSourceConfigOptions] val
+  =>
+    let opts = recover trn Map[String, TCPSourceConfigOptions] end
 
     for input in inputs.split(",").values() do
-      let i = input.split(":")
-      opts.push(TCPSourceConfigOptions(i(0)?, i(1)?))
+      try
+        let source_name_and_address = input.split("@")
+        let address_data = source_name_and_address(1)?.split(":")
+        opts.update(source_name_and_address(0)?,
+          TCPSourceConfigOptions(address_data(0)?, address_data(1)?,
+          source_name_and_address(0)?))
+      else
+        FatalUserError("Inputs must be in the `source_name@host:service`" +
+          " format!")
+      end
     end
 
     consume opts
@@ -55,36 +67,49 @@ primitive TCPSourceConfigCLIParser
 class val TCPSourceConfigOptions
   let host: String
   let service: String
+  let source_name: String
 
-  new val create(host': String, service': String) =>
+  new val create(host': String, service': String, source_name': String) =>
     host = host'
     service = service'
+    source_name = source_name'
 
 class val TCPSourceConfig[In: Any val]
-  let _handler: FramedSourceHandler[In] val
-  let _host: String
-  let _service: String
-  let _parallelism: USize
+  let handler: FramedSourceHandler[In] val
+  let parallelism: USize
+  let _worker_source_config: WorkerTCPSourceConfig
 
   new val create(handler': FramedSourceHandler[In] val, host': String,
-    service': String, parallelism': USize = 10)
+    service': String, source_name': String, parallelism': USize = 10)
   =>
-    _handler = handler'
-    _host = host'
-    _service = service'
-    _parallelism = parallelism'
+    handler = handler'
+    parallelism = parallelism'
+    _worker_source_config = WorkerTCPSourceConfig(source_name', host', service')
 
   new val from_options(handler': FramedSourceHandler[In] val,
     opts: TCPSourceConfigOptions, parallelism': USize = 10)
   =>
-    _handler = handler'
-    _host = opts.host
-    _service = opts.service
-    _parallelism = parallelism'
+    handler = handler'
+    parallelism = parallelism'
+    _worker_source_config = WorkerTCPSourceConfig(opts.source_name, opts.host,
+      opts.service)
 
-  fun source_listener_builder_builder(): TCPSourceListenerBuilderBuilder[In] =>
-    TCPSourceListenerBuilderBuilder[In](_host, _service, _parallelism,
-      _handler)
+  fun val source_listener_builder_builder(): TCPSourceListenerBuilderBuilder[In] =>
+    TCPSourceListenerBuilderBuilder[In](this)
 
   fun default_partitioner_builder(): PartitionerBuilder =>
     RandomPartitionerBuilder
+
+  fun worker_source_config(): WorkerSourceConfig =>
+    _worker_source_config
+
+class val WorkerTCPSourceConfig is WorkerSourceConfig
+  let host: String
+  let service: String
+  let source_name: String
+
+  new val create(source_name': String, host': String, service': String) =>
+    host = host'
+    service = service'
+    source_name = source_name'
+

--- a/lib/wallaroo/core/source/tcp_source/tcp_source_listener.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source_listener.pony
@@ -87,9 +87,9 @@ actor TCPSourceListener[In: Any val] is SourceListener
     outgoing_boundary_builders: Map[String, OutgoingBoundaryBuilder] val,
     event_log: EventLog, auth: AmbientAuth,
     layout_initializer: LayoutInitializer,
-    recovering: Bool, target_router: Router = EmptyRouter, parallelism: USize,
-    handler: FramedSourceHandler[In] val,
-    host: String = "", service: String = "0",
+    recovering: Bool, target_router: Router = EmptyRouter,
+    parallelism: USize, handler: FramedSourceHandler[In] val,
+    host: String, service: String,
     init_size: USize = 64, max_size: USize = 16384)
   =>
     """
@@ -116,8 +116,8 @@ actor TCPSourceListener[In: Any val] is SourceListener
     _service = service
 
     _event = @pony_os_listen_tcp[AsioEventID](this,
-      host.cstring(), service.cstring())
-    _limit = parallelism
+      _host.cstring(), _service.cstring())
+    _limit = _parallelism
     _init_size = init_size
     _max_size = max_size
     _fd = @pony_asio_event_fd(_event)
@@ -132,7 +132,8 @@ actor TCPSourceListener[In: Any val] is SourceListener
     end
 
     @printf[I32]((pipeline_name + " source attempting to listen on "
-      + host + ":" + service + "\n").cstring())
+      + _host + ":" + _service +
+      "\n").cstring())
     _notify_listening()
 
     for i in Range(0, _limit) do

--- a/lib/wallaroo/core/topology/runner.pony
+++ b/lib/wallaroo/core/topology/runner.pony
@@ -239,7 +239,7 @@ class StatelessComputationRunner[In: Any val, Out: Any val] is Runner
           metrics_id + 1
         end
 
-      //!@ This is unnecessary work since we only ever pass along the
+      // !TODO! This is unnecessary work since we only ever pass along the
       // input watermark for stateless computations (i.e. the output
       // watermark always equals the input after each message).
       (let new_watermark_ts, let old_watermark_ts) =
@@ -327,7 +327,6 @@ class StateRunner[In: Any val, Out: Any val, S: State ref] is (Runner &
     router: Router, metrics_reporter: MetricsReporter ref,
     watermarks: StageWatermarks)
   =>
-    // @printf[I32]("!@ on_timeout called on StateRunner\n".cstring())
     let on_timeout_ts = Time.nanos()
     for (key, sw) in _state_map.pairs() do
       let input_watermark_ts = watermarks.check_effective_input_watermark(
@@ -484,15 +483,6 @@ class StateRunner[In: Any val, Out: Any val, S: State ref] is (Runner &
         _rb.append(s as Array[U8] val)
         let state_wrapper = _state_initializer.decode(_rb, _auth)?
         ifdef "checkpoint_trace" then
-          //!@
-          // match state
-          // | let st: Stringablike =>
-          //   (let sec', let ns') = Time.now()
-          //   let us' = ns' / 1000
-          //   let ts' = PosixDate(sec', ns').format("%Y-%m-%d %H:%M:%S." + us'
-          //     .string())
-          //   @printf[I32]("DESERIALIZE (%s): loading new %s on step %s with tag %s\n".cstring(), ts'.cstring(), st.string().cstring(), _step_id.string().cstring(), (digestof this).string().cstring())
-          // end
           @printf[I32]("Successfully imported key %s\n".cstring(),
             key.cstring())
         end
@@ -571,16 +561,7 @@ class StateRunner[In: Any val, Out: Any val, S: State ref] is (Runner &
         bytes_left = bytes_left - state_size
         let state_wrapper = _state_initializer.decode(reader, _auth)?
         ifdef "checkpoint_trace" then
-          //!@
-          // match state
-          // | let st: Stringablike =>
-          //   (let sec', let ns') = Time.now()
-          //   let us' = ns' / 1000
-          //   let ts' = PosixDate(sec', ns').format("%Y-%m-%d %H:%M:%S." +
-          //     us'.string())
-          //   @printf[I32]("DESERIALIZE (%s): loading new state %s on step %s with tag %s\n".cstring(), ts'.cstring(), st.string().cstring(), _step_id.string().cstring(), (digestof this).string().cstring())
-          // end
-          @printf[I32]("OVERWRITING STATE FOR KEY %s\n".cstring(),
+           @printf[I32]("OVERWRITING STATE FOR KEY %s\n".cstring(),
             key.cstring())
         end
         _state_map(key) = state_wrapper

--- a/lib/wallaroo/core/topology/steps.pony
+++ b/lib/wallaroo/core/topology/steps.pony
@@ -474,8 +474,9 @@ actor Step is (Producer & Consumer & BarrierProcessor)
   =>
     if _inputs.contains(step_id) then
       ifdef "checkpoint_trace" then
-        @printf[I32]("Receive Barrier %s at Step %s\n".cstring(),
-          barrier_token.string().cstring(), _id.string().cstring())
+        @printf[I32]("Process Barrier %s at Step %s from %s\n".cstring(),
+          barrier_token.string().cstring(), _id.string().cstring(),
+          step_id.string().cstring())
       end
       match barrier_token
       | let srt: CheckpointRollbackBarrierToken =>

--- a/lib/wallaroo/core/topology/steps.pony
+++ b/lib/wallaroo/core/topology/steps.pony
@@ -161,6 +161,9 @@ actor Step is (Producer & Consumer & BarrierProcessor)
   fun ref metrics_reporter(): MetricsReporter =>
     _metrics_reporter
 
+  fun routing_id(): RoutingId =>
+    _id
+
   be update_router(router': Router) =>
     _update_router(router')
 

--- a/lib/wallaroo/core/windows/windows.pony
+++ b/lib/wallaroo/core/windows/windows.pony
@@ -216,7 +216,7 @@ class val RangeWindowsStateInitializer[In: Any val, Out: Any val,
     StateRunnerBuilder[In, Out, Acc](this, step_group_id, parallelization)
 
   fun timeout_interval(): U64 =>
-    // !@ !TODO!: Decide if we should set a minimum to this interval to
+    // !TODO!: Decide if we should set a minimum to this interval to
     // avoid extremely frequent timer messages.
     let range_delay_based = (_range + _delay) * 2
     // if range_delay_based > Seconds(1) then

--- a/lib/wallaroo/ent/barrier/barrier_initiator.pony
+++ b/lib/wallaroo/ent/barrier/barrier_initiator.pony
@@ -401,10 +401,6 @@ actor BarrierInitiator is Initializable
       else
         Fail()
       end
-
-      for s in _sources.values() do
-        s.initiate_barrier(barrier_token)
-      end
     end
 
   be worker_ack_barrier_start(w: String, token: BarrierToken) =>
@@ -487,8 +483,8 @@ actor BarrierInitiator is Initializable
     for all worker acks.
     """
     if not _disposed then
-      let next_handler = WorkerAcksBarrierHandler(this, barrier_token, _workers,
-        workers_acked, result_promise)
+      let next_handler = WorkerAcksBarrierHandler(this, barrier_token,
+        _workers, workers_acked, result_promise)
       try
         _active_barriers.update_handler(barrier_token, next_handler)?
       else

--- a/lib/wallaroo/ent/barrier/barrier_step_forwarder.pony
+++ b/lib/wallaroo/ent/barrier/barrier_step_forwarder.pony
@@ -74,8 +74,8 @@ class BarrierStepForwarder
 
     if barrier_token != _barrier_token then
       @printf[I32]("Received %s when still processing %s at step %s\n"
-        .cstring(), _barrier_token.string().cstring(),
-        barrier_token.string().cstring(), _step_id.string().cstring())
+        .cstring(), barrier_token.string().cstring(),
+        _barrier_token.string().cstring(), _step_id.string().cstring())
       Fail()
     end
 

--- a/lib/wallaroo/ent/barrier/barrier_step_forwarder.pony
+++ b/lib/wallaroo/ent/barrier/barrier_step_forwarder.pony
@@ -60,7 +60,8 @@ class BarrierStepForwarder
     // have already been cleared to make way for it.
     ifdef debug then
       if barrier_token > _barrier_token then
-        @printf[I32]("Invariant violation: received barrier %s is greater than current barrier %s \n".cstring(), barrier_token.string().cstring(), _barrier_token.string().cstring())
+        @printf[I32]("Invariant violation: received barrier %s is greater than current barrier %s at Step %s\n".cstring(), barrier_token.string().cstring(), _barrier_token.string().cstring(),
+          _step_id.string().cstring())
       end
 
       Invariant(not (barrier_token > _barrier_token))

--- a/lib/wallaroo/ent/data_receiver/data_receiver.pony
+++ b/lib/wallaroo/ent/data_receiver/data_receiver.pony
@@ -69,9 +69,6 @@ actor DataReceiver is Producer
   let _step_group_producers: Map[RoutingId, SetIs[RoutingId]] =
     _step_group_producers.create()
 
-  // Checkpoint
-  var _next_checkpoint_id: CheckpointId = 1
-
   var _phase: _DataReceiverPhase = _DataReceiverNotProcessingPhase
 
   new create(auth: AmbientAuth, id: RoutingId, worker_name: String,
@@ -342,10 +339,6 @@ actor DataReceiver is Producer
     if seq_id > _last_id_seen then
       _ack_counter = _ack_counter + 1
       _last_id_seen = seq_id
-      match barrier_token
-      | let sbt: CheckpointBarrierToken =>
-        checkpoint_state(sbt.id)
-      end
       _router.forward_barrier(target_step_id, origin_step_id, this,
         barrier_token)
     end
@@ -365,7 +358,7 @@ actor DataReceiver is Producer
     """
     DataReceivers don't currently write out any data as part of the checkpoint.
     """
-    _next_checkpoint_id = checkpoint_id + 1
+    None
 
   be prepare_for_rollback() =>
     """
@@ -379,7 +372,6 @@ actor DataReceiver is Producer
     """
     There is nothing for a DataReceiver to rollback to.
     """
-    _next_checkpoint_id = checkpoint_id + 1
     event_log.ack_rollback(_id)
 
   ///////////////

--- a/lib/wallaroo/startup.pony
+++ b/lib/wallaroo/startup.pony
@@ -351,7 +351,8 @@ actor Startup
           recovery_reconnecter, checkpoint_initiator, barrier_initiator,
           _local_topology_file, _data_channel_file, _worker_names_file,
           local_keys_filepath,
-          _the_journal as SimpleJournal, _startup_options.do_local_file_io)
+          _the_journal as SimpleJournal, _startup_options.do_local_file_io,
+          _pipeline.worker_source_configs())
 
       if (_external_host != "") or (_external_service != "") then
         let external_channel_notifier =
@@ -579,8 +580,8 @@ actor Startup
           event_log, recovery, recovery_reconnecter, checkpoint_initiator,
           barrier_initiator, _local_topology_file, _data_channel_file,
           _worker_names_file, local_keys_filepath,
-          _the_journal as SimpleJournal, _startup_options.do_local_file_io
-          where is_joining = true)
+          _the_journal as SimpleJournal, _startup_options.do_local_file_io,
+          _pipeline.worker_source_configs() where is_joining = true)
 
       if (_external_host != "") or (_external_service != "") then
         let external_channel_notifier =

--- a/lib/wallaroo/wallaroo_config.pony
+++ b/lib/wallaroo/wallaroo_config.pony
@@ -23,9 +23,6 @@ use "wallaroo/ent/spike"
 
 class StartupOptions
   var m_arg: (Array[String] | None) = None
-  var input_addrs: Map[String, (String, String)] val =
-    recover input_addrs.create() end
-  // var input_addrs: Array[Array[String]] val = recover Array[Array[String]] end
   var c_addr: Array[String] = [""; "0"]
   var c_host: String = ""
   var c_service: String = "0"
@@ -66,15 +63,7 @@ primitive WallarooConfig
     (let so, let z) = _parse(args where handle_help = true)?
     so
 
-  fun wactor_args(args: Array[String] val): StartupOptions ? =>
-    // The wactor system expects to get input addresses from this function,
-    // Wallaroo expects applications to parse this information themselves.
-    (let so, let z) = _parse(args where handle_help = true,
-      include_input_addrs = true)?
-    so
-
-  fun _parse(args: Array[String] val, handle_help: Bool,
-    include_input_addrs: Bool = true): (StartupOptions, Array[String] val) ?
+  fun _parse(args: Array[String] val, handle_help: Bool): (StartupOptions, Array[String] val) ?
   =>
     let so: StartupOptions ref = StartupOptions
 
@@ -119,25 +108,12 @@ primitive WallarooConfig
       options.add("help", "h", None)
     end
 
-    if include_input_addrs then
-      options.add("in", "i", StringArgument)
-    end
-
     for option in options do
       match option
       | ("help", let arg: None) =>
         StartupHelp()
       | ("metrics", let arg: String) =>
         so.m_arg = arg.split(":")
-      | ("in", let arg: String) =>
-        let input_addrs_trn = recover trn Map[String, (String, String)] end
-        for input_address in arg.split(",").values() do
-          let source_and_address = input_address.split("@")
-          let address_data = source_and_address(1)?.split(":")
-          input_addrs_trn.update(source_and_address(0)?,
-            (address_data(0)?, address_data(1)?))
-        end
-        so.input_addrs = consume input_addrs_trn
       | ("control", let arg: String) =>
         so.c_addr = arg.split(":")
         so.c_host = so.c_addr(0)?

--- a/lib/wallaroo/wallaroo_config.pony
+++ b/lib/wallaroo/wallaroo_config.pony
@@ -16,13 +16,16 @@ Copyright 2017 The Wallaroo Authors.
 
 */
 
+use "collections"
 use "wallaroo_labs/mort"
 use "wallaroo_labs/options"
 use "wallaroo/ent/spike"
 
 class StartupOptions
   var m_arg: (Array[String] | None) = None
-  var input_addrs: Array[Array[String]] val = recover Array[Array[String]] end
+  var input_addrs: Map[String, (String, String)] val =
+    recover input_addrs.create() end
+  // var input_addrs: Array[Array[String]] val = recover Array[Array[String]] end
   var c_addr: Array[String] = [""; "0"]
   var c_host: String = ""
   var c_service: String = "0"
@@ -71,7 +74,7 @@ primitive WallarooConfig
     so
 
   fun _parse(args: Array[String] val, handle_help: Bool,
-    include_input_addrs: Bool = false): (StartupOptions, Array[String] val) ?
+    include_input_addrs: Bool = true): (StartupOptions, Array[String] val) ?
   =>
     let so: StartupOptions ref = StartupOptions
 
@@ -127,11 +130,14 @@ primitive WallarooConfig
       | ("metrics", let arg: String) =>
         so.m_arg = arg.split(":")
       | ("in", let arg: String) =>
-        let i_addrs_write = recover trn Array[Array[String]] end
-        for addr in arg.split(",").values() do
-          i_addrs_write.push(addr.split(":"))
+        let input_addrs_trn = recover trn Map[String, (String, String)] end
+        for input_address in arg.split(",").values() do
+          let source_and_address = input_address.split("@")
+          let address_data = source_and_address(1)?.split(":")
+          input_addrs_trn.update(source_and_address(0)?,
+            (address_data(0)?, address_data(1)?))
         end
-        so.input_addrs = consume i_addrs_write
+        so.input_addrs = consume input_addrs_trn
       | ("control", let arg: String) =>
         so.c_addr = arg.split(":")
         so.c_host = so.c_addr(0)?

--- a/testing/correctness/apps/decoder_filter/Makefile
+++ b/testing/correctness/apps/decoder_filter/Makefile
@@ -47,7 +47,7 @@ integration-tests-testing-correctness-apps-decoder_filter: testing_decoder_filte
 testing_decoder_filter_test:
 	cd $(TESTING_DECODER_FILTER_PATH) && \
 	integration_test \
-		--sequence-sender '(0,1000]' \
+		--sequence-sender '(0,1000]' '"Filter Test"' \
 		--validation-cmd './validator/validator -e 500' \
 		--log-level error \
 		--batch-size 10 \

--- a/testing/correctness/apps/decoder_filter/decoder_filter.pony
+++ b/testing/correctness/apps/decoder_filter/decoder_filter.pony
@@ -33,7 +33,7 @@ actor Main
       let pipeline = recover val
         Wallaroo.source[U64]("Filter Test",
             TCPSourceConfig[(U64 | None)].from_options(OddFilterDecoder,
-              TCPSourceConfigCLIParser(env.args)?(0)?))
+              TCPSourceConfigCLIParser(env.args)?("Filter Test")?))
           // .to(PassThrough)
           .to_sink(TCPSinkConfig[U64].from_options(FramedU64Encoder,
             TCPSinkConfigCLIParser(env.args)?(0)?))

--- a/testing/correctness/apps/multi_partition_detector/Makefile
+++ b/testing/correctness/apps/multi_partition_detector/Makefile
@@ -41,13 +41,13 @@ MULTI_PARTITION_DETECTOR_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 include $(rules_mk_path)
 
 
-build-testing-correctness-apps-multi_partition_detector: build-machida
-build-testing-correctness-apps-multi_partition_detector: build-machida3
+#build-testing-correctness-apps-multi_partition_detector: build-machida
+#build-testing-correctness-apps-multi_partition_detector: build-machida3
 build-testing-correctness-apps-multi_partition_detector: build-testing-correctness-apps-multi_partition_detector-validator
 integration-tests-testing-correctness-apps-multi_partition_detector: build-testing-correctness-apps-multi_partition_detector
 integration-tests-testing-correctness-apps-multi_partition_detector: multi_partition_detector_tests_pony
-integration-tests-testing-correctness-apps-multi_partition_detector: multi_partition_detector_tests_python
-integration-tests-testing-correctness-apps-multi_partition_detector: multi_partition_detector_tests_python3
+#integration-tests-testing-correctness-apps-multi_partition_detector: multi_partition_detector_tests_python
+#integration-tests-testing-correctness-apps-multi_partition_detector: multi_partition_detector_tests_python3
 
 # group the tests by target API (Pony, Python, Python3)
 # Pony
@@ -197,8 +197,8 @@ multi_partition_detector_test_python3_gen_source_10_worker:
 multi_partition_detector_test_pony:
 	cd $(MULTI_PARTITION_DETECTOR_PATH) && \
 	integration_test \
-	  --sequence-sender '(0,100]' 0 '>I' key_0 \
-	  --sequence-sender '(0,100]' 0 '>I' key_1 \
+	  --sequence-sender '(0,100]' Detector '>I' key_0 \
+	  --sequence-sender '(0,100]' Detector '>I' key_1 \
 	  --log-level error \
 		--command './multi_partition_detector $(RUN_WITH_RESILIENCE)' \
 		--validation-cmd './validator/validator -e 100 -a -i' \
@@ -212,7 +212,6 @@ multi_partition_detector_test_pony_gen_source:
 	integration_test \
 	  --log-level error \
 		--command './multi_partition_detector --gen-source $(RUN_WITH_RESILIENCE)' \
-		--sources 0 \
 		--validation-cmd './validator/validator -a -i' \
 		--output 'received.txt' \
 		--batch-size 10 \
@@ -223,16 +222,16 @@ multi_partition_detector_test_pony_gen_source:
 multi_partition_detector_test_pony_10_worker:
 	cd $(MULTI_PARTITION_DETECTOR_PATH) && \
 	integration_test \
-	  --sequence-sender '(0,1000]' 0 '>I' key_0 \
-	  --sequence-sender '(0,1000]' 0 '>I' key_1 \
-	  --sequence-sender '(0,1000]' 0 '>I' key_2 \
-	  --sequence-sender '(0,1000]' 0 '>I' key_3 \
-	  --sequence-sender '(0,1000]' 0 '>I' key_4 \
-	  --sequence-sender '(0,1000]' 0 '>I' key_5 \
-	  --sequence-sender '(0,1000]' 0 '>I' key_6 \
-	  --sequence-sender '(0,1000]' 0 '>I' key_7 \
-	  --sequence-sender '(0,1000]' 0 '>I' key_8 \
-	  --sequence-sender '(0,1000]' 0 '>I' key_9 \
+	  --sequence-sender '(0,1000]' Detector '>I' key_0 \
+	  --sequence-sender '(0,1000]' Detector '>I' key_1 \
+	  --sequence-sender '(0,1000]' Detector '>I' key_2 \
+	  --sequence-sender '(0,1000]' Detector '>I' key_3 \
+	  --sequence-sender '(0,1000]' Detector '>I' key_4 \
+	  --sequence-sender '(0,1000]' Detector '>I' key_5 \
+	  --sequence-sender '(0,1000]' Detector '>I' key_6 \
+	  --sequence-sender '(0,1000]' Detector '>I' key_7 \
+	  --sequence-sender '(0,1000]' Detector '>I' key_8 \
+	  --sequence-sender '(0,1000]' Detector '>I' key_9 \
 	  --log-level error \
 		--command './multi_partition_detector $(RUN_WITH_RESILIENCE)' \
 		--validation-cmd './validator/validator -e 1000 -a -i' \
@@ -246,7 +245,6 @@ multi_partition_detector_test_pony_gen_source_10_worker:
 	integration_test \
 	  --log-level error \
 		--command './multi_partition_detector --gen-source $(RUN_WITH_RESILIENCE)' \
-		--sources 0 \
 		--validation-cmd './validator/validator -a -i' \
 		--output 'received.txt' \
 		--batch-size 10 \

--- a/testing/correctness/apps/multi_partition_detector/multi_partition_detector.pony
+++ b/testing/correctness/apps/multi_partition_detector/multi_partition_detector.pony
@@ -85,7 +85,7 @@ actor Main
           Wallaroo.source[t.Message]("Detector",
             TCPSourceConfig[t.Message]
               .from_options(PartitionedU64FramedHandler,
-                TCPSourceConfigCLIParser(env.args)?(0)?))
+                TCPSourceConfigCLIParser(env.args)?("Detector")?))
         end
         // Add as many layers of depth as specified in the `--depth` option
         for x in Range[USize](1, depth + 1) do

--- a/testing/correctness/apps/multi_pipeline/Makefile
+++ b/testing/correctness/apps/multi_pipeline/Makefile
@@ -46,15 +46,14 @@ integration-tests-testing-correctness-apps-multi_pipeline: multi_pipeline_test
 multi_pipeline_test:
 	cd $(MULTI_PIPELINE_PATH) && \
 	integration_test \
-		--framed-file-sender _test.msg 0 \
-		--framed-file-sender _test.msg 1 \
+		--framed-file-sender _test.msg '"Celsius Conversion0"' \
+		--framed-file-sender _test.msg '"Celsius Conversion1"' \
 		--validation-cmp \
 	  --expected-file _expected.msg \
 		--log-level error \
 		--command './multi_pipeline $(RUN_WITH_RESILIENCE)' \
 		--sink-expect 200 \
-		--sinks 1 \
-		--sources 2
+		--sinks 1
 
 # end of prevent rules from being evaluated/included multiple times
 endif

--- a/testing/correctness/apps/multi_pipeline/README.md
+++ b/testing/correctness/apps/multi_pipeline/README.md
@@ -16,36 +16,42 @@ nc -l 127.0.0.1 7003 > multi_pipeline_2.out
 2. Single Worker: Start the application
 
 ```bash
-./multi_pipeline --in 127.0.0.1:7010,127.0.0.1:7011 --out \
-  127.0.0.1:7002,127.0.0.1:7003 --metrics 127.0.0.1:5001 \
+./multi_pipeline \
+  --in "Celsius Conversion0"@127.0.0.1:7010,"Celsius Conversion1"@127.0.0.1:7011 \
+  --out 127.0.0.1:7002,127.0.0.1:7003 --metrics 127.0.0.1:5001 \
   --control 127.0.0.1:12500 --data 127.0.0.1:12501 --cluster-initializer
 ```
 
 3. Two Workers: Start the application
 
 ```bash
-./multi_pipeline --in 127.0.0.1:7010,127.0.0.1:7011 --out \
-  127.0.0.1:7002,127.0.0.1:7003 --metrics 127.0.0.1:5001 \
+./multi_pipeline \
+  --in "Celsius Conversion0"@127.0.0.1:7010,"Celsius Conversion1"@127.0.0.1:7011 \
+  --out 127.0.0.1:7002,127.0.0.1:7003 --metrics 127.0.0.1:5001 \
   --control 127.0.0.1:12500 --data 127.0.0.1:12501 -w 2 --cluster-initializer
 
-./multi_pipeline --in 127.0.0.1:7010,127.0.0.1:7011 --out \
-  127.0.0.1:7002,127.0.0.1:7003 --metrics 127.0.0.1:5001 \
+./multi_pipeline \
+  --in "Celsius Conversion0"@127.0.0.1:7020,"Celsius Conversion1"@127.0.0.1:7021 \
+  --out 127.0.0.1:7002,127.0.0.1:7003 --metrics 127.0.0.1:5001 \
   --control 127.0.0.1:12500 --name worker2
 ```
 
 4. Three Workers: Start the application
 
 ```bash
-./multi_pipeline --in 127.0.0.1:7010,127.0.0.1:7011 --out \
-  127.0.0.1:7002,127.0.0.1:7003 --metrics 127.0.0.1:5001 \
+./multi_pipeline \
+  --in "Celsius Conversion0"@127.0.0.1:7010,"Celsius Conversion1"@127.0.0.1:7011 \
+  --out 127.0.0.1:7002,127.0.0.1:7003 --metrics 127.0.0.1:5001 \
   --control 127.0.0.1:12500 --data 127.0.0.1:12501 -w 3 --cluster-initializer
 
-./multi_pipeline --in 127.0.0.1:7010,127.0.0.1:7011 --out \
-  127.0.0.1:7002,127.0.0.1:7003 --metrics 127.0.0.1:5001 \
+./multi_pipeline \
+  --in "Celsius Conversion0"@127.0.0.1:7020,"Celsius Conversion1"@127.0.0.1:7021 \
+  --out 127.0.0.1:7002,127.0.0.1:7003 --metrics 127.0.0.1:5001 \
   --control 127.0.0.1:12500 --name worker2
 
-./multi_pipeline --in 127.0.0.1:7010,127.0.0.1:7011 --out \
-  127.0.0.1:7002,127.0.0.1:7003 --metrics 127.0.0.1:5001 \
+./multi_pipeline \
+  --in "Celsius Conversion0"@127.0.0.1:7030,"Celsius Conversion1"@127.0.0.1:7031 \
+  --out 127.0.0.1:7002,127.0.0.1:7003 --metrics 127.0.0.1:5001 \
   --control 127.0.0.1:12500 --name worker3
 ```
 

--- a/testing/correctness/apps/multi_pipeline/multi_pipeline.pony
+++ b/testing/correctness/apps/multi_pipeline/multi_pipeline.pony
@@ -30,16 +30,16 @@ actor Main
   new create(env: Env) =>
     try
       let pipeline = recover val
-        let inputs1 = Wallaroo.source[F32]("Celsius Conversion",
+        let inputs1 = Wallaroo.source[F32]("Celsius Conversion0",
             TCPSourceConfig[F32].from_options(CelsiusDecoder,
-              TCPSourceConfigCLIParser(env.args)?(0)?))
+              TCPSourceConfigCLIParser(env.args)?("Celsius Conversion0")?))
             .collect()
             .to[F32](Multiply)
             .to[F32](Add)
 
-        let inputs2 = Wallaroo.source[F32]("Celsius Conversion",
+        let inputs2 = Wallaroo.source[F32]("Celsius Conversion1",
             TCPSourceConfig[F32].from_options(CelsiusDecoder,
-              TCPSourceConfigCLIParser(env.args)?(1)?))
+              TCPSourceConfigCLIParser(env.args)?("Celsius Conversion1")?))
             .collect()
             .to[F32](Multiply)
             .to[F32](Add)

--- a/testing/correctness/apps/multi_sink/Makefile
+++ b/testing/correctness/apps/multi_sink/Makefile
@@ -45,14 +45,13 @@ integration-tests-testing-correctness-apps-multi_sink: multi_sink_test
 multi_sink_test:
 	cd $(MULTI_SINK_PATH) && \
 	integration_test \
-		--framed-file-sender _test.msg 0 \
+		--framed-file-sender _test.msg '"Celsius Conversion"' \
 		--validation-cmp \
 	  --expected-file _expected.msg \
 		--log-level error \
 		--command './multi_sink $(RUN_WITH_RESILIENCE)' \
 		--sink-expect 100 \
-		--sinks 2 \
-		--sources 1
+		--sinks 2
 
 # end of prevent rules from being evaluated/included multiple times
 endif

--- a/testing/correctness/apps/multi_sink/README.md
+++ b/testing/correctness/apps/multi_sink/README.md
@@ -16,7 +16,7 @@ nc -l 127.0.0.1 7003 > multi_sink_2.out
 2. Single Worker: Start the application
 
 ```bash
-./multi_sink --in 127.0.0.1:7010 --out \
+./multi_sink --in "Celsius Conversion"@127.0.0.1:7010 --out \
   127.0.0.1:7002,127.0.0.1:7003 --metrics 127.0.0.1:5001 \
   --control 127.0.0.1:12500 --data 127.0.0.1:12501 --cluster-initializer
 ```
@@ -24,11 +24,11 @@ nc -l 127.0.0.1 7003 > multi_sink_2.out
 3. Two Workers: Start the application
 
 ```bash
-./multi_sink --in 127.0.0.1:7010,127.0.0.1:7011 --out \
+./multi_sink --in "Celsius Conversion"@127.0.0.1:7010 --out \
   127.0.0.1:7002,127.0.0.1:7003 --metrics 127.0.0.1:5001 \
   --control 127.0.0.1:12500 --data 127.0.0.1:12501 -w 2 --cluster-initializer
 
-./multi_sink --in 127.0.0.1:7010,127.0.0.1:7011 --out \
+./multi_sink --in "Celsius Conversion"@127.0.0.1:7011 --out \
   127.0.0.1:7002,127.0.0.1:7003 --metrics 127.0.0.1:5001 \
   --control 127.0.0.1:12500 --name worker2
 ```
@@ -36,15 +36,15 @@ nc -l 127.0.0.1 7003 > multi_sink_2.out
 4. Three Workers: Start the application
 
 ```bash
-./multi_sink --in 127.0.0.1:7010,127.0.0.1:7011 --out \
+./multi_sink --in "Celsius Conversion"@127.0.0.1:7010 --out \
   127.0.0.1:7002,127.0.0.1:7003 --metrics 127.0.0.1:5001 \
   --control 127.0.0.1:12500 --data 127.0.0.1:12501 -w 3 --cluster-initializer
 
-./multi_sink --in 127.0.0.1:7010,127.0.0.1:7011 --out \
+./multi_sink --in "Celsius Conversion"@127.0.0.1:7011 --out \
   127.0.0.1:7002,127.0.0.1:7003 --metrics 127.0.0.1:5001 \
   --control 127.0.0.1:12500 --name worker2
 
-./multi_sink --in 127.0.0.1:7010,127.0.0.1:7011 --out \
+./multi_sink --in "Celsius Conversion"@127.0.0.1:7012 --out \
   127.0.0.1:7002,127.0.0.1:7003 --metrics 127.0.0.1:5001 \
   --control 127.0.0.1:12500 --name worker3
 ```

--- a/testing/correctness/apps/multi_sink/multi_sink.pony
+++ b/testing/correctness/apps/multi_sink/multi_sink.pony
@@ -32,7 +32,7 @@ actor Main
       let pipeline = recover val
         let values = Wallaroo.source[F32]("Celsius Conversion",
               TCPSourceConfig[F32].from_options(CelsiusDecoder,
-                TCPSourceConfigCLIParser(env.args)?(0)?))
+                TCPSourceConfigCLIParser(env.args)?("Celsius Conversion")?))
 
         values
           .collect()

--- a/testing/correctness/apps/ping_pong/ping_pong.pony
+++ b/testing/correctness/apps/ping_pong/ping_pong.pony
@@ -69,14 +69,14 @@ actor Main
           | Ping =>
             Wallaroo.source[U8]("Ping",
               TCPSourceConfig[U8].from_options(PongDecoder,
-                TCPSourceConfigCLIParser(env.args)?(0)?))
+                TCPSourceConfigCLIParser(env.args)?("Ping")?))
               .to[U8](Pingify)
               .to_sink(TCPSinkConfig[U8].from_options(PingPongEncoder,
                 TCPSinkConfigCLIParser(env.args)?(0)?))
           | Pong =>
             Wallaroo.source[U8]("Pong",
               TCPSourceConfig[U8].from_options(PingDecoder,
-                TCPSourceConfigCLIParser(env.args)?(0)?))
+                TCPSourceConfigCLIParser(env.args)?("Pong")?))
               .to[U8](Pongify)
               .to_sink(TCPSinkConfig[U8].from_options(PingPongEncoder,
                 TCPSinkConfigCLIParser(env.args)?(0)?))

--- a/testing/correctness/apps/sequence_window/Makefile
+++ b/testing/correctness/apps/sequence_window/Makefile
@@ -49,7 +49,7 @@ integration-tests-testing-correctness-apps-sequence_window: sequence_window_test
 
 sequence_window_test:
 	cd $(SEQUENCE_WINDOW_PATH) && \
-	integration_test --sequence-sender '(0,1000]' \
+	integration_test --sequence-sender '(0,1000]' '"Sequence Window"' \
 	  --log-level error \
 		--command './sequence_window $(RUN_WITH_RESILIENCE)' \
 		--validation-cmd './validator/validator -e 1000 -a -i' \

--- a/testing/correctness/apps/sequence_window/main.pony
+++ b/testing/correctness/apps/sequence_window/main.pony
@@ -36,13 +36,15 @@ To run, use the following commands:
 ```
 2. Initializer worker
 ```bash
-./sequence_window -i 127.0.0.1:7000 -o 127.0.0.1:5555 -m 127.0.0.1:5001 \
+./sequence_window -i "Sequence Window"@127.0.0.1:7000 \
+-o 127.0.0.1:5555 -m 127.0.0.1:5001 \
 --ponythreads=4 --ponypinasio --ponynoblock -c 127.0.0.1:12500 \
 -d 127.0.0.1:12501 -r res-data -w 2 -n worker1 -t
 ```
 3. Second worker
 ```bash
-./sequence_window -i 127.0.0.1:7000 -o 127.0.0.1:5555 -m 127.0.0.1:5001 \
+./sequence_window -i "Sequence Window"@127.0.0.1:7001 \
+-o 127.0.0.1:5555 -m 127.0.0.1:5001 \
 --ponythreads=4 --ponypinasio --ponynoblock -c 127.0.0.1:12500 \
 -r res-data -n worker2
 ```
@@ -95,7 +97,7 @@ actor Main
       let pipeline = recover val
         let inputs = Wallaroo.source[U64]("Sequence Window",
             TCPSourceConfig[U64 val].from_options(U64FramedHandler,
-              TCPSourceConfigCLIParser(env.args)?(0)?))
+              TCPSourceConfigCLIParser(env.args)?("Sequence Window")?))
 
         inputs
           .collect()

--- a/testing/correctness/apps/sequence_window_simple_state/Makefile
+++ b/testing/correctness/apps/sequence_window_simple_state/Makefile
@@ -50,7 +50,7 @@ integration-tests-testing-correctness-apps-sequence_window_simple_state: sequenc
 
 sequence_window_simple_state_test:
 	cd $(SEQUENCE_WINDOW_SIMPLE_STATE_PATH) && \
-	integration_test --sequence-sender '(0,10000]' \
+	integration_test --sequence-sender '(0,10000]' '"Sequence Window"' \
 	  --log-level error \
 		--command './sequence_window_simple_state $(RUN_WITH_RESILIENCE)' \
 		--validation-cmd 'validator -e 10000 -a -i' \

--- a/testing/correctness/apps/sequence_window_simple_state/main.pony
+++ b/testing/correctness/apps/sequence_window_simple_state/main.pony
@@ -36,13 +36,15 @@ To run, use the following commands:
 ```
 2. Initializer worker
 ```bash
-./sequence_window_simple_state -i 127.0.0.1:7000 -o 127.0.0.1:5555 -m 127.0.0.1:5001 \
+./sequence_window_simple_state -i "Sequence Window"@127.0.0.1:7000 \
+-o 127.0.0.1:5555 -m 127.0.0.1:5001 \
 --ponythreads=4 --ponypinasio --ponynoblock -c 127.0.0.1:12500 \
 -d 127.0.0.1:12501 -r res-data -w 2 -n worker1 -t
 ```
 3. Second worker
 ```bash
-./sequence_window_simple_state -i 127.0.0.1:7000 -o 127.0.0.1:5555 -m 127.0.0.1:5001 \
+./sequence_window_simple_state -i "Sequence Window"@127.0.0.1:7000 \
+-o 127.0.0.1:5555 -m 127.0.0.1:5001 \
 --ponythreads=4 --ponypinasio --ponynoblock -c 127.0.0.1:12500 \
 -r res-data -n worker2
 ```
@@ -96,7 +98,7 @@ actor Main
       let pipeline = recover val
         Wallaroo.source[U64]("Sequence Window",
             TCPSourceConfig[U64].from_options(U64FramedHandler,
-              TCPSourceConfigCLIParser(env.args)?(0)?))
+              TCPSourceConfigCLIParser(env.args)?("Sequence Window")?))
           .key_by(ExtractWindow)
           .to[String val](ObserveNewValue)
           .to_sink(TCPSinkConfig[String val].from_options(WindowEncoder,

--- a/testing/performance/apps/market-spread/Makefile
+++ b/testing/performance/apps/market-spread/Makefile
@@ -45,8 +45,8 @@ integration-tests-testing-performance-apps-market-spread: market-spread_pony_tes
 market-spread_pony_test:
 	cd $(MARKET_SPREAD_PONY_PATH) && \
 	python _test/gen.py && \
-	integration_test --framed-file-sender _market.txt 1 \
-	  --framed-file-sender _orders.txt 0 \
+	integration_test --framed-file-sender _market.txt '"Nbbo"' \
+	  --framed-file-sender _orders.txt '"Orders"' \
 	  --log-level error \
 	  --command './market-spread $(RUN_WITH_RESILIENCE)' \
 	  --validation-cmd 'python _test/validate.py --expected $(MARKET_SPREAD_PONY_PATH)/_expected.txt --output' \

--- a/testing/performance/apps/market-spread/PERFORMANCE_TESTING_MARKET_SPREAD.md
+++ b/testing/performance/apps/market-spread/PERFORMANCE_TESTING_MARKET_SPREAD.md
@@ -173,7 +173,7 @@ SSH into `wallaroo-leader-1`
 Start the Market Spread application with the following command:
 
 ```bash
-sudo cset proc -s user -e numactl -- -C 1-16,17 chrt -f 80 ~/wallaroo/testing/performance/apps/market-spread/market-spread -i wallaroo-leader-1:7000,wallaroo-leader-1:7001 -o wallaroo-follower-2:5555 -m wallaroo-follower-2:5001 -c wallaroo-leader-1:12500 -d wallaroo-leader-1:12501 -t -e wallaroo-leader-1:5050 --ponynoblock --ponythreads=16 --ponypinasio --ponyminthreads=999
+sudo cset proc -s user -e numactl -- -C 1-16,17 chrt -f 80 ~/wallaroo/testing/performance/apps/market-spread/market-spread -i Orders@wallaroo-leader-1:7000,Nbbo@wallaroo-leader-1:7001 -o wallaroo-follower-2:5555 -m wallaroo-follower-2:5001 -c wallaroo-leader-1:12500 -d wallaroo-leader-1:12501 -t -e wallaroo-leader-1:5050 --ponynoblock --ponythreads=16 --ponypinasio --ponyminthreads=999
 
 ```
 
@@ -351,7 +351,7 @@ SSH into `wallaroo-leader-1`
 Start the Market Spread application's Initializer with the following command:
 
 ```bash
-sudo cset proc -s user -e numactl -- -C 1-16,17 chrt -f 80 ~/wallaroo/testing/performance/apps/market-spread/market-spread  -i wallaroo-leader-1:7000,wallaroo-leader-1:7001 -o wallaroo-follower-2:5555 -m wallaroo-follower-2:5001 -c wallaroo-leader-1:12500 -d wallaroo-leader-1:12501 -t -e wallaroo-leader-1:5050  -w 2 --ponynoblock --ponythreads=16 --ponypinasio --ponyminthreads=999
+sudo cset proc -s user -e numactl -- -C 1-16,17 chrt -f 80 ~/wallaroo/testing/performance/apps/market-spread/market-spread  -i Orders@wallaroo-leader-1:7000,Nbbo@wallaroo-leader-1:7001 -o wallaroo-follower-2:5555 -m wallaroo-follower-2:5001 -c wallaroo-leader-1:12500 -d wallaroo-leader-1:12501 -t -e wallaroo-leader-1:5050  -w 2 --ponynoblock --ponythreads=16 --ponypinasio --ponyminthreads=999
 ```
 
 SSH into `wallaroo-follower-3`
@@ -359,7 +359,7 @@ SSH into `wallaroo-follower-3`
 Start the Market Spread application's 2nd Worker with the following command:
 
 ```bash
-sudo cset proc -s user -e numactl -- -C 1-8,17 chrt -f 80 ~/wallaroo/testing/performance/apps/market-spread/market-spread  -i wallaroo-leader-1:7000,wallaroo-leader-1:7001 -o wallaroo-follower-2:5555 -m wallaroo-follower-2:5001 -c wallaroo-leader-1:12500 -x wallaroo-follower-3:12500 -y wallaroo-follower-3:12501 -n worker2 --ponythreads=8 --ponypinasio --ponynoblock --ponyminthreads=999
+sudo cset proc -s user -e numactl -- -C 1-8,17 chrt -f 80 ~/wallaroo/testing/performance/apps/market-spread/market-spread  -i Orders@wallaroo-follower-3:7000,Nbbo@wallaroo-follower-3:7001 -o wallaroo-follower-2:5555 -m wallaroo-follower-2:5001 -c wallaroo-leader-1:12500 -x wallaroo-follower-3:12500 -y wallaroo-follower-3:12501 -n worker2 --ponythreads=8 --ponypinasio --ponynoblock --ponyminthreads=999
 
 ```
 

--- a/testing/performance/apps/market-spread/market-spread.pony
+++ b/testing/performance/apps/market-spread/market-spread.pony
@@ -29,12 +29,12 @@ nc -l 127.0.0.1 5001 >> /dev/null
 350 Symbols
 
 3a) market spread app (1 worker):
-./market-spread -i 127.0.0.1:7000,127.0.0.1:7001 -o 127.0.0.1:5555 -m 127.0.0.1:5001 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n node-name -t --ponythreads=4 --ponynoblock
+./market-spread -i Orders@127.0.0.1:7000,Nbbo@127.0.0.1:7001 -o 127.0.0.1:5555 -m 127.0.0.1:5001 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n node-name -t --ponythreads=4 --ponynoblock
 
 3b) market spread app (2 workers):
-./market-spread -i 127.0.0.1:7000,127.0.0.1:7001 -o 127.0.0.1:5555 -m 127.0.0.1:5001 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n node-name --ponythreads=4 --ponynoblock -t -w 2
+./market-spread -i Orders@127.0.0.1:7000,Nbbo@127.0.0.1:7001 -o 127.0.0.1:5555 -m 127.0.0.1:5001 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n node-name --ponythreads=4 --ponynoblock -t -w 2
 
-./market-spread -i 127.0.0.1:7000,127.0.0.1:7001 -o 127.0.0.1:5555 -m 127.0.0.1:5001 -c 127.0.0.1:6000 -n worker2 --ponythreads=4 --ponynoblock
+./market-spread -i Orders@127.0.0.1:7010,Nbbo@127.0.0.1:7011 -o 127.0.0.1:5555 -m 127.0.0.1:5001 -c 127.0.0.1:6000 -n worker2 --ponythreads=4 --ponynoblock
 
 4) initial nbbo (must be sent in or all orders will be rejected):
 giles/sender/sender -h 127.0.0.1:7001 -m 350 -s 300 -i 2_500_000 -f testing/data/market_spread/nbbo/350-symbols_initial-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 -w
@@ -48,12 +48,12 @@ giles/sender/sender -h 127.0.0.1:7001 -m 10000000000 -s 300 -i 1_250_000 -f test
 R3K or other Symbol Set (700, 1400, 2100)
 
 3a) market spread app (1 worker):
-./market-spread -i 127.0.0.1:7000,127.0.0.1:7001 -o 127.0.0.1:5555 -m 127.0.0.1:5001 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n node-name -t -s ../../../data/market_spread/symbols/r3k-legal-symbols.msg --ponythreads=4 --ponynoblock
+./market-spread -i Orders@127.0.0.1:7000,Nbbo@127.0.0.1:7001 -o 127.0.0.1:5555 -m 127.0.0.1:5001 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n node-name -t -s ../../../data/market_spread/symbols/r3k-legal-symbols.msg --ponythreads=4 --ponynoblock
 
 3b) market spread app (2 workers):
-./market-spread -i 127.0.0.1:7000,127.0.0.1:7001 -o 127.0.0.1:5555 -m 127.0.0.1:5001 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n node-name -s ../../../data/market_spread/symbols/r3k-legal-symbols.msg --ponythreads=4 --ponynoblock -t -w 2
+./market-spread -i Orders@127.0.0.1:7000,Nbbo@127.0.0.1:7001 -o 127.0.0.1:5555 -m 127.0.0.1:5001 -c 127.0.0.1:6000 -d 127.0.0.1:6001 -n node-name -s ../../../data/market_spread/symbols/r3k-legal-symbols.msg --ponythreads=4 --ponynoblock -t -w 2
 
-./market-spread -i 127.0.0.1:7000,127.0.0.1:7001 -o 127.0.0.1:5555 -m 127.0.0.1:5001 -c 127.0.0.1:6000 -n worker2 --ponythreads=4 --ponynoblock
+./market-spread -i Orders@127.0.0.1:7010,Nbbo@127.0.0.1:7011 -o 127.0.0.1:5555 -m 127.0.0.1:5001 -c 127.0.0.1:6000 -n worker2 --ponythreads=4 --ponynoblock
 
 4) initial nbbo (must be sent in or all orders will be rejected):
 giles/sender/sender -h 127.0.0.1:7001 -m 2926 -s 300 -i 2_500_000 -f testing/data/market_spread/nbbo/r3k-symbols_initial-nbbo-fixish.msg -r --ponythreads=1 -y -g 46 -w
@@ -93,12 +93,12 @@ actor Main
       let pipeline = recover val
         let orders = Wallaroo.source[FixOrderMessage val]("Orders",
             TCPSourceConfig[FixOrderMessage val].from_options(FixOrderFrameHandler,
-              TCPSourceConfigCLIParser(env.args)?(0)?))
+              TCPSourceConfigCLIParser(env.args)?("Orders")?))
           .key_by(OrderSymbolExtractor)
 
         let nbbos = Wallaroo.source[FixNbboMessage val]("Nbbo",
             TCPSourceConfig[FixNbboMessage val].from_options(FixNbboFrameHandler,
-              TCPSourceConfigCLIParser(env.args)?(1)?))
+              TCPSourceConfigCLIParser(env.args)?("Nbbo")?))
           .key_by(NbboSymbolExtractor)
 
         orders.merge[FixNbboMessage val](nbbos)

--- a/testing/tools/integration/cluster.py
+++ b/testing/tools/integration/cluster.py
@@ -226,7 +226,7 @@ class Runner(threading.Thread):
 
 
 BASE_COMMAND = r'''{command} \
-    {in_block} \
+    {{in_block}} \
     {out_block} \
     --metrics {metrics_addr} \
     --resilience-dir {res_dir} \
@@ -266,10 +266,6 @@ def start_runners(runners, command, source_addrs, sink_addrs, metrics_addr,
                   res_dir, workers, worker_addrs=[], alt_block=None,
                   alt_func=lambda x: False, spikes={}):
     cmd_stub = BASE_COMMAND.format(command=command,
-                                   in_block=(
-                                       IN_BLOCK.format(inputs=','.join(
-                                           source_addrs))
-                                       if source_addrs else ''),
                                    out_block=(
                                        OUT_BLOCK.format(outputs=','.join(
                                            sink_addrs))
@@ -296,6 +292,11 @@ def start_runners(runners, command, source_addrs, sink_addrs, metrics_addr,
             worker_count=WORKER_COUNT_CMD.format(worker_count=workers),
             data_addr=worker_addrs[0][1],
             external_addr=worker_addrs[0][2]),
+        in_block=(
+            IN_BLOCK.format(inputs=','.join(
+                '{}@{}'.format(src_nm, addr)
+                for src_nm, addr in source_addrs[0].items()))
+            if source_addrs else ''),
         worker_block='',
         join_block=CONTROL_CMD.format(control_addr=worker_addrs[0][0]),
         alt_block=alt_block if alt_func(x) else '',
@@ -317,6 +318,11 @@ def start_runners(runners, command, source_addrs, sink_addrs, metrics_addr,
             spike_block = ''
         cmd = cmd_stub.format(name='worker{}'.format(x),
                               initializer_block='',
+                              in_block=(
+                                  IN_BLOCK.format(inputs=','.join(
+                                      '{}@{}'.format(src_nm, addr)
+                                      for src_nm, addr in source_addrs[x].items()))
+                                  if source_addrs else ''),
                               worker_block=WORKER_CMD.format(
                                   control_addr=worker_addrs[x][0],
                                   data_addr=worker_addrs[x][1],
@@ -365,10 +371,6 @@ def add_runner(worker_id, runners, command, source_addrs, sink_addrs, metrics_ad
                my_control_addr, my_data_addr, my_external_addr,
                alt_block=None, alt_func=lambda x: False, spikes={}):
     cmd_stub = BASE_COMMAND.format(command=command,
-                                   in_block=(
-                                       IN_BLOCK.format(inputs=','.join(
-                                           source_addrs))
-                                       if source_addrs else ''),
                                    out_block=(
                                        OUT_BLOCK.format(outputs=','.join(
                                            sink_addrs))
@@ -400,6 +402,11 @@ def add_runner(worker_id, runners, command, source_addrs, sink_addrs, metrics_ad
                               control_addr=my_control_addr,
                               data_addr=my_data_addr,
                               external_addr=my_external_addr),
+                          in_block=(
+                              IN_BLOCK.format(inputs=','.join(
+                                  '{}@{}'.format(src_nm, addr)
+                                  for src_nm, addr in source_addrs.items()))
+                              if source_addrs else ''),
                           join_block=JOIN_CMD.format(
                               join_addr=control_addr,
                               worker_count=(WORKER_COUNT_CMD.format(
@@ -443,7 +450,7 @@ SinkData = namedtuple('SinkData',
 
 
 class Cluster(object):
-    def __init__(self, command, host='127.0.0.1', sources=1, workers=1,
+    def __init__(self, command, host='127.0.0.1', sources=[], workers=1,
             sinks=1, sink_mode='framed', worker_join_timeout=30,
             is_ready_timeout=30, res_dir=None, persistent_data={}):
         # Create attributes
@@ -456,6 +463,7 @@ class Cluster(object):
         self.dead_workers = TypedList(types=(Runner,))
         self.restarted_workers = TypedList(types=(Runner,))
         self.runners = TypedList(types=(Runner,))
+        self.source_names = sources
         self.source_addrs = []
         self.sink_addrs = []
         self.sinks = []
@@ -496,13 +504,22 @@ class Cluster(object):
                                .format(*map(str,s.get_connection_info()))
                                for s in self.sinks]
 
-            num_ports = sources + 3 * workers
+            # TODO: when support for different per-worker sourced defs is
+            # available, figure out how to allocate sources to workers here
+            sources = len(self.source_names)
+            num_ports = (sources + 3) * workers
             ports = get_port_values(num=num_ports, host=host)
             addresses = ['{}:{}'.format(host, p) for p in ports]
-            (self.source_addrs, worker_addrs) = (
-                addresses[:sources],
-                [addresses[sources:][i:i+3]
-                 for i in range(0, len(addresses[sources:]), 3)])
+            (source_addrs, worker_addrs) = (
+                addresses[:sources*workers],
+                [addresses[sources*workers:][i:i+3]
+                 for i in range(0, len(addresses[sources*workers:]), 3)])
+            # Construct a list of {name: addr} dicts, one dict for each worker
+            for i in range(workers):
+                d = dict(zip(self.source_names,
+                             source_addrs[i * sources: (i+1) * sources]))
+                if d:
+                    self.source_addrs.append(d)
             start_runners(self.workers, self.command, self.source_addrs,
                           self.sink_addrs,
                           self.metrics_addr, self.res_dir, workers,
@@ -539,11 +556,21 @@ class Cluster(object):
             by, timeout, with_test))
         pre_partitions = self.get_partition_data() if with_test else None
         runners = []
-        new_ports = get_port_values(num = 3 * by,
+        sources = len(self.source_names)
+        new_ports = get_port_values(num = (sources + 3) * by,
                                     host = self.host,
                                     base_port=25000)
-        addrs = [["{}:{}".format(self.host, p) for p in new_ports[i*3: i*3 + 3]]
-                 for i in range(by)]
+        # format all the addresses to host:port using self.host
+        addrs = ["{}:{}".format(self.host, p) for p in new_ports]
+        # split addresses into worker_addrs and source_addrs
+        worker_addrs = [addrs[i*3: i*3 + 3] for i in range(by)]
+        addrs = addrs[3*by:]
+        for i in range(by):
+            d = dict(zip(
+                         self.source_names,
+                         addrs[i*sources: (i+1)*source]))
+            if d:
+                self.source_addrs.append(d)
         for x in range(by):
             runner = add_runner(
                 worker_id=self._worker_id_counter,

--- a/testing/tools/integration/integration.py
+++ b/testing/tools/integration/integration.py
@@ -43,7 +43,7 @@ DEFAULT_RUNNER_JOIN_TIMEOUT = 30
 FROM_TAIL = int(os.environ.get("FROM_TAIL", 10))
 
 
-def pipeline_test(generator, expected, command, workers=1, sources=1,
+def pipeline_test(sources, expected, command, workers=1,
                   mode='framed', sinks=1, decoder=None, pre_processor=None,
                   batch_size=1, sender_interval=0.001,
                   sink_expect=None, sink_expect_allow_more=False,
@@ -62,8 +62,9 @@ def pipeline_test(generator, expected, command, workers=1, sources=1,
     yourself. This only works for 1-source, 1-sink topologies.
 
     Parameters:
-    - `generator`: either a single data generator to use in a Sender's Reader,
-        or a list of tuples of (generator, source_index) for use with
+    - `sources`: either a single (generator, source_name) tuple
+        to use in a Sender's Reader,
+        or a list of tuples of (generator, source_name) for use with
         multi-source applications. In the latter case, the senders are run
         sequentially, and the index is 0-based against the input addresses.
         the values in this set should be either strings or stringable. If they
@@ -76,7 +77,6 @@ def pipeline_test(generator, expected, command, workers=1, sources=1,
         `--cluster-initializer`, and `--ponynoblock`.
         These will be applied by the test setup utility.
     - `workers`: the number of workers to use in the test. Default: 1.
-    - `sources`: the number of sources in the application. Default: 1.
     - `mode`: the decoding mode to use in the sink. Can be `'framed'` or
         `'newlines'`. Default: `'framed'`
     - `sinks`: the number of sinks to set up for the application. Default: 1.
@@ -148,8 +148,11 @@ def pipeline_test(generator, expected, command, workers=1, sources=1,
             if len(sink_await) != sinks:
                 sink_await = [sink_await[:] for x in range(sinks)]
 
+        # figure out source count based on source names
+        source_names = list(set([src[1] for src in sources]))
+
         # Start cluster
-        with Cluster(command=command, host=host, sources=sources,
+        with Cluster(command=command, host=host, sources=source_names,
                      workers=workers, sinks=sinks, sink_mode=mode,
                      worker_join_timeout=runner_join_timeout,
                      is_ready_timeout = ready_timeout,
@@ -157,12 +160,14 @@ def pipeline_test(generator, expected, command, workers=1, sources=1,
                      persistent_data=persistent_data) as cluster:
 
             # Create senders
-            if generator:
-                if not isinstance(generator, list):
-                    generator = [(generator, 0)]
-                for gen, idx in generator:
+            if sources:
+                if not isinstance(sources, list):
+                    sources = [sources]
+                for gen, src_name in sources:
                     reader = Reader(gen)
-                    sender = Sender(cluster.source_addrs[idx], reader,
+                    # TODO [NH]: figure out how to support sending to workers
+                    # other than initializer via command parameters
+                    sender = Sender(cluster.source_addrs[0][src_name], reader,
                                     batch_size=batch_size,
                                     interval=sender_interval)
                     cluster.add_sender(sender)

--- a/testing/tools/integration_test
+++ b/testing/tools/integration_test
@@ -31,25 +31,21 @@ Run an integration test as a CLI
 class CSVGenAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         """
-        Permit three cases: 1, 2, and 3 values.
-        1 value: Take {0} as iter, use source 0, and header format '>I'
+        Permit two cases: 2, and 3 values.
         2 values: Take {0} as iter, use source {1}, and header format '>I'
         3 values: Take {0} as iter, use source {1}, and header format {2}
         """
-        if len(values) == 1:
+        if len(values) == 2:
             gen = iter_generator(values[0].split(','))
-            source = 0
-        elif len(values) == 2:
-            gen = iter_generator(values[0].split(','))
-            source = int(values[1])
+            source = values[1]
         elif len(values) == 3:
             gen = iter_generator(values[0].split(','),
                                  header_fmt=values[2])
-            source = int(values[1])
+            source = values[1]
         else:
-            msg = ('Argument "{f}" requires 1, 2, or 3 arguments specifying '
-                   'comma-separated-list [, source-index [, header format]].\n'
-                   "When unspecified, source-index is 0, and header format is "
+            msg = ('Argument "{f}" requires 2, or 3 arguments specifying '
+                   'comma-separated-list, source-name [, header format].\n'
+                   "When unspecified, header format is "
                    "'>I'".format(f=self.dest))
             raise argparse.ArgumentTypeError(msg)
 
@@ -67,8 +63,7 @@ class CSVGenAction(argparse.Action):
 class SeqGenAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         """
-        Permit four cases: 1, 2, 3, and 4 values
-        1 value: range = {0}, source = 0, header format = '>I'
+        Permit four cases: 2, 3, and 4 values
         2 values: range = {0}, source = {1}, header format = '>I'
         3 values: range = {0}, source = {1}, header format = {2}
         4 values: range = {0}, source = {1}, header format = {2}, partition = {3}
@@ -78,30 +73,26 @@ class SeqGenAction(argparse.Action):
         E.g. (0, 1000] will produce 1, 2, 3, ..., 1000. And [0, 1000) will
         produce 0, 1, 2, ..., 999.
         """
-        if len(values) == 1:
+        if len(values) == 2:
             start, stop = self.__range_parse__(values[0])
-            source = 0
-            gen = sequence_generator(stop, start)
-        elif len(values) == 2:
-            start, stop = self.__range_parse__(values[0])
-            source = int(values[1])
+            source = values[1]
             gen = sequence_generator(stop, start)
         elif len(values) == 3:
             start, stop = self.__range_parse__(values[0])
-            source = int(values[1])
+            source = values[1]
             header_fmt = values[2]
             gen = sequence_generator(stop, start, header_fmt)
         elif len(values) == 4:
             start, stop = self.__range_parse__(values[0])
-            source = int(values[1])
+            source = values[1]
             header_fmt = values[2]
             partition = values[3]
             gen = sequence_generator(stop, start, header_fmt, partition)
         else:
-            msg = ('Argument "{f}" requires 1, 2, 3, or 4 arguments specifying '
-                   '(start, stop] [, source-index [, header format '
-                   '[, partition]]].\n'
-                   "When unspecified, source-index is 0, header format is "
+            msg = ('Argument "{f}" requires 2, 3, or 4 arguments specifying '
+                   '(start, stop], source-index [, header format '
+                   '[, partition]].\n'
+                   "When unspecified, header format is "
                    "'>I', and partition is empty".format(f=self.dest))
             raise argparse.ArgumentTypeError(msg)
 
@@ -138,26 +129,22 @@ class SeqGenAction(argparse.Action):
 class NewlineGenAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         """
-        Permit three cases: 1, 2, and 3 values
-        1 value: paths = {0}, source = 0, header format = '>I'
+        Permit three cases: 2, and 3 values
         2 values: paths = {0}, source = {1}, header format = '>I'
         3 values: paths = {0}, source = {1}, header format = {2}
         """
         paths = values[0].split(',')
-        if len(values) == 1:
-            source = 0
-            gen = files_generator(paths, mode='newlines')
-        elif len(values) == 2:
-            source = int(values[1])
+        if len(values) == 2:
+            source = values[1]
             gen = files_generator(paths, mode='newlines')
         elif len(values) == 3:
-            source = int(values[1])
+            source = values[1]
             gen = files_generator(paths, mode='newlines',
                                   header_fmt = values[2])
         else:
-            msg = ('Argument "{f}" requires 1, 2, or 3 arguments specifying '
-                   'paths [, source-index [, header format]].\n'
-                   "When unspecified, source-index is 0, and header format is "
+            msg = ('Argument "{f}" requires 2, or 3 arguments specifying '
+                   'paths, source-name [, header format].\n'
+                   "When unspecified, header format is "
                    "'>I'".format(f=self.dest))
             raise argparse.ArgumentTypeError(msg)
 
@@ -175,26 +162,22 @@ class NewlineGenAction(argparse.Action):
 class FramedGenAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         """
-        Permit three cases: 1, 2, and 3 values
-        1 value: paths = {0}, source = 0, header format = '>I'
+        Permit three cases: 2, and 3 values
         2 values: paths = {0}, source = {1}, header format = '>I'
         3 values: paths = {0}, source = {1}, header format = {2}
         """
         paths = values[0].split(',')
-        if len(values) == 1:
-            source = 0
-            gen = files_generator(paths, mode='framed')
-        elif len(values) == 2:
-            source = int(values[1])
+        if len(values) == 2:
+            source = values[1]
             gen = files_generator(paths, mode='framed')
         elif len(values) == 3:
-            source = int(values[1])
+            source = values[1]
             gen = files_generator(paths, mode='framed',
                                   header_fmt = values[2])
         else:
-            msg = ('Argument "{f}" requires 1, 2, or 3 arguments specifying '
-                   'paths [, source-index [, header format]].\n'
-                   "When unspecified, source-index is 0, and header format is "
+            msg = ('Argument "{f}" requires 2, or 3 arguments specifying '
+                   'paths, source-name [, header format].\n'
+                   "When unspecified, header format is "
                    "'>I'".format(f=self.dest))
             raise argparse.ArgumentTypeError(msg)
 
@@ -364,25 +347,25 @@ def CLI():
           (https://docs.python.org/2/library/struct.html#format-characters).
           Default: '>I'
         ''')
-    gens.add_argument('--framed-file-sender', dest='generators',
+    gens.add_argument('--framed-file-sender', dest='sources', default=[],
                       action=FramedGenAction, nargs='+',
-                      metavar=('filepaths', 'source_index', 'header_format'),
+                      metavar=('filepaths', 'source_name', 'header_format'),
                       help=("Send values from a comma-separated list of "
                            "files."))
-    gens.add_argument('--newline-file-sender', dest='generators',
+    gens.add_argument('--newline-file-sender', dest='sources', default=[],
                       action=NewlineGenAction, nargs='+',
-                      metavar=('filepaths', 'source_index', 'header_format'),
+                      metavar=('filepaths', 'source_name', 'header_format'),
                       help=("Send values form a comma-separated list of "
                             "files that use newlines to separate records."))
-    gens.add_argument('--sequence-sender', dest='generators',
+    gens.add_argument('--sequence-sender', dest='sources', default=[],
                       action=SeqGenAction, nargs='+',
-                      metavar=('range', 'source_index', 'header_format',
+                      metavar=('range', 'source_name', 'header_format',
                                'partition'),
                       help=("Send values from the set of integers "
                             "(start,stop]"))
-    gens.add_argument('--csv-sender', dest='generators', action=CSVGenAction,
-                      nargs='+',
-                      metavar=('item1,item2,...', 'source_index', 'header_format'),
+    gens.add_argument('--csv-sender', dest='sources', default=[],
+                      action=CSVGenAction, nargs='+',
+                      metavar=('item1,item2,...', 'source_name', 'header_format'),
                       help="Send values from a comma delimited string")
 
     # Network parameters
@@ -431,8 +414,6 @@ def CLI():
     # Detail for the specific run
     parser.add_argument('--workers', type=int, default=1,
                         help="Number of workers to use in the test.")
-    parser.add_argument('--sources', type=int, default=1,
-                        help="Number of sources the application listens on.")
     parser.add_argument('--sinks', type=int, default=1,
                         help="Number of sinks the application outputs to.")
     parser.add_argument('--sink-mode', default='framed',
@@ -538,11 +519,10 @@ def CLI():
                 for k, v in args._get_kwargs():
                     logging.debug('%s: %r' % (k, v))
                 pipeline_test(
-                    generator = args.generators,
                     expected = args.expected_val,
                     command = args.command,
                     workers = args.workers,
-                    sources = args.sources,
+                    sources = args.sources, # list of (generator, source_name) tuples
                     sinks = args.sinks,
                     mode = args.sink_mode,
                     batch_size = args.batch_size,


### PR DESCRIPTION
**DO NOT MERGE**

This PR is open only for review and is not intended to be merged to `master` in its current state.

## Testing

Testing to confirm that sources start on multiple workers can be done using the `multi_partition_detector` application.

**Manual Testing**

1. `cd testing/correctness/apps/multi_partition_detector`
2. `make build build-giles-sender build-utils-data_receiver`
3.Start Data Receiver: ```./utils/data_receiver/data_receiver -l 127.0.0.1:45674 -f > received.txt```
4. Start Initializer: ```./multi_partition_detector --in Detector@127.0.0.1:20000 --out 127.0.0.1:45674 --metrics 127.0.0.1:40614 --name initializer --worker-count 2 --data 127.0.0.1:20002 --external 127.0.0.1:20013 --cluster-initializer  --control 127.0.0.1:20015   --ponythreads=1 --ponypinasio --ponynoblock```
5. Start Worker 2: ```./multi_partition_detector --in Detector@127.0.0.1:20010 --out 127.0.0.1:40757 --metrics 127.0.0.1:46008 --name worker1   --my-control 127.0.0.1:20004 --my-data 127.0.0.1:20005 --external 127.0.0.1:20006 --control 127.0.0.1:20015   --ponythreads=1 --ponypinasio --ponynoblock```
6. Start Sender for `key_0`: ```giles/sender/sender -h 127.0.0.1:20000 -s 1 -i 50_000_000  --ponythreads=1 -y -g 12 -w -u -m 100 -p key_0```
7. Start Sender for `key_1`: ```giles/sender/sender -h 127.0.0.1:20010 -s 1 -i 50_000_000  --ponythreads=1 -y -g 12 -w -u -m 100 -p key_1```
8. Run `validator`: ```./testing/correctness/apps/multi_partition_detector/validator/validator -i received.txt ```

**Automated Testing**
1. `cd testing/correctness/apps/multi_partition_detector`
2.Run tests ` make integration-tests-testing-correctness-apps-multi_partition_detector`
3. Run tests with resilience ` make integration-tests-testing-correctness-apps-multi_partition_detector`

**NOTE:** Currently the 10 worker tests fail when resilience is on with the following error:

```
ExternalChannelConnectNotifier (initializer): server closed
ExternalChannelConnectNotifier (initializer): server closed
Detector source: accepted a connection
worker_ack_barrier from InProgressPrimaryBarrierHandler
worker_ack_barrier from InProgressPrimaryBarrierHandler
worker_ack_barrier from InProgressPrimaryBarrierHandler
TCPSource connection closed
Detector source: accepted a connection
Received CheckpointBarrierToken(2) when still processing CheckpointBarrierToken(3) at step 172758834876403722331532747725528212546
This should never happen: failure in /home/vagrant/dev/wallaroo/lib/wallaroo/ent/barrier/barrier_step_forwarder.pony at line 79
```


