### PR TITLE
Rename `lws` -> `leaving_workers` for readability

### DIFF
--- a/lib/wallaroo/core/autoscale/autoscale_tokens.pony
+++ b/lib/wallaroo/core/autoscale/autoscale_tokens.pony
@@ -25,8 +25,10 @@ class val AutoscaleTokens
   let initial_token: AutoscaleBarrierToken
   let resume_token: AutoscaleResumeBarrierToken
 
-  new val create(w: String, id': AutoscaleId, lws: Array[WorkerName] val) =>
+  new val create(w: String, id': AutoscaleId,
+    leaving_workers: Array[WorkerName] val)
+  =>
     worker = w
     id = id'
-    initial_token = AutoscaleBarrierToken(w, id, lws)
+    initial_token = AutoscaleBarrierToken(w, id, leaving_workers)
     resume_token = AutoscaleResumeBarrierToken(w, id)

--- a/lib/wallaroo/core/barrier/barrier_token.pony
+++ b/lib/wallaroo/core/barrier/barrier_token.pony
@@ -52,11 +52,11 @@ class val AutoscaleBarrierToken is BarrierToken
   let _leaving_workers: Array[WorkerName] val
 
   new val create(worker': String, id': AutoscaleId,
-    lws: Array[WorkerName] val)
+    leaving_workers': Array[WorkerName] val)
   =>
     _worker = worker'
     _id = id'
-    _leaving_workers = lws
+    _leaving_workers = leaving_workers'
 
   fun eq(that: box->BarrierToken): Bool =>
     match that


### PR DESCRIPTION
Closes #2801 

First to review can merge this, I think.