### PR TITLE
Terraform cluster name fixes

### DIFF
--- a/orchestration/terraform/Makefile
+++ b/orchestration/terraform/Makefile
@@ -541,7 +541,7 @@ acquire-vpc-lock: check-cluster-name ## Acquire vpc lock in order to safely run 
 
 check-cluster-name: # check for valid cluster name
 	$(if $(cluster_name),,$(error 'cluster_name' cannot be empty!))
-	$(if $(filter $(cluster_name),$(shell echo '$(cluster_name)' | sed 's/[^a-zA-Z0-9\-\.]//g')),,$(error 'cluster_name' can only have [a-zA-Z0-9-.] in it!))
+	$(if $(filter $(cluster_name),$(shell echo '$(cluster_name)' | sed 's/[^-a-zA-Z0-9]//g')),,$(error 'cluster_name' can only have [-a-zA-Z0-9] in it!))
 
 init-vpc-terraform: check-cluster-name ## Initialize/reset local terraform state based on what is in S3 for vpc
 	@echo "\033[36m==> Initializing terraform state for VPC in region \


### PR DESCRIPTION
Fix two problems in the terraform makefile:

- "." breaks aws.py inventory script: if I use "." in a cluster name, all of the `make configure` steps will say `skipping: no hosts matched`
- move hyphen to the front of the `[]` pattern.

```
BROKEN: make cluster cluster_name=slf.tcp.foo num_leaders=1 num_followers=2 force_instance=c4.8xlarge ansible_system_cpus=0,18 no_spot=true cluster_project_name=wallaroo_perf_testing ansible_install_devtools=true terraform_args="-var placement_tenancy=dedicated"
WORKS : make cluster cluster_name=slfyo       num_leaders=1 num_followers=2 force_instance=c4.8xlarge ansible_system_cpus=0,18 no_spot=true cluster_project_name=wallaroo_perf_testing ansible_install_devtools=true terraform_args="-var placement_tenancy=dedicated"
BROKEN! make cluster cluster_name=slf.yo      num_leaders=1 num_followers=2 force_instance=c4.8xlarge ansible_system_cpus=0,18 no_spot=true cluster_project_name=wallaroo_perf_testing ansible_install_devtools=true terraform_args="-var placement_tenancy=dedicated"
NO    : make cluster cluster_name=slf-yo      num_leaders=1 num_followers=2 force_instance=c4.8xlarge ansible_system_cpus=0,18 no_spot=true cluster_project_name=wallaroo_perf_testing ansible_install_devtools=true terraform_args="-var placement_tenancy=dedicated"
Makefile:543: *** 'cluster_name' can only have [a-zA-Z0-9-.] in it!.  Stop.
```