### PR TITLE
Log rotation - new tests + validations

### DIFF
--- a/.ci-dockerfiles/ci-standard/Dockerfile
+++ b/.ci-dockerfiles/ci-standard/Dockerfile
@@ -52,11 +52,11 @@ ENV LANGUAGE en_US:en
 
 # python2 testing dependencies
 RUN python2 -m pip install --upgrade pip enum34 \
-  && python2 -m pip install pytest==3.7.4
+  && python2 -m pip install pytest==3.7.4 inotify==0.2.10
 
 # python3 testing dependencies
 RUN python3 -m pip install --upgrade pip enum34 \
-  && python3 -m pip install pytest==3.7.4
+  && python3 -m pip install pytest==3.7.4 inotify==0.2.10
 
 # install go
 RUN wget https://dl.google.com/go/go1.9.2.linux-amd64.tar.gz \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
 
   unit-tests:
     docker:
-      - image: wallaroolabs/wallaroo-ci:2019.04.02.1
+      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -18,7 +18,7 @@ jobs:
 
   integration-tests:
     docker:
-      - image: wallaroolabs/wallaroo-ci:2019.04.02.1
+      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -35,7 +35,7 @@ jobs:
 
   integration-tests-correctness:
     docker:
-      - image: wallaroolabs/wallaroo-ci:2019.04.02.1
+      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -45,7 +45,7 @@ jobs:
 
   integration-tests-resilience:
     docker:
-      - image: wallaroolabs/wallaroo-ci:2019.04.02.1
+      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -56,7 +56,7 @@ jobs:
 
   integration-tests-resilience-correctness:
     docker:
-      - image: wallaroolabs/wallaroo-ci:2019.04.02.1
+      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -66,7 +66,7 @@ jobs:
 
   autoscale-tests-pony:
     docker:
-      - image: wallaroolabs/wallaroo-ci:2019.04.02.1
+      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -79,7 +79,7 @@ jobs:
 
   autoscale-tests-pony-resilience:
     docker:
-      - image: wallaroolabs/wallaroo-ci:2019.04.02.1
+      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -92,7 +92,7 @@ jobs:
 
   autoscale-tests-python2:
     docker:
-      - image: wallaroolabs/wallaroo-ci:2019.04.02.1
+      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -105,7 +105,7 @@ jobs:
 
   autoscale-tests-python2-resilience:
     docker:
-      - image: wallaroolabs/wallaroo-ci:2019.04.02.1
+      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -118,7 +118,7 @@ jobs:
 
   autoscale-tests-python3:
     docker:
-      - image: wallaroolabs/wallaroo-ci:2019.04.02.1
+      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -131,7 +131,7 @@ jobs:
 
   autoscale-tests-python3-resilience:
     docker:
-      - image: wallaroolabs/wallaroo-ci:2019.04.02.1
+      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -144,7 +144,7 @@ jobs:
 
   resilience-tests-pony:
     docker:
-      - image: wallaroolabs/wallaroo-ci:2019.04.02.1
+      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -157,7 +157,7 @@ jobs:
 
   resilience-tests-python2:
     docker:
-      - image: wallaroolabs/wallaroo-ci:2019.04.02.1
+      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -170,7 +170,7 @@ jobs:
 
   resilience-tests-python3:
     docker:
-      - image: wallaroolabs/wallaroo-ci:2019.04.02.1
+      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -183,7 +183,7 @@ jobs:
 
   topology-tests-python2:
     docker:
-      - image: wallaroolabs/wallaroo-ci:2019.04.02.1
+      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -196,7 +196,7 @@ jobs:
 
   topology-tests-python3-resilience:
     docker:
-      - image: wallaroolabs/wallaroo-ci:2019.04.02.1
+      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -209,7 +209,7 @@ jobs:
 
   topology-tests-python3:
     docker:
-      - image: wallaroolabs/wallaroo-ci:2019.04.02.1
+      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -222,7 +222,7 @@ jobs:
 
   topology-tests-python3-resilience:
     docker:
-      - image: wallaroolabs/wallaroo-ci:2019.04.02.1
+      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ tags
 #Stable files
 .deps
 .deps/*
+
+TODO-EventLog-rotation-history.txt

--- a/examples/pony/alerts_local_aggregations/Makefile
+++ b/examples/pony/alerts_local_aggregations/Makefile
@@ -35,18 +35,18 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := false
 $(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := false
 
 
-ALERTS_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+PONY_ALERTS_LOCAL_AGGREGATIONS_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 # standard rules generation makefile
 include $(rules_mk_path)
 
 
 # integration-tests-examples-pony-alerts_stateless: build-examples-pony-alerts_stateless
-# integration-tests-examples-pony-alerts_stateless: alerts_stateless_test
+# integration-tests-examples-pony-alerts_stateless: pony_alerts_local_aggregations_test
 
-alerts_stateless_test:
+pony_alerts_local_aggregations_test:
 	# TODO: Update to use gensource
-	# cd $(ALERTS_PATH) && \
+	# cd $(PONY_ALERTS_LOCAL_AGGREGATIONS_PATH) && \
 	# integration_test --framed-file-sender \
 	#   _test.txt --validation-cmp \
 	#   --expected-file _expected.txt \

--- a/examples/pony/alerts_stateless/Makefile
+++ b/examples/pony/alerts_stateless/Makefile
@@ -35,18 +35,18 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := false
 $(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := false
 
 
-ALERTS_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+PONY_ALERTS_STATELESS_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 # standard rules generation makefile
 include $(rules_mk_path)
 
 
 # integration-tests-examples-pony-alerts_stateless: build-examples-pony-alerts_stateless
-# integration-tests-examples-pony-alerts_stateless: alerts_stateless_test
+# integration-tests-examples-pony-alerts_stateless: pony_alerts_stateless_test
 
-alerts_stateless_test:
+pony_alerts_stateless_test:
 	# TODO: Update to use gensource
-	# cd $(ALERTS_PATH) && \
+	# cd $(PONY_ALERTS_STATELESS_PATH) && \
 	# integration_test --framed-file-sender \
 	#   _test.txt --validation-cmp \
 	#   --expected-file _expected.txt \

--- a/lib/wallaroo/core/recovery/backend.pony
+++ b/lib/wallaroo/core/recovery/backend.pony
@@ -163,7 +163,7 @@ class FileBackend is Backend
     end
 
     @printf[I32](("RESILIENCE: Rolling back to checkpoint %s from recovery " +
-      "log file: \n").cstring(), checkpoint_id.string().cstring(),
+      "log file: %s\n").cstring(), checkpoint_id.string().cstring(),
       _filepath.path.cstring())
 
     // First task: append a _LogRestartEntry record to the log.
@@ -226,7 +226,7 @@ class FileBackend is Backend
     end
     if not target_checkpoint_found then
       @printf[I32](("RESILIENCE: Rolling back to checkpoint %s from recovery "+
-        "log file failed: not found \n").cstring(),
+        "log file failed: %s not found \n").cstring(),
         checkpoint_id.string().cstring(), _filepath.path.cstring())
       Fail()
     end
@@ -490,6 +490,7 @@ class RotatingFileBackend is Backend
       // TODO This is a placeholder for recording that we're rotating
       // an EventLog backend file, which is a prototype quick hack for
       // keeping such state within an SimpleJournal collection thingie.
+      // TODO: https://github.com/WallarooLabs/wallaroo/issues/2884
       let rotation_history = AsyncJournalledFile(FilePath(_auth, "TODO-EventLog-rotation-history.txt")?, _the_journal, _auth,
         _do_local_file_io)
       rotation_history.print("START of rotation: finished writing to " + _backend.get_path())

--- a/testing/correctness/apps/sequence_window/README.log_rotation.md
+++ b/testing/correctness/apps/sequence_window/README.log_rotation.md
@@ -66,3 +66,9 @@ Sender:
 ../../../../giles/sender/sender -h 127.0.0.1:20000 -s 100 -i 50_000_000 \
 --ponythreads=1 -y -g 12 -w -u -m 10000
 ```
+
+
+external log rotation trigger
+```bash
+../../../tools/external_sender/external_sender --external 127.0.0.1:20004 -t rotate-log -m initializer
+```

--- a/testing/correctness/apps/sequence_window/README.log_rotation.md
+++ b/testing/correctness/apps/sequence_window/README.log_rotation.md
@@ -1,0 +1,68 @@
+# Running a manual log rotation test using this app
+
+## Build
+
+```bash
+make clean
+make build debug=true resilience=on
+make build-utils-data_receiver build-giles-sender
+```
+
+## Run
+
+Receiver:
+
+```bash
+../../../../utils/data_receiver/data_receiver --listen 127.0.0.1:21000 --framed
+```
+
+Initializer:
+
+```bash
+mkdir -p res-dataA
+rm res-data/*
+./sequence_window \
+  --run-with-resilience \
+  --in "Sequence Window"@127.0.0.1:20000 \
+  --out 127.0.0.1:21000 \
+  --metrics 127.0.0.1:35000 \
+  --resilience-dir res-data \
+  --name initializer  \
+  --worker-count 2 \
+  --data 127.0.0.1:20003 \
+  --external 127.0.0.1:20004 \
+  --cluster-initializer  \
+  --control 127.0.0.1:20002   \
+  --ponythreads=1 \
+  --ponypinasio \
+  --ponynoblock
+  --log-rotation \
+  --event-log-file-size 50000
+```
+
+Worker:
+
+```
+./sequence_window \
+  --run-with-resilience \
+  --out 127.0.0.1:21000 \
+  --metrics 127.0.0.1:35000 \
+  --resilience-dir res-data \
+  --name worker  \
+  --control 127.0.0.1:20002   \
+  --my-data 127.0.0.1:20103 \
+  --my-control 127.0.0.1:20102   \
+  --external 127.0.0.1:20104 \
+  --ponythreads=1 \
+  --ponypinasio \
+  --ponynoblock \
+  --log-rotation \
+  --event-log-file-size 50000
+```
+
+Sender:
+
+```bash
+../../../../giles/sender/sender -h 127.0.0.1:20000 -s 100 -i 50_000_000 \
+--ponythreads=1 -y -g 12 -w -u -m 10000
+```

--- a/testing/correctness/tests/resilience/resilience.py
+++ b/testing/correctness/tests/resilience/resilience.py
@@ -452,6 +452,10 @@ def _run(persistent_data, res_ops, command, ops=[], initial=None,
     if not isinstance(ops, (list, tuple)):
         raise TypeError("ops must be a list or tuple of operations")
 
+    # determine whether there is log rotation in the ops
+    log_rotation = any(isinstance(op, Rotate) for op in ops)
+    logging.info("log_rotation={}".format(log_rotation))
+
     # If no initial workers value is given, determine the minimum number
     # required at the start so that the cluster never goes below 1 worker.
     # If a number is given, then verify it is sufficient.
@@ -502,6 +506,7 @@ def _run(persistent_data, res_ops, command, ops=[], initial=None,
     with Cluster(command=command, host=host,
                  sources=[source_name] if source_type != 'gensource' else [],
                  workers=workers, sinks=sinks, sink_mode=sink_mode,
+                 log_rotation=log_rotation,
                  persistent_data=persistent_data) as cluster:
 
         # start senders

--- a/testing/correctness/tests/resilience/resilience.py
+++ b/testing/correctness/tests/resilience/resilience.py
@@ -248,6 +248,7 @@ class Rotate(ResilienceOperation):
 
     def apply(self, cluster, data=None):
         # TODO: Get current last log chunk
+        # Use WaitForLogRotation controller in control.py for this.
         rotated = cluster.rotate_logs()
         # TODO: watch for new log chunks to confirm rotation
         return rotated

--- a/testing/correctness/tests/resilience/resilience.py
+++ b/testing/correctness/tests/resilience/resilience.py
@@ -235,6 +235,24 @@ class Recover(ResilienceOperation):
         return restarted
 
 
+class Rotate(ResilienceOperation):
+    def __init__(self):
+        """
+        Trigger a log rotation on all workers using via their external control
+        channel.
+        """
+        super(Rotate, self).__init__(0, check_size=False)
+
+    def sign(self):
+        return 0
+
+    def apply(self, cluster, data=None):
+        # TODO: Get current last log chunk
+        rotated = cluster.rotate_logs()
+        # TODO: watch for new log chunks to confirm rotation
+        return rotated
+
+
 class Wait(ResilienceOperation):
     def __init__(self, seconds):
         if not isinstance(seconds, Number):

--- a/testing/correctness/tests/resilience/resilience_tests.py
+++ b/testing/correctness/tests/resilience/resilience_tests.py
@@ -17,6 +17,7 @@
 from resilience import (Crash,
                         Grow,
                         Recover,
+                        Rotate,
                         Shrink,
                         Wait,
                         _test_resilience)
@@ -87,7 +88,13 @@ RESILIENCE_SEQS = [
     [Wait(2), Crash(1), Wait(2), Recover(1), Wait(5)],
 
     # crash2, recover2
-    [Wait(2), Crash(2), Wait(2), Recover(2), Wait(5)]
+    [Wait(2), Crash(2), Wait(2), Recover(2), Wait(5)],
+
+    # Log rotate
+    [Wait(2), Rotate(), Wait(2)],
+
+    # Log rotate and crash
+    [Wait(2), Rotate(), Wait(2), Crash(1), Wait(2), Recover(1), Wait(2)],
     ]
 
 # Generate resilience test functions for each api, for each of the op seqs

--- a/testing/tools/integration/cluster.py
+++ b/testing/tools/integration/cluster.py
@@ -44,6 +44,7 @@ from .errors import (ClusterError,
 
 from .external import (clean_resilience_path,
                       get_port_values,
+                      send_rotate_command,
                       send_shrink_command,
                       setup_resilience_path)
 
@@ -238,6 +239,7 @@ BASE_COMMAND = r'''{command} \
     {{join_block}} \
     {{spike_block}} \
     {{alt_block}} \
+    {log_rotation} \
     --ponythreads=1 \
     --ponypinasio \
     --ponynoblock'''
@@ -262,18 +264,21 @@ SPIKE_CMD = r'''--spike-drop \
 SPIKE_SEED = r'''--spike-seed {seed}'''
 SPIKE_PROB = r'''--spike-prob {prob}'''
 SPIKE_MARGIN = r'''--spike-margin {margin}'''
+LOG_ROTATION = r'''--log-rotation'''
 
 
 def start_runners(runners, command, source_addrs, sink_addrs, metrics_addr,
-                  res_dir, workers, worker_addrs=[], alt_block=None,
-                  alt_func=lambda x: False, spikes={}):
+                  res_dir, workers, worker_addrs=[], log_rotation=False,
+                  alt_block=None, alt_func=lambda x: False, spikes={}):
     cmd_stub = BASE_COMMAND.format(command=command,
                                    out_block=(
                                        OUT_BLOCK.format(outputs=','.join(
                                            sink_addrs))
                                        if sink_addrs else ''),
                                    metrics_addr=metrics_addr,
-                                   res_dir=res_dir)
+                                   res_dir=res_dir,
+                                   log_rotation = (LOG_ROTATION if log_rotation
+                                                   else ''))
 
     # for each worker, assign `name` and `cluster-initializer` values
     if workers < 1:
@@ -373,6 +378,7 @@ def start_runners(runners, command, source_addrs, sink_addrs, metrics_addr,
 def add_runner(worker_id, runners, command, source_addrs, sink_addrs, metrics_addr,
                control_addr, res_dir, workers,
                my_control_addr, my_data_addr, my_external_addr,
+               log_rotation=False,
                alt_block=None, alt_func=lambda x: False, spikes={}):
     cmd_stub = BASE_COMMAND.format(command=command,
                                    out_block=(
@@ -380,7 +386,9 @@ def add_runner(worker_id, runners, command, source_addrs, sink_addrs, metrics_ad
                                            sink_addrs))
                                        if sink_addrs else ''),
                                    metrics_addr=metrics_addr,
-                                   res_dir=res_dir)
+                                   res_dir=res_dir,
+                                   log_rotation = (LOG_ROTATION if log_rotation
+                                                   else ''))
 
     # Test that the new worker *can* join
     if len(runners) < 1:
@@ -464,11 +472,13 @@ SinkData = namedtuple('SinkData',
 class Cluster(object):
     def __init__(self, command, host='127.0.0.1', sources=[], workers=1,
             sinks=1, sink_mode='framed', worker_join_timeout=30,
-            is_ready_timeout=30, res_dir=None, persistent_data={}):
+            is_ready_timeout=30, res_dir=None, log_rotation=False,
+            persistent_data={}):
         # Create attributes
         self._finalized = False
         self._exited = False
         self._raised = False
+        self.log_rotation = log_rotation
         self.command = command
         self.host = host
         self.workers = TypedList(types=(Runner,))
@@ -535,7 +545,7 @@ class Cluster(object):
             start_runners(self.workers, self.command, self.source_addrs,
                           self.sink_addrs,
                           self.metrics_addr, self.res_dir, workers,
-                          worker_addrs)
+                          worker_addrs, self.log_rotation)
             self.runners.extend(self.workers)
             self._worker_id_counter = len(self.workers)
 
@@ -559,6 +569,29 @@ class Cluster(object):
             self.errors.append(err)
             self.__finally__()
             raise err
+
+    ################
+    # Log Rotation #
+    ################
+    def rotate_logs(self, workers=None):
+        """
+        Rotate the named workers, or all workers if no workers are named
+        """
+        logging.log(1, "rotate(workers={})".format(workers))
+        if workers is None:
+            to_rotate = self.workers
+        else:
+            # check all named workers exist
+            valid = {r.name: r for r in self.workers}
+            to_rotate = []
+            for w in workers:
+                to_rotate.append(valid[w])  # fail if w not in valid
+
+        # for each worker, send a log rotate command directly to its external
+        # channel
+        for w in to_rotate:
+            send_rotate_command(w.external, w.name)
+        return to_rotate
 
     #############
     # Autoscale #
@@ -595,7 +628,8 @@ class Cluster(object):
                 workers=by,
                 my_control_addr=worker_addrs[x][0],
                 my_data_addr=worker_addrs[x][1],
-                my_external_addr=worker_addrs[x][2])
+                my_external_addr=worker_addrs[x][2],
+                log_rotation=self.log_rotation)
             self._worker_id_counter += 1
             runners.append(runner)
             self.runners.append(runner)

--- a/testing/tools/integration/control.py
+++ b/testing/tools/integration/control.py
@@ -251,33 +251,69 @@ class WaitForLogRotation(StoppableThread):
     """
     __base_name__ = 'WaitForLogRottion'
 
-    def __init__(self, base_path, prefixes=[], log_suffix='.evlog', timeout=30):
+    def __init__(self, cluster, base_path, prefixes=[], log_suffix='.evlog',
+                 timeout=30):
         super(WaitForLogRotation, self).__init__()
+        logging.debug("{}({}, {}, {}, {})".format(self.__base_name__,
+            base_path, prefixes, log_suffix, timeout))
+        self.cluster = cluster
         self.base_path = base_path
         self.prefixes = prefixes
         self.timeout = timeout
-        self.notifier = EvLogFileNotifier(handler=self, base_path)
+        self.notifier = EvLogFileNotifier(handler=self, path=base_path,
+                log_suffix=log_suffix)
+        self.wait_for = set(self.prefixes)
+        self.error = None
+
 
     def run(self):
         while not self.stopped():
-            self.notifier.run()
+            self.notifier.start()
             self.notifier.join(self.timeout)
             if self.notifier.is_alive():
                 self.notifier.stop()
                 self.stop()
-                err = TimeoutError("WaitForrLogRotation timed out after "
+                self.error = TimeoutError("WaitForrLogRotation timed out after "
                 " {} seconds while waiting for {!r} to rotate"
                 .format(self.timeout, self.prefixes))
-                self.cluster.raise_from_error(err)
-                break
+                self.cluster.raise_from_error(self.error)
+                return self.error
             else:
                 self.stop()
-                return
+                return self.error
             time.sleep(0.05)
 
     def file_created(self, base_name, new_chunk, old_chunk):
-        # TODO
+        logging.log(1, "{}.file_created({}, {}, {})".format(self.__base_name__,
+            base_name, new_chunk, old_chunk))
+        logging.debug("Log {} rotated from {} to {}".format(
+            base_name, old_chunk, new_chunk))
+        # Extract the prefix from the base_name, which includes the application
+        # name
+        worker = next((p for p in self.prefixes if base_name.endswith(p)),
+                      False)
+        if worker is False:
+            logging.debug("Couldn't find a worker for the base_name: {} {} {}"
+                    .format(base_name, old_chunk, new_chunk))
+            return
+        if worker in self.wait_for:
+            logging.debug("Worker {} rotated from {} to {}".format(
+                worker, "{}-{}.evlog".format(base_name, old_chunk),
+                "{}-{}.evlog".format(base_name, new_chunk)))
+            self.wait_for.remove(worker)
+        if len(self.wait_for) == 0:
+            logging.debug("All workers in the wait_for group have rotated their"
+                    " logs")
+            self.notifier.stop()
+            self.stop()
 
     def file_deleted(self, base_name, chunk):
-        # TODO
+        logging.debug("Log file deleted: {}-{}".format(base_name, chunk))
+        # TODO: change this when we add log chunk deletion
+        self.error = ExpectationError("Log file was deleted: {}-{}".format(
+            base_name, chunk))
+        self.stop()
 
+    def evlognotifier_stopped(self, notifier):
+        logging.debug("Notifier {} has stopped.".format(notifier))
+        self.stop()

--- a/testing/tools/integration/external.py
+++ b/testing/tools/integration/external.py
@@ -104,8 +104,22 @@ def get_port_values(num=1, host='127.0.0.1', base_port=20000):
     return ports
 
 
+def send_rotate_command(addr, worker):
+    """
+    Trigger log rotation with external message
+    """
+    cmd_external_rotate = ('external_sender --external {} --type rotate-log '
+                           '--message {}'.format(addr, worker))
+    res = run_shell_cmd(cmd_external_rotate)
+    try:
+        assert(res.success)
+    except AssertionError:
+        raise AssertionError('External log rotation trigger failed with '
+                             'the error:\n{}'.format(res))
+    return res.output
+
+
 def send_shrink_command(addr, workers):
-    # Trigger log rotation with external message
     cmd_external_trigger = ('cluster_shrinker --external {} --workers {}'
                             .format(addr, workers))
 

--- a/testing/tools/integration/observability.py
+++ b/testing/tools/integration/observability.py
@@ -24,6 +24,8 @@ import traceback
 import sys
 import time
 
+import inotify
+
 from .errors import (DuplicateKeyError,
                     TimeoutError)
 from .external import run_shell_cmd
@@ -409,3 +411,78 @@ def coalesce_partition_query_responses(responses):
                                             .format(step, part, dup0, dup1))
                 steps[step][part] = worker
     return steps
+
+
+####################################
+# Log File Observability Functions #
+####################################
+class EvLogFileNotifier(StoppableThread):
+    """
+    Watch the resilience directory and keep track of log files.
+    Call a handler when a log file rotates.
+    """
+
+    __base_name__ = 'EvLogFileNotifier'
+
+    def __init__(self, handler, path, log_suffix='.evlog'):
+        super(EvLogFileNotifier, self).__init__()
+        self.handler = handler
+        self.path = path
+        self.log_suffix = log_suffix
+        self.inotify = Inotify()
+        self.inotify.add_watch(self.path)
+
+        # State management
+        self.log_files = {}
+
+    def run(self):
+        while not self.stopped():
+            try:
+                event_gen = self.inotify.event_gen(timeout_s=5,
+                        yield_nones=False)
+                while not self.stopped():
+                    _, type_names, path, filename = next(event_gen)
+                    if filename.endswith(self.log_suffix):
+                        self.handle_log_file_event(filename, type_names)
+                    elif 'IN_DELETE_SELF' in type_names:
+                        self.stop()
+                        self.handler.evlognotifier_stopped(self)
+                    else:
+                        continue
+            except:
+                continue
+
+    def handle_log_file_event(self, filename, type_names):
+        # type_names we might care about:
+        #   IN_CREATE           - create file/dir
+        #   IN_DELETE           - delete file/dir
+        #   IN_OPEN             - open file (for read/write)
+        #   IN_MODIFY           - save without closing (e.g. flush())
+        #   IN_CLOSE_WRITE      - save + close
+        #   IN_CLOSE_NOWRITE    - close nowrite
+        #   IN_DELETE_SELF      - Watched path deleted, stops the watcher
+
+        base_name, chunk = filename.split('.evlog')[0].rsplit('-', 1)
+        fn_logs = self.log_files.setdefault(base_name, {})
+
+        # Assumption: wallaroo has strict ordering between create-open-close
+        # across files for the same backend (e.g. old is closed before new is
+        # created)
+
+        # CREATE
+        if 'IN_CREATE' in type_names:
+            fn_logs.setdefault('chunks', []).add(chunk)
+            fn_logs.setdefault('active', chunk)
+            new_chunk = chunk
+            old_chunk = (fn_logs['chunks'][-1]
+                         if len(fn_logs['chunks'])>0
+                         else None)
+            self.handler.file_created(basename, new_chunk, old_chunk)
+        # DELETE
+        elif 'IN_DELETE' in type_names:
+            if fn_logs['current'] == chunk:
+                fn_logs['current'] = None
+            self.handler.file_deleted(basename, chunk)
+        else:
+            # dont care
+            pass


### PR DESCRIPTION
- Add a `Rotate` operation to the resilience test harness
- Add an inotify-based validation that watches for log rotation (note that it is making assumptions about the file chunk naming scheme being `<app name>-<worker name>-<chunk id>.evlog`)
- Add a test with log rotation followed by crash-recovery using multi_partition_detector
- Fix the `@printf` in `recovery/backend.pony`  that wasn't including the log file path. It now includes it (the format string was missing a `%s`).

The tests pass locally.

closes #2881 