### PR TITLE
Unaligned windows

### DIFF
--- a/lib/wallaroo/core/state/state.pony
+++ b/lib/wallaroo/core/state/state.pony
@@ -17,6 +17,7 @@ Copyright 2017 The Wallaroo Authors.
 */
 
 use "buffered"
+use "random"
 use "serialise"
 use "wallaroo/core/common"
 use "wallaroo/core/topology"
@@ -55,7 +56,7 @@ primitive PonySerializeStateEncoderDecoder[S: State ref] is
 
 interface val StateInitializer[In: Any val, Out: Any val, S: State ref] is
   Computation[In, Out]
-  fun val state_wrapper(key: Key): StateWrapper[In, Out, S]
+  fun val state_wrapper(key: Key, rand: Rand): StateWrapper[In, Out, S]
   fun name(): String
   fun timeout_interval(): U64
   fun val decode(in_reader: Reader, auth: AmbientAuth):

--- a/lib/wallaroo/core/topology/computations.pony
+++ b/lib/wallaroo/core/topology/computations.pony
@@ -18,6 +18,7 @@ Copyright 2017 The Wallaroo Authors.
 
 use "buffered"
 use "collections"
+use "random"
 use "time"
 use "wallaroo"
 use "wallaroo/core/common"
@@ -64,7 +65,8 @@ trait val StateComputation[In: Any val, Out: Any val, S: State ref] is
   =>
     StateRunnerBuilder[In, Out, S](this, step_group_id, parallelization)
 
-  fun val state_wrapper(key: Key): StateWrapper[In, Out, S] =>
+  fun val state_wrapper(key: Key, rand: Rand): StateWrapper[In, Out, S]
+  =>
     StateComputationWrapper[In, Out, S](this, initial_state())
 
   fun val decode(in_reader: Reader, auth: AmbientAuth):

--- a/lib/wallaroo/core/topology/runner.pony
+++ b/lib/wallaroo/core/topology/runner.pony
@@ -20,6 +20,7 @@ use "buffered"
 use "collections"
 use "crypto"
 use "net"
+use "random"
 use "time"
 use "serialise"
 use "wallaroo/core/common"
@@ -299,6 +300,10 @@ class StateRunner[In: Any val, Out: Any val, S: State ref] is (Runner &
   let _auth: AmbientAuth
   var _step_id: (RoutingId | None)
 
+  // !TODO! This is for creating unaligned windows with random starting
+  // points. We should refactor so that we can control the seed for testing.
+  let _rand: Rand = Rand
+
   // Timeouts
   var _step_timeout_trigger: (StepTimeoutTrigger | None) = None
   let _msg_id_gen: MsgIdGenerator = MsgIdGenerator
@@ -402,7 +407,7 @@ class StateRunner[In: Any val, Out: Any val, S: State ref] is (Runner &
           match producer
           | let s: Step ref =>
             s.register_key(_step_group, key)
-            let new_state = _state_initializer.state_wrapper(key)
+            let new_state = _state_initializer.state_wrapper(key, _rand)
             _state_map(key) = new_state
             new_state
           else
@@ -434,7 +439,6 @@ class StateRunner[In: Any val, Out: Any val, S: State ref] is (Runner &
         else
           state_wrapper(input, event_ts, watermark_ts)
         end
-        // state_wrapper(input, event_ts, watermark_ts)
       let computation_end = WallClock.nanoseconds()
 
       (let new_watermark_ts, let old_watermark_ts) =
@@ -520,7 +524,7 @@ class StateRunner[In: Any val, Out: Any val, S: State ref] is (Runner &
     else
       // We got the key but no accompanying state, so we initialize
       // ourselves.
-      _state_map(key) = _state_initializer.state_wrapper(key)
+      _state_map(key) = _state_initializer.state_wrapper(key, _rand)
       step.register_key(s_group, key)
     end
 
@@ -530,7 +534,7 @@ class StateRunner[In: Any val, Out: Any val, S: State ref] is (Runner &
       try
         _state_map.remove(key)?._2
       else
-        _state_initializer.state_wrapper(key)
+        _state_initializer.state_wrapper(key, _rand)
       end
     state_wrapper.encode(_auth)
 

--- a/lib/wallaroo/core/windows/_windows_test.pony
+++ b/lib/wallaroo/core/windows/_windows_test.pony
@@ -99,7 +99,7 @@ class iso _TestSlidingWindowsOutputEventTimes is UnitTest
     let slide: U64 = Seconds(5)
     let delay: U64 = Seconds(10)
     let sw = RangeWindows[USize, USize, _Total]("key", _Sum, range, slide,
-      delay)
+      delay, _Zeros)
              .>apply(1, Seconds(111), Seconds(111))
              .>apply(2, Seconds(121), Seconds(121))
 
@@ -231,7 +231,7 @@ class iso _TestOutputWatermarkTsIsJustBeforeNextWindowStart is UnitTest
     let upstream_id: U128 = 1000
     let now: U64 = 1000
     let tw = RangeWindows[USize, USize, _Total]("key", _NonZeroSum, range,
-      slide, delay)
+      slide, delay, _Zeros)
     tw(1, Milliseconds(5000), Milliseconds(5000))
 
     // when
@@ -991,7 +991,8 @@ primitive _TumblingWindow
   =>
     let slide = range
     let delay: U64 = 0
-    RangeWindows[USize, USize, _Total]("key", _NonZeroSum, range, slide, delay)
+    RangeWindows[USize, USize, _Total]("key",
+      _NonZeroSum, range, slide, delay, _Zeros)
 
 class _Zeros is Random
   new ref create(x: U64 val = 0, y: U64 val = 0) => None

--- a/lib/wallaroo/core/windows/_windows_test.pony
+++ b/lib/wallaroo/core/windows/_windows_test.pony
@@ -20,6 +20,7 @@ use "collections"
 use "itertools"
 use "ponytest"
 use "promises"
+use "random"
 use "wallaroo/core/aggregations"
 use "wallaroo/core/common"
 use "wallaroo/core/state"
@@ -250,7 +251,7 @@ class iso _TestTumblingWindows is UnitTest
     let slide = range
     let delay: U64 = Seconds(10)
     let tw = RangeWindows[USize, USize, _Total]("key", _Sum, range, slide,
-      delay)
+      delay, _Zeros)
 
     // First window's data
     var res = tw(2, Seconds(96), Seconds(101))
@@ -293,7 +294,7 @@ class iso _TestSlidingWindows is UnitTest
     let slide: U64 = Seconds(2)
     let delay: U64 = Seconds(10)
     let sw = RangeWindows[USize, USize, _Total]("key", _Sum, range, slide,
-      delay)
+      delay, _Zeros)
 
     // First 2 windows values
     h.assert_array_eq[USize]([], _OutArray(sw(2, Seconds(92), Seconds(100)))?)
@@ -354,8 +355,8 @@ class iso _TestSlidingWindowsNoDelay is UnitTest
     let slide: U64 = Seconds(2)
     let delay: U64 = Seconds(0)
     let sw = RangeWindows[USize, USize, _Total]("key", _Sum, range, slide,
-      delay)
-    // First 2 windows values
+      delay, _Zeros)
+
     h.assert_array_eq[USize]([], _OutArray(sw(2, Seconds(92), Seconds(100)))?)
     h.assert_array_eq[USize]([], _OutArray(sw(3, Seconds(93), Seconds(102)))?)
     h.assert_array_eq[USize]([], _OutArray(sw(4, Seconds(94), Seconds(103)))?)
@@ -396,7 +397,7 @@ class iso _TestSlidingWindowsOutOfOrder is UnitTest
     let slide: U64 = Seconds(2)
     let delay: U64 = Seconds(10)
     let sw = RangeWindows[USize, USize, _Total]("key", _Sum, range, slide,
-      delay)
+      delay, _Zeros)
 
     // First 2 windows values
     h.assert_array_eq[USize]([], _OutArray(sw(5, Seconds(95), Seconds(100)))?)
@@ -439,7 +440,7 @@ class iso _TestSlidingWindowsGCD is UnitTest
     // of the slide.
     let delay: U64 = Seconds(10)
     let sw = RangeWindows[USize, USize, _Total]("key", _Sum, range, slide,
-      delay)
+      delay, _Zeros)
 
     // First set of windows values
     h.assert_array_eq[USize]([], _OutArray(sw(2, Seconds(92), Seconds(100)))?)
@@ -498,7 +499,7 @@ class iso _TestSlidingWindowsLateData is UnitTest
     let slide: U64 = Seconds(2)
     let delay: U64 = Seconds(10)
     let sw = RangeWindows[USize, USize, _Total]("key", _Sum, range, slide,
-      delay)
+      delay, _Zeros)
 
     // Some initial values
     h.assert_array_eq[USize]([], _OutArray(sw(1, Seconds(92), Seconds(100)))?)
@@ -521,7 +522,7 @@ class iso _TestSlidingWindowsEarlyData is UnitTest
     let slide: U64 = Seconds(2)
     let delay: U64 = Seconds(10)
     let sw = RangeWindows[USize, USize, _Total]("key", _Sum, range, slide,
-      delay)
+      delay, _Zeros)
 
     // First values
     h.assert_array_eq[USize]([], _OutArray(sw(2, Seconds(92), Seconds(100)))?)
@@ -574,7 +575,7 @@ class iso _TestSlidingWindowsStragglers is UnitTest
     let slide: U64 = Seconds(2)
     let delay: U64 = Seconds(1_000)
     let sw = RangeWindows[USize, USize, _Total]("key", _Sum, range, slide,
-      delay)
+      delay, _Zeros)
 
     // Last heard threshold of 100 seconds
     let watermarks = StageWatermarks(Seconds(100_000))
@@ -626,7 +627,7 @@ class iso _TestSlidingWindowsStragglersSequence is UnitTest
     let slide: U64 = Seconds(2)
     let delay: U64 = Seconds(1_000)
     let sw = RangeWindows[USize, Array[USize] val, Collected]("key",
-      _Collect, range, slide, delay)
+      _Collect, range, slide, delay, _Zeros)
 
     // Last heard threshold of 100 seconds
     let watermarks = StageWatermarks(Seconds(100_000))
@@ -713,7 +714,7 @@ class iso _TestSlidingWindowsSequence is UnitTest
     let slide: U64 = Seconds(25)
     let delay: U64 = Seconds(3000)
     let sw = RangeWindows[USize, Array[USize] val, Collected]("key",
-      _Collect, range, slide, delay)
+      _Collect, range, slide, delay, _Zeros)
 
     // var wm: USize = 4_888
     // res = sw(0, Seconds(4_889), Seconds(wm))
@@ -991,3 +992,7 @@ primitive _TumblingWindow
     let slide = range
     let delay: U64 = 0
     RangeWindows[USize, USize, _Total]("key", _NonZeroSum, range, slide, delay)
+
+class _Zeros is Random
+  new ref create(x: U64 val = 0, y: U64 val = 0) => None
+  fun ref next(): U64 => 0

--- a/lib/wallaroo/core/windows/panes_range_windows.pony
+++ b/lib/wallaroo/core/windows/panes_range_windows.pony
@@ -75,8 +75,8 @@ class _PanesSlidingWindows[In: Any val, Out: Any val, Acc: State ref] is
     _panes = Array[(Acc | EmptyPane)](pane_count)
     _panes_start_ts = Array[U64](pane_count)
     _earliest_window_idx = 0
-    var pane_start: U64 =
-      (watermark_ts - _delay) + window_alignment_offset
+    var pane_start: U64 = ((watermark_ts - _delay) - window_alignment_offset)
+
     for i in Range(0, pane_count) do
       _panes.push(EmptyPane)
       _panes_start_ts.push(pane_start)

--- a/lib/wallaroo/core/windows/windows.pony
+++ b/lib/wallaroo/core/windows/windows.pony
@@ -230,8 +230,8 @@ class val RangeWindowsStateInitializer[In: Any val, Out: Any val,
 
   fun state_wrapper(key: Key, rand: Random): StateWrapper[In, Out, Acc] =>
     // If the application will be using aligned windows, we must
-    // ingore the provided Rand and supply Zeros.
-    let rand' = if _align_windows then Zeros else rand end
+    // ingore the provided Rand and supply Zeroes.
+    let rand' = if _align_windows then _Zeroes else rand end
     RangeWindows[In, Out, Acc](key, _agg, _range,
                                _slide, _delay, rand')
 
@@ -262,10 +262,6 @@ class val RangeWindowsStateInitializer[In: Any val, Out: Any val,
 
   fun name(): String =>
     _agg.name()
-
-class Zeros is Random
-  new create(_: U64 = 0 , _: U64 = 0) => None
-  fun ref next(): U64 => 0
 
 class RangeWindows[In: Any val, Out: Any val, Acc: State ref] is
   Windows[In, Out, Acc]
@@ -447,3 +443,7 @@ class TumblingCountWindows[In: Any val, Out: Any val, Acc: State ref] is
       Fail()
       recover Array[U8] end
     end
+
+class _Zeroes is Random
+  new create(_: U64 = 0 , _: U64 = 0) => None
+  fun ref next(): U64 => 0


### PR DESCRIPTION
Staggers window start times upon creation by a random amount, up to 80% of the window range.
Applications may call `.aligned()` on the window builder to have all windows be perfectly aligned to the initial event times of their first event. `.unaliged()` is also avaialable to express explicitly the fact that windows are not aligned, but this is the default setting when neither of the above methods are called.

Closes #2777 