### PR TITLE
Replace inotify with watchdog for macos compatibility

### DIFF
--- a/.ci-dockerfiles/ci-standard/Dockerfile
+++ b/.ci-dockerfiles/ci-standard/Dockerfile
@@ -52,11 +52,11 @@ ENV LANGUAGE en_US:en
 
 # python2 testing dependencies
 RUN python2 -m pip install --upgrade pip enum34 \
-  && python2 -m pip install pytest==3.7.4 inotify==0.2.10
+  && python2 -m pip install pytest==3.7.4 watchdog==0.9.0
 
 # python3 testing dependencies
 RUN python3 -m pip install --upgrade pip enum34 \
-  && python3 -m pip install pytest==3.7.4 inotify==0.2.10
+  && python3 -m pip install pytest==3.7.4 watchdog==0.9.0
 
 # install go
 RUN wget https://dl.google.com/go/go1.9.2.linux-amd64.tar.gz \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,28 @@
-version: 2
-jobs:
-  verify-changelog:
+version: 2.1
+executors:
+  wallaroo-ci:
+    docker:
+      - image: wallaroolabs/wallaroo-ci:2019.05.21.1
+  pony-changelog:
     docker:
       - image: ponylang/changelog-tool:release
+jobs:
+  verify-changelog:
+    executor: pony-changelog
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
       - run: changelog-tool verify CHANGELOG.md
 
   unit-tests:
-    docker:
-      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
+    executor: wallaroo-ci
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
       - run: make unit-tests debug=true
 
   integration-tests:
-    docker:
-      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
+    executor: wallaroo-ci
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -33,19 +37,8 @@ jobs:
       - store_artifacts:
           path: /tmp/wallaroo_test_errors
 
-  integration-tests-correctness:
-    docker:
-      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
-    steps:
-      - checkout
-      - run: .circleci/clone_tracker.sh
-      - run: make integration-tests-testing-correctness-apps-all debug=true
-      - store_artifacts:
-          path: /tmp/wallaroo_test_errors
-
-  integration-tests-resilience:
-    docker:
-      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
+  integration-tests-with-resilience:
+    executor: wallaroo-ci
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -54,9 +47,17 @@ jobs:
       - store_artifacts:
           path: /tmp/wallaroo_test_errors
 
-  integration-tests-resilience-correctness:
-    docker:
-      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
+  integration-tests-testing-correctness-apps:
+    executor: wallaroo-ci
+    steps:
+      - checkout
+      - run: .circleci/clone_tracker.sh
+      - run: make integration-tests-testing-correctness-apps-all debug=true
+      - store_artifacts:
+          path: /tmp/wallaroo_test_errors
+
+  integration-tests-testing-correctness-apps-with-resilience:
+    executor: wallaroo-ci
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -65,8 +66,7 @@ jobs:
           path: /tmp/wallaroo_test_errors
 
   autoscale-tests-pony:
-    docker:
-      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
+    executor: wallaroo-ci
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -77,9 +77,8 @@ jobs:
       - store_artifacts:
           path: /tmp/wallaroo_test_errors
 
-  autoscale-tests-pony-resilience:
-    docker:
-      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
+  autoscale-tests-pony-with-resilience:
+    executor: wallaroo-ci
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -91,8 +90,7 @@ jobs:
           path: /tmp/wallaroo_test_errors
 
   autoscale-tests-python2:
-    docker:
-      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
+    executor: wallaroo-ci
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -103,9 +101,8 @@ jobs:
       - store_artifacts:
           path: /tmp/wallaroo_test_errors
 
-  autoscale-tests-python2-resilience:
-    docker:
-      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
+  autoscale-tests-python2-with-resilience:
+    executor: wallaroo-ci
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -117,8 +114,7 @@ jobs:
           path: /tmp/wallaroo_test_errors
 
   autoscale-tests-python3:
-    docker:
-      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
+    executor: wallaroo-ci
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -129,9 +125,8 @@ jobs:
       - store_artifacts:
           path: /tmp/wallaroo_test_errors
 
-  autoscale-tests-python3-resilience:
-    docker:
-      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
+  autoscale-tests-python3-with-resilience:
+    executor: wallaroo-ci
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -143,8 +138,7 @@ jobs:
           path: /tmp/wallaroo_test_errors
 
   resilience-tests-pony:
-    docker:
-      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
+    executor: wallaroo-ci
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -156,8 +150,7 @@ jobs:
           path: /tmp/wallaroo_test_errors
 
   resilience-tests-python2:
-    docker:
-      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
+    executor: wallaroo-ci
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -169,8 +162,7 @@ jobs:
           path: /tmp/wallaroo_test_errors
 
   resilience-tests-python3:
-    docker:
-      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
+    executor: wallaroo-ci
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -182,8 +174,7 @@ jobs:
           path: /tmp/wallaroo_test_errors
 
   topology-tests-python2:
-    docker:
-      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
+    executor: wallaroo-ci
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -194,9 +185,8 @@ jobs:
       - store_artifacts:
           path: /tmp/wallaroo_test_errors
 
-  topology-tests-python3-resilience:
-    docker:
-      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
+  topology-tests-python2-with-resilience:
+    executor: wallaroo-ci
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -208,8 +198,7 @@ jobs:
           path: /tmp/wallaroo_test_errors
 
   topology-tests-python3:
-    docker:
-      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
+    executor: wallaroo-ci
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -220,9 +209,8 @@ jobs:
       - store_artifacts:
           path: /tmp/wallaroo_test_errors
 
-  topology-tests-python3-resilience:
-    docker:
-      - image: wallaroolabs/wallaroo-ci:2019.05.08.1
+  topology-tests-python3-with-resilience:
+    executor: wallaroo-ci
     steps:
       - checkout
       - run: .circleci/clone_tracker.sh
@@ -245,105 +233,105 @@ workflows:
           requires:
             - unit-tests
 
-      - integration-tests-correctness:
+      - integration-tests-with-resilience:
           requires:
             - unit-tests
 
-      - integration-tests-resilience:
+      - integration-tests-testing-correctness-apps:
           requires:
             - unit-tests
 
-      - integration-tests-resilience-correctness:
+      - integration-tests-testing-correctness-apps-with-resilience:
           requires:
             - unit-tests
 
       - autoscale-tests-pony:
           requires:
             - integration-tests
-            - integration-tests-correctness
-            - integration-tests-resilience
-            - integration-tests-resilience-correctness
+            - integration-tests-testing-correctness-apps
+            - integration-tests-with-resilience
+            - integration-tests-testing-correctness-apps-with-resilience
 
-      - autoscale-tests-pony-resilience:
+      - autoscale-tests-pony-with-resilience:
           requires:
             - integration-tests
-            - integration-tests-correctness
-            - integration-tests-resilience
-            - integration-tests-resilience-correctness
+            - integration-tests-testing-correctness-apps
+            - integration-tests-with-resilience
+            - integration-tests-testing-correctness-apps-with-resilience
 
       - autoscale-tests-python2:
           requires:
             - integration-tests
-            - integration-tests-correctness
-            - integration-tests-resilience
-            - integration-tests-resilience-correctness
+            - integration-tests-testing-correctness-apps
+            - integration-tests-with-resilience
+            - integration-tests-testing-correctness-apps-with-resilience
 
-      - autoscale-tests-python2-resilience:
+      - autoscale-tests-python2-with-resilience:
           requires:
             - integration-tests
-            - integration-tests-correctness
-            - integration-tests-resilience
-            - integration-tests-resilience-correctness
+            - integration-tests-testing-correctness-apps
+            - integration-tests-with-resilience
+            - integration-tests-testing-correctness-apps-with-resilience
 
       - autoscale-tests-python3:
           requires:
             - integration-tests
-            - integration-tests-correctness
-            - integration-tests-resilience
-            - integration-tests-resilience-correctness
+            - integration-tests-testing-correctness-apps
+            - integration-tests-with-resilience
+            - integration-tests-testing-correctness-apps-with-resilience
 
-      - autoscale-tests-python3-resilience:
+      - autoscale-tests-python3-with-resilience:
           requires:
             - integration-tests
-            - integration-tests-correctness
-            - integration-tests-resilience
-            - integration-tests-resilience-correctness
+            - integration-tests-testing-correctness-apps
+            - integration-tests-with-resilience
+            - integration-tests-testing-correctness-apps-with-resilience
 
       - resilience-tests-pony:
           requires:
             - integration-tests
-            - integration-tests-correctness
-            - integration-tests-resilience
-            - integration-tests-resilience-correctness
+            - integration-tests-testing-correctness-apps
+            - integration-tests-with-resilience
+            - integration-tests-testing-correctness-apps-with-resilience
 
       - resilience-tests-python2:
           requires:
             - integration-tests
-            - integration-tests-correctness
-            - integration-tests-resilience
-            - integration-tests-resilience-correctness
+            - integration-tests-testing-correctness-apps
+            - integration-tests-with-resilience
+            - integration-tests-testing-correctness-apps-with-resilience
 
       - resilience-tests-python3:
           requires:
             - integration-tests
-            - integration-tests-correctness
-            - integration-tests-resilience
-            - integration-tests-resilience-correctness
+            - integration-tests-testing-correctness-apps
+            - integration-tests-with-resilience
+            - integration-tests-testing-correctness-apps-with-resilience
 
       - topology-tests-python2:
           requires:
             - integration-tests
-            - integration-tests-correctness
-            - integration-tests-resilience
-            - integration-tests-resilience-correctness
+            - integration-tests-testing-correctness-apps
+            - integration-tests-with-resilience
+            - integration-tests-testing-correctness-apps-with-resilience
 
-      - topology-tests-python3-resilience:
+      - topology-tests-python2-with-resilience:
           requires:
             - integration-tests
-            - integration-tests-correctness
-            - integration-tests-resilience
-            - integration-tests-resilience-correctness
+            - integration-tests-testing-correctness-apps
+            - integration-tests-with-resilience
+            - integration-tests-testing-correctness-apps-with-resilience
 
       - topology-tests-python3:
           requires:
             - integration-tests
-            - integration-tests-correctness
-            - integration-tests-resilience
-            - integration-tests-resilience-correctness
+            - integration-tests-testing-correctness-apps
+            - integration-tests-with-resilience
+            - integration-tests-testing-correctness-apps-with-resilience
 
-      - topology-tests-python3-resilience:
+      - topology-tests-python3-with-resilience:
           requires:
             - integration-tests
-            - integration-tests-correctness
-            - integration-tests-resilience
-            - integration-tests-resilience-correctness
+            - integration-tests-testing-correctness-apps
+            - integration-tests-with-resilience
+            - integration-tests-testing-correctness-apps-with-resilience

--- a/testing/correctness/apps/multi_partition_detector/Makefile
+++ b/testing/correctness/apps/multi_partition_detector/Makefile
@@ -91,7 +91,7 @@ multi_partition_detector_test_python_alo:
 		--alo-sequence-sender key_1 '(100,200]' Detector \
 		--log-level $(LOGLEVEL) \
 		--command 'machida --application-module multi_partition_detector --source alo $(RUN_WITH_RESILIENCE)' \
-		--validation-cmd 'python _validate.py --output' \
+		--validation-cmd 'python3 _validate.py --output' \
 		--output 'received.txt' \
 		--batch-size 10 \
 		--workers 2 \
@@ -123,7 +123,7 @@ multi_partition_detector_test_python_alo_10_worker:
 		--alo-sequence-sender key_9 '(100,200]' Detector \
 		--log-level $(LOGLEVEL) \
 		--command 'machida --application-module multi_partition_detector --source alo $(RUN_WITH_RESILIENCE)' \
-		--validation-cmd 'python _validate.py --output' \
+		--validation-cmd 'python3 _validate.py --output' \
 		--output 'received.txt' \
 		--batch-size 10 \
 		--workers 2 \
@@ -145,7 +145,7 @@ multi_partition_detector_test_python:
 		--sequence-sender '(0,200]' Detector '>I' key_1 \
 		--log-level $(LOGLEVEL) \
 		--command 'machida --application-module multi_partition_detector $(RUN_WITH_RESILIENCE)' \
-		--validation-cmd 'python _validate.py --output' \
+		--validation-cmd 'python3 _validate.py --output' \
 		--output 'received.txt' \
 		--batch-size 10 \
 		--workers 2 \
@@ -157,7 +157,7 @@ multi_partition_detector_test_python_gen_source:
 	integration_test \
 		--log-level $(LOGLEVEL) \
 		--command 'machida --application-module multi_partition_detector --source gensource $(RUN_WITH_RESILIENCE)' \
-		--validation-cmd 'python _validate.py --output' \
+		--validation-cmd 'python3 _validate.py --output' \
 		--output 'received.txt' \
 		--batch-size 10 \
 		--workers 2 \
@@ -179,7 +179,7 @@ multi_partition_detector_test_python_10_worker:
 		--sequence-sender '(0,1000]' Detector '>I' key_9 \
 		--log-level $(LOGLEVEL) \
 		--command 'machida --application-module multi_partition_detector $(RUN_WITH_RESILIENCE)' \
-		--validation-cmd 'python _validate.py --output' \
+		--validation-cmd 'python3 _validate.py --output' \
 		--output 'received.txt' \
 		--batch-size 10 \
 		--workers 10 \
@@ -190,7 +190,7 @@ multi_partition_detector_test_python_gen_source_10_worker:
 	integration_test \
 		--log-level $(LOGLEVEL) \
 		--command 'machida --application-module multi_partition_detector --source gensource $(RUN_WITH_RESILIENCE)' \
-		--validation-cmd 'python _validate.py --output' \
+		--validation-cmd 'python3 _validate.py --output' \
 		--output 'received.txt' \
 		--batch-size 10 \
 		--workers 10 \
@@ -207,7 +207,7 @@ multi_partition_detector_test_python3_alo:
 		--alo-sequence-sender key_1 '(100,200]' Detector \
 		--log-level $(LOGLEVEL) \
 		--command 'machida3 --application-module multi_partition_detector --source alo $(RUN_WITH_RESILIENCE)' \
-		--validation-cmd 'python _validate.py --output' \
+		--validation-cmd 'python3 _validate.py --output' \
 		--output 'received.txt' \
 		--batch-size 10 \
 		--workers 2 \
@@ -239,7 +239,7 @@ multi_partition_detector_test_python3_alo_10_worker:
 		--alo-sequence-sender key_9 '(100,200]' Detector \
 		--log-level $(LOGLEVEL) \
 		--command 'machida3 --application-module multi_partition_detector --source alo $(RUN_WITH_RESILIENCE)' \
-		--validation-cmd 'python _validate.py --output' \
+		--validation-cmd 'python3 _validate.py --output' \
 		--output 'received.txt' \
 		--batch-size 10 \
 		--workers 2 \
@@ -261,7 +261,7 @@ multi_partition_detector_test_python3:
 		--sequence-sender '(0,100]' Detector '>I' key_1 \
 		--log-level $(LOGLEVEL) \
 		--command 'machida3 --application-module multi_partition_detector $(RUN_WITH_RESILIENCE)' \
-		--validation-cmd 'python _validate.py --output' \
+		--validation-cmd 'python3 _validate.py --output' \
 		--output 'received.txt' \
 		--batch-size 10 \
 		--workers 2 \
@@ -272,7 +272,7 @@ multi_partition_detector_test_python3_gen_source:
 	integration_test \
 		--log-level $(LOGLEVEL) \
 		--command 'machida3 --application-module multi_partition_detector --source gensource $(RUN_WITH_RESILIENCE)' \
-		--validation-cmd 'python _validate.py --output' \
+		--validation-cmd 'python3 _validate.py --output' \
 		--output 'received.txt' \
 		--batch-size 10 \
 		--workers 2 \
@@ -294,7 +294,7 @@ multi_partition_detector_test_python3_10_worker:
 		--sequence-sender '(0,1000]' Detector '>I' key_9 \
 		--log-level $(LOGLEVEL) \
 		--command 'machida3 --application-module multi_partition_detector $(RUN_WITH_RESILIENCE)' \
-		--validation-cmd 'python _validate.py --output' \
+		--validation-cmd 'python3 _validate.py --output' \
 		--output 'received.txt' \
 		--batch-size 10 \
 		--workers 10 \
@@ -305,7 +305,7 @@ multi_partition_detector_test_python3_gen_source_10_worker:
 	integration_test \
 		--log-level $(LOGLEVEL) \
 		--command 'machida3 --application-module multi_partition_detector --source gensource $(RUN_WITH_RESILIENCE)' \
-		--validation-cmd 'python _validate.py --output' \
+		--validation-cmd 'python3 _validate.py --output' \
 		--output 'received.txt' \
 		--batch-size 10 \
 		--workers 10 \
@@ -322,7 +322,7 @@ multi_partition_alo_source_test_pony:
 		--alo-sequence-sender key_1 '(100,200]' Detector \
 		--log-level $(LOGLEVEL) \
 		--command './multi_partition_detector --source alo $(RUN_WITH_RESILIENCE)' \
-		--validation-cmd 'python _validate.py --output' \
+		--validation-cmd 'python3 _validate.py --output' \
 		--output 'received.txt' \
 		--batch-size 10 \
 		--workers 2 \
@@ -336,7 +336,7 @@ multi_partition_detector_test_pony:
 		--sequence-sender '(0,100]' Detector '>I' key_1 \
 		--log-level $(LOGLEVEL) \
 		--command './multi_partition_detector $(RUN_WITH_RESILIENCE)' \
-		--validation-cmd 'python _validate.py --output' \
+		--validation-cmd 'python3 _validate.py --output' \
 		--output 'received.txt' \
 		--batch-size 10 \
 		--workers 2 \
@@ -348,7 +348,7 @@ multi_partition_detector_test_pony_gen_source:
 	integration_test \
 		--log-level $(LOGLEVEL) \
 		--command './multi_partition_detector --source gensource $(RUN_WITH_RESILIENCE)' \
-		--validation-cmd 'python _validate.py --output' \
+		--validation-cmd 'python3 _validate.py --output' \
 		--output 'received.txt' \
 		--batch-size 10 \
 		--workers 2 \
@@ -380,7 +380,7 @@ multi_partition_alo_source_test_pony_10_worker:
 		--alo-sequence-sender key_9 '(100,200]' Detector \
 		--log-level $(LOGLEVEL) \
 		--command './multi_partition_detector --source alo $(RUN_WITH_RESILIENCE)' \
-		--validation-cmd 'python _validate.py --output' \
+		--validation-cmd 'python3 _validate.py --output' \
 		--output 'received.txt' \
 		--batch-size 10 \
 		--workers 10 \
@@ -410,7 +410,7 @@ multi_partition_detector_test_pony_10_worker:
 		--sequence-sender '(0,1000]' Detector '>I' key_9 \
 		--log-level $(LOGLEVEL) \
 		--command './multi_partition_detector $(RUN_WITH_RESILIENCE)' \
-		--validation-cmd 'python _validate.py --output' \
+		--validation-cmd 'python3 _validate.py --output' \
 		--output 'received.txt' \
 		--batch-size 10 \
 		--workers 10 \
@@ -421,7 +421,7 @@ multi_partition_detector_test_pony_gen_source_10_worker:
 	integration_test \
 		--log-level $(LOGLEVEL) \
 		--command './multi_partition_detector --source gensource $(RUN_WITH_RESILIENCE)' \
-		--validation-cmd 'python _validate.py --output' \
+		--validation-cmd 'python3 _validate.py --output' \
 		--output 'received.txt' \
 		--batch-size 10 \
 		--workers 10 \

--- a/testing/correctness/apps/multi_partition_detector/_validate.py
+++ b/testing/correctness/apps/multi_partition_detector/_validate.py
@@ -24,12 +24,6 @@ class OrderError(Exception):
     pass
 
 
-def validate_window(window):
-    assert(win == sorted(win)), ("Out of order violation for key: {}, "
-                                 "w_key: {}, window: {}, sorted: {}"
-                                 .format(k, w_key, window, sorted(window)))
-
-
 def validate_stream(stream):
     # rules
     # 1. increments are either +1 or +n, n>1
@@ -120,7 +114,9 @@ sequences = {}
 for fname, data in sink_data.items():
     for k in data.keys():
         for ts, win in data[k]:
-            validate_window(win)
+            assert(win == sorted(win)), ("Out of order violation for key: {}, "
+                                         "ts: {}, window: {}, sorted: {}"
+                                         .format(k, ts, win, sorted(win)))
             sequences.setdefault(k, {}).setdefault(fname, []).append(win[-1])
 
 # TODO:

--- a/testing/correctness/tests/autoscale/autoscale_tests.py
+++ b/testing/correctness/tests/autoscale/autoscale_tests.py
@@ -35,7 +35,7 @@ CMD_PONY = 'multi_partition_detector --depth 1'
 CMD_PYTHON = 'machida --application-module multi_partition_detector --depth 1'
 CMD_PYTHON3 = 'machida3 --application-module multi_partition_detector --depth 1'
 
-VALIDATION_CMD = 'python ../../apps/multi_partition_detector/_validate.py --output {out_file}'
+VALIDATION_CMD = 'python3 ../../apps/multi_partition_detector/_validate.py --output {out_file}'
 
 APIS = {'pony': CMD_PONY, 'python2': CMD_PYTHON, 'python3': CMD_PYTHON3}
 

--- a/testing/correctness/tests/resilience/resilience_tests.py
+++ b/testing/correctness/tests/resilience/resilience_tests.py
@@ -34,25 +34,25 @@ APIS = {
     'pony': [
         {'app': 'multi_partition_detector',
          'cmd': 'multi_partition_detector --depth 1 --run-with-resilience',
-         'validation_cmd': 'python ../../apps/multi_partition_detector/_validate.py --output {out_file}'}],
+         'validation_cmd': 'python3 ../../apps/multi_partition_detector/_validate.py --output {out_file}'}],
     'python2': [
         {'app': 'multi_partition_detector',
          'cmd': 'machida --application-module multi_partition_detector --depth 1 --run-with-resilience',
-         'validation_cmd': 'python ../../apps/multi_partition_detector/_validate.py --output {out_file}'},
+         'validation_cmd': 'python3 ../../apps/multi_partition_detector/_validate.py --output {out_file}'},
         # {'app': 'window_detector_tumbling',
         #  'cmd': 'machida --application-module window_detector --window-type tumbling --window-delay 100 --run-with-resilience',
-        #  'validation_cmd': 'python ../../apps/window_detector/_validate.py --window-type tumbling --output {out_file}'},
+        #  'validation_cmd': 'python3 ../../apps/window_detector/_validate.py --window-type tumbling --output {out_file}'},
         # {'app': 'window_detector_counting',
         #  'cmd': 'machida --application-module window_detector --window-type counting --run-with-resilience',
-        #  'validation_cmd': 'python ../../apps/window_detector/_validate.py --window-type counting --output {out_file}'},
+        #  'validation_cmd': 'python3 ../../apps/window_detector/_validate.py --window-type counting --output {out_file}'},
         # {'app': 'window_detector_sliding',
         #  'cmd': 'machida --application-module window_detector --window-type sliding --window-delay 100 --run-with-resilience',
-        #  'validation_cmd': 'python ../../apps/window_detector/_validate.py --window-type sliding --output {out_file}'}
+        #  'validation_cmd': 'python3 ../../apps/window_detector/_validate.py --window-type sliding --output {out_file}'}
     ],
     'python3': [
         {'app': 'multi_partition_detector',
          'cmd': 'machida3 --application-module multi_partition_detector --depth 1 --run-with-resilience',
-         'validation_cmd': 'python ../../apps/multi_partition_detector/_validate.py --output {out_file}'},
+         'validation_cmd': 'python3 ../../apps/multi_partition_detector/_validate.py --output {out_file}'},
         # {'app': 'window_detector_tumbling',
         #  'cmd': 'machida3 --application-module window_detector --window-type tumbling --window-delay 100 --run-with-resilience',
         #  'validation_cmd': 'python3 ../../apps/window_detector/_validate.py --window-type tumbling --output {out_file}'},

--- a/testing/tools/integration/control.py
+++ b/testing/tools/integration/control.py
@@ -265,9 +265,11 @@ class WaitForLogRotation(StoppableThread):
 
 
     def run(self):
+        logging.debug("Started WaitForLogRotation")
         while not self.stopped():
             self.notifier.start()
             self.notifier.join(self.timeout)
+            logging.debug("EvLogFileNotifier joined")
             if self.notifier.is_alive():
                 self.notifier.stop()
                 self.stop()

--- a/testing/tools/integration/integration.py
+++ b/testing/tools/integration/integration.py
@@ -29,7 +29,8 @@ from .control import (SinkAwaitValue,
 from .end_points import (ALOSender,
                          Sender,
                          Reader)
-from .external import run_shell_cmd
+from .external import (run_shell_cmd,
+                       save_logs_to_file)
 from .errors import (PipelineTestError,
                      TimeoutError)
 from .logger import INFO2
@@ -291,13 +292,12 @@ def pipeline_test(sources, expected, command, workers=1,
                                      ' '.join(res.command))
                 else:
                     outputs = runner_data_format(persistent_data.get('runner_data', []))
-                    logging.error("Application outputs:\n{}".format(outputs))
-                    logging.error("Validation command '%s' failed with the output:\n"
-                                  "--\n%s",
-                                  res.command, res.output)
+                    if outputs:
+                        logging.error("Application outputs:\n{}".format(outputs))
+                    error = ("Validation command '%s' failed with the output:\n"
+                             "--\n%s" % (res.command, res.output))
                     # Save logs to file in case of error
-                    save_logs_to_file(base_dir, log_stream, persistent_data)
-                    raise PipelineTestError
+                    raise PipelineTestError(error)
 
             else:  # compare expected to processed
                 logging.debug('Begin validation phase...')

--- a/testing/tools/integration_test
+++ b/testing/tools/integration_test
@@ -570,7 +570,8 @@ def CLI():
                     runner_join_timeout=args.runner_join_timeout,
                     resilience_dir=args.resilience_dir,
                     spikes=args.spike,
-                    persistent_data = persistent_data)
+                    persistent_data = persistent_data,
+                    log_error = False)
                 # Test run was successful, break out of loop and proceed to
                 # validation
                 logging.info("Run phase complete. Proceeding to validation.")


### PR DESCRIPTION
- Replace python inotify with python watchdog for log rotation tests
- Watchdog is compatible with linux, macos, and windows. inotify is only compatible with linux.
- Update ci docker image
- Update circleci config version from 2.0 to 2.1
- Add use of reusable executor in circleci config to make future docker image updates easier (only need to update one line instead of several)

closes #2893 