### PR TITLE
Check that file exists before flushing

### DIFF
--- a/testing/tools/integration/cluster.py
+++ b/testing/tools/integration/cluster.py
@@ -208,10 +208,11 @@ class Runner(threading.Thread):
         logging.log(1, "get_output(start_from={})".format(start_from))
         if self._output:
             return self._output[start_from:]
-        self._file.flush()
-        with open(self._file.name, 'r', errors='backslashreplace') as ro:
-            ro.seek(start_from)
-            return ro.read()
+        if self._file is not None:
+            self._file.flush()
+            with open(self._file.name, 'r', errors='backslashreplace') as ro:
+                ro.seek(start_from)
+                return ro.read()
 
     def tell(self):
         logging.log(1, "tell()")


### PR DESCRIPTION
Addresses a bug where the test harness fails to capture worker output if a worker crashed _before_ another worker that is starting has finished starting up.

See https://circleci.com/gh/WallarooLabs/wallaroo/18752 for reference
