### PR TITLE
Add missing sections to README.MD in Wallaroo Pony apps

### DIFF
--- a/examples/pony/alerts_local_aggregations/README.md
+++ b/examples/pony/alerts_local_aggregations/README.md
@@ -6,6 +6,29 @@ This is an example of a stateful application that builds up worker
 local aggregations before sending the results downstream where they
 are tallied across workers.
 
+## Prerequisites
+	
+- ponyc
+- pony-stable
+- Wallaroo
+        
+See [Wallaroo Environment Setup Instructions](https://docs.wallaroolabs.com/python-installation/).
+
+## Building
+
+Build Alerts (local aggregations) with
+```bash
+make
+```
+
+## alerts_local_aggregations arguments
+
+In a shell, run the following to get help on arguments to the application:
+
+```bash
+./alerts_local_aggregations --help
+```
+
 ### Input
 
 For simplicity, we use a generator source that creates a stream of transaction

--- a/examples/pony/alerts_stateless/README.md
+++ b/examples/pony/alerts_stateless/README.md
@@ -5,6 +5,30 @@
 This is an example of a stateless application that takes a transaction
 and sends an alert if its value is above or below a threshold.
 
+## Prerequisites
+
+- ponyc
+- pony-stable
+- Wallaroo
+
+See [Wallaroo Environment Setup Instructions](https://docs.wallaroolabs.com/python-installation/).
+
+## Building
+
+Build Alerts (stateless) with
+
+```bash
+make
+```
+
+## alerts_stateless arguments
+
+In a shell, run the following to get help on arguments to the application:
+
+```bash
+./alerts_stateless --help
+```
+
 ### Input
 
 For simplicity, we use a generator source that creates a stream of transaction

--- a/examples/pony/alerts_windowed/README.md
+++ b/examples/pony/alerts_windowed/README.md
@@ -1,9 +1,33 @@
-# Alerts (stateless)
+# Alerts (windowed)
 
 ## About The Application
 
-This is an example of a stateless application that takes a transaction
-and sends an alert if its value is above or below a threshold.
+This is an example of a windowed application that takes transactions
+in sliding windows and sends an alert if its value is above or below 
+a threshold.
+
+## Prerequisites
+	
+- ponyc
+- pony-stable
+- Wallaroo
+        
+See [Wallaroo Environment Setup Instructions](https://docs.wallaroolabs.com/python-installation/).
+
+## Building
+
+Build Alerts (windowed) with
+```bash
+make
+```
+
+## alerts_windowed arguments
+
+In a shell, run the following to get help on arguments to the application:
+
+```bash
+./alerts_windowed --help
+```
 
 ### Input
 


### PR DESCRIPTION
This PR adds the following sections to some of the README.MDs in
the example Wallaroo Pony apps

##Prerequisites
##Building
##<app> arguments
   ./<app> --help

and a correction to the README.md in alerts_windowed app.

(Reason : I was trying to run some of the Wallaroo Pony apps using README 
skipping the build step which was missing in the README. :-)

[skip ci]