### PR TITLE
Done with 0th draft: replace @printf behind-the-scenes

### DIFF
--- a/lib/wallaroo_labs/logging/Makefile
+++ b/lib/wallaroo_labs/logging/Makefile
@@ -1,17 +1,18 @@
+# include root makefile
+ifndef ROOT_MAKEFILE_MK
+include ../../../Makefile
+endif
+
 # prevent rules from being evaluated/included multiple times
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-ROOT_MAKEFILE_MK := 1
-ROOT_MAKEFILE := $(lastword $(MAKEFILE_LIST))
-ROOT_MAKEFILE_PATH := $(dir $(ROOT_MAKEFILE))
-rules_mk_path := $(ROOT_MAKEFILE_PATH)/rules.mk
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
 # `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
@@ -23,33 +24,37 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
 
 # `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
 # otherwise targets only get created if there are elixir sources (*.exs) in this directory.
-$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := false
 
 # `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
 # otherwise targets only get created if there is a Dockerfile in this directory
-$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := false
 
 # `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
 # (and by recursion every makefile in the tree that is referenced)
-$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := false
+
+
+LOGGING_LIB_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 # standard rules generation makefile
 include $(rules_mk_path)
 
-#LOGGING_LIB_DIR=$(wallaroo_path)/utils/logging-lib
-#LOGGING_LIB_OBJ=$(LOGGING_LIB_DIR)/logging-lib.o
-#LOGGING_LIB_A=$(LOGGING_LIB_DIR)/logging-lib.a
-#
-#$(LOGGING_LIB_DIR): $(LOGGING_LIB_A)
-#$(LOGGING_LIB_A): $(LOGGING_LIB_OBJ)
-#	ar rvs $@ $<
-#$(LOGGING_LIB_OBJ): $(LOGGING_LIB_DIR)/logging-lib.c
-#	cc -g -o $@ -c $<
-#
-#clean:
-#	rm -f $(LOGGING_LIB_DIR)/*.o $(LOGGING_LIB_DIR)/*.a
+LOGGING_LIB_DIR=$(LOGGING_LIB_PATH)
+LOGGING_LIB_OBJ=$(LOGGING_LIB_DIR)wallaroo-logging.o
+LOGGING_LIB_A=$(LOGGING_LIB_DIR)libwallaroo-logging.a
+
+build-lib-wallaroo_labs-logging: $(LOGGING_LIB_A)
+$(LOGGING_LIB_A): $(LOGGING_LIB_OBJ)
+	ar rvs $@ $<
+$(LOGGING_LIB_OBJ): $(LOGGING_LIB_DIR)logging-lib.c
+	cc -g -o $@ -c $<
+
+# The rule below will trigger a "overriding commands" warning when
+# there is a Pony source file in this directory.  Instead, there'source
+# a special "rm -f" command in rules.mk to delete the obj & lib files.
+#clean-lib-wallaroo_labs-logging:
+#	$(QUIET)rm -f $(LOGGING_LIB_DIR)/*.o $(LOGGING_LIB_DIR)/*.a
 
 # end of prevent rules from being evaluated/included multiple times
 endif
-
-

--- a/lib/wallaroo_labs/logging/Makefile
+++ b/lib/wallaroo_labs/logging/Makefile
@@ -16,11 +16,11 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
-$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := false
 
 # `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
 # it can be overridden manually
-$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := false
 
 # `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
 # otherwise targets only get created if there are elixir sources (*.exs) in this directory.
@@ -49,6 +49,9 @@ $(LOGGING_LIB_A): $(LOGGING_LIB_OBJ)
 	ar rvs $@ $<
 $(LOGGING_LIB_OBJ): $(LOGGING_LIB_DIR)logging-lib.c
 	cc -g -o $@ -c $<
+
+unit-tests-lib-wallaroo_labs-logging-all:
+integration-tests-lib-wallaroo_labs-logging-all:
 
 # The rule below will trigger a "overriding commands" warning when
 # there is a Pony source file in this directory.  Instead, there'source

--- a/lib/wallaroo_labs/logging/logging-lib.c
+++ b/lib/wallaroo_labs/logging/logging-lib.c
@@ -1,0 +1,77 @@
+/*
+
+Copyright (C) 2016-2019, Wallaroo Labs
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/time.h>
+#include <ctype.h>
+
+#define FMT_BUF_SIZE 1024
+
+int printf(const char *fmt, ...)
+{
+  char fmt2[FMT_BUF_SIZE];
+  int fmt2_len;
+  struct timeval tv;
+  va_list ap;
+  int ret;
+
+  gettimeofday(&tv, NULL);
+#ifdef  __APPLE__  
+  snprintf(fmt2, sizeof(fmt2), "%ld.%06d ", tv.tv_sec, tv.tv_usec);
+#else
+  snprintf(fmt2, sizeof(fmt2), "%ld.%06lu ", tv.tv_sec, tv.tv_usec);
+#endif
+
+  va_start(ap, fmt);
+  fmt2_len = strlen(fmt2);
+  if (strlen(fmt) > (sizeof(fmt2) - fmt2_len)) {
+    /* Our static buffer isn't big enough, so call vprintf() as is. */
+    ret = vprintf(fmt, ap);
+  } else {
+    memcpy(fmt2 + fmt2_len, fmt, strlen(fmt));
+    ret = vprintf(fmt2, ap);
+  }
+  va_end(ap);
+  return ret;
+}
+
+#ifdef MAIN
+#include <assert.h>
+int main(void)
+{
+  char *fmt1 = "Hello, world (with timestamp)!\n";
+  char *fmt2 = "Hello, world (too big, no timestamp) Hello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, world!\n";
+
+  assert(strlen(fmt1) < FMT_BUF_SIZE);
+  printf("Hello, world (with timestamp)!\n");
+  assert(strlen(fmt2) > FMT_BUF_SIZE);
+  printf("Hello, world (too big, no timestamp) Hello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, world!\n");
+}
+#endif

--- a/lib/wallaroo_labs/logging/wallaroo-logging.pony
+++ b/lib/wallaroo_labs/logging/wallaroo-logging.pony
@@ -1,0 +1,21 @@
+/*
+
+Copyright 2019 The Wallaroo Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing
+ permissions and limitations under the License.
+
+*/
+
+// Tell ponyc that we're going to use the external C functions
+// in the libwallaroo-logging.a library.
+use "lib:wallaroo-logging"

--- a/rules.mk
+++ b/rules.mk
@@ -266,12 +266,13 @@ ifneq ($(arch),native)
 endif
 
 # function call for compiling with ponyc and generating dependency info
+PONYC_LOGGING_LIB_FLAGS = --path $(LOGGING_LIB_DIR)
 define PONYC
   $(QUIET)cd $(1) && $(ponyc_docker_args) $(PONYSTABLE) fetch \
     $(if $(filter $(ponyc_docker_args),docker),$(quote))
   $(QUIET)cd $(1) && $(ponyc_docker_args) $(PONYSTABLE) env $(PONYCC) $(ponyc_arch_args) \
     $(debug_arg) $(spike_arg) $(trace_arg) $(autoscale_arg) $(clustering_arg) $(resilience_arg) \
-    $(PONYCFLAGS) $(EXTRA_PONYCFLAGS) $(target_cpu_arg) --features=-avx512f . $(if $(filter $(ponyc_docker_args),docker),$(quote))
+    $(PONYCFLAGS) $(EXTRA_PONYCFLAGS) $(PONYC_LOGGING_LIB_FLAGS) $(target_cpu_arg) --features=-avx512f . $(if $(filter $(ponyc_docker_args),docker),$(quote))
   $(QUIET)cd $(1) && echo "$@: $(wildcard $(abspath $(1))/bundle.json)" | tr '\n' ' ' > $(notdir $(abspath $(1:%/=%))).d
   $(QUIET)cd $(1) && $(ponyc_docker_args) $(PONYSTABLE) env $(PONYCC) $(ponyc_arch_args) \
     $(debug_arg) $(spike_arg) $(trace_arg) $(autoscale_arg) $(clustering_arg) $(resilience_arg) \
@@ -376,6 +377,7 @@ clean-pony-all: clean-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
 clean-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))-all += clean-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
 clean-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))):
 	$(QUIET)rm -f $(abspath $1)/$(notdir $(abspath $(1:%/=%))) $(abspath $1)/$(notdir $(abspath $(1:%/=%))).o
+	$(QUIET)rm -f $(abspath $1)/$(notdir $(abspath $(1:%/=%))) $(abspath $1)/$(notdir $(abspath $(1:%/=%))).a
 	$(QUIET)rm -f $(abspath $1)/$(notdir $(abspath $(1:%/=%))).d
 	$(QUIET)rm -rf $(abspath $1)/.deps
 	$(QUIET)rm -rf $(abspath $1)/$(notdir $(abspath $(1:%/=%))).dSYM
@@ -746,6 +748,7 @@ clean: clean-$(ROOT_TARGET_SUFFIX) ## Clean all projects (pony & monhub) and cle
 	$(QUIET)rm -f $(abs_wallaroo_dir)/AppRun $(abs_wallaroo_dir)/metrics_ui.desktop $(abs_wallaroo_dir)/metrics_ui.png
 	$(QUIET)rm -f lib/wallaroo/wallaroo lib/wallaroo/wallaroo.o
 	$(QUIET)rm -f sent.txt received.txt
+	$(QUIET)rm -f $(LOGGING_LIB_OBJ) $(LOGGING_LIB_A)
 	$(QUIET)echo 'Done cleaning.'
 
 list: ## List all targets (including automagically generated ones)

--- a/utils/data_receiver/Makefile
+++ b/utils/data_receiver/Makefile
@@ -34,6 +34,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
 # (and by recursion every makefile in the tree that is referenced)
 $(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
 
+# Boilerplate for Pony source: use "lib:wallaroo-logging"
+# This dep must appear prior to include $(rules_mk_path)
+build-utils-data_receiver: $(LOGGING_LIB_A)
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/utils/data_receiver/data_receiver.pony
+++ b/utils/data_receiver/data_receiver.pony
@@ -18,6 +18,7 @@ Copyright 2017 The Wallaroo Authors.
 
 use "net"
 use "wallaroo_labs/bytes"
+use "wallaroo_labs/logging"
 use "wallaroo_labs/options"
 
 actor Main
@@ -27,6 +28,7 @@ actor Main
     var output_mode: OutputMode = Write
     var input_mode: InputMode = Streaming
 
+    @printf[I32]("SLF: Hello, world!\n".cstring()) // For demo purposes only
     try
       var options = Options(env.args)
 


### PR DESCRIPTION
All review is optional, though if you have strongly-held opinions, feel free to vent.  This is the first in a short epic to add a logging API to Wallaroo.

We don't have many (any?) places where `printf(3)` calls are
embedded in the C libraries that we're using (though I haven't
checked all of the Python code yet, and it's possible that a
Python function such as `print` might end up calling
`printf(3)`?), so this flat-out replacement will get us a
lot of mileage.

The statement added to data_receiver.pony emits the following
when run:

    1560980285.457195 SLF: Hello, world!

Fixes #2937