### PR TITLE
Fix test setup causing order violation error

### DIFF
--- a/testing/correctness/apps/multi_partition_detector/Makefile
+++ b/testing/correctness/apps/multi_partition_detector/Makefile
@@ -141,10 +141,8 @@ multi_partition_detector_test_python_alo_10_worker:
 multi_partition_detector_test_python:
 	cd $(MULTI_PARTITION_DETECTOR_PATH) && \
 	integration_test \
-		--sequence-sender '(0,100]' Detector '>I' key_0 \
-		--sequence-sender '(0,100]' Detector '>I' key_1 \
-		--sequence-sender '(100,200]' Detector '>I' key_0 \
-		--sequence-sender '(100,200]' Detector '>I' key_1 \
+		--sequence-sender '(0,200]' Detector '>I' key_0 \
+		--sequence-sender '(0,200]' Detector '>I' key_1 \
 		--log-level $(LOGLEVEL) \
 		--command 'machida --application-module multi_partition_detector $(RUN_WITH_RESILIENCE)' \
 		--validation-cmd 'python _validate.py --output' \


### PR DESCRIPTION
- The test used two tcp senders for the same key. Since each sender
probably connects to a different connector source actor, there are no
ordering guarantees between the first and second sender for the same
key.
This results in order violations being detector at validation.

closes #2841