### PR TITLE
Make CheckpointInitiator implicit states explicit

### DIFF
--- a/lib/wallaroo/core/autoscale/autoscale_initiator.pony
+++ b/lib/wallaroo/core/autoscale/autoscale_initiator.pony
@@ -93,7 +93,6 @@ actor AutoscaleInitiator
   be autoscale_resume_complete(barrier_token: BarrierToken) =>
     if barrier_token != _current_autoscale_tokens.resume_token then Fail() end
     _autoscale_token_in_progress = false
-    _checkpoint_initiator.restart_repeating_checkpoints()
 
   be dispose() =>
     @printf[I32]("Shutting down AutoscaleInitiator\n".cstring())

--- a/lib/wallaroo/core/checkpoint/checkpoint_initiator.pony
+++ b/lib/wallaroo/core/checkpoint/checkpoint_initiator.pony
@@ -198,10 +198,6 @@ actor CheckpointInitiator is Initializable
     _clear_pending_checkpoints()
     promise(None)
 
-  be restart_repeating_checkpoints() =>
-    _clear_pending_checkpoints()
-    _phase.initiate_checkpoint(_checkpoint_group, this)
-
   fun ref _initiate_checkpoint(checkpoint_group: USize) =>
     ifdef "resilience" then
       _clear_pending_checkpoints()

--- a/lib/wallaroo/core/checkpoint/checkpoint_initiator.pony
+++ b/lib/wallaroo/core/checkpoint/checkpoint_initiator.pony
@@ -36,12 +36,31 @@ use "wallaroo_labs/string_set"
 
 
 actor CheckpointInitiator is Initializable
+  """
+  Phases:
+    _WaitingCheckpointInitiatorPhase: Waiting for a checkpoint to be initiated.
+
+    _CheckpointingPhase: A checkpoint barrier is in flight. Waiting for a
+      the barrier to be acked by all sinks.
+      |||| ASSUMPTION: There is only one checkpoint barrier in flight
+      |||| at a time. The barrier protocol in general does not require this,
+      |||| but we currently assume that all checkpoint event log entries for a
+      |||| single checkpoint id are consecutive.
+
+    _WaitingForEventLogIdWrittenPhase: Waiting for event log to persist a
+      committed checkpoint id.
+
+    _RollbackCheckpointInitiatorPhase: A rollback is ongoing, so we ignore any
+      current checkpoint activity. Waiting for rollback to complete.
+
+    _DisposedCheckpointInitiatorPhase: This actor is disposed, so we ignore all
+      activity.
+  """
   let _self: CheckpointInitiator tag = this
 
   let _auth: AmbientAuth
   let _worker_name: WorkerName
   var _primary_worker: WorkerName
-  var _is_active: Bool
   var _time_between_checkpoints: U64
   let _event_log: EventLog
   let _barrier_initiator: BarrierInitiator
@@ -62,8 +81,6 @@ actor CheckpointInitiator is Initializable
   let _do_local_file_io: Bool
 
   var _is_recovering: Bool
-  var _ignoring_checkpoints: Bool = false
-  var _disposed: Bool = false
 
   var _phase: _CheckpointInitiatorPhase = _WaitingCheckpointInitiatorPhase
 
@@ -77,7 +94,6 @@ actor CheckpointInitiator is Initializable
     _auth = auth
     _worker_name = worker_name
     _primary_worker = primary_worker
-    _is_active = is_active
     _time_between_checkpoints = time_between_checkpoints
     _event_log = event_log
     _barrier_initiator = barrier_initiator
@@ -134,13 +150,22 @@ actor CheckpointInitiator is Initializable
 
   be application_ready_to_work(initializer: LocalTopologyInitializer) =>
     ifdef "resilience" then
-      if _is_active and (_worker_name == _primary_worker) then
-        let t = Timer(_InitiateCheckpoint(this, _checkpoint_group),
-          1_000_000_000)
-        _timers(consume t)
+      if _worker_name == _primary_worker then
+        _phase.start_checkpoint_timer(1_000_000_000, this)
       end
     end
     _is_recovering = false
+
+  fun ref _start_checkpoint_timer(time_until_checkpoint: U64) =>
+    """
+    Ignoring the initial checkpoint, we only set a new checkpoint timer once
+    the last checkpoint is complete. That means that "time_until_checkpoint"
+    is the absolute minimum time between checkpoints. In reality, we need to
+    add the time taken to actually complete the checkpoint to this time.
+    """
+    let t = Timer(_InitiateCheckpoint(this, _checkpoint_group),
+      time_until_checkpoint)
+    _timers(consume t)
 
   fun workers(): StringSet box => _workers
 
@@ -165,7 +190,9 @@ actor CheckpointInitiator is Initializable
     p((_last_complete_checkpoint_id, _last_rollback_id))
 
   be initiate_checkpoint(checkpoint_group: USize) =>
-    _initiate_checkpoint(checkpoint_group)
+    if checkpoint_group == _checkpoint_group then
+      _phase.initiate_checkpoint(checkpoint_group, this)
+    end
 
   be clear_pending_checkpoints(promise: Promise[None]) =>
     _clear_pending_checkpoints()
@@ -173,55 +200,51 @@ actor CheckpointInitiator is Initializable
 
   be restart_repeating_checkpoints() =>
     _clear_pending_checkpoints()
-    _initiate_checkpoint(_checkpoint_group)
+    _phase.initiate_checkpoint(_checkpoint_group, this)
 
-  fun ref _initiate_checkpoint(checkpoint_group: USize,
-    repeating: Bool = true)
-  =>
+  fun ref _initiate_checkpoint(checkpoint_group: USize) =>
     ifdef "resilience" then
-      if not _ignoring_checkpoints and (checkpoint_group == _checkpoint_group)
-      then
-        _clear_pending_checkpoints()
-        _current_checkpoint_id = _current_checkpoint_id + 1
+      _clear_pending_checkpoints()
+      _current_checkpoint_id = _current_checkpoint_id + 1
 
-        ifdef "checkpoint_trace" then
-          (let s, let ns) = Time.now()
-          let us = ns / 1000
-          let ts = PosixDate(s, ns).format("%Y-%m-%d %H:%M:%S." + us.string())
-          @printf[I32]("Initiating checkpoint %s at %s\n".cstring(),
-            _current_checkpoint_id.string().cstring(), ts.string().cstring())
-        end
-
-        let event_log_promise = Promise[CheckpointId]
-        event_log_promise.next[None](
-          recover this~event_log_checkpoint_complete(_worker_name) end)
-        _event_log.initiate_checkpoint(_current_checkpoint_id,
-          event_log_promise)
-
-        try
-          let msg = ChannelMsgEncoder.event_log_initiate_checkpoint(
-            _current_checkpoint_id, _worker_name, _auth)?
-          _connections.send_control_to_cluster(msg)
-        else
-          Fail()
-        end
-
-        let token = CheckpointBarrierToken(_current_checkpoint_id)
-
-        let barrier_promise = Promise[BarrierToken]
-        barrier_promise.next[None](
-          recover this~checkpoint_barrier_complete() end)
-        _barrier_initiator.inject_barrier(token, barrier_promise)
-
-        _phase = _CheckpointingPhase(token, repeating, this)
+      ifdef "checkpoint_trace" then
+        (let s, let ns) = Time.now()
+        let us = ns / 1000
+        let ts = PosixDate(s, ns).format("%Y-%m-%d %H:%M:%S." + us.string())
+        @printf[I32]("Initiating checkpoint %s at %s\n".cstring(),
+          _current_checkpoint_id.string().cstring(), ts.string().cstring())
       end
+
+      let event_log_promise = Promise[CheckpointId]
+      event_log_promise.next[None](
+        recover this~event_log_checkpoint_complete(_worker_name) end)
+      _event_log.initiate_checkpoint(_current_checkpoint_id,
+        event_log_promise)
+
+      try
+        let msg = ChannelMsgEncoder.event_log_initiate_checkpoint(
+          _current_checkpoint_id, _worker_name, _auth)?
+        _connections.send_control_to_cluster(msg)
+      else
+        Fail()
+      end
+
+      let token = CheckpointBarrierToken(_current_checkpoint_id)
+
+      let barrier_promise = Promise[BarrierToken]
+      barrier_promise.next[None](
+        recover this~checkpoint_barrier_complete() end)
+      _barrier_initiator.inject_barrier(token, barrier_promise)
+
+      _phase = _CheckpointingPhase(token, this)
     end
 
-  be resume_checkpoint() =>
+  be resume_checkpointing_from_rollback() =>
     ifdef "checkpoint_trace" then
-      @printf[I32]("CheckpointInitiator: resume_checkpoint()\n".cstring())
+      @printf[I32]("CheckpointInitiator: resume_checkpointing_from_rollback()\n"
+        .cstring())
     end
-    if _is_active and (_worker_name == _primary_worker) then
+    if _worker_name == _primary_worker then
       _clear_pending_checkpoints()
       ifdef "resilience" then
         let promise = Promise[BarrierToken]
@@ -230,32 +253,40 @@ actor CheckpointInitiator is Initializable
         _barrier_initiator.inject_barrier(
           CheckpointRollbackResumeBarrierToken(_last_rollback_id,
             _last_complete_checkpoint_id), promise)
-        _ignoring_checkpoints = false
+        _phase.resume_checkpointing_from_rollback()
       end
     else
       try
         ifdef "resilience" then
           let msg = ChannelMsgEncoder.resume_checkpoint(_worker_name, _auth)?
           _connections.send_control(_primary_worker, msg)
-          _ignoring_checkpoints = false
+          _phase.resume_checkpointing_from_rollback()
         end
       else
         Fail()
       end
     end
 
+  fun ref wait_for_next_checkpoint() =>
+    _phase = _WaitingCheckpointInitiatorPhase
+
   be checkpoint_barrier_complete(token: BarrierToken) =>
-    if not _ignoring_checkpoints then
-      ifdef debug then
-        @printf[I32]("Checkpoint_Initiator: Checkpoint Barrier %s Complete\n"
-          .cstring(), token.string().cstring())
-      end
-      _phase.checkpoint_barrier_complete(token)
+    """
+    This is called when all sinks have acked the checkpoint barrier.
+    """
+    ifdef debug then
+      @printf[I32]("Checkpoint_Initiator: Checkpoint Barrier %s Complete\n"
+        .cstring(), token.string().cstring())
     end
+    _phase.checkpoint_barrier_complete(token)
 
   be event_log_checkpoint_complete(worker: WorkerName,
     checkpoint_id: CheckpointId)
   =>
+    """
+    This is called when the EventLog has written all entries in the scope of
+    this checkpoint
+    """
     ifdef debug then
       @printf[I32](("Checkpoint_Initiator: Event Log CheckpointId %s " +
         "complete for worker %s\n").cstring(), checkpoint_id.string()
@@ -264,9 +295,16 @@ actor CheckpointInitiator is Initializable
     _phase.event_log_checkpoint_complete(worker, checkpoint_id)
 
   be event_log_id_written(worker: WorkerName, checkpoint_id: CheckpointId) =>
+    """
+    This is called once the EventLog on this worker has persisted this
+    checkpoint id.
+    """
     _phase.event_log_id_written(worker, checkpoint_id)
 
   be inform_recovering_worker(w: WorkerName, conn: TCPConnection) =>
+    """
+    Tell a recovering worker what the last complete checkpoint was.
+    """
     try
       @printf[I32]("Sending recovery data to %\n".cstring(),
         w.cstring())
@@ -277,8 +315,10 @@ actor CheckpointInitiator is Initializable
       Fail()
     end
 
+  // fun ref event_log_write_checkpoint_id(checkpoint_id: CheckpointId,
+  //   token: CheckpointBarrierToken, repeating: Bool)
   fun ref event_log_write_checkpoint_id(checkpoint_id: CheckpointId,
-    token: CheckpointBarrierToken, repeating: Bool)
+    token: CheckpointBarrierToken)
   =>
     ifdef "checkpoint_trace" then
       @printf[I32]("CheckpointInitiator: event_log_write_checkpoint_id()\n"
@@ -303,52 +343,51 @@ actor CheckpointInitiator is Initializable
       end
     end
 
-    _phase = _WaitingForEventLogIdWrittenPhase(token, repeating, this)
+    _phase = _WaitingForEventLogIdWrittenPhase(token, this)
 
-  fun ref checkpoint_complete(token: BarrierToken, repeating: Bool) =>
-    if not _ignoring_checkpoints and not _disposed then
-      ifdef "resilience" then
-        match token
-        | let st: CheckpointBarrierToken =>
-          if st.id != _current_checkpoint_id then Fail() end
-          ifdef "checkpoint_trace" then
-            @printf[I32]("CheckpointInitiator: Checkpoint %s is complete!\n".
-              cstring(), st.id.string().cstring())
-          end
-          _save_checkpoint_id(st.id, _last_rollback_id)
-          _last_complete_checkpoint_id = st.id
+  fun ref checkpoint_complete(token: BarrierToken) =>
+    """
+    This is called once all workers in the cluster have committed the
+    checkpoitn id for this token.
+    """
+    ifdef "resilience" then
+      match token
+      | let st: CheckpointBarrierToken =>
+        if st.id != _current_checkpoint_id then Fail() end
+        ifdef "checkpoint_trace" then
+          @printf[I32]("CheckpointInitiator: Checkpoint %s is complete!\n".
+            cstring(), st.id.string().cstring())
+        end
+        _save_checkpoint_id(st.id, _last_rollback_id)
+        _last_complete_checkpoint_id = st.id
 
-          try
-            let msg = ChannelMsgEncoder.commit_checkpoint_id(st.id,
-              _last_rollback_id, _worker_name, _auth)?
-            _connections.send_control_to_cluster(msg)
-          else
-            Fail()
-          end
-
-          // Prepare for next checkpoint
-          if repeating and _is_active and (_worker_name == _primary_worker)
-          then
-            ifdef "checkpoint_trace" then
-              @printf[I32]("Creating _InitiateCheckpoint timer for future checkpoint %s\n".cstring(),
-                (_current_checkpoint_id + 1).string().cstring())
-            end
-            let t = Timer(_InitiateCheckpoint(this, _checkpoint_group),
-              _time_between_checkpoints)
-            _timers(consume t)
-          end
+        try
+          let msg = ChannelMsgEncoder.commit_checkpoint_id(st.id,
+            _last_rollback_id, _worker_name, _auth)?
+          _connections.send_control_to_cluster(msg)
         else
           Fail()
+        end
+
+        // Prepare for next checkpoint
+        if _worker_name == _primary_worker then
+          ifdef "checkpoint_trace" then
+            @printf[I32]("Creating _InitiateCheckpoint timer for future checkpoint %s\n".cstring(),
+              (_current_checkpoint_id + 1).string().cstring())
+          end
+          _phase = _WaitingCheckpointInitiatorPhase
+          _phase.start_checkpoint_timer(_time_between_checkpoints, this)
         end
       else
         Fail()
       end
-      _phase = _WaitingCheckpointInitiatorPhase
+    else
+      Fail()
     end
 
   be prepare_for_rollback() =>
-    if _is_active and (_worker_name == _primary_worker) then
-      _ignoring_checkpoints = true
+    if _worker_name == _primary_worker then
+      _phase = _RollbackCheckpointInitiatorPhase(this)
     end
     _clear_pending_checkpoints()
 
@@ -474,7 +513,7 @@ actor CheckpointInitiator is Initializable
   be dispose() =>
     @printf[I32]("Shutting down CheckpointInitiator\n".cstring())
     _clear_pending_checkpoints()
-    _disposed = true
+    _phase = _DisposedCheckpointInitiatorPhase
 
 primitive LatestCheckpointId
   fun read(auth: AmbientAuth, checkpoint_id_file: String):

--- a/lib/wallaroo/core/checkpoint/checkpoint_initiator_phase.pony
+++ b/lib/wallaroo/core/checkpoint/checkpoint_initiator_phase.pony
@@ -28,6 +28,17 @@ use "wallaroo_labs/mort"
 trait _CheckpointInitiatorPhase
   fun name(): String
 
+  fun ref start_checkpoint_timer(time_until_next_checkpoint: U64,
+    checkpoint_initiator: CheckpointInitiator ref)
+  =>
+    _invalid_call()
+    Fail()
+
+  fun ref initiate_checkpoint(checkpoint_group: USize,
+    checkpoint_initiator: CheckpointInitiator ref)
+  =>
+    checkpoint_initiator._initiate_checkpoint(checkpoint_group)
+
   fun ref checkpoint_barrier_complete(token: BarrierToken) =>
     _invalid_call()
     Fail()
@@ -44,6 +55,10 @@ trait _CheckpointInitiatorPhase
     _invalid_call()
     Fail()
 
+  fun ref resume_checkpointing_from_rollback() =>
+    _invalid_call()
+    Fail()
+
   fun _invalid_call() =>
     @printf[I32]("Invalid call on checkpoint initiator phase %s\n".cstring(),
       name().cstring())
@@ -51,19 +66,25 @@ trait _CheckpointInitiatorPhase
 class _WaitingCheckpointInitiatorPhase is _CheckpointInitiatorPhase
   fun name(): String => "_WaitingCheckpointInitiatorPhase"
 
+  fun ref start_checkpoint_timer(time_until_next_checkpoint: U64,
+    checkpoint_initiator: CheckpointInitiator ref)
+  =>
+    checkpoint_initiator._start_checkpoint_timer(time_until_next_checkpoint)
+
+  fun ref resume_checkpointing_from_rollback() =>
+    None
+
 class _CheckpointingPhase is _CheckpointInitiatorPhase
   let _token: CheckpointBarrierToken
   let _c_initiator: CheckpointInitiator ref
-  let _repeating: Bool
   var _barrier_complete: Bool = false
   var _event_log_checkpoints_complete: Bool = false
   let _acked_workers: SetIs[WorkerName] = _acked_workers.create()
 
-  new create(token: CheckpointBarrierToken, repeating: Bool,
+  new create(token: CheckpointBarrierToken,
     c_initiator: CheckpointInitiator ref)
   =>
     _token = token
-    _repeating = repeating
     _c_initiator = c_initiator
 
   fun name(): String => "_CheckpointingPhase"
@@ -99,21 +120,18 @@ class _CheckpointingPhase is _CheckpointInitiatorPhase
 
   fun ref _check_completion() =>
     if _barrier_complete and _event_log_checkpoints_complete then
-      _c_initiator.event_log_write_checkpoint_id(_token.id, _token,
-        _repeating)
+      _c_initiator.event_log_write_checkpoint_id(_token.id, _token)
     end
 
 class _WaitingForEventLogIdWrittenPhase is _CheckpointInitiatorPhase
   let _token: CheckpointBarrierToken
   let _c_initiator: CheckpointInitiator ref
-  let _repeating: Bool
   let _acked_workers: SetIs[WorkerName] = _acked_workers.create()
 
-  new create(token: CheckpointBarrierToken, repeating: Bool,
+  new create(token: CheckpointBarrierToken,
     c_initiator: CheckpointInitiator ref)
   =>
     _token = token
-    _repeating = repeating
     _c_initiator = c_initiator
 
   fun name(): String => "_WaitingForEventLogIdWrittenPhase"
@@ -136,5 +154,67 @@ class _WaitingForEventLogIdWrittenPhase is _CheckpointInitiatorPhase
         _c_initiator.workers().size().string().cstring())
     end
     if (_acked_workers.size() == _c_initiator.workers().size()) then
-      _c_initiator.checkpoint_complete(_token, _repeating)
+      _c_initiator.checkpoint_complete(_token)
     end
+
+class _RollbackCheckpointInitiatorPhase is _CheckpointInitiatorPhase
+  let _c_initiator: CheckpointInitiator ref
+
+  new create(c_initiator: CheckpointInitiator ref) =>
+    _c_initiator = c_initiator
+
+  fun name(): String => "_RollbackCheckpointInitiatorPhase"
+
+  fun ref _initiate_checkpoint(checkpoint_group: USize,
+    checkpoint_initiator: CheckpointInitiator ref)
+  =>
+    """
+    We're rolling back, so we should not initiate a new checkpoint yet.
+    """
+    None
+
+  fun ref checkpoint_barrier_complete(token: BarrierToken) =>
+    """
+    We're rolling back. Ignore all current checkpoint activity.
+    """
+    None
+
+  fun ref event_log_checkpoint_complete(worker: WorkerName,
+    checkpoint_id: CheckpointId)
+  =>
+    """
+    We're rolling back. Ignore all current checkpoint activity.
+    """
+    None
+
+  fun ref event_log_id_written(worker: WorkerName,
+    checkpoint_id: CheckpointId)
+  =>
+    """
+    We're rolling back. Ignore all current checkpoint activity.
+    """
+    None
+
+  fun ref resume_checkpointing_from_rollback() =>
+    _c_initiator.wait_for_next_checkpoint()
+
+class _DisposedCheckpointInitiatorPhase is _CheckpointInitiatorPhase
+  fun name(): String => "_DisposedCheckpointInitiatorPhase"
+
+  fun ref _initiate_checkpoint(checkpoint_group: USize,
+    checkpoint_initiator: CheckpointInitiator ref)
+  =>
+    None
+
+  fun ref checkpoint_barrier_complete(token: BarrierToken) =>
+    None
+
+  fun ref event_log_checkpoint_complete(worker: WorkerName,
+    checkpoint_id: CheckpointId)
+  =>
+    None
+
+  fun ref event_log_id_written(worker: WorkerName,
+    checkpoint_id: CheckpointId)
+  =>
+    None

--- a/lib/wallaroo/core/network/control_channel_tcp.pony
+++ b/lib/wallaroo/core/network/control_channel_tcp.pony
@@ -600,7 +600,7 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
         ifdef "checkpoint_trace" then
           @printf[I32]("Rcvd ResumeCheckpointMsg!!\n".cstring())
         end
-        _checkpoint_initiator.resume_checkpoint()
+        _checkpoint_initiator.resume_checkpointing_from_rollback()
       | let m: ResumeProcessingMsg =>
         ifdef "trace" then
           @printf[I32]("Received ResumeTheWorldMsg from %s\n".cstring(),

--- a/lib/wallaroo/core/recovery/recovery.pony
+++ b/lib/wallaroo/core/recovery/recovery.pony
@@ -279,7 +279,7 @@ actor Recovery
       Fail()
     end
 
-    _checkpoint_initiator.resume_checkpoint()
+    _checkpoint_initiator.resume_checkpointing_from_rollback()
 
   fun ref _abort_early(worker: WorkerName) =>
     """


### PR DESCRIPTION
There are some implicit states in the CheckpointInitiator state machine handled by Boolean fields, which this moves to the explicit phase classes. This PR also adds more documentation to make the state machine and transitions easier to understand.  