### PR TITLE
Logging1 part 3: filtering + default overrides via environment var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,19 +36,6 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
 # standard rules generation makefile
 include $(rules_mk_path)
 
-#LOGGING_LIB_DIR=$(wallaroo_path)/utils/logging-lib
-#LOGGING_LIB_OBJ=$(LOGGING_LIB_DIR)/logging-lib.o
-#LOGGING_LIB_A=$(LOGGING_LIB_DIR)/logging-lib.a
-#
-#$(LOGGING_LIB_DIR): $(LOGGING_LIB_A)
-#$(LOGGING_LIB_A): $(LOGGING_LIB_OBJ)
-#	ar rvs $@ $<
-#$(LOGGING_LIB_OBJ): $(LOGGING_LIB_DIR)/logging-lib.c
-#	cc -g -o $@ -c $<
-#
-#clean:
-#	rm -f $(LOGGING_LIB_DIR)/*.o $(LOGGING_LIB_DIR)/*.a
-
 # end of prevent rules from being evaluated/included multiple times
 endif
 

--- a/lib/wallaroo_labs/logging/Makefile
+++ b/lib/wallaroo_labs/logging/Makefile
@@ -50,9 +50,6 @@ $(LOGGING_LIB_A): $(LOGGING_LIB_OBJ)
 $(LOGGING_LIB_OBJ): $(LOGGING_LIB_DIR)logging-lib.c
 	cc -g -o $@ -c $<
 
-unit-tests-lib-wallaroo_labs-logging-all:
-integration-tests-lib-wallaroo_labs-logging-all:
-
 # The rule below will trigger a "overriding commands" warning when
 # there is a Pony source file in this directory.  Instead, there'source
 # a special "rm -f" command in rules.mk to delete the obj & lib files.

--- a/lib/wallaroo_labs/logging/logging-lib.c
+++ b/lib/wallaroo_labs/logging/logging-lib.c
@@ -120,7 +120,7 @@ int printf(const char *fmt, ...)
 **               otherwise false
 */
 
-unsigned char le(unsigned char severity, unsigned char category)
+unsigned char log_enabled(unsigned char severity, unsigned char category)
 {
   if (severity > _cat2sev_threshold[category]) {
     return 0;
@@ -129,7 +129,7 @@ unsigned char le(unsigned char severity, unsigned char category)
 }
 
 /*
-** logf(), the severity + category + format + variable-args logging function.
+** l(), the severity + category + format + variable-args logging function.
 **
 ** severity - numeric severity from 0 to MAX_SEVERITY
 ** category - application category number from 0 to MAX_CATEGORY
@@ -139,7 +139,7 @@ unsigned char le(unsigned char severity, unsigned char category)
 ** Return value: # of bytes written
 */
 
-int logf(unsigned char severity, unsigned char category, const char *fmt, ...)
+int l(unsigned char severity, unsigned char category, const char *fmt, ...)
 {
   char fmt2[FMT_BUF_SIZE];
   va_list ap;

--- a/lib/wallaroo_labs/logging/logging-lib.c
+++ b/lib/wallaroo_labs/logging/logging-lib.c
@@ -151,7 +151,7 @@ int l(unsigned char severity, unsigned char category, const char *fmt, ...)
   }
 
   va_start(ap, fmt);
-  snprintf(fmt2, sizeof(fmt2), "%s,%s,%s",
+  snprintf(fmt2, sizeof(fmt2), "%s,%s,%s\n",
     _severity_labels[severity], _category_labels[category], fmt);
   return _w_vprintf(fmt2, ap);
 }

--- a/lib/wallaroo_labs/logging/logging-lib.c
+++ b/lib/wallaroo_labs/logging/logging-lib.c
@@ -83,11 +83,11 @@ static void _w_initialize_labels()
   int i;
   char buf[16];
 
-  for (i = 0; i < MAX_SEVERITY; i++) {
+  for (i = 0; i < MAX_SEVERITY+1; i++) {
     snprintf(buf, sizeof(buf), "sev-%d", i);
     _severity_labels[i] = strdup(buf);
   }
-  for (i = 0; i < MAX_CATEGORY; i++) {
+  for (i = 0; i < MAX_CATEGORY+1; i++) {
     snprintf(buf, sizeof(buf), "cat-%d", i);
     _category_labels[i] = strdup(buf);
     _cat2sev_threshold[i] = MAX_SEVERITY;
@@ -109,6 +109,16 @@ int printf(const char *fmt, ...)
   // va_end() already done
 }
 
+/*
+** le(), is logging enabled for a (severity, category) tuple
+**
+** severity - numeric severity from 0 to MAX_SEVERITY
+** category - application category number from 0 to MAX_CATEGORY
+**
+** Return value: true if logging is enabled for this tuple,
+**               otherwise false
+*/
+
 unsigned char le(unsigned char severity, unsigned char category)
 {
   if (severity > _cat2sev_threshold[category]) {
@@ -116,6 +126,17 @@ unsigned char le(unsigned char severity, unsigned char category)
   }
   return 1;
 }
+
+/*
+** l(), the severity + category + format + variable-args logging function.
+**
+** severity - numeric severity from 0 to MAX_SEVERITY
+** category - application category number from 0 to MAX_CATEGORY
+** fmt - snprintf(3)-style formatting string
+** 0 or or arguments - snprintf(3)-style arguments
+**
+** Return value: # of bytes written
+*/
 
 int l(unsigned char severity, unsigned char category, const char *fmt, ...)
 {
@@ -136,6 +157,12 @@ int l(unsigned char severity, unsigned char category, const char *fmt, ...)
 }
 
 
+/*
+** w_set_severity(), set the formatted label for a severity number
+**
+** severity - numeric severity from 0 to MAX_SEVERITY
+*/
+
 void w_set_severity(unsigned char severity, char *label)
 {
   if (! _labels_initialized) {
@@ -145,6 +172,12 @@ void w_set_severity(unsigned char severity, char *label)
     _severity_labels[severity] = strdup(label);
   }
 }
+
+/*
+** w_set_category(), set the formatted label for a category number
+**
+** category - application category number from 0 to MAX_CATEGORY
+*/
 
 void w_set_category(unsigned char category, char *label)
 {
@@ -156,14 +189,36 @@ void w_set_category(unsigned char category, char *label)
   }
 }
 
+/*
+** w_set_severity_threshold(), set the severity threshold for all categories
+**
+** severity - numeric severity from 0 to MAX_SEVERITY
+*/
+
 void w_severity_threshold(unsigned char severity)
 {
   int i;
 
-  if (severity < MAX_SEVERITY) {
+  if (severity < MAX_SEVERITY+1) {
     for (i = 0; i < MAX_CATEGORY+1; i++) {
       _cat2sev_threshold[i] = severity;
     }
+  }
+}
+
+/*
+** w_set_severity_cat_threshold(), set the severity threshold for a category
+**
+** severity - numeric severity from 0 to MAX_SEVERITY
+** category - application category number from 0 to MAX_CATEGORY
+*/
+
+void w_severity_cat_threshold(unsigned char severity, unsigned char category)
+{
+  int i;
+
+  if (severity < MAX_SEVERITY+1 && category < MAX_CATEGORY+1) {
+    _cat2sev_threshold[category] = severity;
   }
 }
 

--- a/lib/wallaroo_labs/logging/logging-lib.c
+++ b/lib/wallaroo_labs/logging/logging-lib.c
@@ -129,7 +129,7 @@ unsigned char le(unsigned char severity, unsigned char category)
 }
 
 /*
-** l(), the severity + category + format + variable-args logging function.
+** logf(), the severity + category + format + variable-args logging function.
 **
 ** severity - numeric severity from 0 to MAX_SEVERITY
 ** category - application category number from 0 to MAX_CATEGORY
@@ -139,7 +139,7 @@ unsigned char le(unsigned char severity, unsigned char category)
 ** Return value: # of bytes written
 */
 
-int l(unsigned char severity, unsigned char category, const char *fmt, ...)
+int logf(unsigned char severity, unsigned char category, const char *fmt, ...)
 {
   char fmt2[FMT_BUF_SIZE];
   va_list ap;

--- a/lib/wallaroo_labs/logging/logging-lib.c
+++ b/lib/wallaroo_labs/logging/logging-lib.c
@@ -34,7 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define FMT_BUF_SIZE  1024
 #define MAX_SEVERITY  8
-#define MAX_CATEGORY  32
+#define MAX_CATEGORY  64
 
 static int _labels_initialized = 0;
 
@@ -109,6 +109,14 @@ int printf(const char *fmt, ...)
   // va_end() already done
 }
 
+unsigned char le(unsigned char severity, unsigned char category)
+{
+  if (severity > _cat2sev_threshold[category]) {
+    return 0;
+  }
+  return 1;
+}
+
 int l(unsigned char severity, unsigned char category, const char *fmt, ...)
 {
   char fmt2[FMT_BUF_SIZE];
@@ -126,6 +134,7 @@ int l(unsigned char severity, unsigned char category, const char *fmt, ...)
     _severity_labels[severity], _category_labels[category], fmt);
   return _w_vprintf(fmt2, ap);
 }
+
 
 void w_set_severity(unsigned char severity, char *label)
 {
@@ -147,11 +156,11 @@ void w_set_category(unsigned char category, char *label)
   }
 }
 
-void w_severity_threshold(char severity)
+void w_severity_threshold(unsigned char severity)
 {
   int i;
 
-  if (severity >= 0 && severity < MAX_SEVERITY) {
+  if (severity < MAX_SEVERITY) {
     for (i = 0; i < MAX_CATEGORY+1; i++) {
       _cat2sev_threshold[i] = severity;
     }

--- a/lib/wallaroo_labs/logging/wallaroo-logging.pony
+++ b/lib/wallaroo_labs/logging/wallaroo-logging.pony
@@ -33,10 +33,11 @@ primitive Log
   fun max_severity() => debug()
 
   // categories
-  fun c_checkpoint(): U8       => U8(0)
-  fun c_source_migration(): U8 => U8(1)
-  fun c_2pc(): U8              => U8(2)
-  fun c_dos_client(): U8       => U8(3)
+  // Don't use category 0
+  fun c_checkpoint(): U8       => U8(1)
+  fun c_source_migration(): U8 => U8(2)
+  fun c_2pc(): U8              => U8(3)
+  fun c_dos_client(): U8       => U8(4)
 
   fun category_map(): Array[(U8, String)] =>
     [
@@ -46,7 +47,13 @@ primitive Log
       (c_dos_client(),       "DOS_CLIENT")
     ]
 
-  fun set_categories() =>
+  fun set_categories(do_overrides: Bool) =>
+    // These are Wallaroo defaults
     for (cat, label) in category_map().values() do
       @w_set_category[None](cat, label.cstring())
+    end
+
+    // Process any overries
+    if do_overrides then
+      @w_process_category_overrides[None]()
     end

--- a/lib/wallaroo_labs/logging/wallaroo-logging.pony
+++ b/lib/wallaroo_labs/logging/wallaroo-logging.pony
@@ -19,3 +19,34 @@ Copyright 2019 The Wallaroo Authors.
 // Tell ponyc that we're going to use the external C functions
 // in the libwallaroo-logging.a library.
 use "lib:wallaroo-logging"
+
+primitive Log
+  // severity levels
+  fun emerg(): U8  => U8(0)
+  fun alert(): U8  => U8(1)
+  fun crit(): U8   => U8(2)
+  fun err(): U8    => U8(3)
+  fun warn(): U8   => U8(4)
+  fun notice(): U8 => U8(5)
+  fun info(): U8   => U8(6)
+  fun debug(): U8  => U8(7)
+  fun max_severity() => debug()
+
+  // categories
+  fun c_checkpoint(): U8       => U8(0)
+  fun c_source_migration(): U8 => U8(1)
+  fun c_2pc(): U8              => U8(2)
+  fun c_dos_client(): U8       => U8(3)
+
+  fun category_map(): Array[(U8, String)] =>
+    [
+      (c_checkpoint(),       "CHECKPOINT")
+      (c_source_migration(), "SOURCE_MIGRATION")
+      (c_2pc(),              "2PC")
+      (c_dos_client(),       "DOS_CLIENT")
+    ]
+
+  fun set_categories() =>
+    for (cat, label) in category_map().values() do
+      @w_set_category[None](cat, label.cstring())
+    end

--- a/lib/wallaroo_labs/logging/wallaroo-logging.pony
+++ b/lib/wallaroo_labs/logging/wallaroo-logging.pony
@@ -35,14 +35,14 @@ primitive Log
   fun default_severity(): U8 => info()
 
   // categories
-  fun c_none(): U8             => U8(0)
-  fun c_checkpoint(): U8       => U8(1)
-  fun c_source_migration(): U8 => U8(2)
-  fun c_2pc(): U8              => U8(3)
-  fun c_dos_client(): U8       => U8(4)
+  // fun none(): U8             => U8(0) // reuse 0 value from severity none()
+  fun checkpoint(): U8       => U8(1)
+  fun source_migration(): U8 => U8(2)
+  fun twopc(): U8            => U8(3)
+  fun dos_client(): U8       => U8(4)
 
   fun severity_map(): Array[(U8, String)] =>
-    [
+    [ // BEGIN severity_map
       (none(),  "NONE")
       (emerg(),  "EMERGENCY")
       (alert(),  "ALERT")
@@ -52,16 +52,16 @@ primitive Log
       (notice(), "NOTICE")
       (info(),   "INFO")
       (debug(),  "DEBUG")
-    ]
+    ] // END severity_map
 
   fun category_map(): Array[(U8, U8, String)] =>
-    [
-      (default_severity(), c_none(),             "none")
-      (default_severity(), c_checkpoint(),       "checkpoint")
-      (default_severity(), c_source_migration(), "source_migration")
-      (default_severity(), c_2pc(),              "2PC")
-      (default_severity(), c_dos_client(),       "DOS_client")
-    ]
+    [ // BEGIN category_map
+      (default_severity(), none(),             "none")
+      (default_severity(), checkpoint(),       "checkpoint")
+      (default_severity(), source_migration(), "source_migration")
+      (default_severity(), twopc(),            "2PC")
+      (default_severity(), dos_client(),       "DOS_client")
+    ] // END category_map
 
   fun set_defaults() =>
     set_severities()

--- a/lib/wallaroo_labs/logging/wallaroo-logging.pony
+++ b/lib/wallaroo_labs/logging/wallaroo-logging.pony
@@ -89,3 +89,6 @@ primitive Log
     if do_overrides then
       @w_process_category_overrides[None]()
     end
+
+  fun make_sev_cat(severity: U8, category: U8): U16 =>
+    severity.u16().shl(8) + category.u16()

--- a/lib/wallaroo_labs/logging/wallaroo-logging.pony
+++ b/lib/wallaroo_labs/logging/wallaroo-logging.pony
@@ -22,35 +22,60 @@ use "lib:wallaroo-logging"
 
 primitive Log
   // severity levels
-  fun emerg(): U8  => U8(0)
-  fun alert(): U8  => U8(1)
-  fun crit(): U8   => U8(2)
-  fun err(): U8    => U8(3)
-  fun warn(): U8   => U8(4)
-  fun notice(): U8 => U8(5)
-  fun info(): U8   => U8(6)
-  fun debug(): U8  => U8(7)
+  fun none(): U8   => U8(0)
+  fun emerg(): U8  => U8(1)
+  fun alert(): U8  => U8(2)
+  fun crit(): U8   => U8(3)
+  fun err(): U8    => U8(4)
+  fun warn(): U8   => U8(5)
+  fun notice(): U8 => U8(6)
+  fun info(): U8   => U8(7)
+  fun debug(): U8  => U8(8)
   fun max_severity(): U8 => debug()
   fun default_severity(): U8 => info()
 
   // categories
-  // Don't use category 0
+  fun c_none(): U8             => U8(0)
   fun c_checkpoint(): U8       => U8(1)
   fun c_source_migration(): U8 => U8(2)
   fun c_2pc(): U8              => U8(3)
   fun c_dos_client(): U8       => U8(4)
 
+  fun severity_map(): Array[(U8, String)] =>
+    [
+      (none(),  "NONE")
+      (emerg(),  "EMERGENCY")
+      (alert(),  "ALERT")
+      (crit(),   "CRITICAL")
+      (err(),    "ERROR")
+      (warn(),   "WARNING")
+      (notice(), "NOTICE")
+      (info(),   "INFO")
+      (debug(),  "DEBUG")
+    ]
+
   fun category_map(): Array[(U8, U8, String)] =>
     [
-      (default_severity(), c_checkpoint(),       "CHECKPOINT")
-      (default_severity(), c_source_migration(), "SOURCE_MIGRATION")
+      (default_severity(), c_none(),             "none")
+      (default_severity(), c_checkpoint(),       "checkpoint")
+      (default_severity(), c_source_migration(), "source_migration")
       (default_severity(), c_2pc(),              "2PC")
-      (default_severity(), c_dos_client(),       "DOS_CLIENT")
+      (default_severity(), c_dos_client(),       "DOS_client")
     ]
+
+  fun set_defaults() =>
+    set_severities()
+    set_categories()
+    set_thresholds()
+
+  fun set_severities() =>
+    for (severity, label) in severity_map().values() do
+      @w_set_severity[None](severity, label.cstring())
+    end
 
   fun set_categories() =>
     for (severity, category, label) in category_map().values() do
-      @w_severity_cat_threshold[None](severity, category)
+      @w_set_category[None](category, label.cstring())
     end
 
   fun set_thresholds(do_defaults: Bool = true, do_overrides: Bool = true) =>

--- a/utils/data_receiver/data_receiver.pony
+++ b/utils/data_receiver/data_receiver.pony
@@ -52,8 +52,16 @@ actor Main
     @printf[I32]("SLF: critical enabled = false? res = %s\n".cstring(),
       @le[Bool](Log.crit(), cat_mumble).string().cstring())
 
-    Log.set_categories()
+    Log.set_categories(false)
     @l[I32](Log.emerg(), Log.c_source_migration(), "Visible migration event".cstring())
+
+    @w_process_category_overrides[None]()
+    let aa: Array[(U8, U8)] = [ (7,20); (2,20); (7, 21); (2, 21)]
+    for (sev, cat) in aa.values() do
+      let b = @le[Bool](sev, cat)
+      @printf[I32]("SLF: enabled sev=%d,cat=%d? res = %s\n".cstring(),
+        sev, cat, @le[Bool](sev, cat).string().cstring())
+    end
 
     try
       var options = Options(env.args)

--- a/utils/data_receiver/data_receiver.pony
+++ b/utils/data_receiver/data_receiver.pony
@@ -35,15 +35,15 @@ actor Main
     let cat_mumble = U8(40)
 
     @printf[I32]("SLF: Hello, world!\n".cstring()) // For demo purposes only
-    @l[I32](Log.crit(), cat_mumble, "SLF: Hello, %s!\n".cstring(), "everything".cstring()) // For demo purposes only
+    @l[I32](Log.crit(), cat_mumble, "SLF: Hello, %s\n".cstring(), "everything".cstring()) // For demo purposes only
     @w_set_severity[None](Log.crit(), "2-severity-yo".cstring())
     @w_set_category[None](cat_mumble, "my-mumble-cat".cstring())
-    @l[I32](Log.crit(), cat_mumble, "SLF: Hello, %s!\n".cstring(), "everything".cstring()) // For demo purposes only
+    @l[I32](Log.crit(), cat_mumble, "SLF: Hello, %s!".cstring(), "everything".cstring()) // For demo purposes only
 
     @w_severity_threshold[None](Log.alert())
-    @l[I32](Log.emerg(), cat_mumble, "SLF: visible!\n".cstring()) // For demo purposes only
-    @l[I32](Log.alert(), cat_mumble, "SLF: visible!\n".cstring()) // For demo purposes only
-    @l[I32](Log.crit(), cat_mumble, "SLF: this one should be filtered out\n".cstring()) // For demo purposes only
+    @l[I32](Log.emerg(), cat_mumble, "SLF: visible!".cstring()) // For demo purposes only
+    @l[I32](Log.alert(), cat_mumble, "SLF: visible!".cstring()) // For demo purposes only
+    @l[I32](Log.crit(), cat_mumble, "SLF: this one should be filtered out".cstring()) // For demo purposes only
 
     @printf[I32]("SLF: emergency enabled = true? res = %s\n".cstring(),
       @le[Bool](Log.emerg(), cat_mumble).string().cstring())
@@ -53,7 +53,7 @@ actor Main
       @le[Bool](Log.crit(), cat_mumble).string().cstring())
 
     Log.set_categories()
-    @l[I32](Log.emerg(), Log.c_source_migration(), "Visible migration event\n".cstring())
+    @l[I32](Log.emerg(), Log.c_source_migration(), "Visible migration event".cstring())
 
     try
       var options = Options(env.args)

--- a/utils/data_receiver/data_receiver.pony
+++ b/utils/data_receiver/data_receiver.pony
@@ -21,6 +21,8 @@ use "wallaroo_labs/bytes"
 use "wallaroo_labs/logging"
 use "wallaroo_labs/options"
 
+use @l[I32](severity: U8, category: U8, fmt: Pointer[U8] tag, ...)
+
 actor Main
   new create(env: Env) =>
     var required_args_are_present = true

--- a/utils/data_receiver/data_receiver.pony
+++ b/utils/data_receiver/data_receiver.pony
@@ -52,10 +52,10 @@ actor Main
     @printf[I32]("SLF: critical enabled = false? res = %s\n".cstring(),
       @le[Bool](Log.crit(), cat_mumble).string().cstring())
 
-    Log.set_categories(false)
+    Log.set_categories()
     @l[I32](Log.emerg(), Log.c_source_migration(), "Visible migration event".cstring())
 
-    @w_process_category_overrides[None]()
+    Log.set_thresholds(false, true)
     let aa: Array[(U8, U8)] = [ (7,20); (2,20); (7, 21); (2, 21)]
     for (sev, cat) in aa.values() do
       let b = @le[Bool](sev, cat)

--- a/utils/data_receiver/data_receiver.pony
+++ b/utils/data_receiver/data_receiver.pony
@@ -21,7 +21,7 @@ use "wallaroo_labs/bytes"
 use "wallaroo_labs/logging"
 use "wallaroo_labs/options"
 
-use @l[I32](severity: U8, category: U8, fmt: Pointer[U8] tag, ...)
+use @logf[I32](severity: U8, category: U8, fmt: Pointer[U8] tag, ...)
 
 actor Main
   new create(env: Env) =>
@@ -37,15 +37,15 @@ actor Main
     let cat_mumble = U8(40)
 
     @printf[I32]("SLF: Hello, world!\n".cstring()) // For demo purposes only
-    @l[I32](Log.crit(), cat_mumble, "SLF: Hello, %s\n".cstring(), "everything".cstring()) // For demo purposes only
+    @logf(Log.crit(), cat_mumble, "SLF: Hello, %s\n".cstring(), "everything".cstring()) // For demo purposes only
     @w_set_severity[None](Log.crit(), "2-severity-yo".cstring())
     @w_set_category[None](cat_mumble, "my-mumble-cat".cstring())
-    @l[I32](Log.crit(), cat_mumble, "SLF: Hello, %s!".cstring(), "everything".cstring()) // For demo purposes only
+    @logf(Log.crit(), cat_mumble, "SLF: Hello, %s!".cstring(), "everything".cstring()) // For demo purposes only
 
     @w_severity_threshold[None](Log.alert())
-    @l[I32](Log.emerg(), cat_mumble, "SLF: visible!".cstring()) // For demo purposes only
-    @l[I32](Log.alert(), cat_mumble, "SLF: visible!".cstring()) // For demo purposes only
-    @l[I32](Log.crit(), cat_mumble, "SLF: this one should be filtered out".cstring()) // For demo purposes only
+    @logf(Log.emerg(), cat_mumble, "SLF: visible!".cstring()) // For demo purposes only
+    @logf(Log.alert(), cat_mumble, "SLF: visible!".cstring()) // For demo purposes only
+    @logf(Log.crit(), cat_mumble, "SLF: this one should be filtered out".cstring()) // For demo purposes only
 
     @printf[I32]("SLF: emergency enabled = true? res = %s\n".cstring(),
       @le[Bool](Log.emerg(), cat_mumble).string().cstring())
@@ -55,7 +55,7 @@ actor Main
       @le[Bool](Log.crit(), cat_mumble).string().cstring())
 
     Log.set_categories()
-    @l[I32](Log.emerg(), Log.c_source_migration(), "Visible migration event".cstring())
+    @logf(Log.emerg(), Log.c_source_migration(), "Visible migration event".cstring())
 
     Log.set_thresholds(false, true)
     let aa: Array[(U8, U8)] = [ (7,20); (2,20); (7, 21); (2, 21)]

--- a/utils/data_receiver/data_receiver.pony
+++ b/utils/data_receiver/data_receiver.pony
@@ -22,6 +22,7 @@ use "wallaroo_labs/logging"
 use "wallaroo_labs/options"
 
 use @l[I32](severity: U8, category: U8, fmt: Pointer[U8] tag, ...)
+use @ll[I32](sev_cat: U16, fmt: Pointer[U8] tag, ...)
 use @log_enabled[Bool](severity: U8, category: U8)
 
 actor Main
@@ -57,6 +58,8 @@ actor Main
 
     Log.set_categories()
     @l(Log.emerg(), Log.source_migration(), "Visible migration event".cstring())
+    let emerg_s_mig = Log.make_sev_cat(Log.emerg(), Log.source_migration())
+    @ll(emerg_s_mig, "ll-visible migration event".cstring())
 
     // @l(Log.source_migration_info(), "Visible migration event".cstring())
     // @l(Log.emerg(), Log.source_migration(), "Visible migration event".cstring())

--- a/utils/data_receiver/data_receiver.pony
+++ b/utils/data_receiver/data_receiver.pony
@@ -33,6 +33,9 @@ actor Main
     @w_set_severity[None](U8(2), "2-severity-yo".cstring())
     @w_set_category[None](U8(3), "my-3-cat-cat".cstring())
     @l[I32](U8(2), U8(3), "SLF: Hello, %s!\n".cstring(), "everything".cstring()) // For demo purposes only
+    @w_severity_threshold[None](U8(1))
+    @l[I32](U8(2), U8(3), "SLF: this one should be filtered out\n".cstring()) // For demo purposes only
+    @l[I32](U8(1), U8(3), "SLF: visible!\n".cstring()) // For demo purposes only
     try
       var options = Options(env.args)
 

--- a/utils/data_receiver/data_receiver.pony
+++ b/utils/data_receiver/data_receiver.pony
@@ -21,7 +21,8 @@ use "wallaroo_labs/bytes"
 use "wallaroo_labs/logging"
 use "wallaroo_labs/options"
 
-use @logf[I32](severity: U8, category: U8, fmt: Pointer[U8] tag, ...)
+use @l[I32](severity: U8, category: U8, fmt: Pointer[U8] tag, ...)
+use @log_enabled[Bool](severity: U8, category: U8)
 
 actor Main
   new create(env: Env) =>
@@ -37,32 +38,35 @@ actor Main
     let cat_mumble = U8(40)
 
     @printf[I32]("SLF: Hello, world!\n".cstring()) // For demo purposes only
-    @logf(Log.crit(), cat_mumble, "SLF: Hello, %s\n".cstring(), "everything".cstring()) // For demo purposes only
+    @l(Log.crit(), cat_mumble, "SLF: Hello, %s\n".cstring(), "everything".cstring()) // For demo purposes only
     @w_set_severity[None](Log.crit(), "2-severity-yo".cstring())
     @w_set_category[None](cat_mumble, "my-mumble-cat".cstring())
-    @logf(Log.crit(), cat_mumble, "SLF: Hello, %s!".cstring(), "everything".cstring()) // For demo purposes only
+    @l(Log.crit(), cat_mumble, "SLF: Hello, %s!".cstring(), "everything".cstring()) // For demo purposes only
 
     @w_severity_threshold[None](Log.alert())
-    @logf(Log.emerg(), cat_mumble, "SLF: visible!".cstring()) // For demo purposes only
-    @logf(Log.alert(), cat_mumble, "SLF: visible!".cstring()) // For demo purposes only
-    @logf(Log.crit(), cat_mumble, "SLF: this one should be filtered out".cstring()) // For demo purposes only
+    @l(Log.emerg(), cat_mumble, "SLF: visible!".cstring()) // For demo purposes only
+    @l(Log.alert(), cat_mumble, "SLF: visible!".cstring()) // For demo purposes only
+    @l(Log.crit(), cat_mumble, "SLF: this one should be filtered out".cstring()) // For demo purposes only
 
     @printf[I32]("SLF: emergency enabled = true? res = %s\n".cstring(),
-      @le[Bool](Log.emerg(), cat_mumble).string().cstring())
+      @log_enabled(Log.emerg(), cat_mumble).string().cstring())
     @printf[I32]("SLF: alert enabled = true? res = %s\n".cstring(),
-      @le[Bool](Log.alert(), cat_mumble).string().cstring())
+      @log_enabled(Log.alert(), cat_mumble).string().cstring())
     @printf[I32]("SLF: critical enabled = false? res = %s\n".cstring(),
-      @le[Bool](Log.crit(), cat_mumble).string().cstring())
+      @log_enabled(Log.crit(), cat_mumble).string().cstring())
 
     Log.set_categories()
-    @logf(Log.emerg(), Log.c_source_migration(), "Visible migration event".cstring())
+    @l(Log.emerg(), Log.source_migration(), "Visible migration event".cstring())
+
+    // @l(Log.source_migration_info(), "Visible migration event".cstring())
+    // @l(Log.emerg(), Log.source_migration(), "Visible migration event".cstring())
+
 
     Log.set_thresholds(false, true)
     let aa: Array[(U8, U8)] = [ (7,20); (2,20); (7, 21); (2, 21)]
     for (sev, cat) in aa.values() do
-      let b = @le[Bool](sev, cat)
       @printf[I32]("SLF: enabled sev=%d,cat=%d? res = %s\n".cstring(),
-        sev, cat, @le[Bool](sev, cat).string().cstring())
+        sev, cat, @log_enabled(sev, cat).string().cstring())
     end
 
     try

--- a/utils/data_receiver/data_receiver.pony
+++ b/utils/data_receiver/data_receiver.pony
@@ -28,14 +28,30 @@ actor Main
     var output_mode: OutputMode = Write
     var input_mode: InputMode = Streaming
 
+    let sev_emergency = U8(0)
+    let sev_alert = U8(1)
+    let sev_crit = U8(2)
+    let sev_error = U8(3)
+    let cat_mumble = U8(40)
+
     @printf[I32]("SLF: Hello, world!\n".cstring()) // For demo purposes only
-    @l[I32](U8(2), U8(3), "SLF: Hello, %s!\n".cstring(), "everything".cstring()) // For demo purposes only
-    @w_set_severity[None](U8(2), "2-severity-yo".cstring())
-    @w_set_category[None](U8(3), "my-3-cat-cat".cstring())
-    @l[I32](U8(2), U8(3), "SLF: Hello, %s!\n".cstring(), "everything".cstring()) // For demo purposes only
-    @w_severity_threshold[None](U8(1))
-    @l[I32](U8(2), U8(3), "SLF: this one should be filtered out\n".cstring()) // For demo purposes only
-    @l[I32](U8(1), U8(3), "SLF: visible!\n".cstring()) // For demo purposes only
+    @l[I32](sev_crit, cat_mumble, "SLF: Hello, %s!\n".cstring(), "everything".cstring()) // For demo purposes only
+    @w_set_severity[None](sev_crit, "2-severity-yo".cstring())
+    @w_set_category[None](cat_mumble, "my-mumble-cat".cstring())
+    @l[I32](sev_crit, cat_mumble, "SLF: Hello, %s!\n".cstring(), "everything".cstring()) // For demo purposes only
+
+    @w_severity_threshold[None](sev_alert)
+    @l[I32](sev_emergency, cat_mumble, "SLF: visible!\n".cstring()) // For demo purposes only
+    @l[I32](sev_alert, cat_mumble, "SLF: visible!\n".cstring()) // For demo purposes only
+    @l[I32](sev_crit, cat_mumble, "SLF: this one should be filtered out\n".cstring()) // For demo purposes only
+
+    @printf[I32]("SLF: emergency enabled = 1? res = %s\n".cstring(),
+      @le[Bool](sev_emergency, cat_mumble).string().cstring())
+    @printf[I32]("SLF: alert enabled = 1? res = %s\n".cstring(),
+      @le[Bool](sev_alert, cat_mumble).string().cstring())
+    @printf[I32]("SLF: critical enabled = 0? res = %s\n".cstring(),
+      @le[Bool](sev_crit, cat_mumble).string().cstring())
+
     try
       var options = Options(env.args)
 

--- a/utils/data_receiver/data_receiver.pony
+++ b/utils/data_receiver/data_receiver.pony
@@ -29,7 +29,10 @@ actor Main
     var input_mode: InputMode = Streaming
 
     @printf[I32]("SLF: Hello, world!\n".cstring()) // For demo purposes only
-    @l[I32](U8(42), U8(43), "SLF: Hello, %s!\n".cstring(), "everything".cstring()) // For demo purposes only
+    @l[I32](U8(2), U8(3), "SLF: Hello, %s!\n".cstring(), "everything".cstring()) // For demo purposes only
+    @w_set_severity[None](U8(2), "2-severity-yo".cstring())
+    @w_set_category[None](U8(3), "my-3-cat-cat".cstring())
+    @l[I32](U8(2), U8(3), "SLF: Hello, %s!\n".cstring(), "everything".cstring()) // For demo purposes only
     try
       var options = Options(env.args)
 

--- a/utils/data_receiver/data_receiver.pony
+++ b/utils/data_receiver/data_receiver.pony
@@ -29,6 +29,7 @@ actor Main
     var input_mode: InputMode = Streaming
 
     @printf[I32]("SLF: Hello, world!\n".cstring()) // For demo purposes only
+    @l[I32](U8(42), U8(43), "SLF: Hello, %s!\n".cstring(), "everything".cstring()) // For demo purposes only
     try
       var options = Options(env.args)
 

--- a/utils/data_receiver/data_receiver.pony
+++ b/utils/data_receiver/data_receiver.pony
@@ -45,11 +45,11 @@ actor Main
     @l[I32](sev_alert, cat_mumble, "SLF: visible!\n".cstring()) // For demo purposes only
     @l[I32](sev_crit, cat_mumble, "SLF: this one should be filtered out\n".cstring()) // For demo purposes only
 
-    @printf[I32]("SLF: emergency enabled = 1? res = %s\n".cstring(),
+    @printf[I32]("SLF: emergency enabled = true? res = %s\n".cstring(),
       @le[Bool](sev_emergency, cat_mumble).string().cstring())
-    @printf[I32]("SLF: alert enabled = 1? res = %s\n".cstring(),
+    @printf[I32]("SLF: alert enabled = true? res = %s\n".cstring(),
       @le[Bool](sev_alert, cat_mumble).string().cstring())
-    @printf[I32]("SLF: critical enabled = 0? res = %s\n".cstring(),
+    @printf[I32]("SLF: critical enabled = false? res = %s\n".cstring(),
       @le[Bool](sev_crit, cat_mumble).string().cstring())
 
     try

--- a/utils/data_receiver/data_receiver.pony
+++ b/utils/data_receiver/data_receiver.pony
@@ -28,29 +28,32 @@ actor Main
     var output_mode: OutputMode = Write
     var input_mode: InputMode = Streaming
 
-    let sev_emergency = U8(0)
-    let sev_alert = U8(1)
-    let sev_crit = U8(2)
-    let sev_error = U8(3)
+    // let Log.emerg = U8(0)
+    // let Log.alert = U8(1)
+    // let Log.crit = U8(2)
+    // let Log.err = U8(3)
     let cat_mumble = U8(40)
 
     @printf[I32]("SLF: Hello, world!\n".cstring()) // For demo purposes only
-    @l[I32](sev_crit, cat_mumble, "SLF: Hello, %s!\n".cstring(), "everything".cstring()) // For demo purposes only
-    @w_set_severity[None](sev_crit, "2-severity-yo".cstring())
+    @l[I32](Log.crit(), cat_mumble, "SLF: Hello, %s!\n".cstring(), "everything".cstring()) // For demo purposes only
+    @w_set_severity[None](Log.crit(), "2-severity-yo".cstring())
     @w_set_category[None](cat_mumble, "my-mumble-cat".cstring())
-    @l[I32](sev_crit, cat_mumble, "SLF: Hello, %s!\n".cstring(), "everything".cstring()) // For demo purposes only
+    @l[I32](Log.crit(), cat_mumble, "SLF: Hello, %s!\n".cstring(), "everything".cstring()) // For demo purposes only
 
-    @w_severity_threshold[None](sev_alert)
-    @l[I32](sev_emergency, cat_mumble, "SLF: visible!\n".cstring()) // For demo purposes only
-    @l[I32](sev_alert, cat_mumble, "SLF: visible!\n".cstring()) // For demo purposes only
-    @l[I32](sev_crit, cat_mumble, "SLF: this one should be filtered out\n".cstring()) // For demo purposes only
+    @w_severity_threshold[None](Log.alert())
+    @l[I32](Log.emerg(), cat_mumble, "SLF: visible!\n".cstring()) // For demo purposes only
+    @l[I32](Log.alert(), cat_mumble, "SLF: visible!\n".cstring()) // For demo purposes only
+    @l[I32](Log.crit(), cat_mumble, "SLF: this one should be filtered out\n".cstring()) // For demo purposes only
 
     @printf[I32]("SLF: emergency enabled = true? res = %s\n".cstring(),
-      @le[Bool](sev_emergency, cat_mumble).string().cstring())
+      @le[Bool](Log.emerg(), cat_mumble).string().cstring())
     @printf[I32]("SLF: alert enabled = true? res = %s\n".cstring(),
-      @le[Bool](sev_alert, cat_mumble).string().cstring())
+      @le[Bool](Log.alert(), cat_mumble).string().cstring())
     @printf[I32]("SLF: critical enabled = false? res = %s\n".cstring(),
-      @le[Bool](sev_crit, cat_mumble).string().cstring())
+      @le[Bool](Log.crit(), cat_mumble).string().cstring())
+
+    Log.set_categories()
+    @l[I32](Log.emerg(), Log.c_source_migration(), "Visible migration event\n".cstring())
 
     try
       var options = Options(env.args)


### PR DESCRIPTION
Thoughts?

```
/*
** w_process_category_overrides, process any env var overrides
**
** If the environment variable WALLAROO_THRESHOLDS exists, then
** parse that string and apply a set of overrides to the
** _cat2sev_thresholds.
**
** The string should contain a list of zero or more
** category.severity pairs, e.g, "22.5" for category 23 and
** severity 5 (which corresponds to Log.notice()).  The string
** "*" can be used to specify all categories.
**
** Items in the list are separated by commas and are processed
** in order.  The "*" for all categories, if used, probably ought
** to be first in the list.  For example, "*.1,22.5,3.7,4.0".
*/
```

A simple logging example is:

        @logf(Log.info(), Log.checkpoint(), "Message goes here".cstring())
