### PR TITLE
Update _last_id_acked when receiving a boundary reconnect

### DIFF
--- a/lib/wallaroo/core/data_receiver/data_receiver.pony
+++ b/lib/wallaroo/core/data_receiver/data_receiver.pony
@@ -236,6 +236,7 @@ actor DataReceiver is Producer
     // improved.
     if highest_seq_id < _last_id_seen then
       _last_id_seen = highest_seq_id
+      _last_id_acked = _last_id_seen
     end
 
     _phase.data_connect(highest_seq_id)


### PR DESCRIPTION
When a boundary reconnects after a worker has crashed and recovered,
the recovering worker will reset the seq id for that connection to the
point it has recovered to. The DataReceiver needs to update its booking
accordingly. However, it was only updating the last id seen. It also
should reset its last id acked, since information about higher ids
acked is now irrelevant.

Closes #2889 
