### PR TITLE
Add support for explicit late data policies

### DIFF
--- a/lib/wallaroo/core/windows/_late_data_test.pony
+++ b/lib/wallaroo/core/windows/_late_data_test.pony
@@ -1,0 +1,236 @@
+/*
+
+Copyright 2018 The Wallaroo Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing
+ permissions and limitations under the License.
+
+*/
+
+use "collections"
+use "ponytest"
+use "promises"
+use "random"
+use "time"
+use "wallaroo/core/aggregations"
+use "wallaroo/core/common"
+use "wallaroo/core/state"
+use "wallaroo/core/topology"
+use "wallaroo_labs/time"
+
+
+actor _LateDataPolicyTests is TestList
+  new create(env: Env) => PonyTest(env, this)
+  new make() => None
+  fun tag tests(test: PonyTest) =>
+    test(_LateDataIgnoredUnderDrop)
+    test(_LateDataTriggersOwnWindowUnderFirePerMessage)
+    test(_LateDataTriggersNewWindowUnderFirePerMessage)
+    test(_PlaceInOldestWindowOneWindow)
+    test(_PlaceInOldestWindowTwoWindows)
+    test(_PlaceInOldestWindowDoesntAutomaticallyTrigger)
+
+class iso _LateDataIgnoredUnderDrop is UnitTest
+  fun name(): String => "windows/late_data/_LateDataIgnoredUnderDrop"
+
+  fun apply(h: TestHelper) ? =>
+    // First message starts window
+    // Second message is late data
+    // Third message triggers window including first message (needs watermark
+    // past range and delay, and event ts that places it in that same window)
+
+    // Result:
+    //  [1; 3]
+
+    // given
+    let range: U64 = Seconds(10)
+    let slide = range
+    let delay: U64 = 0
+    let tw = RangeWindows[USize, Array[USize] val, Collected]("key",
+      _Collect, range, slide, delay, _Zeros, LateDataPolicy.drop())
+        .>apply(1, Seconds(100), Seconds(100))
+        .>apply(2, Seconds(50), Seconds(100))
+
+    // when
+    let res = tw(3, Seconds(101), Seconds(111))
+
+    // then
+    let res_array = _ForceArrayArray(res._1)?
+    h.assert_eq[USize](res_array.size(), 1)
+    h.assert_array_eq[USize](res_array(0)?, [1; 3])
+
+
+class iso _LateDataTriggersOwnWindowUnderFirePerMessage is UnitTest
+  fun name(): String =>
+    "windows/late_data/_LateDataTriggersOwnWindowUnderFirePerMessage"
+
+  fun apply(h: TestHelper) ? =>
+    // First message starts window
+    // Second message is late data
+    // Third message triggers window including first message (needs watermark
+    // past range and delay, and event ts that places it in that same window)
+
+    // Result:
+    //   [2]
+    //   [1; 3]
+
+    // given
+    let range: U64 = Seconds(10)
+    let slide = range
+    let delay: U64 = 0
+    let tw = RangeWindows[USize, Array[USize] val, Collected]("key",
+      _Collect, range, slide, delay, _Zeros, LateDataPolicy.fire_per_message())
+        .>apply(1, Seconds(100), Seconds(100))
+
+    // when
+    let res1 = tw(2, Seconds(50), Seconds(100))
+    let res2 = tw(3, Seconds(101), Seconds(111))
+
+    // then
+    let res_array1 = _ForceArrayArray(res1._1)?
+    h.assert_eq[USize](res_array1.size(), 1)
+    h.assert_array_eq[USize](res_array1(0)?, [2])
+    let res_array2 = _ForceArrayArray(res2._1)?
+    h.assert_eq[USize](res_array2.size(), 1)
+    h.assert_array_eq[USize](res_array2(0)?, [1; 3])
+
+class iso _LateDataTriggersNewWindowUnderFirePerMessage is UnitTest
+  fun name(): String =>
+    "windows/late_data/_LateDataTriggersNewWindowUnderFirePerMessage"
+
+  fun apply(h: TestHelper) ? =>
+    // First message starts window
+    // Second message joins/triggers window
+    // Third message is late data
+
+    // Result:
+    //   [1; 2]
+    //   [3]
+
+    // given
+    let range: U64 = Seconds(10)
+    let slide = range
+    let delay: U64 = 0
+    let tw = RangeWindows[USize, Array[USize] val, Collected]("key",
+      _Collect, range, slide, delay, _Zeros, LateDataPolicy.fire_per_message())
+        .>apply(1, Seconds(100), Seconds(100))
+
+    // when
+    let res1 = tw(2, Seconds(101), Seconds(111))
+    let res2 = tw(3, Seconds(50), Seconds(111))
+
+    // then
+    let res_array1 = _ForceArrayArray(res1._1)?
+    h.assert_eq[USize](res_array1.size(), 1)
+    h.assert_array_eq[USize](res_array1(0)?, [1; 2])
+    let res_array2 = _ForceArrayArray(res2._1)?
+    h.assert_eq[USize](res_array2.size(), 1)
+    h.assert_array_eq[USize](res_array2(0)?, [3])
+
+class iso _PlaceInOldestWindowOneWindow is UnitTest
+  fun name(): String => "windows/late_data/_PlaceInOldestWindowOneWindow"
+
+  fun apply(h: TestHelper) ? =>
+    // First message starts window (ensure there is only one window?)
+    // Second message is late data
+    // Third message triggers all windows(needs watermark
+    // past range and delay for first window, and event ts that places it in
+    // that same window)
+
+    // Result:
+    //   [1; 2; 3]
+
+    // given
+    let range: U64 = Seconds(10)
+    let slide = range
+    let delay: U64 = 0
+    let tw = RangeWindows[USize, Array[USize] val, Collected]("key",
+      _Collect, range, slide, delay, _Zeros,
+      LateDataPolicy.place_in_oldest_window())
+        .>apply(1, Seconds(100), Seconds(100))
+        .>apply(2, Seconds(50), Seconds(100))
+
+    // when
+    let res = tw(3, Seconds(101), Seconds(111))
+
+    // then
+    let res_array = _ForceArrayArray(res._1)?
+    h.assert_eq[USize](res_array.size(), 1)
+    h.assert_array_eq[USize](res_array(0)?, [1; 2; 3])
+
+class iso _PlaceInOldestWindowTwoWindows is UnitTest
+  fun name(): String => "windows/late_data/_PlaceInOldestWindowTwoWindows"
+
+  fun apply(h: TestHelper) ? =>
+    // First message starts window
+    // Second message starts second window
+    // Third message is late data
+    // Fourth message triggers all windows(needs watermark
+    // past range and delay for second window, and event ts that places it in
+    // that same window)
+
+    // Result:
+    //   [1; 3]
+    //   [2; 4]
+
+    // given
+    let range: U64 = Seconds(10)
+    let slide = range
+    let delay: U64 = 0
+    let tw = RangeWindows[USize, Array[USize] val, Collected]("key",
+      _Collect, range, slide, delay, _Zeros,
+      LateDataPolicy.place_in_oldest_window())
+        .>apply(1, Seconds(100), Seconds(100))
+        .>apply(2, Seconds(111), Seconds(100))
+        .>apply(3, Seconds(50), Seconds(100))
+
+    // when
+    let res = tw(4, Seconds(112), Seconds(121))
+
+    // then
+    let res_array = _ForceArrayArray(res._1)?
+    h.assert_eq[USize](res_array.size(), 2)
+    h.assert_array_eq[USize](res_array(0)?, [1; 3])
+    h.assert_array_eq[USize](res_array(1)?, [2; 4])
+
+class iso _PlaceInOldestWindowDoesntAutomaticallyTrigger is UnitTest
+  fun name(): String =>
+    "windows/late_data/_PlaceInOldestWindowDoesntAutomaticallyTrigger"
+
+  fun apply(h: TestHelper) ? =>
+    // First message starts window
+    // Second message joins/triggers window
+    // Third message is late data
+
+    // Result:
+    //  [1; 2]
+
+    // given
+    let range: U64 = Seconds(10)
+    let slide = range
+    let delay: U64 = 0
+    let tw = RangeWindows[USize, Array[USize] val, Collected]("key",
+      _Collect, range, slide, delay, _Zeros,
+      LateDataPolicy.place_in_oldest_window())
+        .>apply(1, Seconds(100), Seconds(100))
+
+    // when
+    let res1 = tw(2, Seconds(101), Seconds(111))
+    let res2 = tw(3, Seconds(50), Seconds(111))
+
+    // then
+    let res_array1 = _ForceArrayArray(res1._1)?
+    h.assert_eq[USize](res_array1.size(), 1)
+    h.assert_array_eq[USize](res_array1(0)?, [1; 2])
+    let res_array2 = _ForceArrayArray(res2._1)?
+    h.assert_eq[USize](res_array2.size(), 0)
+

--- a/lib/wallaroo/core/windows/_test.pony
+++ b/lib/wallaroo/core/windows/_test.pony
@@ -31,3 +31,4 @@ actor Main is TestList
     _WindowTests.make().tests(test)
     _ExpandSlidingWindowTests.make().tests(test)
     _WatermarkTests.make().tests(test)
+    _LateDataPolicyTests.make().tests(test)

--- a/lib/wallaroo/core/windows/_windows_test.pony
+++ b/lib/wallaroo/core/windows/_windows_test.pony
@@ -62,7 +62,7 @@ class iso _TestTumblingWindowsTimeoutTrigger is UnitTest
     // given
     let watermark: U64 = Seconds(111)
     let range: U64 = Seconds(1)
-    let tw = _TumblingWindow(range, _Sum)
+    let tw = _TotalTumblingWindow(range, _Sum)
              .>apply(111, watermark, watermark)
 
     // when
@@ -80,7 +80,7 @@ class iso _TestTumblingWindowsOutputEventTimes is UnitTest
   fun apply(h: TestHelper) ? =>
     // given
     let range: U64 = Seconds(3)
-    let tw = _TumblingWindow(range, _Sum)
+    let tw = _TotalTumblingWindow(range, _Sum)
              .>apply(1, Seconds(111), Seconds(111))
              .>apply(2, Seconds(112), Seconds(112))
 
@@ -142,7 +142,7 @@ class iso _TestOnTimeoutWatermarkTsIsJustBeforeNextWindowStart is UnitTest
     let range: U64 = Milliseconds(50)
     let slide = range
     let delay: U64 = 0
-    let tw = _TumblingWindow(Milliseconds(50), _NonZeroSum)
+    let tw = _TotalTumblingWindow(Milliseconds(50), _NonZeroSum)
              .>apply(1, Milliseconds(5000), Milliseconds(5000))
 
     // when
@@ -160,7 +160,7 @@ class iso _TestEventInNewWindowCausesPreviousToFlush is UnitTest
 
   fun apply(h: TestHelper) ? =>
     // given
-    let tw = _TumblingWindow(Milliseconds(50), _NonZeroSum)
+    let tw = _TotalTumblingWindow(Milliseconds(50), _NonZeroSum)
              .>apply(1, Milliseconds(5000), Milliseconds(5000))
              .>apply(2, Milliseconds(5025), Milliseconds(5025))
     // when
@@ -175,7 +175,7 @@ class iso _TestTimeoutAfterEndOfWindowCausesFlush is UnitTest
 
   fun apply(h: TestHelper) ? =>
     // given
-    let tw = _TumblingWindow(Milliseconds(50), _NonZeroSum)
+    let tw = _TotalTumblingWindow(Milliseconds(50), _NonZeroSum)
              .>apply(1, Milliseconds(5000), Milliseconds(5000))
              .>apply(2, Milliseconds(5025), Milliseconds(5025))
     // when
@@ -190,7 +190,7 @@ class iso _Test10 is UnitTest  // TODO: Rename this test
 
   fun apply(h: TestHelper) ? =>
     // given
-    let tw = _TumblingWindow(Milliseconds(50000), _NonZeroSum)
+    let tw = _TotalTumblingWindow(Milliseconds(50000), _NonZeroSum)
              .>apply(1, Milliseconds(5000), Milliseconds(5000))
              .>apply(3, Milliseconds(5300), Milliseconds(5300))
              .>apply(11, Milliseconds(6050), Milliseconds(6050))
@@ -213,7 +213,7 @@ class iso _TestTumblingWindowCountIsCorrectAfterFlush is UnitTest
 
   fun apply(h: TestHelper) =>
     // given
-    let tw = _TumblingWindow(Milliseconds(50), _NonZeroSum)
+    let tw = _TotalTumblingWindow(Milliseconds(50), _NonZeroSum)
              .>apply(1, Milliseconds(5000), Milliseconds(5000))
 
     // when
@@ -1034,7 +1034,7 @@ primitive _ForceArrayArray
       consume a'
     else error end
 
-primitive _TumblingWindow
+primitive _TotalTumblingWindow
   fun apply(range: U64, calculation: Aggregation[USize, USize, _Total]):
     RangeWindows[USize, USize, _Total]
   =>
@@ -1042,6 +1042,15 @@ primitive _TumblingWindow
     let delay: U64 = 0
     RangeWindows[USize, USize, _Total]("key",
       _NonZeroSum, range, slide, delay, _Zeros)
+
+primitive _CollectTumblingWindow
+  fun apply(range: U64, calculation: Aggregation[USize, Array[USize] val,
+    Collected]): RangeWindows[USize, Array[USize] val, Collected]
+  =>
+    let slide = range
+    let delay: U64 = 0
+    RangeWindows[USize, Array[USize] val, Collected]("key",
+      _Collect, range, slide, delay, _Zeros)
 
 
 class _Zeros is Random

--- a/lib/wallaroo/core/windows/_windows_test.pony
+++ b/lib/wallaroo/core/windows/_windows_test.pony
@@ -630,7 +630,7 @@ class iso _TestSlidingWindowsStragglersSequence is UnitTest
     let range: U64 = Seconds(10)
     let slide: U64 = Seconds(2)
     let delay: U64 = Seconds(1_000)
-    let sw = RangeWindows[USize, Array[USize] val, Collected]("key",
+    let sw = RangeWindows[USize, Array[USize] val, _Collected]("key",
       _Collect, range, slide, delay, _Zeros)
 
     // Last heard threshold of 100 seconds
@@ -717,7 +717,7 @@ class iso _TestSlidingWindowsSequence is UnitTest
     let range: U64 = Seconds(50)
     let slide: U64 = Seconds(25)
     let delay: U64 = Seconds(3000)
-    let sw = RangeWindows[USize, Array[USize] val, Collected]("key",
+    let sw = RangeWindows[USize, Array[USize] val, _Collected]("key",
       _Collect, range, slide, delay, _Zeros)
 
     // var wm: USize = 4_888
@@ -948,12 +948,12 @@ class _NonZeroSum is Aggregation[USize, USize, _Total]
     if acc.v > 0 then acc.v end
   fun name(): String => "_NonZeroSum"
 
-primitive _Collect is Aggregation[USize, Array[USize] val, Collected]
-  fun initial_accumulator(): Collected => Collected
-  fun update(input: USize, acc: Collected) =>
+primitive _Collect is Aggregation[USize, Array[USize] val, _Collected]
+  fun initial_accumulator(): _Collected => _Collected
+  fun update(input: USize, acc: _Collected) =>
     acc.push(input)
-  fun combine(acc1: Collected, acc2: Collected): Collected =>
-    let new_arr = Collected
+  fun combine(acc1: _Collected, acc2: _Collected): _Collected =>
+    let new_arr = _Collected
     for m1 in acc1.values() do
       new_arr.push(m1)
     end
@@ -961,7 +961,7 @@ primitive _Collect is Aggregation[USize, Array[USize] val, Collected]
       new_arr.push(m2)
     end
     new_arr
-  fun output(key: Key, window_end_ts: U64, acc: Collected): Array[USize] val =>
+  fun output(key: Key, window_end_ts: U64, acc: _Collected): Array[USize] val =>
     let arr: Array[USize] iso = recover Array[USize] end
     for m in acc.values() do
       arr.push(m)
@@ -969,7 +969,7 @@ primitive _Collect is Aggregation[USize, Array[USize] val, Collected]
     consume arr
   fun name(): String => "_Collect"
 
-class Collected is State
+class _Collected is State
   let arr: Array[USize] = arr.create()
 
   fun ref push(u: USize) =>
@@ -1045,11 +1045,11 @@ primitive _TotalTumblingWindow
 
 primitive _CollectTumblingWindow
   fun apply(range: U64, calculation: Aggregation[USize, Array[USize] val,
-    Collected]): RangeWindows[USize, Array[USize] val, Collected]
+    _Collected]): RangeWindows[USize, Array[USize] val, _Collected]
   =>
     let slide = range
     let delay: U64 = 0
-    RangeWindows[USize, Array[USize] val, Collected]("key",
+    RangeWindows[USize, Array[USize] val, _Collected]("key",
       _Collect, range, slide, delay, _Zeros)
 
 

--- a/lib/wallaroo/core/windows/late_data_policy.pony
+++ b/lib/wallaroo/core/windows/late_data_policy.pony
@@ -1,0 +1,5 @@
+
+primitive LateDataPolicy
+  fun drop(): U16 => 0
+  fun fire_per_message(): U16 => 1
+  fun place_in_oldest_window(): U16 => 2

--- a/lib/wallaroo/core/windows/panes_range_windows.pony
+++ b/lib/wallaroo/core/windows/panes_range_windows.pony
@@ -112,7 +112,7 @@ class _PanesSlidingWindows[In: Any val, Out: Any val, Acc: State ref] is
       end
 
       // Check if we need to trigger and clear windows
-      (var outs, let output_watermark_ts) = attempt_to_trigger(watermark_ts)
+      (var outs, var output_watermark_ts) = attempt_to_trigger(watermark_ts)
 
       // If we haven't already applied the input, do it now.
       if not applied then
@@ -143,6 +143,7 @@ class _PanesSlidingWindows[In: Any val, Out: Any val, Acc: State ref] is
             // as the window end timestamp.
             outs.push((o, event_ts))
           end
+          output_watermark_ts = output_watermark_ts.max(event_ts)
         | LateDataPolicy.place_in_oldest_window() =>
           let new_earliest_ts = _earliest_ts()?
           _apply_input(input, new_earliest_ts, new_earliest_ts)


### PR DESCRIPTION
Currently, the default treatment of data received late relative to a
window definition is simply to drop it.  This commit introduces support
for specifying explicit late data policies, adding `fire_per_message` and
`place_in_oldest_window` alongside the default `drop` policy.

Closes #2760 
