### PR TITLE
Declarative Conformance Testing API - #2894

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,6 +221,30 @@ jobs:
       - store_artifacts:
           path: /tmp/wallaroo_test_errors
 
+  conformance-tests:
+    executor: wallaroo-ci
+    steps:
+      - checkout
+      - run: .circleci/clone_tracker.sh
+      - run: |
+          ulimit -c unlimited
+          ulimit -a
+          make integration-tests-testing-conformance debug=true
+      - store_artifacts:
+          path: /tmp/wallaroo_test_errors
+
+  conformance-tests-with-resilience:
+    executor: wallaroo-ci
+    steps:
+      - checkout
+      - run: .circleci/clone_tracker.sh
+      - run: |
+          ulimit -c unlimited
+          ulimit -a
+          make integration-tests-testing-conformance debug=true resilience=on
+      - store_artifacts:
+          path: /tmp/wallaroo_test_errors
+
 workflows:
   version: 2
   test:
@@ -330,6 +354,20 @@ workflows:
             - integration-tests-testing-correctness-apps-with-resilience
 
       - topology-tests-python3-with-resilience:
+          requires:
+            - integration-tests
+            - integration-tests-testing-correctness-apps
+            - integration-tests-with-resilience
+            - integration-tests-testing-correctness-apps-with-resilience
+
+      - conformance-tests:
+          requires:
+            - integration-tests
+            - integration-tests-testing-correctness-apps
+            - integration-tests-with-resilience
+            - integration-tests-testing-correctness-apps-with-resilience
+
+      - conformance-tests-with-resilience:
           requires:
             - integration-tests
             - integration-tests-testing-correctness-apps

--- a/testing/conformance/Makefile
+++ b/testing/conformance/Makefile
@@ -1,0 +1,58 @@
+# include root makefile
+ifndef ROOT_MAKEFILE_MK
+include ../../Makefile
+endif
+
+# prevent rules from being evaluated/included multiple times
+ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
+$(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
+
+
+# The following are control variables that determine what logic from `rules.mk` is enabled
+
+# `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
+# applies to both the pony and elixir test targets
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
+
+# `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
+# otherwise targets only get created if there are pony sources (*.pony) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+
+# `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
+# it can be overridden manually
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+
+# `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
+# otherwise targets only get created if there are elixir sources (*.exs) in this directory.
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+
+# `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
+# otherwise targets only get created if there is a Dockerfile in this directory
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+
+# `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
+# (and by recursion every makefile in the tree that is referenced)
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+
+
+CONFORMANCE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+conformance_tests : CUSTOM_PATH = $(MULTI_PARTITION_DETECTOR_PATH):$(MULTI_PART_VALIDATOR_PATH):$(CLUSTER_SHRINKER_PATH):$(WINDOW_DETECTOR_PATH)
+conformance_tests : CUSTOM_PYTHONPATH = $(MULTI_PARTITION_DETECTOR_PATH):$(WINDOW_DETECTOR_PATH)
+
+# standard rules generation makefile
+include $(rules_mk_path)
+
+build-testing-conformance: build-testing-correctness-apps-multi_partition_detector
+build-testing-conformance: build-testing-correctness-apps-window_detector
+build-testing-conformance: build-utils-cluster_shrinker
+build-testing-conformance: build-machida
+build-testing-conformance: build-machida3
+integration-tests-testing-conformance: build-testing-conformance
+integration-tests-testing-conformance: conformance_tests
+
+conformance_tests:
+	cd $(CONFORMANCE_PATH) && \
+	python3 -m pytest -c $(integration_path)/pytest.ini tests/*.py $(pytest_exp)
+
+# end of prevent rules from being evaluated/included multiple times
+endif

--- a/testing/conformance/conformance/__init__.py
+++ b/testing/conformance/conformance/__init__.py
@@ -1,0 +1,24 @@
+# Copyright 2019 The Wallaroo Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+
+# Add integration and  wallaroo libs to import path
+import sys
+import os
+cwd = os.getcwd()
+root = cwd.rsplit("/testing/conformance")[0]
+testing_tools  = os.path.join(root, "testing", "tools")
+wallaroo_lib = os.path.join(root, "machida", "lib")
+sys.path.append(testing_tools)
+sys.path.append(wallaroo_lib)

--- a/testing/conformance/conformance/applications.py
+++ b/testing/conformance/conformance/applications.py
@@ -23,14 +23,21 @@ class WindowDetector(Application):
     name = 'WindowDetector'
     command = 'window_detector'
 
-    def __init__(self, config=base_window_policy):
+    def __init__(self, config={}):
         super().__init__()
         self.sources = ['Detector']
-        self.config = config
+        self.config = base_window_policy.copy()
+        self.config.update(config)
+        logging.info("Running {!r} with config {!r}".format(
+            self.__class__.name, self.config))
+
+    # Provide a function for iter_generator to use to serialise each item
+    def serialise_input(self, v):
+        return json.dumps(v).encode()
 
     def parse_output(self, bs):
         logging.debug('parse_output: {}'.format(repr(bs)))
-        return json.loads(bs[4:])['value']
+        return json.loads(bs[4:].decode())['value']
 
     def collect(self):
         data = super().collect(None) # {'0': [...]}

--- a/testing/conformance/conformance/applications.py
+++ b/testing/conformance/conformance/applications.py
@@ -1,0 +1,46 @@
+# Copyright 2019 The Wallaroo Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+from .base import Application
+from .configurations import base_window_policy
+
+
+class WindowDetector(Application):
+    name = 'WindowDetector'
+    command = 'window_detector'
+
+    def __init__(self, config=base_window_policy):
+        super().__init__()
+        self.sources = ['Detector']
+        self.config = config
+
+
+class WindowDetectorPython3(Application):
+    name = 'WindowDetector'
+    command = 'machida3 --application-module window_detector'
+
+    def __init__(self, config=base_window_policy):
+        super().__init__()
+        self.sources = ['Detector']
+        self.config = config
+
+
+class MultiPartitionDetector(Application):
+    name = 'MultiPartitionDetector'
+    command = 'multi_partition_detector'
+
+    def __init__(self, config=base_window_policy):
+        super().__init__()
+        self.sources = ['Detector']
+        self.config = config

--- a/testing/conformance/conformance/applications.py
+++ b/testing/conformance/conformance/applications.py
@@ -12,6 +12,9 @@
 #  implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 
+import json
+import logging
+
 from .base import Application
 from .configurations import base_window_policy
 
@@ -24,6 +27,16 @@ class WindowDetector(Application):
         super().__init__()
         self.sources = ['Detector']
         self.config = config
+
+    def parse_output(self, bs):
+        logging.debug('parse_output: {}'.format(repr(bs)))
+        return json.loads(bs[4:])['value']
+
+    def collect(self):
+        data = super().collect(None) # {'0': [...]}
+        output = [self.parse_output(v) for v in data[0]]
+
+        return output
 
 
 class WindowDetectorPython3(Application):

--- a/testing/conformance/conformance/base.py
+++ b/testing/conformance/conformance/base.py
@@ -1,0 +1,135 @@
+# Copyright 2019 The Wallaroo Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+
+import datetime
+import logging
+import os
+import time
+
+
+from integration.cluster import Cluster
+
+from integration.logger import (add_in_memory_log_stream,
+                                set_logging)
+
+from integration.end_points import (Reader,
+                                    Sender)
+
+from integration.external import save_logs_to_file
+
+set_logging(name="conformance")
+
+
+class TestHarnessException(Exception):
+    pass
+
+
+class Application:
+    name = 'BaseApplication'
+    command = None
+    config = {}
+    host = '127.0.0.1'
+    workers = 1
+    sources = ['Detector']
+    sinks = 1
+    sink_mode = 'framed'
+    split_streams = True
+    log_rotation = False
+
+    ##########
+    # In/Out #
+    ##########
+    def send_tcp(self, gen, src_name=None, block=True):
+        logging.debug("send_tcp")
+        sender = self.add_tcp_sender(gen, src_name)
+        if block:
+            sender.join()
+            if sender.error:
+                raise sender.error
+        logging.debug("end of send_tcp")
+        return sender
+
+    def add_tcp_sender(self, gen, src_name=None, start=True):
+        if not self.cluster:
+            raise TestHarnessException("Can't add a sender before creating "
+                    "a cluster!")
+        if src_name is None:
+            src_name = self.sources[0]
+        sender = Sender(address = self.cluster.source_addrs[0][src_name],
+                        reader = Reader(gen))
+        self.cluster.add_sender(sender, start)
+        return sender
+
+    def sink_await(self, values, timeout=30, func=lambda x: x, sink=-1):
+        if not self.cluster:
+            raise TestHarnessException("Can't sink_await before creating "
+                    "a cluster!")
+        self.cluster.sink_await(values, timeout, func, sink)
+
+    # TODO
+    #def sink_expect(self, *args, **kwargs):
+
+    def collect(self, sink=None):
+        if not self.cluster:
+            raise TestHarnessException("Can't collect before creating "
+                    "a cluster!")
+        if sink:
+            return self.cluster.sinks[sink].data
+        return self.cluster.sinks[0].data
+
+
+    ###########################
+    ## Context Manager parst ##
+    ###########################
+    def __init__(self):
+        self.log_stream = add_in_memory_log_stream(level=logging.DEBUG)
+        current_test = (os.environ.get('PYTEST_CURRENT_TEST')
+                        .rsplit(' (call)')[0])
+        cwd = os.getcwd()
+        trunc_head = cwd.find('/wallaroo/') + len('/wallaroo/')
+        t0 = datetime.datetime.now()
+        self.base_dir = os.path.join('/tmp/wallaroo_test_errors',
+            cwd[trunc_head:],
+            current_test,
+            t0.strftime('%Y%m%d_%H%M%S'))
+        self.persistent_data = {}
+
+    def __enter__(self):
+        if self.command is None:
+            raise ValueError("command cannot be None. Please initialize {}"
+                    " with a valid command argument!".format(
+                        self))
+        command = "{} {}".format(self.command,
+            " ".join(("--{} {}".format(k, v)
+                      for k, v in self.config.items())))
+        self.cluster = Cluster(command = command,
+                     host = self.host,
+                     sources = self.sources,
+                     workers = self.workers,
+                     split_streams = self.split_streams,
+                     log_rotation = self.log_rotation,
+                     persistent_data = self.persistent_data)
+        self.cluster.__enter__()
+        time.sleep(0.1)
+        return self
+
+    def __exit__(self, _type, _value, _traceback):
+        logging.debug("{}.__exit__({}, {}, {})".format(self, _type, _value,
+            _traceback))
+        self.cluster.__exit__(None, None, None) #_type, _value, _traceback)
+        if _type or _value or _traceback:
+            save_logs_to_file(self.base_dir,
+                              self.log_stream,
+                              self.persistent_data)

--- a/testing/conformance/conformance/base.py
+++ b/testing/conformance/conformance/base.py
@@ -127,6 +127,8 @@ class Application:
         command = "{} {}".format(self.command,
             " ".join(("--{} {}".format(k, v)
                       for k, v in self.config.items())))
+        if os.environ.get("resilience") == 'on':
+                command += ' --run-with-resilience'
         self.cluster = Cluster(command = command,
                      host = self.host,
                      sources = self.sources,

--- a/testing/conformance/conformance/completes_when.py
+++ b/testing/conformance/conformance/completes_when.py
@@ -12,3 +12,12 @@
 #  implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 
+
+from integration.errors import TimeoutError
+
+def data_in_sink(data, timeout=30, sink=-1):
+    def data_in_sink_func(context):
+        context.sink_await(data, timeout=timeout, func=context.parse_output,
+                           sink=sink)
+        return True
+    return data_in_sink_func

--- a/testing/conformance/conformance/completes_when.py
+++ b/testing/conformance/conformance/completes_when.py
@@ -15,9 +15,9 @@
 
 from integration.errors import TimeoutError
 
-def data_in_sink(data, timeout=30, sink=-1):
-    def data_in_sink_func(context):
+def data_in_sink_contains(data, timeout=30, sink=-1):
+    def data_in_sink_contains_func(context):
         context.sink_await(data, timeout=timeout, func=context.parse_output,
                            sink=sink)
         return True
-    return data_in_sink_func
+    return data_in_sink_contains_func

--- a/testing/conformance/conformance/configurations.py
+++ b/testing/conformance/conformance/configurations.py
@@ -1,0 +1,23 @@
+# Copyright 2019 The Wallaroo Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+base_window_policy = {
+                      'window-delay': 0,
+                      'window-policy': 'drop',
+                      'window-size': 1000,
+                      'window-slide': 0,
+                      'window-type': 'tumbling',
+                      'decoder': 'json',
+                      }
+

--- a/testing/conformance/conformance/configurations.py
+++ b/testing/conformance/conformance/configurations.py
@@ -14,7 +14,7 @@
 
 base_window_policy = {
                       'window-delay': 0,
-                      'window-policy': 'drop',
+                      'window-late-data-policy': 'drop',
                       'window-size': 1000,
                       'window-slide': 0,
                       'window-type': 'tumbling',

--- a/testing/conformance/conformance/control.py
+++ b/testing/conformance/conformance/control.py
@@ -1,0 +1,97 @@
+# Copyright 2019 The Wallaroo Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+
+from copy import deepcopy
+from functools import partial
+import logging
+import time
+import traceback
+from types import FunctionType
+import sys
+
+from integration.errors import TimeoutError
+from integration.stoppable_thread import StoppableThread
+
+
+class CompletesWhenError(Exception):
+    pass
+
+
+class CompletesWhenTimeoutError(TimeoutError):
+    pass
+
+
+def get_func_name(f):
+    """
+    Recursively look for the original function's name.
+    Works for both regular functions created with `def` as well as
+    functions created with `functools.partial`.
+    """
+    if isinstance(f, FunctionType):
+        return f.__name__
+    elif isinstance(f, partial):
+        return get_func_name(f.func)
+    raise ValueError("Can't get func_name of provided function {}".format(f))
+
+
+class CompletesWhenNotifier(StoppableThread):
+    """
+    Run a notifier loop with a query function and a check condition function
+    """
+    def __init__(self, context, test_func, timeout=30, period=1):
+        super().__init__()
+        self.context = context
+        self.test_func = test_func
+        self.test_func_name = get_func_name(test_func)
+        self.error = None
+        self.timeout = timeout
+        self.period = period
+
+    def stop(self, error=None):
+        super().stop(error)
+
+    def run(self):
+        logging.debug("Scheduling CompletesWhenNotifier")
+        started = time.time()
+        while not self.stopped():
+            res = None
+            try:
+                res = self.test_func(self.context)
+            except Exception as err:
+                self.error = err
+
+            # If result are error free, break
+            if res is True:
+                self.stop()
+                break
+
+            # Else either wait for next cycle or timeout.
+            if time.time() - started > self.timeout:
+                test_error = self.error
+                self.error = CompletesWhenTimeoutError(
+                    "CompletesWhenNotifier(context={!r}, test_func={!r}, "
+                    "timeout={!r}, period={!r}) timed out "
+                    "with result:\n\t"
+                    "{}\nAnd error:\n\t{}".format(
+                        self.context,
+                        self.test_func_name,
+                        self.timeout,
+                        self.period,
+                        res,
+                        self.error))
+                self.error.test_error = test_error
+                self.stop()
+                break
+            time.sleep(self.period)

--- a/testing/conformance/conformance/expectations.py
+++ b/testing/conformance/conformance/expectations.py
@@ -1,0 +1,17 @@
+# Copyright 2019 The Wallaroo Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+out_of_order_ts_drop = [2, 3, 4, 5]
+out_of_order_ts_firepermessage = [1, 2, 3, 4, 5]
+

--- a/testing/conformance/conformance/expectations.py
+++ b/testing/conformance/conformance/expectations.py
@@ -12,6 +12,4 @@
 #  implied. See the License for the specific language governing
 #  permissions and limitations under the License.
 
-out_of_order_ts_drop = [2, 3, 4, 5]
-out_of_order_ts_firepermessage = [1, 2, 3, 4, 5]
 

--- a/testing/conformance/conformance/inputs.py
+++ b/testing/conformance/conformance/inputs.py
@@ -1,0 +1,20 @@
+# Copyright 2019 The Wallaroo Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+
+out_of_order_ts = [{'ts': 1000, 'key': 'key', 'value': 2},
+                   {'ts': 1001, 'key': 'key', 'value': 3},
+                   {'ts': 1002, 'key': 'key', 'value': 4},
+                   {'ts':   50, 'key': 'key', 'value': 1},
+                   {'ts': 1003, 'key': 'key', 'value': 5}]

--- a/testing/conformance/conformance/integration.py
+++ b/testing/conformance/conformance/integration.py
@@ -1,0 +1,14 @@
+# Copyright 2019 The Wallaroo Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+#  implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+

--- a/testing/conformance/tests/window_policy.py
+++ b/testing/conformance/tests/window_policy.py
@@ -31,27 +31,28 @@ def parse_output(bs):
 
 def test_drop_policy():
     # Test specific configration
+    # TODO: policy is override subset rather than full policy
     policy = base_window_policy.copy()
     policy['window-policy'] = 'drop'
 
     # boiler plate test execution entry point
     with WindowDetector(config=policy) as test:
         # Create a data generator
+        # Obviated by below TODO
         gen = iter_generator(items=out_of_order_ts, to_bytes = serialise_input)
 
         # Send some data, use block=False to background senders
-        # call returns sender instance
+        # call returns sender instanceA
+        # TODO: replace with `test.send(data:iterable [, src_name, block,
+        # sender_type])`
         test.send_tcp(gen)
 
         # Specify end condition (as function over sink)
+        # TODO: replace with `test.completes_when(condition_func)`
         test.sink_await(out_of_order_ts_drop, timeout=30, func=parse_output)
 
         # Test validation logic
-        output = []
-        for fd, stream in test.collect().items():
-            # merge streams
-            for message in stream:
-                output.append(parse_output(message))
+        output = test.collect()
         assert(out_of_order_ts_drop == output), (
             "Expected {} but received {}"
             .format(out_of_order_ts_drop, output))

--- a/testing/conformance/tests/window_policy.py
+++ b/testing/conformance/tests/window_policy.py
@@ -1,0 +1,85 @@
+import json
+import logging
+import time
+
+
+# This first import is required for integration harness and wallaroo lib
+# imports to work (it does path mungling to ensure they're available)
+import conformance
+
+# Test specific imports
+from conformance.applications import WindowDetector
+from conformance.configurations import base_window_policy
+from conformance.inputs import out_of_order_ts
+from conformance.expectations import (out_of_order_ts_drop,
+                                      out_of_order_ts_firepermessage)
+
+# Get a data generator
+from integration.end_points import iter_generator
+
+
+# Provide a function for iter_generator to use to serialise each item
+def serialise_input(v):
+    return json.dumps(v).encode()
+
+
+# A function for converting byte output from sink to match expectation values
+def parse_output(bs):
+    logging.debug('parse_output: {}'.format(repr(bs)))
+    return json.loads(bs[4:])['value']
+
+
+def test_drop_policy():
+    # Test specific configration
+    policy = base_window_policy.copy()
+    policy['window-policy'] = 'drop'
+
+    # boiler plate test execution entry point
+    with WindowDetector(config=policy) as test:
+        # Create a data generator
+        gen = iter_generator(items=out_of_order_ts, to_bytes = serialise_input)
+
+        # Send some data, use block=False to background senders
+        # call returns sender instance
+        test.send_tcp(gen)
+
+        # Specify end condition (as function over sink)
+        test.sink_await(out_of_order_ts_drop, timeout=30, func=parse_output)
+
+        # Test validation logic
+        output = []
+        for fd, stream in test.collect().items():
+            # merge streams
+            for message in stream:
+                output.append(parse_output(message))
+        assert(out_of_order_ts_drop == output), (
+            "Expected {} but received {}"
+            .format(out_of_order_ts_drop, output))
+
+
+def test_firepermessage_policy():
+    # Test specific configration
+    policy = base_window_policy.copy()
+    policy['window-policy'] = 'fire-per-message'
+
+    # boiler plate test execution entry point
+    with WindowDetector(config=policy) as test:
+        # Create a data generator
+        gen = iter_generator(items=out_of_order_ts, to_bytes = serialise_input)
+
+        # Send some data, use block=False to background senders
+        # call returns sender instance
+        test.send_tcp(gen)
+
+        # Specify end condition (as function over sink)
+        test.sink_await(out_of_order_ts_drop, timeout=30, func=parse_output)
+
+        # Test validation logic
+        output = []
+        for fd, stream in test.collect().items():
+            # merge streams
+            for message in stream:
+                output.append(parse_output(message))
+        assert(out_of_order_ts_firepermessage == output), (
+            "Expected {} but received {}"
+            .format(out_of_order_ts_firepermessage, output))

--- a/testing/conformance/tests/window_policy.py
+++ b/testing/conformance/tests/window_policy.py
@@ -8,7 +8,7 @@ import conformance
 
 # Test specific imports
 from conformance.applications import WindowDetector
-from conformance.completes_when import data_in_sink
+from conformance.completes_when import data_in_sink_contains
 
 
 # input
@@ -24,16 +24,17 @@ out_of_order_ts_firepermessage = [1, 2, 3, 4, 5]
 
 
 def test_drop_policy():
-    policy = {'window-policy': 'drop'}
+    conf = {'window-late-data-policy': 'drop'}
 
     # boiler plate test execution entry point
-    with WindowDetector(config=policy) as test:
+    with WindowDetector(config=conf) as test:
         # Send some data, use block=False to background senders
         # call returns sender instanceA
         test.send(out_of_order_ts)
 
         # Specify end condition (as function over sink)
-        test.completes_when(data_in_sink(out_of_order_ts_drop), timeout=30)
+        test.completes_when(data_in_sink_contains(out_of_order_ts_drop),
+            timeout=30)
 
         # Test validation logic
         output = test.collect()
@@ -43,14 +44,16 @@ def test_drop_policy():
 
 
 def test_firepermessage_policy():
-    policy = {'window-policy': 'fire-per-message'}
+    conf = {'window-late-data-policy': 'fire-per-message'}
 
     # boiler plate test execution entry point
-    with WindowDetector(config=policy) as test:
+    with WindowDetector(config=conf) as test:
         test.send(out_of_order_ts)
 
         # Specify end condition (as function over sink)
-        test.completes_when(data_in_sink(out_of_order_ts_drop), timeout=30)
+        test.completes_when(
+            data_in_sink_contains(out_of_order_ts_firepermessage),
+            timeout=30)
 
         # Test validation logic
         output = test.collect()

--- a/testing/correctness/apps/window_detector/.gitignore
+++ b/testing/correctness/apps/window_detector/.gitignore
@@ -1,0 +1,2 @@
+window_detector
+window_detector.d

--- a/testing/correctness/apps/window_detector/Makefile
+++ b/testing/correctness/apps/window_detector/Makefile
@@ -49,11 +49,16 @@ integration-tests-testing-correctness-apps-window_detector: window_detector_test
 
 
 # single name space for testing
+window_detector_tests: window_detector_tests_pony
 window_detector_tests: window_detector_tests_python
 window_detector_tests: window_detector_tests_python3
 
 # group the tests by target API (Pony, Python, Python3)
+
 # Pony
+window_detector_tests_pony: window_detector_tumbling_test_pony
+window_detector_tests_pony: window_detector_counting_test_pony
+window_detector_tests_pony: window_detector_sliding_test_pony
 
 # Python
 window_detector_tests_python: window_detector_tumbling_test_python
@@ -80,6 +85,49 @@ window_detector_tests_python3: window_detector_sliding_alo_source_test_python3
 
 # Individual test definitions below
 #
+# Pony tests
+window_detector_tumbling_test_pony:
+	cd $(WINDOW_DETECTOR_PATH) && \
+	integration_test \
+		--sequence-sender '(0,100]' Detector '>I' key_0 \
+		--sequence-sender '(0,100]' Detector '>I' key_1 \
+		--log-level $(LOGLEVEL) \
+		--command './window_detector --window-type tumbling $(RUN_WITH_RESILIENCE)' \
+		--validation-cmd 'python _validate.py --window-type tumbling --output' \
+		--output 'received.txt' \
+		--batch-size 50 \
+		--workers 5 \
+		--sink-await-key key_0 100 \
+		--sink-await-key key_1 100
+
+window_detector_counting_test_pony:
+	cd $(WINDOW_DETECTOR_PATH) && \
+	integration_test \
+		--sequence-sender '(0,100]' Detector '>I' key_0 \
+		--sequence-sender '(0,100]' Detector '>I' key_1 \
+		--log-level $(LOGLEVEL) \
+		--command './window_detector --window-type counting $(RUN_WITH_RESILIENCE)' \
+		--validation-cmd 'python _validate.py --window-type counting --output' \
+		--output 'received.txt' \
+		--batch-size 50 \
+		--workers 5 \
+		--sink-await-key key_0 100 \
+		--sink-await-key key_1 100
+
+window_detector_sliding_test_pony:
+	cd $(WINDOW_DETECTOR_PATH) && \
+	integration_test \
+		--sequence-sender '(0,100]' Detector '>I' key_0 \
+		--sequence-sender '(0,100]' Detector '>I' key_1 \
+		--log-level $(LOGLEVEL) \
+		--command './window_detector --window-type sliding $(RUN_WITH_RESILIENCE)' \
+		--validation-cmd 'python _validate.py --window-type sliding --output' \
+		--output 'received.txt' \
+		--batch-size 50 \
+		--workers 5 \
+		--sink-await-key key_0 100 \
+		--sink-await-key key_1 100
+
 # Python tests
 window_detector_tumbling_alo_source_test_python:
 	cd $(WINDOW_DETECTOR_PATH) && \

--- a/testing/correctness/apps/window_detector/bundle.json
+++ b/testing/correctness/apps/window_detector/bundle.json
@@ -1,0 +1,7 @@
+{
+  "deps": [
+    { "type": "local",
+      "local-path": "../../../../lib/"
+    }
+  ]
+}

--- a/testing/correctness/apps/window_detector/window_detector.pony
+++ b/testing/correctness/apps/window_detector/window_detector.pony
@@ -73,7 +73,7 @@ actor Main
       let window_policy_options: Array[String] val = ["drop"
         "fire-per-message"
         "place-in-oldest-window"]
-      options.add("window-policy", "", StringArgument)
+      options.add("window-late-data-policy", "", StringArgument)
       var window_policy: WindowPolicy = Drop
       options.add("window-type", "", StringArgument)
       var window_type: WindowType = Tumbling
@@ -89,7 +89,7 @@ actor Main
 
       for option in options do
         match option
-        | ("window-policy", let arg: String) =>
+        | ("window-late-data-policy", let arg: String) =>
           if arg == "fire-per-message" then
             window_policy = FirePerMessage
           elseif arg == "place-in-oldest-window" then
@@ -128,7 +128,7 @@ actor Main
 
       // Print out options
       env.out.print("Running window_detector.pony with options:")
-      env.out.print("  --window-policy: " + window_policy.name())
+      env.out.print("  --window-late-data-policy: " + window_policy.name())
       env.out.print("  --window-type: " + window_type.name())
       env.out.print("  --window-delay: " + window_delay.string())
       env.out.print("  --window-size: " + window_size.string())

--- a/testing/correctness/apps/window_detector/window_detector.pony
+++ b/testing/correctness/apps/window_detector/window_detector.pony
@@ -1,0 +1,379 @@
+/*
+ Copyright 2019 The Wallaroo Authors.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+  implied. See the License for the specific language governing
+  permissions and limitations under the License.
+*/
+
+
+//stdlib
+use "assert"
+use "buffered"
+use "collections"
+use "json"
+use "options"
+use "serialise"
+use "time"
+
+// wallaroo/lib
+use "wallaroo"
+use "wallaroo/core/aggregations"
+use "wallaroo/core/common"
+use "wallaroo/core/sink/tcp_sink"
+use "wallaroo/core/source"
+use "wallaroo/core/source/connector_source"
+use "wallaroo/core/source/gen_source"
+use "wallaroo/core/source/tcp_source"
+use "wallaroo/core/state"
+use "wallaroo/core/topology"
+use "wallaroo/core/windows"
+
+// wallaroo/lib/wallaroo_labs
+use "wallaroo_labs/bytes"
+use "wallaroo_labs/mort"
+use "wallaroo_labs/time"
+
+
+primitive Tumbling
+primitive Counting
+primitive Sliding
+type WindowType is (Tumbling | Counting | Sliding)
+
+primitive Drop
+  fun apply(): U16 => LateDataPolicy.drop()
+primitive FirePerMessage
+  fun apply(): U16 => LateDataPolicy.fire_per_message()
+primitive PlaceInOldestWindow
+  fun apply(): U16 => LateDataPolicy.place_in_oldest_window()
+type WindowPolicy is (Drop | FirePerMessage | PlaceInOldestWindow)
+
+
+actor Main
+  new create(env: Env) =>
+
+    try
+      // Add options:
+      let options = Options(env.args, false)
+
+      let window_policy_options: Array[String] val = ["drop"
+        "fire-per-message"
+        "place-in-oldest-window"]
+      options.add("window-policy", "", StringArgument)
+      var window_policy: WindowPolicy = Drop
+      options.add("window-type", "", StringArgument)
+      var window_type: WindowType = Tumbling
+      options.add("window-delay", "", I64Argument)
+      var window_delay: USize = 0
+      options.add("window-size", "", I64Argument)
+      var window_size: USize = 50
+      options.add("window-slide", "", I64Argument)
+      var window_slide: USize = 0
+      options.add("decoder", "", StringArgument)
+      var decoder_type: String = "binary"
+      let decoder_options: Array[String] val = ["binary"; "json"]
+
+      for option in options do
+        match option
+        | ("window-policy", let arg: String) =>
+          if arg == "fire-per-message" then
+            window_policy = FirePerMessage
+          elseif arg == "place-in-oldest-window" then
+            window_policy = PlaceInOldestWindow
+          elseif arg == "drop" then
+            window_policy = Drop
+          else
+            env.err.print("Invalid window policy. Please use one of [" +
+              ", ".join(window_policy_options.values()) + "]")
+            Fail()
+          end
+        | ("window-type", let arg: String) =>
+          match arg
+          | "tumbling" => window_type = Tumbling
+          | "counting" => window_type = Counting
+          | "sliding" => window_type = Sliding
+          else
+            @printf[I32](("argument for window-type must be one of " +
+              "[tumbling, counting, sliding]\n").cstring())
+            error
+          end
+        | ("window-delay", let arg: I64) =>
+          window_delay = arg.usize()
+        | ("window-size", let arg: I64) =>
+          window_size = arg.usize()
+        | ("window_slide", let arg: I64) =>
+          window_slide = arg.usize()
+        | ("decoder", let arg: String) =>
+          if arg == "binary" then decoder_type = "binary"
+          elseif arg == "json" then decoder_type = "json"
+          else env.err.print("Invalid decoder option. Please use one of [" +
+            ", ".join(decoder_options.values()) + "]")
+          end
+        end
+      end
+
+      // Pre-construct the window step based on config option
+      let window_step = match window_type
+      | Counting =>
+         Wallaroo.count_windows(window_size)
+          .over[Message, WindowMessage, WindowState](Collect)
+      | (let arg: (Sliding | Tumbling)) =>
+        Wallaroo.range_windows(Milliseconds(window_size))
+          .with_slide(if window_slide != 0 then Milliseconds(window_slide)
+            else Milliseconds(window_size) end)
+          .with_delay(Milliseconds(window_delay))
+          .with_late_data_policy(window_policy())
+          .over[Message, WindowMessage, WindowState](Collect)
+      end
+
+      let decoder = if decoder_type == "json" then
+        JsonDecoder
+      else
+        Decoder
+      end
+
+      let pipeline = recover val
+        Wallaroo.source[Message]("Detector",
+          TCPSourceConfig[Message]
+            .from_options(decoder,
+              TCPSourceConfigCLIParser("Detector", env.args)?))
+          .key_by(ExtractKey)
+          .to[WindowMessage](window_step)
+          .to[Message](SplitAccumulated)
+          .to_sink(TCPSinkConfig[Message].from_options(Encoder,
+              TCPSinkConfigCLIParser(env.args)?(0)?))
+      end
+      Wallaroo.build_application(env, "window_detector", pipeline)
+    else
+      env.out.print("Couldn't build topology!")
+    end
+
+
+// Message
+class val Message
+  let _key: String
+  let _value: U64
+  let _ts: U64
+
+  new val create(k: String, v: U64, ts': (U64 | None) = None) =>
+    _key = k
+    _value = v
+    _ts = match ts'
+    | let t: U64 =>
+      t
+    else
+      Time.nanos()
+    end
+
+  fun ts(): U64 =>
+    _ts
+
+  fun key(): String =>
+    _key
+
+  fun value(): U64 =>
+    _value
+
+  fun string(): String =>
+    "{\"key\": \"" + _key
+     + "\", \"value\": " + _value.string()
+     + ", \"ts\": " + _ts.string()
+     + "}"
+
+// ExtractKey
+primitive ExtractKey
+  fun apply(m: Message): String => m.key()
+
+// WindowState
+class WindowState is State
+  var key: String = ""
+  let values: Array[U64]
+
+  new create(key': String = "", values': (Array[U64] ref^ | None) = None) =>
+    key = key'
+    values = match values'
+    | None =>
+      Array[U64]
+    | let v: Array[U64] ref^ =>
+      consume v
+    end
+
+  fun ref update(msg: Message) =>
+    if key == "" then
+      key = msg.key()
+    end
+    ifdef debug then
+      if key != msg.key() then
+        @printf[I32](("Illegal state update: Wrong key.\nState key is %s but" +
+          " message key is %s\n").cstring(), key.cstring(), msg.key().cstring())
+        Fail()
+      end
+    end
+    values.push(msg.value())
+
+  fun combine(other: WindowState box): WindowState =>
+    ifdef debug then
+      if key != other.key then
+        if ((values.size() > 0) and (key == "")) or
+           ((other.values.size() > 0) and (other.key == "")) then
+          @printf[I32](("Illegal state combine: Wrong key.\nThis.key is" +
+            "%s but" +
+            " other.key is %s\n").cstring(), key.cstring(), other.key.cstring())
+          Fail()
+        end
+      end
+    end
+    let key' = if key == "" then
+      other.key
+    else
+      key
+    end
+    let local = values.clone()
+    local.append(other.values)
+    WindowState(key', local.clone())
+
+  fun val clone(): Array[U64] ref^ =>
+    values.clone()
+
+// WindowMessage
+class val WindowMessage
+  let _key: String
+  let _values: Array[U64] val
+  let _ts: U64
+
+  new val create(k: String, v: Array[U64] val, ts': (U64 | None) = None) =>
+    _key = k
+    _values = v
+    _ts = match ts'
+    | let t: U64 =>
+      t
+    else
+      Time.nanos()
+    end
+
+  fun ts(): U64 =>
+    _ts
+
+  fun key(): String =>
+    _key
+
+  fun values(): Array[U64] val =>
+    _values
+
+// Decoder
+primitive Decoder is FramedSourceHandler[Message]
+  fun header_length(): USize => 4
+
+  fun payload_length(data: Array[U8] iso): USize ? =>
+    Bytes.to_u32(data(0)?, data(1)?, data(2)?, data(3)?).usize()
+
+  fun decode(data: Array[U8] val): Message ? =>
+    let u: U64 = Bytes.to_u64(data(0)?, data(1)?, data(2)?, data(3)?,
+      data(4)?, data(5)?, data(6)?, data(7)?)
+    let k: String = String.from_array(recover data.slice(8) end)
+    let m = Message(k, u)
+    ifdef debug then
+        (let sec', let ns') = Time.now()
+        let us' = ns' / 1000
+      try
+        let ts' = PosixDate(sec', ns').format("%Y-%m-%d %H:%M:%S." + us'.string())?
+        @printf[I32]("%s Source decoded: %s\n".cstring(), ts'.cstring(),
+          m.string().cstring())
+      end
+    end
+    consume m
+
+// JsonDecoder
+primitive JsonDecoder is FramedSourceHandler[Message]
+  fun header_length(): USize => 4
+
+  fun payload_length(data: Array[U8] iso): USize ? =>
+    Bytes.to_u32(data(0)?, data(1)?, data(2)?, data(3)?).usize()
+
+  fun decode(data: Array[U8] val): Message ? =>
+    let s = String.from_array(data)
+    let doc = JsonDoc
+    doc.parse(s)?
+    let json: JsonObject = doc.data as JsonObject
+    let key: String = json.data("key")? as String
+    let value: U64 = (json.data("value")? as I64).u64()
+    let ts: U64 = (json.data("ts")? as I64).u64()
+    let m = Message(key, value, ts)
+    ifdef debug then
+        (let sec', let ns') = Time.now()
+        let us' = ns' / 1000
+      try
+        let ts' = PosixDate(sec', ns').format("%Y-%m-%d %H:%M:%S." + us'.string())?
+        @printf[I32]("%s Source decoded: %s\n".cstring(), ts'.cstring(),
+          m.string().cstring())
+      end
+    end
+    consume m
+
+  fun event_time_ns(m: Message): U64 => 
+    ifdef debug then @printf[I32]("event_time_ts()\n".cstring()) end
+    m.ts()
+
+// Collect
+primitive Collect is Aggregation[Message, (WindowMessage | None), WindowState]
+
+  fun name(): String => "Collect"
+
+  fun initial_accumulator(): WindowState =>
+    WindowState
+
+  fun update(msg: Message, state: WindowState) =>
+    ifdef debug then
+      @printf[I32]("Update on %s\n".cstring(), msg.string().cstring())
+    end
+    state.update(msg)
+
+  fun combine(s1: WindowState box, s2: WindowState box): WindowState =>
+    ifdef debug then
+      @printf[I32]("combine\n".cstring())
+    end
+    s1.combine(s2)
+
+  fun output(key: Key, window_end_ts: U64, s: WindowState):
+    (WindowMessage | None)
+  =>
+    ifdef debug then @printf[I32]("Output\n".cstring()) end
+    if s.values.size() > 0 then
+      let vals: Array[U64] iso = recover Array[U64] end
+      for v in s.values.values() do
+        vals.push(v)
+      end
+      WindowMessage(key.string(), consume vals)
+    else
+      None
+    end
+
+// SplitAccumulated
+primitive SplitAccumulated is StatelessComputation[WindowMessage, Message]
+  fun name(): String => "SplitAccumulated"
+
+  fun apply(wm: WindowMessage): Array[Message] val =>
+    let messages = recover trn Array[Message] end
+    let ts = wm.ts()
+    let k = wm.key()
+    for v in wm.values().values() do
+      messages.push(Message(k, v, ts))
+    end
+    consume messages
+
+// Encoder
+primitive Encoder
+  fun apply(m: Message, wb: Writer = Writer): Array[ByteSeq] val =>
+    ifdef debug then
+      @printf[I32]("output: %s\n".cstring(), m.string().cstring())
+    end
+    wb.writev(Bytes.length_encode(m.string()))
+    wb.done()

--- a/testing/correctness/apps/window_detector/window_detector.pony
+++ b/testing/correctness/apps/window_detector/window_detector.pony
@@ -44,16 +44,22 @@ use "wallaroo_labs/time"
 
 
 primitive Tumbling
+  fun name(): String => "Tumbling"
 primitive Counting
+  fun name(): String => "Counting"
 primitive Sliding
+  fun name(): String => "Sliding"
 type WindowType is (Tumbling | Counting | Sliding)
 
 primitive Drop
   fun apply(): U16 => LateDataPolicy.drop()
+  fun name(): String => "Drop"
 primitive FirePerMessage
   fun apply(): U16 => LateDataPolicy.fire_per_message()
+  fun name(): String => "FirePerMessage"
 primitive PlaceInOldestWindow
   fun apply(): U16 => LateDataPolicy.place_in_oldest_window()
+  fun name(): String => "PlaceInOldestWindow"
 type WindowPolicy is (Drop | FirePerMessage | PlaceInOldestWindow)
 
 
@@ -119,6 +125,15 @@ actor Main
           end
         end
       end
+
+      // Print out options
+      env.out.print("Running window_detector.pony with options:")
+      env.out.print("  --window-policy: " + window_policy.name())
+      env.out.print("  --window-type: " + window_type.name())
+      env.out.print("  --window-delay: " + window_delay.string())
+      env.out.print("  --window-size: " + window_size.string())
+      env.out.print("  --window-slide: " + window_slide.string())
+      env.out.print("  --decoder: " + decoder_type)
 
       // Pre-construct the window step based on config option
       let window_step = match window_type

--- a/testing/correctness/apps/window_detector/window_detector.py
+++ b/testing/correctness/apps/window_detector/window_detector.py
@@ -38,6 +38,8 @@ def application_setup(args):
     parser.add_argument("--window-slide", type=int, default=25,
                         help=("Window slide size, in milliseconds. "
                               "(Default: 25)"))
+    parser.add_argument("--window-policy", default="drop",
+                        choices=["drop", "fire-per-message"])
     parser.add_argument("--source", choices=['tcp', 'gensource', 'alo'],
                          default='tcp',
                          help=("Choose source type for resilience tests. "

--- a/testing/tools/integration/control.py
+++ b/testing/tools/integration/control.py
@@ -140,15 +140,18 @@ class SinkAwaitValue(StoppableThread):
     def run(self):
         started = time.time()
         logging.debug("SinkAwait started for values: {}".format(self.values))
-        view = self.sink.view()
+        view = self.sink.view(blocking=False)
+        msgs = 0
         while not self.stopped():
             msg = next(view)
-            processed = self.func(msg)
-            if processed in self.values:
-                self.values.discard(processed)
-                logging.debug("{} matched on value {!r}."
-                               .format(self.name,
-                                       processed))
+            processed = self.func(msg) if msg is not None else None
+            if processed:
+                msgs += 1
+                if processed in self.values:
+                    self.values.discard(processed)
+                    logging.debug("{} matched on value {!r}."
+                                   .format(self.name,
+                                           processed))
             if not self.values:
                 self.stop()
                 logging.debug("SinkAwait complete with remaining values: {}"

--- a/testing/tools/integration/control.py
+++ b/testing/tools/integration/control.py
@@ -143,20 +143,22 @@ class SinkAwaitValue(StoppableThread):
         view = self.sink.view(blocking=False)
         msgs = 0
         while not self.stopped():
-            msg = next(view)
-            processed = self.func(msg) if msg is not None else None
-            if processed:
-                msgs += 1
-                if processed in self.values:
-                    self.values.discard(processed)
-                    logging.debug("{} matched on value {!r}."
-                                   .format(self.name,
-                                           processed))
             if not self.values:
                 self.stop()
                 logging.debug("SinkAwait complete with remaining values: {}"
                         .format(self.values))
                 break
+            msg = next(view)
+            if msg is not None:
+                msgs += 1
+                processed = self.func(msg)
+                if processed in self.values:
+                    self.values.discard(processed)
+                    logging.debug("{} matched on value {!r}."
+                                   .format(self.name,
+                                           processed))
+            else:
+                time.sleep(0.001)
             if time.time() - started > self.timeout:
                 self.error = TimeoutError('{}: has timed out after {} seconds'
                                           ', with {} messages. before '

--- a/testing/tools/integration/end_points.py
+++ b/testing/tools/integration/end_points.py
@@ -178,6 +178,7 @@ class MultiClientStreamView(object):
                     # sleep after a full round on all keys produces no value
                     time.sleep(0.001)
                 else:
+                    time.sleep(0.001)
                     return None
             # implicit:  continue
 

--- a/testing/tools/integration/external.py
+++ b/testing/tools/integration/external.py
@@ -180,12 +180,13 @@ def save_logs_to_file(base_dir, log_stream=None, persistent_data={}):
                 f.write(log_stream.getvalue())
 
         # Save ops log data to file
-        with open(os.path.join(base_dir, "ops.log"), "w") as ops_log:
-            try:
-                for op in persistent_data['ops']:
-                    ops_log.write("{}\n".format(op))
-            except KeyError:
-                None
+        if persistent_data.get('ops', None):
+            with open(os.path.join(base_dir, "ops.log"), "w") as ops_log:
+                try:
+                    for op in persistent_data['ops']:
+                        ops_log.write("{}\n".format(op))
+                except KeyError:
+                    None
 
         # save worker data to files
         runner_data = persistent_data.get('runner_data', [])


### PR DESCRIPTION
- [x] Add pony window_detector version
- [x] Create testing/conformance directory
- [x] Create modular python conformance testing harness
  - [x] Use a context manager class as the base class for applications
    - [x] take config values in `__init__`
    - [x] start the e2e harness's `Cluster` context in the `__enter__`
      method
    - [x] Provide easy wrappers for sending:
      - [x] creating a typed sender (tcp, kafka, alo, etc.)
        - [x] data from a list
        - [x] data from a generator
        - [x] single messages (directly)
      - [x] Using notify pattern for end-condition checking
      - [x] collecting output from sinks
    - [x] Create classes for basic applications
      - [x] window-detector
      - [x] multi-partition-detector

ref #2984


Note that the tests still fail... but I'm not sure if that's because the drop policy isn't implemented yet, or for other reasons?


**Still To Do:**
- [ ] migrate tests from `testing/correctness/tests`
