### PR TITLE
Propagate the `Key` type further down into the rest of Wallaroo

### DIFF
--- a/lib/wallaroo/core/initialization/local_topology.pony
+++ b/lib/wallaroo/core/initialization/local_topology.pony
@@ -451,7 +451,7 @@ actor LocalTopologyInitializer is LayoutInitializer
         _save_worker_names()
 
         // Determine if we need to read in local keys for our state collections
-        let local_keys: Map[RoutingId, StringSet val] val =
+        let local_keys: Map[RoutingId, KeySet val] val =
           if _is_recovering then
             @printf[I32]("Reading local keys from file.\n".cstring())
             try
@@ -459,12 +459,12 @@ actor LocalTopologyInitializer is LayoutInitializer
                 checkpoint_target as CheckpointId)
             else
               Fail()
-              recover val Map[RoutingId, StringSet val] end
+              recover val Map[RoutingId, KeySet val] end
             end
           else
             // We don't have any local keys yet since this is our initial
             // startup.
-            recover iso Map[RoutingId, StringSet val] end
+            recover iso Map[RoutingId, KeySet val] end
           end
 
         if t.is_empty() then

--- a/lib/wallaroo/core/keys/local_keys_file.pony
+++ b/lib/wallaroo/core/keys/local_keys_file.pony
@@ -78,9 +78,9 @@ class LocalKeysFile
     _file.writev(_writer.done())
 
   fun ref read_local_keys(checkpoint_id: CheckpointId):
-    Map[RoutingId, StringSet val] val
+    Map[RoutingId, KeySet val] val
   =>
-    let lks = Map[RoutingId, StringSet]
+    let lks = Map[RoutingId, KeySet]
     let r = Reader
     _file.seek_start(0)
     if _file.size() > 0 then
@@ -111,7 +111,7 @@ class LocalKeysFile
 
             match cmd
             | LocalKeysFileCommand.add() =>
-              lks.insert_if_absent(step_group, StringSet)?.set(key)
+              lks.insert_if_absent(step_group, KeySet)?.set(key)
             | LocalKeysFileCommand.remove() =>
               if lks.contains(step_group) then
                 try
@@ -138,9 +138,9 @@ class LocalKeysFile
     end
     @printf[I32]("Finished reading local keys\n".cstring())
 
-    let lks_iso = recover iso Map[RoutingId, StringSet val] end
+    let lks_iso = recover iso Map[RoutingId, KeySet val] end
     for (r_id, keys) in lks.pairs() do
-      let ks = recover iso StringSet end
+      let ks = recover iso KeySet end
       for k in keys.values() do
         ks.set(k)
       end

--- a/lib/wallaroo/core/router_registry/router_registry.pony
+++ b/lib/wallaroo/core/router_registry/router_registry.pony
@@ -71,7 +71,7 @@ actor RouterRegistry is (KeyRegistry & WorldStopperAndResumer)
   let _checkpoint_initiator: CheckpointInitiator
   let _autoscale_initiator: AutoscaleInitiator
   var _data_router: DataRouter
-  var _local_keys: Map[RoutingId, StringSet] = _local_keys.create()
+  var _local_keys: Map[RoutingId, KeySet] = _local_keys.create()
   let _partition_routers: Map[RoutingId, StatePartitionRouter] =
     _partition_routers.create()
   let _stateless_partition_routers: Map[RoutingId, StatelessPartitionRouter] =
@@ -107,7 +107,7 @@ actor RouterRegistry is (KeyRegistry & WorldStopperAndResumer)
   // route outputs to a stateless partition. Map is from partition id to
   // state name of state steps that need to know.
   let _stateless_partition_routers_router_subs:
-    Map[U128, StringSet] =
+    Map[U128, KeySet] =
     _stateless_partition_routers_router_subs.create()
   //
   ////////////////
@@ -139,7 +139,7 @@ actor RouterRegistry is (KeyRegistry & WorldStopperAndResumer)
 
   // TODO: Add management of pending keys to Autoscale protocol class
   // Keys migrated out and waiting for acknowledgement
-  let _key_waiting_list: StringSet = _key_waiting_list.create()
+  let _key_waiting_list: KeySet = _key_waiting_list.create()
 
   // TODO: Add management of pending source listeners to Autoscale protocol
   // class
@@ -259,7 +259,7 @@ actor RouterRegistry is (KeyRegistry & WorldStopperAndResumer)
   =>
     _partition_routers(step_group) = pr
     if not _local_keys.contains(step_group) then
-      _local_keys(step_group) = StringSet
+      _local_keys(step_group) = KeySet
     end
 
   be set_stateless_partition_router(partition_id: U128,
@@ -476,7 +476,7 @@ actor RouterRegistry is (KeyRegistry & WorldStopperAndResumer)
   =>
     try
       if not _local_keys.contains(step_group) then
-        _local_keys(step_group) = StringSet
+        _local_keys(step_group) = KeySet
       end
       _local_keys(step_group)?.set(key)
       (_local_topology_initializer as LocalTopologyInitializer)
@@ -494,7 +494,7 @@ actor RouterRegistry is (KeyRegistry & WorldStopperAndResumer)
     checkpoint_id: (CheckpointId | None) = None)
   =>
     try
-      _local_keys.insert_if_absent(step_group, StringSet)?
+      _local_keys.insert_if_absent(step_group, KeySet)?
       _local_keys(step_group)?.unset(key)
       (_local_topology_initializer as LocalTopologyInitializer)
         .unregister_key(step_group, key, checkpoint_id)
@@ -821,12 +821,12 @@ actor RouterRegistry is (KeyRegistry & WorldStopperAndResumer)
   /////////////////////////////////////////////////////////////////////////////
   // ROLLBACK
   /////////////////////////////////////////////////////////////////////////////
-  be rollback_keys(r_keys: Map[RoutingId, StringSet val] val,
+  be rollback_keys(r_keys: Map[RoutingId, KeySet val] val,
     promise: Promise[None])
   =>
-    let new_keys = Map[RoutingId, StringSet]
+    let new_keys = Map[RoutingId, KeySet]
     for (step_group, keys) in r_keys.pairs() do
-      let ks = StringSet
+      let ks = KeySet
       for k in keys.values() do
         ks.set(k)
       end

--- a/lib/wallaroo/core/source/connector_source/connector_framed_source_notify.pony
+++ b/lib/wallaroo/core/source/connector_source/connector_framed_source_notify.pony
@@ -458,23 +458,17 @@ class ConnectorSourceNotify[In: Any val]
                 end
 
                 // get message key
-                let key_string =
+                let key =
                   match m.key
-                  | None =>
+                  | let k: Key =>
+                    k
+                  else
                     ""
-                  | let str: String val =>
-                    str
-                  | let a: Array[U8] val =>
-                    let k' = recover trn String(a.size()) end
-                    for c in a.values() do
-                      k'.push(c)
-                    end
-                    consume k'
                   end
 
                 // process message
                 return _run_and_subsequent_activity(latest_metrics_id, ingest_ts,
-                  pipeline_time_spent, key_string, source, decoded, s,
+                  pipeline_time_spent, key, source, decoded, s,
                   m.message_id, m.flags)
               else
                 // _handler.decode(bytes) failed
@@ -522,7 +516,7 @@ class ConnectorSourceNotify[In: Any val]
   fun ref _run_and_subsequent_activity(latest_metrics_id: U16,
     ingest_ts: U64,
     pipeline_time_spent: U64,
-    key_string: String val,
+    key: Key,
     source: ConnectorSource[In] ref,
     decoded: (In val| None val),
     s: _StreamState,
@@ -542,8 +536,8 @@ class ConnectorSourceNotify[In: Any val]
     // needs a way to provide the Kafka key here.
 
     let initial_key =
-      if key_string isnt None then
-        key_string
+      if key isnt None then
+        key
       else
         // TODO [post-source-migration] should this be stream_id for messages
         // that do not provide a key?

--- a/lib/wallaroo/core/topology/router.pony
+++ b/lib/wallaroo/core/topology/router.pony
@@ -562,7 +562,7 @@ class val StatePartitionRouter is Router
       else
         ifdef debug then
           @printf[I32](("StatePartitionRouter.route: No state step for " +
-            "key '%s'\n\n").cstring(), key.string().cstring())
+            "key '%s'\n\n").cstring(), HashableKey.string(key).cstring())
         end
         Fail()
         (false, latest_ts)
@@ -867,7 +867,8 @@ class val StatePartitionRouter is Router
         step.send_state(boundary, _step_group, key, checkpoint_id)
         @printf[I32](
           "^^Migrating key %s to outgoing boundary %s/%lx\n"
-            .cstring(), HashableKey.string(key).cstring(), target_worker.cstring(), boundary)
+            .cstring(), HashableKey.string(key).cstring(),
+            target_worker.cstring(), boundary)
       end
       true
     else

--- a/lib/wallaroo/core/topology/router.pony
+++ b/lib/wallaroo/core/topology/router.pony
@@ -537,7 +537,7 @@ class val StatePartitionRouter is Router
         _hash_partitions.get_claimant_by_key(key)?
       else
         @printf[I32](("Could not find claimant for key " +
-          " '%s'\n\n").cstring(), key.string().cstring())
+          " '%s'\n\n").cstring(), HashableKey.string(key).cstring())
         Fail()
         return (true, latest_ts)
       end
@@ -704,7 +704,7 @@ class val StatePartitionRouter is Router
   fun val rebalance_steps_grow(auth: AmbientAuth,
     target_workers: Array[(String, OutgoingBoundary)] val,
     router_registry: RouterRegistry ref,
-    local_keys: StringSet,
+    local_keys: KeySet,
     checkpoint_id: CheckpointId): (StatePartitionRouter, Bool)
   =>
     """
@@ -791,7 +791,7 @@ class val StatePartitionRouter is Router
     target_workers: Array[(String, OutgoingBoundary)] val,
     leaving_workers: Array[String] val,
     router_registry: RouterRegistry ref,
-    local_keys: StringSet,
+    local_keys: KeySet,
     checkpoint_id: CheckpointId): Bool
   =>
     // If we're using local routing, then there is nothing to migrate.
@@ -867,7 +867,7 @@ class val StatePartitionRouter is Router
         step.send_state(boundary, _step_group, key, checkpoint_id)
         @printf[I32](
           "^^Migrating key %s to outgoing boundary %s/%lx\n"
-            .cstring(), key.cstring(), target_worker.cstring(), boundary)
+            .cstring(), HashableKey.string(key).cstring(), target_worker.cstring(), boundary)
       end
       true
     else

--- a/lib/wallaroo/core/topology/runner.pony
+++ b/lib/wallaroo/core/topology/runner.pony
@@ -556,7 +556,7 @@ class StateRunner[In: Any val, Out: Any val, S: State ref] is (Runner &
         let state_wrapper = _state_initializer.decode(_rb, _auth)?
         ifdef "checkpoint_trace" then
           @printf[I32]("Successfully imported key %s\n".cstring(),
-            key.string().cstring())
+            HashableKey.string(key).cstring())
         end
         _state_map(key) = state_wrapper
         step.register_key(s_group, key)
@@ -598,7 +598,8 @@ class StateRunner[In: Any val, Out: Any val, S: State ref] is (Runner &
             Fail()
           end
         end
-        @printf[I32]("SERIALIZING KEY %s\n".cstring(), HashableKey.string(k).cstring())
+        @printf[I32]("SERIALIZING KEY %s\n".cstring(),
+          HashableKey.string(k).cstring())
       end
 
       let key_size = k.size()

--- a/lib/wallaroo_labs/collection_helpers/collections_helpers.pony
+++ b/lib/wallaroo_labs/collection_helpers/collections_helpers.pony
@@ -17,6 +17,8 @@ Copyright 2017 The Wallaroo Authors.
 */
 
 use "collections"
+use "wallaroo/core/common"
+use "wallaroo_labs/mort"
 
 primitive SetHelpers[V]
   fun forall(s: SetIs[V] box, pred: {(box->V!): Bool}): Bool =>
@@ -77,3 +79,17 @@ primitive ArrayHelpers[V]
       return false
     end
     true
+
+primitive HashableKey
+  fun hash(k: box->Key!): USize =>
+    @ponyint_hash_block[USize](k.cpointer(0), k.size())
+
+  fun eq(x: box->Key!, y: box->Key!): Bool =>
+    if x.size() != y.size() then
+      false
+    else
+      @memcmp[I32](x.cpointer(0), y.cpointer(0), x.size()) == 0
+    end
+
+  fun string(k: Key): String =>
+    k

--- a/lib/wallaroo_labs/messages/external_messages.pony
+++ b/lib/wallaroo_labs/messages/external_messages.pony
@@ -166,7 +166,7 @@ primitive ExternalMsgEncoder
     _encode(_StateEntityQuery(), "", wb)
 
   fun state_entity_query_response(
-    local_keys: Map[RoutingId, StringSet],
+    local_keys: Map[RoutingId, KeySet],
     wb: Writer = Writer): Array[ByteSeq] val
   =>
     let digest_map = _state_entity_digest(local_keys)
@@ -196,7 +196,7 @@ primitive ExternalMsgEncoder
     _encode(_StateEntityCountQuery(), "", wb)
 
   fun state_entity_count_query_response(
-    local_keys: Map[U128, StringSet],
+    local_keys: Map[U128, KeySet],
     wb: Writer = Writer): Array[ByteSeq] val
   =>
     let digest_map = _state_entity_digest(local_keys)
@@ -243,8 +243,8 @@ primitive ExternalMsgEncoder
     digest_map("stateless_partitions") = consume stateless_ps
     consume digest_map
 
-  fun _state_entity_digest(local_keys: Map[RoutingId, StringSet]):
-    Map[String, Array[String] val] val
+  fun _state_entity_digest(local_keys: Map[RoutingId, KeySet]):
+    Map[String, Array[Key] val] val
   =>
     let state_ps = recover trn Map[String, Array[Key] val] end
 

--- a/lib/wallaroo_labs/query/_test.pony
+++ b/lib/wallaroo_labs/query/_test.pony
@@ -22,6 +22,7 @@ use "debug"
 use "itertools"
 use "json"
 use "ponytest"
+use "wallaroo/core/common"
 
 actor Main is TestList
   new create(env: Env) => PonyTest(env, this)
@@ -48,9 +49,9 @@ class iso _TestStateEntityEncode is UnitTest
   fun name(): String => "query_json/test_state_entity_encode"
 
   fun apply(h: TestHelper) ? =>
-    let source_ids_a: Array[String] val = ["a";"b";"c"]
-    let source_ids_b: Array[String] val = ["x";"y";"z"]
-    let e = recover trn Map[String, Array[String] val] end
+    let source_ids_a: Array[Key] val = ["a";"b";"c"]
+    let source_ids_b: Array[Key] val = ["x";"y";"z"]
+    let e = recover trn Map[String, Array[Key] val] end
     e.update("worker_a", source_ids_a)
     e.update("worker_b", source_ids_b)
     let encoded = StateEntityQueryEncoder.state_entity_keys(consume e)
@@ -95,7 +96,7 @@ class iso _TestEncodeDecodeClusterStatus is UnitTest
     end
 
 primitive _AssertJsonArrayEq
-  fun apply(h: TestHelper, json_arr: JsonArray, arr: Array[String] val) ? =>
+  fun apply(h: TestHelper, json_arr: JsonArray, arr: Array[Key] val) ? =>
     for i in Range(0, json_arr.data.size()) do
       h.assert_eq[String](json_arr.data(i)? as String, arr(i)?)
     end

--- a/lib/wallaroo_labs/string_set/string_set.pony
+++ b/lib/wallaroo_labs/string_set/string_set.pony
@@ -17,6 +17,8 @@ Copyright 2017 The Wallaroo Authors.
 */
 
 use "collections"
+use "wallaroo/core/common"
+use "wallaroo_labs/collection_helpers"
 
 /////////////////////////////////////////////////////////////////////////////
 // TODO: Replace using this with the badly named SetIs once we address a bug
@@ -41,5 +43,28 @@ class StringSet
 
   fun values(): MapValues[String, String, HashEq[String],
     this->HashMap[String, String, HashEq[String]]]^
+  =>
+    _map.values()
+
+class KeySet
+  let _map: HashMap[Key, Key, HashableKey] = _map.create()
+
+  fun ref set(s: Key) =>
+    _map(s) = s
+
+  fun ref unset(s: Key) =>
+    try _map.remove(s)? end
+
+  fun contains(s: Key): Bool =>
+    _map.contains(s)
+
+  fun ref clear() =>
+    _map.clear()
+
+  fun size(): USize =>
+    _map.size()
+
+  fun values(): MapValues[Key, Key, HashableKey,
+    this->HashMap[Key, Key, HashableKey]]^
   =>
     _map.values()


### PR DESCRIPTION
This PR changes the `String` type in a lot of places to the more correct `Key`, if/when that type changes.  (For example, I have an experimental branch that changes `Key` to be `Array[U8]`.)  It also introduces the `KeySet` type for sets of `Key`s.