### PR TITLE
Don't allow expect to exceed max buffer size

### DIFF
--- a/lib/wallaroo/core/tcp_actor/data_channel_tcp_handler.pony
+++ b/lib/wallaroo/core/tcp_actor/data_channel_tcp_handler.pony
@@ -32,6 +32,7 @@ use "collections"
 use "net"
 use "wallaroo/core/network"
 use "wallaroo_labs/bytes"
+use "wallaroo_labs/mort"
 
 
 class val DataChannelTCPHandlerBuilder is TestableTCPHandlerBuilder
@@ -155,7 +156,11 @@ class DataChannelTCPHandler is TestableTCPHandler
     A `received` call on the notifier must contain exactly `qty` bytes. If
     `qty` is zero, the call can contain any amount of data.
     """
-    _expect = qty
+    if qty <= _max_size then
+      _expect = qty
+    else
+      Fail()
+    end
 
   fun ref set_nodelay(state: Bool) =>
     """

--- a/lib/wallaroo/core/tcp_actor/source_tcp_handler.pony
+++ b/lib/wallaroo/core/tcp_actor/source_tcp_handler.pony
@@ -3,7 +3,6 @@ use "collections"
 use "net"
 use "wallaroo_labs/mort"
 
-
 class val SourceTCPHandlerBuilder
   fun apply(tcp_actor: TCPActor ref): SourceTCPHandler =>
     @printf[I32](("Currently you must build a SourceTCPHandler using " +
@@ -213,7 +212,11 @@ class SourceTCPHandler is TestableTCPHandler
     A `received` call on the notifier must contain exactly `qty` bytes. If
     `qty` is zero, the call can contain any amount of data.
     """
-    _expect = qty
+    if qty <= _max_size then
+      _expect = qty
+    else
+      Fail()
+    end
 
   fun ref set_nodelay(state: Bool) =>
     """


### PR DESCRIPTION
With our "faster tcp" code, an expect that exceeds the max buffer size
would result in code that never returns. Rather than silent and quick
death, this commit changes us to have a loud noisy failure.

This is far from the perfect solution, but it's an improvement on what
we currently have.