### PR TITLE
Fix bug causing bad data in notify

### DIFF
--- a/lib/wallaroo/core/source/connector_source/connector_framed_source_notify.pony
+++ b/lib/wallaroo/core/source/connector_source/connector_framed_source_notify.pony
@@ -291,12 +291,11 @@ class ConnectorSourceNotify[In: Any val]
     end
 
     let data': Array[U8] val = consume data
-    let data'': Array[U8] val = recover data'.clone() end
     try
       ifdef "trace" then
         @printf[I32]("TRACE: decode data: %s\n".cstring(), _print_array[U8](data').cstring())
       end
-      let connector_msg = cwm.Frame.decode(consume data')?
+      let connector_msg = cwm.Frame.decode(data')?
       match connector_msg
       | let m: cwm.HelloMsg =>
         ifdef "trace" then
@@ -510,7 +509,7 @@ class ConnectorSourceNotify[In: Any val]
         " source\n").cstring())
       ifdef debug then
         @printf[I32]("Message bytes: %s\n".cstring(),
-          _print_array[U8](data'').cstring())
+          _print_array[U8](data').cstring())
         Fail()
       end
       return _to_error_state(source, "Unable to decode message")


### PR DESCRIPTION
The crash was being caused by a confluence of several different bugs:
1. After sending a restart message, a notify continues to proces data. 
    This is fixed with `if not _session_active then return true end` in the `received` method and `_session_active = false` in the `send_restart` method
2. Despite calling `source.close()` after sending back an error message, `_to_error_message` method returned `true`, which signals to the `ConnectorSource`'s `_pending_reads()` loop to _continue processing data if there is any_.
    This is fixed by returning `false` now instead.
3. Several other places returned `true` or `_continue_perhaps()` when they shouldn't have. These are fixed too.

closes #2845 
