### PR TITLE
Update README's to wrap full `--in` command in single quotes

### DIFF
--- a/examples/python/market_spread/README.md
+++ b/examples/python/market_spread/README.md
@@ -108,7 +108,7 @@ Run `machida` with `--application-module market_spread`:
 
 ```bash
 machida --application-module market_spread \
-  --in Orders@127.0.0.1:7010,'Market Data'@127.0.0.1:7011 --out 127.0.0.1:7002 \
+  --in 'Orders@127.0.0.1:7010,Market Data@127.0.0.1:7011' --out 127.0.0.1:7002 \
   --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
   --worker-name worker1 --external 127.0.0.1:5050 --cluster-initializer \
   --ponythreads=1 --ponynoblock

--- a/examples/python/word_count/README.md
+++ b/examples/python/word_count/README.md
@@ -73,7 +73,7 @@ data_receiver --ponythreads=1 --ponynoblock \
 Run `machida` with `--application-module word_count`:
 
 ```bash
-machida --application-module word_count --in 'Split and Count'@127.0.0.1:7010 --out 127.0.0.1:7002 \
+machida --application-module word_count --in 'Split and Count@127.0.0.1:7010' --out 127.0.0.1:7002 \
   --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
   --name worker-name --external 127.0.0.1:5050 --cluster-initializer \
   --ponythreads=1 --ponynoblock


### PR DESCRIPTION
  - fixes issue where special characters in a command would cause
    the wallaroo example tester to stall and fail

<!--
Make sure you've read the [Contributors Guide](https://github.com/WallarooLabs/wallaroo/blob/master/CONTRIBUTING.md). You'll need to sign our CLA before your issue can be accepted.

Reference the issue your code change relates to if possible
-->
ref #2862 

<!--
Include any other necessary information below. If you have any questions don't hesitate to reach out on the mailing list or on IRC.
-->
