### PR TITLE
Fix failing example tester scripted tests

### DIFF
--- a/misc/example-tester.bash
+++ b/misc/example-tester.bash
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 HERE=$(dirname "$(readlink -e "${0}")")
+echo $HERE
 WALLAROO_DIR="$(readlink -e "${HERE}/..")"
 . "$(readlink -e "${WALLAROO_DIR}/bin/activate")"
 
@@ -234,7 +235,7 @@ parse_and_run() {
     # temporarily disable pipefail and then extract out shell commands for current shell
     set +o pipefail
     # shellcheck disable=SC2016
-    SHELL_COMMAND=$(sed -n "/Shell $old_c:/,/Shell $c:/p" "${file_to_parse}"  | sed -n '/```/,/```/p' | grep -v '```' | tr '\n' '@' | sed 's#\\@# #g' | tr '@' '\n' | tr -s ' ')
+    SHELL_COMMAND=$(sed -n "/Shell $old_c:/,/Shell $c:/p" "${file_to_parse}"  | sed -n '/```/,/```/p' | grep -v '```' | tr '\n' '%' | sed 's#\\%# #g' | tr '%' '\n' | tr -s ' ')
     set -o pipefail
 
     # if no shell commands for current shell, assume we're at end of README


### PR DESCRIPTION
  - this failure was due to a replace command that uses the @ symbol.
    with the addition of @ as part of the Wallaroo tcp input command,
    several tests began to fail as the Wallaroo commands would have
    a new line inserted wherever an @ was.

<!--
Make sure you've read the [Contributors Guide](https://github.com/WallarooLabs/wallaroo/blob/master/CONTRIBUTING.md). You'll need to sign our CLA before your issue can be accepted.

Reference the issue your code change relates to if possible
-->
ref #

<!--
Include any other necessary information below. If you have any questions don't hesitate to reach out on the mailing list or on IRC.
-->
