### PR TITLE
Add metadata about joining workers to autoscale barrier

### DIFF
--- a/lib/wallaroo/core/autoscale/autoscale_tokens.pony
+++ b/lib/wallaroo/core/autoscale/autoscale_tokens.pony
@@ -26,9 +26,11 @@ class val AutoscaleTokens
   let resume_token: AutoscaleResumeBarrierToken
 
   new val create(w: String, id': AutoscaleId,
+    joining_workers: Array[WorkerName] val,
     leaving_workers: Array[WorkerName] val)
   =>
     worker = w
     id = id'
-    initial_token = AutoscaleBarrierToken(w, id, leaving_workers)
+    initial_token = AutoscaleBarrierToken(w, id, joining_workers,
+      leaving_workers)
     resume_token = AutoscaleResumeBarrierToken(w, id)

--- a/lib/wallaroo/core/barrier/barrier_token.pony
+++ b/lib/wallaroo/core/barrier/barrier_token.pony
@@ -49,13 +49,16 @@ primitive InitialBarrierToken is BarrierToken
 class val AutoscaleBarrierToken is BarrierToken
   let _worker: String
   let _id: AutoscaleId
+  let _joining_workers: Array[WorkerName] val
   let _leaving_workers: Array[WorkerName] val
 
   new val create(worker': String, id': AutoscaleId,
+    joining_workers': Array[WorkerName] val,
     leaving_workers': Array[WorkerName] val)
   =>
     _worker = worker'
     _id = id'
+    _joining_workers = joining_workers'
     _leaving_workers = leaving_workers'
 
   fun eq(that: box->BarrierToken): Bool =>
@@ -71,6 +74,9 @@ class val AutoscaleBarrierToken is BarrierToken
 
   fun id(): AutoscaleId =>
     _id
+
+  fun joining_workers(): Array[WorkerName] val =>
+    _joining_workers
 
   fun leaving_workers(): Array[WorkerName] val =>
     _leaving_workers

--- a/lib/wallaroo/core/router_registry/router_registry.pony
+++ b/lib/wallaroo/core/router_registry/router_registry.pony
@@ -659,7 +659,8 @@ actor RouterRegistry
     let promise = Promise[None]
     promise.next[None]({(_: None) =>
       _self.join_autoscale_barrier_complete()})
-    _autoscale_initiator.initiate_autoscale(promise)
+    _autoscale_initiator.initiate_autoscale(promise
+      where joining_workers = new_workers)
 
   fun ref stop_the_world_for_grow_migration(
     new_workers: Array[WorkerName] val)
@@ -698,7 +699,8 @@ actor RouterRegistry
     let promise = Promise[None]
     promise.next[None]({(_: None) =>
       _self.shrink_autoscale_barrier_complete()})
-    _autoscale_initiator.initiate_autoscale(promise, leaving_workers)
+    _autoscale_initiator.initiate_autoscale(promise
+      where leaving_workers = leaving_workers)
 
   fun ref stop_the_world_for_shrink_migration(
     remaining_workers: Array[WorkerName] val,


### PR DESCRIPTION
The autoscale barrier currently has metadata about leaving workers, but
different protocols might also require information about who is
joining. Further work on the connector ActiveStreamRegistry will require it, for example (see #2809).

