### PR TITLE
Move parallelism' factors for all sources from 10 -> N

### DIFF
--- a/lib/wallaroo/core/source/connector_source/connector_source_config.pony
+++ b/lib/wallaroo/core/source/connector_source/connector_source_config.pony
@@ -99,7 +99,7 @@ class val ConnectorSourceConfig[In: Any val] is SourceConfig
 
   new val create(source_name: SourceName, handler': FramedSourceHandler[In] val,
     host: String, service: String, cookie: String,
-    max_credits: U32, refill_credits: U32, parallelism': USize = 10)
+    max_credits: U32, refill_credits: U32, parallelism': USize = 256)
   =>
     handler = handler'
     parallelism = parallelism'
@@ -107,7 +107,7 @@ class val ConnectorSourceConfig[In: Any val] is SourceConfig
       service, cookie, max_credits, refill_credits)
 
   new val from_options(handler': FramedSourceHandler[In] val,
-    opts: ConnectorSourceConfigOptions, parallelism': USize = 10)
+    opts: ConnectorSourceConfigOptions, parallelism': USize = 256)
   =>
     handler = handler'
     parallelism = parallelism'

--- a/lib/wallaroo/core/source/connector_source/connector_source_config.pony
+++ b/lib/wallaroo/core/source/connector_source/connector_source_config.pony
@@ -99,7 +99,7 @@ class val ConnectorSourceConfig[In: Any val] is SourceConfig
 
   new val create(source_name: SourceName, handler': FramedSourceHandler[In] val,
     host: String, service: String, cookie: String,
-    max_credits: U32, refill_credits: U32, parallelism': USize = 256)
+    max_credits: U32, refill_credits: U32, parallelism': USize = 50)
   =>
     handler = handler'
     parallelism = parallelism'
@@ -107,7 +107,7 @@ class val ConnectorSourceConfig[In: Any val] is SourceConfig
       service, cookie, max_credits, refill_credits)
 
   new val from_options(handler': FramedSourceHandler[In] val,
-    opts: ConnectorSourceConfigOptions, parallelism': USize = 256)
+    opts: ConnectorSourceConfigOptions, parallelism': USize = 50)
   =>
     handler = handler'
     parallelism = parallelism'

--- a/lib/wallaroo/core/source/tcp_source/tcp_source_config.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source_config.pony
@@ -88,7 +88,7 @@ class val TCPSourceConfig[In: Any val] is SourceConfig
 
   new val create(source_name': SourceName,
     handler': FramedSourceHandler[In] val, host': String, service': String,
-    valid': Bool, parallelism': USize = 256)
+    valid': Bool, parallelism': USize = 50)
   =>
     handler = handler'
     parallelism = parallelism'
@@ -96,7 +96,7 @@ class val TCPSourceConfig[In: Any val] is SourceConfig
       service', valid')
 
   new val from_options(handler': FramedSourceHandler[In] val,
-    opts: TCPSourceConfigOptions, parallelism': USize = 256)
+    opts: TCPSourceConfigOptions, parallelism': USize = 50)
   =>
     handler = handler'
     parallelism = parallelism'

--- a/lib/wallaroo/core/source/tcp_source/tcp_source_config.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source_config.pony
@@ -88,7 +88,7 @@ class val TCPSourceConfig[In: Any val] is SourceConfig
 
   new val create(source_name': SourceName,
     handler': FramedSourceHandler[In] val, host': String, service': String,
-    valid': Bool, parallelism': USize = 10)
+    valid': Bool, parallelism': USize = 256)
   =>
     handler = handler'
     parallelism = parallelism'
@@ -96,7 +96,7 @@ class val TCPSourceConfig[In: Any val] is SourceConfig
       service', valid')
 
   new val from_options(handler': FramedSourceHandler[In] val,
-    opts: TCPSourceConfigOptions, parallelism': USize = 10)
+    opts: TCPSourceConfigOptions, parallelism': USize = 256)
   =>
     handler = handler'
     parallelism = parallelism'


### PR DESCRIPTION
The default TCPSource parallelism’ factor = 10 is pernicious IMO:

1. The source can open more than 10 TCP connections at a time.
2. The source will *not* read from more than 10 TCP connections.
3. If your load generators only report an average throughput, then you won’t know that you have a bi-modal distribution:
    * 10 connections do everything
    * 11-? connections do nothing

The final value is negotiable, but 10 is too small.