### PR TITLE
Update TCPSource configuration input arg to be optional

### DIFF
--- a/examples/pony/alphabet/alphabet.pony
+++ b/examples/pony/alphabet/alphabet.pony
@@ -36,7 +36,7 @@ actor Main
       let pipeline = recover val
           let votes = Wallaroo.source[Votes]("Alphabet Votes",
                 TCPSourceConfig[Votes].from_options(VotesDecoder,
-                  TCPSourceConfigCLIParser(env.args)?("Alphabet Votes")?))
+                  TCPSourceConfigCLIParser("Alphabet Votes", env.args)?))
 
           votes
             .key_by(ExtractFirstLetter)

--- a/lib/wallaroo/core/source/tcp_source/tcp_source_listener_builder.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source_listener_builder.pony
@@ -48,6 +48,7 @@ class val TCPSourceListenerBuilder[In: Any val] is SourceListenerBuilder
   let _handler: FramedSourceHandler[In] val
   let _host: String
   let _service: String
+  let _valid: Bool
 
   new val create(worker_name: WorkerName, pipeline_name: String,
     runner_builder: RunnerBuilder, partitioner_builder: PartitionerBuilder,
@@ -58,7 +59,7 @@ class val TCPSourceListenerBuilder[In: Any val] is SourceListenerBuilder
     layout_initializer: LayoutInitializer,
     recovering: Bool, target_router: Router = EmptyRouter,
     parallelism: USize, handler: FramedSourceHandler[In] val,
-    host: String, service: String)
+    host: String, service: String, valid: Bool)
   =>
     _worker_name = worker_name
     _pipeline_name = pipeline_name
@@ -78,13 +79,15 @@ class val TCPSourceListenerBuilder[In: Any val] is SourceListenerBuilder
     _handler = handler
     _host = host
     _service = service
+    _valid = valid
 
   fun apply(env: Env): SourceListener =>
     TCPSourceListener[In](env, _worker_name, _pipeline_name, _runner_builder,
       _partitioner_builder, _router, _metrics_conn, _metrics_reporter.clone(),
       _router_registry,
       _outgoing_boundary_builders, _event_log, _auth, _layout_initializer,
-      _recovering, _target_router, _parallelism, _handler, _host, _service)
+      _recovering, _target_router, _parallelism, _handler, _host, _service,
+      _valid)
 
 class val TCPSourceListenerBuilderBuilder[In: Any val] is
   SourceListenerBuilderBuilder
@@ -113,7 +116,7 @@ class val TCPSourceListenerBuilderBuilder[In: Any val] is
         router_registry, outgoing_boundary_builders, event_log, auth,
         layout_initializer, recovering, target_router,
         _source_config.parallelism, _source_config.handler,
-        config.host, config.service)
+        config.host, config.service, config.valid)
     else
       Unreachable()
       TCPSourceListenerBuilder[In](worker_name, pipeline_name, runner_builder,
@@ -121,5 +124,5 @@ class val TCPSourceListenerBuilderBuilder[In: Any val] is
         router_registry, outgoing_boundary_builders, event_log, auth,
         layout_initializer, recovering, target_router,
         _source_config.parallelism, _source_config.handler,
-        "0", "0")
+        "0", "0", false)
     end

--- a/testing/correctness/apps/decoder_filter/decoder_filter.pony
+++ b/testing/correctness/apps/decoder_filter/decoder_filter.pony
@@ -33,7 +33,7 @@ actor Main
       let pipeline = recover val
         Wallaroo.source[U64]("Filter Test",
             TCPSourceConfig[(U64 | None)].from_options(OddFilterDecoder,
-              TCPSourceConfigCLIParser(env.args)?("Filter Test")?))
+              TCPSourceConfigCLIParser("Filter Test", env.args)?))
           // .to(PassThrough)
           .to_sink(TCPSinkConfig[U64].from_options(FramedU64Encoder,
             TCPSinkConfigCLIParser(env.args)?(0)?))

--- a/testing/correctness/apps/multi_partition_detector/multi_partition_detector.pony
+++ b/testing/correctness/apps/multi_partition_detector/multi_partition_detector.pony
@@ -92,7 +92,7 @@ actor Main
           Wallaroo.source[t.Message]("Detector",
             TCPSourceConfig[t.Message]
               .from_options(PartitionedU64FramedHandler,
-                TCPSourceConfigCLIParser(env.args)?("Detector")?))
+                TCPSourceConfigCLIParser("Detector", env.args)?))
         end
         // Add as many layers of depth as specified in the `--depth` option
         for x in Range[USize](1, depth + 1) do

--- a/testing/correctness/apps/multi_pipeline/multi_pipeline.pony
+++ b/testing/correctness/apps/multi_pipeline/multi_pipeline.pony
@@ -32,14 +32,14 @@ actor Main
       let pipeline = recover val
         let inputs1 = Wallaroo.source[F32]("Celsius Conversion0",
             TCPSourceConfig[F32].from_options(CelsiusDecoder,
-              TCPSourceConfigCLIParser(env.args)?("Celsius Conversion0")?))
+              TCPSourceConfigCLIParser("Celsius Conversion0", env.args)?))
             .collect()
             .to[F32](Multiply)
             .to[F32](Add)
 
         let inputs2 = Wallaroo.source[F32]("Celsius Conversion1",
             TCPSourceConfig[F32].from_options(CelsiusDecoder,
-              TCPSourceConfigCLIParser(env.args)?("Celsius Conversion1")?))
+              TCPSourceConfigCLIParser("Celsius Conversion1", env.args)?))
             .collect()
             .to[F32](Multiply)
             .to[F32](Add)

--- a/testing/correctness/apps/multi_sink/multi_sink.pony
+++ b/testing/correctness/apps/multi_sink/multi_sink.pony
@@ -32,7 +32,7 @@ actor Main
       let pipeline = recover val
         let values = Wallaroo.source[F32]("Celsius Conversion",
               TCPSourceConfig[F32].from_options(CelsiusDecoder,
-                TCPSourceConfigCLIParser(env.args)?("Celsius Conversion")?))
+                TCPSourceConfigCLIParser("Celsius Conversion", env.args)?))
 
         values
           .collect()

--- a/testing/correctness/apps/ping_pong/ping_pong.pony
+++ b/testing/correctness/apps/ping_pong/ping_pong.pony
@@ -69,14 +69,14 @@ actor Main
           | Ping =>
             Wallaroo.source[U8]("Ping",
               TCPSourceConfig[U8].from_options(PongDecoder,
-                TCPSourceConfigCLIParser(env.args)?("Ping")?))
+                TCPSourceConfigCLIParser("Ping", env.args)?))
               .to[U8](Pingify)
               .to_sink(TCPSinkConfig[U8].from_options(PingPongEncoder,
                 TCPSinkConfigCLIParser(env.args)?(0)?))
           | Pong =>
             Wallaroo.source[U8]("Pong",
               TCPSourceConfig[U8].from_options(PingDecoder,
-                TCPSourceConfigCLIParser(env.args)?("Pong")?))
+                TCPSourceConfigCLIParser("Pong", env.args)?))
               .to[U8](Pongify)
               .to_sink(TCPSinkConfig[U8].from_options(PingPongEncoder,
                 TCPSinkConfigCLIParser(env.args)?(0)?))

--- a/testing/correctness/apps/sequence_window/main.pony
+++ b/testing/correctness/apps/sequence_window/main.pony
@@ -97,7 +97,7 @@ actor Main
       let pipeline = recover val
         let inputs = Wallaroo.source[U64]("Sequence Window",
             TCPSourceConfig[U64 val].from_options(U64FramedHandler,
-              TCPSourceConfigCLIParser(env.args)?("Sequence Window")?))
+              TCPSourceConfigCLIParser("Sequence Window", env.args)?))
 
         inputs
           .collect()

--- a/testing/correctness/apps/sequence_window_simple_state/main.pony
+++ b/testing/correctness/apps/sequence_window_simple_state/main.pony
@@ -98,7 +98,7 @@ actor Main
       let pipeline = recover val
         Wallaroo.source[U64]("Sequence Window",
             TCPSourceConfig[U64].from_options(U64FramedHandler,
-              TCPSourceConfigCLIParser(env.args)?("Sequence Window")?))
+              TCPSourceConfigCLIParser("Sequence Window", env.args)?))
           .key_by(ExtractWindow)
           .to[String val](ObserveNewValue)
           .to_sink(TCPSinkConfig[String val].from_options(WindowEncoder,

--- a/testing/performance/apps/market-spread/market-spread.pony
+++ b/testing/performance/apps/market-spread/market-spread.pony
@@ -93,12 +93,12 @@ actor Main
       let pipeline = recover val
         let orders = Wallaroo.source[FixOrderMessage val]("Orders",
             TCPSourceConfig[FixOrderMessage val].from_options(FixOrderFrameHandler,
-              TCPSourceConfigCLIParser(env.args)?("Orders")?))
+              TCPSourceConfigCLIParser("Orders", env.args)?))
           .key_by(OrderSymbolExtractor)
 
         let nbbos = Wallaroo.source[FixNbboMessage val]("Nbbo",
-            TCPSourceConfig[FixNbboMessage val].from_options(FixNbboFrameHandler,
-              TCPSourceConfigCLIParser(env.args)?("Nbbo")?))
+            TCPSourceConmarketfig[FixNbboMessage val].from_options(FixNbboFrameHandler,
+              TCPSourceConfigCLIParser("Nbbo", env.args)?))
           .key_by(NbboSymbolExtractor)
 
         orders.merge[FixNbboMessage val](nbbos)

--- a/testing/performance/apps/word_count/word_count.pony
+++ b/testing/performance/apps/word_count/word_count.pony
@@ -41,7 +41,7 @@ actor Main
       let pipeline = recover val
         let lines = Wallaroo.source[String]("Word Count",
           TCPSourceConfig[String].from_options(StringFrameHandler,
-                TCPSourceConfigCLIParser(env.args)?(0)?, 1))
+                TCPSourceConfigCLIParser("Word Count", env.args)?, 1))
 
         lines
           .to[String](Split)


### PR DESCRIPTION
- Workers can optionally provide the --input arg for a TCPSource

- If a input arg is not provided, a TCPSourceListener actor will spin
  up but not listen on any port

- Updates TCPSourceConfigCLIParser to take 2 args, env args and the
  source that it is expecting to find an input address for

- Updates all pony example apps  using TCPSourceConfigCLIParser

<!--
Make sure you've read the [Contributors Guide](https://github.com/WallarooLabs/wallaroo/blob/master/CONTRIBUTING.md). You'll need to sign our CLA before your issue can be accepted.

Reference the issue your code change relates to if possible
-->

<!--
Include any other necessary information below. If you have any questions don't hesitate to reach out on the mailing list or on IRC.
-->
