### PR TITLE
Introducing the new logging API

### DIFF
--- a/examples/pony/alerts_local_aggregations/alerts.pony
+++ b/examples/pony/alerts_local_aggregations/alerts.pony
@@ -25,11 +25,13 @@ use "wallaroo/core/source/gen_source"
 use "wallaroo/core/state"
 use "wallaroo/core/topology"
 use "wallaroo/core/windows"
+use "wallaroo_labs/logging"
 use "wallaroo_labs/mort"
 use "wallaroo_labs/time"
 
 actor Main
   new create(env: Env) =>
+    Log.set_defaults()
     try
       let pipeline = recover val
         let transactions = Wallaroo.source[Transaction](

--- a/examples/pony/alerts_stateless/alerts.pony
+++ b/examples/pony/alerts_stateless/alerts.pony
@@ -22,9 +22,11 @@ use "wallaroo/core/sink/tcp_sink"
 use "wallaroo/core/source"
 use "wallaroo/core/source/gen_source"
 use "wallaroo/core/topology"
+use "wallaroo_labs/logging"
 
 actor Main
   new create(env: Env) =>
+    Log.set_defaults()
     try
       let pipeline = recover val
         let transactions = Wallaroo.source[Transaction]("Alerts (stateless)",

--- a/examples/pony/alerts_windowed/alerts.pony
+++ b/examples/pony/alerts_windowed/alerts.pony
@@ -26,10 +26,12 @@ use "wallaroo/core/source/gen_source"
 use "wallaroo/core/state"
 use "wallaroo/core/topology"
 use "wallaroo/core/windows"
+use "wallaroo_labs/logging"
 use "wallaroo_labs/time"
 
 actor Main
   new create(env: Env) =>
+    Log.set_defaults()
     try
       let pipeline = recover val
         let transactions = Wallaroo.source[Transaction]("Alerts (windowed)",

--- a/examples/pony/alphabet/alphabet.pony
+++ b/examples/pony/alphabet/alphabet.pony
@@ -22,6 +22,7 @@ use "serialise"
 use "wallaroo_labs/bytes"
 use "wallaroo"
 use "wallaroo/core/common"
+use "wallaroo_labs/logging"
 use "wallaroo_labs/mort"
 use "wallaroo_labs/time"
 use "wallaroo/core/sink/tcp_sink"
@@ -33,6 +34,7 @@ use "wallaroo/core/topology"
 
 actor Main
   new create(env: Env) =>
+    Log.set_defaults()
     try
       let pipeline = recover val
           let votes = Wallaroo.source[Votes]("Alphabet Votes",

--- a/examples/pony/celsius-kafka/celsius.pony
+++ b/examples/pony/celsius-kafka/celsius.pony
@@ -22,9 +22,11 @@ use "wallaroo/core/sink/kafka_sink"
 use "wallaroo/core/source"
 use "wallaroo/core/source/kafka_source"
 use "wallaroo/core/topology"
+use "wallaroo_labs/logging"
 
 actor Main
   new create(env: Env) =>
+    Log.set_defaults()
     let ksource_clip = KafkaSourceConfigCLIParser(env.out)
     let ksink_clip = KafkaSinkConfigCLIParser(env.out)
 

--- a/lib/wallaroo/core/sink/connector_sink/connector_sink.pony
+++ b/lib/wallaroo/core/sink/connector_sink/connector_sink.pony
@@ -108,7 +108,7 @@ actor ConnectorSink is Sink
   let _metrics_reporter: MetricsReporter
   var _initializer: (LocalTopologyInitializer | None) = None
   let _conn_debug: U16 = Log.make_sev_cat(Log.debug(), Log.conn_sink())
-  let _conn_info: U16 = Log.make_sev_cat(Log.info(), Log.conn_sink())
+  let _conn_info: U16 = Log.info()
   let _conn_err: U16 = Log.make_sev_cat(Log.err(), Log.conn_sink())
   let _twopc_debug: U16 = Log.make_sev_cat(Log.debug(), Log.twopc())
   let _twopc_info: U16 = Log.make_sev_cat(Log.info(), Log.twopc())

--- a/lib/wallaroo/core/sink/connector_sink/connector_sink.pony
+++ b/lib/wallaroo/core/sink/connector_sink/connector_sink.pony
@@ -48,6 +48,7 @@ use "wallaroo/core/sink"
 use "wallaroo/core/topology"
 use "wallaroo_labs/bytes"
 use cp = "wallaroo_labs/connector_protocol"
+use "wallaroo_labs/logging"
 use "wallaroo_labs/mort"
 use "wallaroo_labs/time"
 
@@ -59,6 +60,7 @@ use @pony_asio_event_resubscribe_read[None](event: AsioEventID)
 use @pony_asio_event_resubscribe_write[None](event: AsioEventID)
 use @pony_asio_event_destroy[None](event: AsioEventID)
 
+use @ll[I32](sev_cat: U16, fmt: Pointer[U8] tag, ...)
 
 primitive _ConnectTimeout
   fun apply(): U64 =>
@@ -105,6 +107,12 @@ actor ConnectorSink is Sink
   let _wb: Writer = Writer
   let _metrics_reporter: MetricsReporter
   var _initializer: (LocalTopologyInitializer | None) = None
+  let _conn_debug: U16 = Log.make_sev_cat(Log.debug(), Log.conn_sink())
+  let _conn_info: U16 = Log.make_sev_cat(Log.info(), Log.conn_sink())
+  let _conn_err: U16 = Log.make_sev_cat(Log.err(), Log.conn_sink())
+  let _twopc_debug: U16 = Log.make_sev_cat(Log.debug(), Log.twopc())
+  let _twopc_info: U16 = Log.make_sev_cat(Log.info(), Log.twopc())
+  let _twopc_err: U16 = Log.make_sev_cat(Log.err(), Log.twopc())
 
   // Consumer
   var _upstreams: SetIs[Producer] = _upstreams.create()
@@ -200,7 +208,7 @@ actor ConnectorSink is Sink
     _phase = NormalSinkPhase(this)
 
     ifdef "identify_routing_ids" then
-      @printf[I32]("===ConnectorSink %s created===\n".cstring(),
+      @ll(_conn_info, "===ConnectorSink %s created===\n".cstring(),
         _sink_id.string().cstring())
     end
 
@@ -225,7 +233,7 @@ actor ConnectorSink is Sink
     None
 
   fun ref _initial_connect() =>
-    @printf[I32]("ConnectorSink initializing connection to %s:%s\n".cstring(),
+    @ll(_conn_info, "ConnectorSink initializing connection to %s:%s\n".cstring(),
       _host.cstring(), _service.cstring())
     _connect_count = @pony_os_connect_tcp[U32](this,
       _host.cstring(), _service.cstring(),
@@ -249,7 +257,7 @@ actor ConnectorSink is Sink
     latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64)
   =>
     ifdef "trace" then
-      @printf[I32]("Rcvd msg at ConnectorSink\n".cstring())
+      @ll(_conn_debug, "Rcvd msg at ConnectorSink\n".cstring())
     end
 
     var receive_ts: U64 = 0
@@ -336,7 +344,7 @@ actor ConnectorSink is Sink
     to be sent but any writes that arrive after this will be
     silently discarded and not acknowleged.
     """
-    @printf[I32]("Shutting down ConnectorSink\n".cstring())
+    @ll(_conn_info, "Shutting down ConnectorSink\n".cstring())
     _no_more_reconnect = true
     _timers.dispose()
     close()
@@ -401,9 +409,7 @@ actor ConnectorSink is Sink
   fun ref abort_decision(reason: String, txn_id: String,
     barrier_token: CheckpointBarrierToken)
   =>
-    ifdef "checkpoint_trace" then
-      @printf[I32]("2PC: abort_decision: txn_id %s %s\n".cstring(), txn_id.cstring(), reason.cstring())
-    end
+    @ll(_twopc_debug, "2PC: abort_decision: txn_id %s %s\n".cstring(), txn_id.cstring(), reason.cstring())
 
     _twopc.set_state_abort()
     _barrier_coordinator.abort_barrier(barrier_token)
@@ -431,9 +437,7 @@ actor ConnectorSink is Sink
     receive one), at which point we can unblock all inputs and
     continue.
     """
-    ifdef "checkpoint_trace" then
-      @printf[I32]("Receive barrier %s at ConnectorSink %s\n".cstring(), barrier_token.string().cstring(), _sink_id.string().cstring())
-    end
+    @ll(_conn_debug, "Receive barrier %s at ConnectorSink %s\n".cstring(), barrier_token.string().cstring(), _sink_id.string().cstring())
     process_barrier(input_id, producer, barrier_token)
 
   fun ref receive_new_barrier(input_id: RoutingId, producer: Producer,
@@ -462,9 +466,7 @@ actor ConnectorSink is Sink
     propagation or processing by other actors in this worker or in
     any other worker.
     """
-    ifdef "checkpoint_trace" then
-      @printf[I32]("Barrier %s complete at ConnectorSink %s\n".cstring(), barrier_token.string().cstring(), _sink_id.string().cstring())
-    end
+    @ll(_conn_debug, "Barrier %s complete at ConnectorSink %s\n".cstring(), barrier_token.string().cstring(), _sink_id.string().cstring())
     var ack_now = true
     match barrier_token
     | let sbt: CheckpointBarrierToken =>
@@ -475,9 +477,7 @@ actor ConnectorSink is Sink
         // messages to us will block the senders.  However, the nature
         // of backpressure may change over time as the runtime's
         // backpressure system changes.
-        ifdef "checkpoint_trace" then
-          @printf[I32]("2PC: preemptive abort: connector sink not fully connected\n".cstring())
-        end
+        @ll(_twopc_debug, "2PC: preemptive abort: connector sink not fully connected\n".cstring())
         abort_decision("connector sink not fully connected",
           _twopc.txn_id, _twopc.barrier_token)
         _twopc.preemptive_txn_abort(sbt)
@@ -491,16 +491,12 @@ actor ConnectorSink is Sink
         // If no data has been processed by the sink since the last
         // checkpoint, then don't bother with 2PC, return early.
         _barrier_coordinator.ack_barrier(this, sbt)
-        ifdef "checkpoint_trace" then
-          @printf[I32]("2PC: no data written during this checkpoint interval, skipping 2PC round\n".cstring())
-        end
+        @ll(_twopc_debug, "2PC: no data written during this checkpoint interval, skipping 2PC round\n".cstring())
         return
 
       | let msg: cp.MessageMsg =>
         _notify.send_msg(this, msg)
-        ifdef "checkpoint_trace" then
-          @printf[I32]("2PC: sent phase 1 for txn_id %s\n".cstring(), _twopc.txn_id.cstring())
-        end
+        @ll(_twopc_debug, "2PC: sent phase 1 for txn_id %s\n".cstring(), _twopc.txn_id.cstring())
       end
 
       // As a 2PC participant as a Wallaroo *sink*, we cannot
@@ -526,27 +522,21 @@ actor ConnectorSink is Sink
     end
 
   be checkpoint_complete(checkpoint_id: CheckpointId) =>
-    ifdef "checkpoint_trace" then
-      @printf[I32]("2PC: Checkpoint complete %d at ConnectorSink %s\n".cstring(), checkpoint_id, _sink_id.string().cstring())
-    end
+    @ll(_twopc_debug, "2PC: Checkpoint complete %d at ConnectorSink %s\n".cstring(), checkpoint_id, _sink_id.string().cstring())
 
     let cpoint_id = ifdef "test_disconnect_at_5" then "5" else "" end
     let drop_phase2_msg = try if _twopc.txn_id.split("=")(1)? == cpoint_id then true else false end else false end
 
     _twopc.checkpoint_complete(this, drop_phase2_msg)
 
-    ifdef "checkpoint_trace" then
-      try @printf[I32]("2PC: DBGDBG: checkpoint_complete: commit, _twopc.last_offset %d _notify.twopc_txn_id_last_committed %s\n".cstring(), _twopc.last_offset, (_notify.twopc_txn_id_last_committed as String).cstring()) else Fail() end
-    end
+    try @ll(_twopc_debug, "2PC: DBGDBG: checkpoint_complete: commit, _twopc.last_offset %d _notify.twopc_txn_id_last_committed %s\n".cstring(), _twopc.last_offset, (_notify.twopc_txn_id_last_committed as String).cstring()) else Fail() end
 
     if _twopc.txn_id == "" then
-      @printf[I32]("Error: checkpoint_complete() with empty _twopc.txn_id = %s.\n".cstring(), _twopc.txn_id.cstring())
+      @ll(_twopc_err, "Error: checkpoint_complete() with empty _twopc.txn_id = %s.\n".cstring(), _twopc.txn_id.cstring())
       Fail()
     else
       _notify.twopc_txn_id_last_committed = _twopc.txn_id
-      ifdef "checkpoint_trace" then
-        try @printf[I32]("2PC: DBGDBG: twopc_txn_id_last_committed = %s.\n".cstring(), (_notify.twopc_txn_id_last_committed as String).cstring()) else Fail() end
-      end
+      try @ll(_twopc_debug, "2PC: DBGDBG: twopc_txn_id_last_committed = %s.\n".cstring(), (_notify.twopc_txn_id_last_committed as String).cstring()) else Fail() end
     end
     _twopc.reset_state()
 
@@ -589,13 +579,11 @@ actor ConnectorSink is Sink
     it to the local event log and reset 2PC state.
     """
     if not (_twopc.state_is_1precommit() or _twopc.state_is_start()) then
-      @printf[I32]("2PC: ERROR: _twopc.state = %d\n".cstring(), _twopc.state())
+      @ll(_twopc_err, "2PC: ERROR: _twopc.state = %d\n".cstring(), _twopc.state())
       Fail()
     end
 
-    ifdef "checkpoint_trace" then
-      @printf[I32]("2PC: Checkpoint state %s at ConnectorSink %s, txn-id %s\n".cstring(), checkpoint_id.string().cstring(), _sink_id.string().cstring(), _twopc.txn_id.cstring())
-    end
+    @ll(_twopc_debug, "2PC: Checkpoint state %s at ConnectorSink %s, txn-id %s\n".cstring(), checkpoint_id.string().cstring(), _sink_id.string().cstring(), _twopc.txn_id.cstring())
 
     let wb: Writer = wb.create()
     wb.u64_be(_twopc.current_offset.u64())
@@ -606,9 +594,7 @@ actor ConnectorSink is Sink
       consume bs)
 
   be prepare_for_rollback() =>
-    ifdef "checkpoint_trace" then
-      @printf[I32]("Prepare for checkpoint rollback at ConnectorSink %s\n".cstring(), _sink_id.string().cstring())
-    end
+    @ll(_conn_debug, "Prepare for checkpoint rollback at ConnectorSink %s\n".cstring(), _sink_id.string().cstring())
     // Don't call _use_normal_processor() here
 
   fun ref finish_preparing_for_rollback() =>
@@ -623,10 +609,8 @@ actor ConnectorSink is Sink
     We may need to re-send phase2=commit for this checkpoint_id.
     (But that's async from our point of view, beware tricksy bugs....)
     """
-    ifdef "checkpoint_trace" then
-      @printf[I32]("Rollback to %s at ConnectorSink %s\n".cstring(), checkpoint_id.string().cstring(), _sink_id.string().cstring())
-      @printf[I32]("2PC: Rollback: twopc_state %d txn_id %s.\n".cstring(), _twopc.state(), _twopc.txn_id.cstring())
-    end
+    @ll(_conn_debug, "Rollback to %s at ConnectorSink %s\n".cstring(), checkpoint_id.string().cstring(), _sink_id.string().cstring())
+    @ll(_twopc_debug, "2PC: Rollback: twopc_state %d txn_id %s.\n".cstring(), _twopc.state(), _twopc.txn_id.cstring())
 
     if _twopc.txn_id != "" then
       // Phase 1 decision was abort + we haven't been disconnected.
@@ -652,15 +636,11 @@ actor ConnectorSink is Sink
     // commit status: commit for checkpoint_id, all greater are invalid.
     _notify.twopc_txn_id_last_committed =
       _twopc.make_txn_id_string(checkpoint_id)
-    ifdef "checkpoint_trace" then
-      try @printf[I32]("DBGDBG: 2PC: twopc_txn_id_last_committed = %s.\n".cstring(), (_notify.twopc_txn_id_last_committed as String).cstring()) else Fail() end
-    end
+    try @ll(_twopc_debug, "DBGDBG: 2PC: twopc_txn_id_last_committed = %s.\n".cstring(), (_notify.twopc_txn_id_last_committed as String).cstring()) else Fail() end
     _notify.twopc_current_txn_aborted = _notify.process_uncommitted_list(this)
 
-    ifdef "checkpoint_trace" then
-      @printf[I32]("DBGDBG: 2PC: twopc_current_txn_aborted = %s.\n".cstring(), _notify.twopc_current_txn_aborted.string().cstring())
-      @printf[I32]("2PC: Rollback: _twopc.last_offset %lu _twopc.current_offset %lu acked_point_of_ref %lu last committed txn %s at ConnectorSink %s\n".cstring(), _twopc.last_offset, _twopc.current_offset, _notify.acked_point_of_ref, try (_notify.twopc_txn_id_last_committed as String).cstring() else "<<<None>>>".string() end, _sink_id.string().cstring())
-    end
+    @ll(_twopc_debug, "DBGDBG: 2PC: twopc_current_txn_aborted = %s.\n".cstring(), _notify.twopc_current_txn_aborted.string().cstring())
+    @ll(_twopc_debug, "2PC: Rollback: _twopc.last_offset %lu _twopc.current_offset %lu acked_point_of_ref %lu last committed txn %s at ConnectorSink %s\n".cstring(), _twopc.last_offset, _twopc.current_offset, _notify.acked_point_of_ref, try (_notify.twopc_txn_id_last_committed as String).cstring() else "<<<None>>>".string() end, _sink_id.string().cstring())
 
     event_log.ack_rollback(_sink_id)
 
@@ -706,7 +686,7 @@ actor ConnectorSink is Sink
             _notify_connecting()
           end
         elseif not _connected and _closed then
-          @printf[I32]("Reconnection asio event\n".cstring())
+          @ll(_conn_info, "Reconnection asio event\n".cstring())
           if @pony_os_connected[Bool](fd) then
             // The connection was successful, make it ours.
             _fd = fd
@@ -1141,7 +1121,7 @@ actor ConnectorSink is Sink
 
   fun ref _schedule_reconnect() =>
     if (_host != "") and (_service != "") and not _no_more_reconnect then
-      @printf[I32]("RE-Connecting ConnectorSink to %s:%s\n".cstring(),
+      @ll(_conn_info, "RE-Connecting ConnectorSink to %s:%s\n".cstring(),
                    _host.cstring(), _service.cstring())
       let timer = Timer(PauseBeforeReconnectConnectorSink(this), _reconnect_pause)
       _timers(consume timer)
@@ -1203,7 +1183,7 @@ actor ConnectorSink is Sink
     """
     "[len=" + array.size().string() + ": " + ", ".join(array.values()) + "]"
 
-  fun get_2pc_state(): U8 =>
+  fun get_twopc_state(): U8 =>
     _twopc.state()
 
 class PauseBeforeReconnectConnectorSink is TimerNotify

--- a/lib/wallaroo/core/sink/connector_sink/connector_sink_builder.pony
+++ b/lib/wallaroo/core/sink/connector_sink/connector_sink_builder.pony
@@ -26,7 +26,10 @@ use "wallaroo/core/sink"
 use "wallaroo/core/barrier"
 use "wallaroo/core/recovery"
 use "wallaroo/core/checkpoint"
+use "wallaroo_labs/logging"
 use "wallaroo_labs/mort"
+
+use @l[I32](severity: LogSeverity, category: LogCategory, fmt: Pointer[U8] tag, ...)
 
 primitive ConnectorSinkConfigCLIParser
   fun apply(args: Array[String] val): Array[ConnectorSinkConfigOptions] val ?
@@ -135,7 +138,8 @@ class val ConnectorSinkBuilder
     barrier_coordinator: BarrierCoordinator, checkpoint_initiator: CheckpointInitiator,
     recovering: Bool, worker_name: WorkerName, auth: AmbientAuth): Sink
   =>
-    @printf[I32](("ConnectorSinkBuilder: Connecting to sink at " + _host + ":" + _service + "\n")
+    @l(Log.info(), Log.conn_sink(),
+      ("ConnectorSinkBuilder: Connecting to sink at " + _host + ":" + _service + "\n")
       .cstring())
 
     let id: RoutingId = RoutingIdGenerator()

--- a/lib/wallaroo/core/sink/connector_sink/connector_sink_notify.pony
+++ b/lib/wallaroo/core/sink/connector_sink/connector_sink_notify.pony
@@ -23,7 +23,11 @@ use "wallaroo/core/common"
 use "wallaroo/core/network"
 use "wallaroo_labs/bytes"
 use cp = "wallaroo_labs/connector_protocol"
+use "wallaroo_labs/logging"
 use "wallaroo_labs/mort"
+
+// use @ll[I32](sev_cat: U16, fmt: Pointer[U8] tag, ...)
+
 
 class ConnectorSinkNotify
   var _fsm_state: cp.ConnectorProtoFsmState = cp.ConnectorProtoFsmDisconnected
@@ -41,6 +45,13 @@ class ConnectorSinkNotify
   var acked_point_of_ref: cp.MessageId = 0
   var message_id: cp.MessageId = acked_point_of_ref
   var _connection_count: USize = 0
+  let _conn_debug: U16 = Log.make_sev_cat(Log.debug(), Log.conn_sink())
+  let _conn_info: U16 = Log.make_sev_cat(Log.info(), Log.conn_sink())
+  let _conn_err: U16 = Log.make_sev_cat(Log.err(), Log.conn_sink())
+  let _twopc_debug: U16 = Log.make_sev_cat(Log.debug(), Log.twopc())
+  let _twopc_info: U16 = Log.make_sev_cat(Log.info(), Log.twopc())
+  let _twopc_err: U16 = Log.make_sev_cat(Log.err(), Log.twopc())
+
   // 2PC
   var _rtag: U64 = 77777
   var twopc_intro_done: Bool = false
@@ -72,7 +83,7 @@ class ConnectorSinkNotify
     None
 
   fun ref connected(conn: WallarooOutgoingNetworkActor ref) =>
-    @printf[I32]("ConnectorSink connected\n".cstring())
+    @ll(_conn_info, "ConnectorSink connected\n".cstring())
     _header = true
     _connected = true
     _throttled = false
@@ -127,7 +138,7 @@ class ConnectorSinkNotify
     is greater than 100), then the connector sink must tell
     us to abort in phase 1 in the next round of 2PC.
     """
-    @printf[I32]("ConnectorSink connection closed, throttling\n".cstring())
+    @ll(_conn_info, "ConnectorSink connection closed, throttling\n".cstring())
     _connected = false
     _throttled = false
     twopc_intro_done = false
@@ -135,10 +146,10 @@ class ConnectorSinkNotify
     throttled(conn)
 
   fun ref dispose() =>
-    @printf[I32]("ConnectorSink connection dispose\n".cstring())
+    @ll(_conn_info, "ConnectorSink connection dispose\n".cstring())
 
   fun ref connect_failed(conn: WallarooOutgoingNetworkActor ref) =>
-    @printf[I32]("ConnectorSink connection failed\n".cstring())
+    @ll(_conn_info, "ConnectorSink connection failed\n".cstring())
 
   fun ref expect(conn: WallarooOutgoingNetworkActor ref, qty: USize): USize =>
     qty
@@ -194,9 +205,7 @@ class ConnectorSinkNotify
     if _connected and (not _throttled) then
       data
     else
-      ifdef "checkpoint_trace" then
-        @printf[I32]("Sink sentv: not connected or throttled: buffering\n".cstring())
-      end
+      @ll(_conn_debug, "Sink sentv: not connected or throttled: buffering\n".cstring())
       for d in data.values() do
         twopc_reconnect_buffer.push(d)
       end
@@ -207,7 +216,7 @@ class ConnectorSinkNotify
     if (not _throttled) or (not twopc_intro_done) then
       _throttled = true
       Backpressure.apply(_auth)
-      @printf[I32](("ConnectorSink is experiencing back pressure, " +
+      @ll(_conn_info, ("ConnectorSink is experiencing back pressure, " +
         "connected = %s\n").cstring(), _connected.string().cstring())
     end
 
@@ -215,23 +224,17 @@ class ConnectorSinkNotify
     if _throttled and twopc_intro_done then
       _throttled = false
       Backpressure.release(_auth)
-      @printf[I32](("ConnectorSink is no longer experiencing" +
+      @ll(_conn_info, ("ConnectorSink is no longer experiencing" +
         " back pressure, connected = %s\n").cstring(),
       _connected.string().cstring())
-      ifdef "checkpoint_trace" then
-        try @printf[I32]("DBGDBG: unthrottled: buffer check, FSM state = %d\n".cstring(), (conn as ConnectorSink ref).get_2pc_state()) else Fail() end
-        @printf[I32]("DBGDBG: unthrottled: buffer: twopc_current_txn_aborted = %s current txn=%s.\n".cstring(), twopc_current_txn_aborted.string().cstring(), twopc_txn_id_current.cstring())
-      end
+      try @ll(_twopc_debug, "DBGDBG: unthrottled: buffer check, FSM state = %d\n".cstring(), (conn as ConnectorSink ref).get_twopc_state()) else Fail() end
+      @ll(_twopc_debug, "DBGDBG: unthrottled: buffer: twopc_current_txn_aborted = %s current txn=%s.\n".cstring(), twopc_current_txn_aborted.string().cstring(), twopc_txn_id_current.cstring())
       if twopc_current_txn_aborted then
-        ifdef "checkpoint_trace" then
-          @printf[I32]("DBGDBG: unthrottled: buffer: twopc_current_txn_aborted = %s discard %d items\n".cstring(), twopc_current_txn_aborted.string().cstring(), twopc_reconnect_buffer.size())
-        end
+        @ll(_twopc_debug, "DBGDBG: unthrottled: buffer: twopc_current_txn_aborted = %s discard %d items\n".cstring(), twopc_current_txn_aborted.string().cstring(), twopc_reconnect_buffer.size())
         None
       else
         for d in twopc_reconnect_buffer.values() do
-          ifdef "checkpoint_trace" then
-            @printf[I32]("DBG: unthrottled: writing buffered %d bytes\n".cstring(), d.size())
-          end
+          @ll(_twopc_debug, "DBG: unthrottled: writing buffered %d bytes\n".cstring(), d.size())
           try (conn as ConnectorSink ref)._write_final(d, None) else Fail() end
         end
       end
@@ -273,9 +276,7 @@ class ConnectorSinkNotify
       _error_and_close(conn, "Bad FSM State: C" + _fsm_state().string())
     | let m: cp.NotifyAckMsg =>
       if _fsm_state is cp.ConnectorProtoFsmStreaming then
-        ifdef "checkpoint_trace" then
-          @printf[I32]("NotifyAck: success %s stream_id %d p-o-r %lu\n".cstring(), m.success.string().cstring(), m.stream_id, m.point_of_ref)
-        end
+        @ll(_conn_debug, "NotifyAck: success %s stream_id %d p-o-r %lu\n".cstring(), m.success.string().cstring(), m.stream_id, m.point_of_ref)
         // We are going to ignore the point of reference sent to us by
         // the connector sink.  We assume that we know best, and if our
         // point of reference is earlier, then we'll send some duplicates
@@ -289,9 +290,7 @@ class ConnectorSinkNotify
         _error_and_close(conn, "Bad FSM State: Ea" + _fsm_state().string())
         return
       end
-      ifdef "checkpoint_trace" then
-        @printf[I32]("2PC: GOT MessageMsg\n".cstring())
-      end
+      @ll(_twopc_debug, "2PC: GOT MessageMsg\n".cstring())
       try
         let inner = cp.TwoPCFrame.decode(m.message as Array[U8] val)?
         match inner
@@ -301,13 +300,11 @@ class ConnectorSinkNotify
           // have already started a new round of 2PC ... so our new
           // round's txn_id may be in the txn_id's list.
           if mi.rtag != _rtag then
-            @printf[I32]("2PC: bad rtag match: %lu != %lu\n".cstring(), mi.rtag, _rtag)
+            @ll(_twopc_err, "2PC: bad rtag match: %lu != %lu\n".cstring(), mi.rtag, _rtag)
             Fail()
           end
-          ifdef "checkpoint_trace" then
-            @printf[I32]("TRACE: uncommitted txns = %d\n".cstring(),
+          @ll(_conn_debug, "TRACE: uncommitted txns = %d\n".cstring(),
               mi.txn_ids.size())
-          end
           twopc_uncommitted_list = mi.txn_ids
           // twopc_current_txn_aborted is used by unthrottled()
           twopc_current_txn_aborted = process_uncommitted_list(
@@ -332,9 +329,7 @@ class ConnectorSinkNotify
           end
           try (conn as ConnectorSink ref).twopc_intro_done() else Fail() end
         | let mi: cp.TwoPCReplyMsg =>
-          ifdef "checkpoint_trace" then
-            @printf[I32]("2PC: reply for txn_id %s was %s\n".cstring(), mi.txn_id.cstring(), mi.commit.string().cstring())
-          end
+          @ll(_twopc_debug, "2PC: reply for txn_id %s was %s\n".cstring(), mi.txn_id.cstring(), mi.commit.string().cstring())
           try (conn as ConnectorSink ref).twopc_phase1_reply(
             mi.txn_id, mi.commit)
           else Fail() end
@@ -378,13 +373,13 @@ class ConnectorSinkNotify
               // ACKs.
               None
             elseif p_o_r < acked_point_of_ref then
-              @printf[I32]("Error: Ack: stream-id %lu p_o_r %lu acked_point_of_ref %lu\n".cstring(), _stream_id, p_o_r, acked_point_of_ref)
+              @ll(_conn_err, "Error: Ack: stream-id %lu p_o_r %lu acked_point_of_ref %lu\n".cstring(), _stream_id, p_o_r, acked_point_of_ref)
               Fail()
             else
               acked_point_of_ref = p_o_r
             end
           else
-            @printf[I32]("Ack: unknown stream_id %d\n".cstring(), s_id)
+            @ll(_conn_err, "Ack: unknown stream_id %d\n".cstring(), s_id)
             Fail()
           end
         end
@@ -392,9 +387,7 @@ class ConnectorSinkNotify
         _error_and_close(conn, "Bad FSM State: F" + _fsm_state().string())
       end
     | let m: cp.RestartMsg =>
-      ifdef "checkpoint_trace" then
-        @printf[I32]("TRACE: got restart message, closing connection\n".cstring())
-      end
+      @ll(_conn_debug, "TRACE: got restart message, closing connection\n".cstring())
       conn.close()
     end
 
@@ -413,18 +406,12 @@ class ConnectorSinkNotify
     | (let last_committed: String, let uncommitted: Array[String] val) =>
       var current_txn_aborted: Bool = false
 
-      ifdef "checkpoint_trace" then
-        @printf[I32]("2PC: process_uncommitted_list processing %d items, last_committed = %s\n".cstring(), uncommitted.size(), last_committed.cstring())
-      end
+      @ll(_twopc_debug, "2PC: process_uncommitted_list processing %d items, last_committed = %s\n".cstring(), uncommitted.size(), last_committed.cstring())
       for txn_id in uncommitted.values() do
         let do_commit = if txn_id == last_committed then true else false end
-        ifdef "checkpoint_trace" then
-          @printf[I32]("2PC: uncommitted txn_id %s commit=%s\n".cstring(), txn_id.cstring(), do_commit.string().cstring())
-        end
+        @ll(_twopc_debug, "2PC: uncommitted txn_id %s commit=%s\n".cstring(), txn_id.cstring(), do_commit.string().cstring())
         if not do_commit and (txn_id == twopc_txn_id_current) then
-          ifdef "checkpoint_trace" then
-            @printf[I32]("2PC: current txn_id %s was aborted\n".cstring(), twopc_txn_id_current.cstring())
-          end
+          @ll(_twopc_debug, "2PC: current txn_id %s was aborted\n".cstring(), twopc_txn_id_current.cstring())
           current_txn_aborted = true
         end
         let p2 = cp.TwoPCEncode.phase2(txn_id, do_commit)
@@ -439,9 +426,7 @@ class ConnectorSinkNotify
       twopc_uncommitted_list = []
       current_txn_aborted
     else
-      ifdef "checkpoint_trace" then
-        @printf[I32]("2PC: process_uncommitted_list waiting\n".cstring())
-      end
+      @ll(_twopc_debug, "2PC: process_uncommitted_list waiting\n".cstring())
       false
     end
 
@@ -472,9 +457,7 @@ class ConnectorSinkNotify
       // are starting for the first time.  There is no prior committed
       // txn_id.
       twopc_txn_id_last_committed = ""
-      ifdef "checkpoint_trace" then
-        try @printf[I32]("DBGDBG: 2PC: twopc_txn_id_last_committed = %s.\n".cstring(), (twopc_txn_id_last_committed as String).cstring()) else Fail() end
-      end
+      try @ll(_twopc_debug, "DBGDBG: 2PC: twopc_txn_id_last_committed = %s.\n".cstring(), (twopc_txn_id_last_committed as String).cstring()) else Fail() end
       process_uncommitted_list(conn)
     end
 

--- a/lib/wallaroo/core/sink/connector_sink/connector_sink_notify.pony
+++ b/lib/wallaroo/core/sink/connector_sink/connector_sink_notify.pony
@@ -26,9 +26,6 @@ use cp = "wallaroo_labs/connector_protocol"
 use "wallaroo_labs/logging"
 use "wallaroo_labs/mort"
 
-// use @ll[I32](sev_cat: U16, fmt: Pointer[U8] tag, ...)
-
-
 class ConnectorSinkNotify
   var _fsm_state: cp.ConnectorProtoFsmState = cp.ConnectorProtoFsmDisconnected
   var _header: Bool = true

--- a/lib/wallaroo/core/source/connector_source/connector_source.pony
+++ b/lib/wallaroo/core/source/connector_source/connector_source.pony
@@ -49,8 +49,11 @@ use "wallaroo/core/source"
 use "wallaroo/core/tcp_actor"
 use "wallaroo/core/topology"
 use cwm = "wallaroo_labs/connector_wire_messages"
+use "wallaroo_labs/logging"
 use "wallaroo_labs/mort"
 
+use @l[I32](severity: LogSeverity, category: LogCategory, fmt: Pointer[U8] tag, ...)
+use @ll[I32](sev_cat: U16, fmt: Pointer[U8] tag, ...)
 
 actor ConnectorSource[In: Any val] is (Source & TCPActor)
   """
@@ -164,7 +167,7 @@ actor ConnectorSource[In: Any val] is (Source & TCPActor)
     end
 
     ifdef "identify_routing_ids" then
-      @printf[I32]("===ConnectorSource %s created===\n".cstring(),
+      @l(Log.info(), Log.conn_source(), "===ConnectorSource %s created===\n".cstring(),
         _source_id.string().cstring())
     end
 
@@ -337,7 +340,7 @@ actor ConnectorSource[In: Any val] is (Source & TCPActor)
       _outgoing_boundaries.remove(worker)?
     else
       ifdef debug then
-        @printf[I32]("ConnectorSource couldn't find boundary to %s to disconnect\n"
+        @l(Log.debug(), Log.conn_source(), "ConnectorSource couldn't find boundary to %s to disconnect\n"
           .cstring(), worker.cstring())
       end
     end
@@ -370,7 +373,7 @@ actor ConnectorSource[In: Any val] is (Source & TCPActor)
       _source_registry.unregister_source(this, _source_id)
       _event_log.unregister_resilient(_source_id, this)
       _unregister_all_outputs()
-      @printf[I32]("Shutting down ConnectorSource\n".cstring())
+      @l(Log.info(), Log.conn_source(), "Shutting down ConnectorSource\n".cstring())
       for b in _outgoing_boundaries.values() do
         b.dispose()
       end
@@ -397,7 +400,7 @@ actor ConnectorSource[In: Any val] is (Source & TCPActor)
         | let ob: OutgoingBoundary => b_count = b_count + 1
         end
       end
-      @printf[I32]("ConnectorSource %s has %s boundaries.\n".cstring(),
+      @l(Log.info(), Log.conn_source(), "ConnectorSource %s has %s boundaries.\n".cstring(),
         _source_id.string().cstring(), b_count.string().cstring())
     end
 
@@ -416,10 +419,7 @@ actor ConnectorSource[In: Any val] is (Source & TCPActor)
   //////////////
   be initiate_barrier(token: BarrierToken) =>
     if not _disposed then
-      ifdef "checkpoint_trace" then
-        @printf[I32]("ConnectorSource received initiate_barrier %s\n"
-          .cstring(), token.string().cstring())
-      end
+      @l(Log.debug(), Log.conn_source(), "ConnectorSource received initiate_barrier %s\n".cstring(), token.string().cstring())
       _initiate_barrier(token)
     end
 
@@ -444,10 +444,7 @@ actor ConnectorSource[In: Any val] is (Source & TCPActor)
     end
 
   be checkpoint_complete(checkpoint_id: CheckpointId) =>
-    ifdef "checkpoint_trace" then
-      @printf[I32]("Checkpoint %s complete at ConnectorSource %s\n".cstring(),
-        checkpoint_id.string().cstring(), _source_id.string().cstring())
-    end
+    @l(Log.debug(), Log.conn_source(), "Checkpoint %s complete at ConnectorSource %s\n".cstring(), checkpoint_id.string().cstring(), _source_id.string().cstring())
     _notify.checkpoint_complete(this, checkpoint_id)
 
   //////////////
@@ -477,7 +474,7 @@ actor ConnectorSource[In: Any val] is (Source & TCPActor)
       end
     end
     ifdef "trace" then
-      @printf[I32]("TRACE: %s.%s my source_id = %s, payload.size = %d\n".cstring(),
+      @l(Log.debug(), Log.conn_source(), "TRACE: %s.%s my source_id = %s, payload.size = %d\n".cstring(),
         __loc.type_name().cstring(), __loc.method_name().cstring(),
         _source_id.string().cstring(), p.size())
     end
@@ -514,7 +511,7 @@ actor ConnectorSource[In: Any val] is (Source & TCPActor)
     _notify.stream_notify_result(this, session_id', success, stream)
 
   be begin_shrink() =>
-    @printf[I32]("ConnectorSource %s beginning shrink migration.\n"
+    @l(Log.info(), Log.conn_source(), "ConnectorSource %s beginning shrink migration.\n"
       .cstring(), _source_id.string().cstring())
     _notify.shrink(this)
 
@@ -523,7 +520,7 @@ actor ConnectorSource[In: Any val] is (Source & TCPActor)
     Send a RESTART message with the (host,service) data that the connector
     should reconnect to.
     """
-    @printf[I32](("ConnectorSource %s completed shrink migration with " +
+    @l(Log.info(), Log.conn_source(), ("ConnectorSource %s completed shrink migration with " +
       "new address: (%s, %s).\n").cstring(),
       _source_id.string().cstring(),
       host.cstring(),
@@ -539,14 +536,14 @@ actor ConnectorSource[In: Any val] is (Source & TCPActor)
   ///////////////
   fun ref _mute() =>
     ifdef debug then
-      @printf[I32]("Muting ConnectorSource\n".cstring())
+      @l(Log.debug(), Log.conn_source(), "Muting ConnectorSource\n".cstring())
     end
     _muted = true
     _tcp_handler.mute()
 
   fun ref _unmute() =>
     ifdef debug then
-      @printf[I32]("Unmuting ConnectorSource\n".cstring())
+      @l(Log.debug(), Log.conn_source(), "Unmuting ConnectorSource\n".cstring())
     end
     _muted = false
     _tcp_handler.unmute()

--- a/lib/wallaroo/core/source/tcp_source/framed_source_notify.pony
+++ b/lib/wallaroo/core/source/tcp_source/framed_source_notify.pony
@@ -32,8 +32,6 @@ use "wallaroo/core/routing"
 use "wallaroo/core/source"
 use "wallaroo/core/topology"
 
-// use @ll[I32](sev_cat: U16, fmt: Pointer[U8] tag, ...)
-
 class TCPSourceNotify[In: Any val]
   let _source_id: RoutingId
   let _auth: AmbientAuth

--- a/lib/wallaroo_labs/_test.pony
+++ b/lib/wallaroo_labs/_test.pony
@@ -36,6 +36,7 @@ use queue = "queue"
 use weighted = "weighted"
 use query = "query"
 use cwm = "connector_wire_messages"
+use logging = "logging"
 
 actor Main is TestList
   new create(env: Env) =>
@@ -55,3 +56,4 @@ actor Main is TestList
     weighted.Main.make().tests(test)
     query.Main.make().tests(test)
     cwm.Main.make().tests(test)
+    logging.Main.make().tests(test)

--- a/lib/wallaroo_labs/logging/.gitignore
+++ b/lib/wallaroo_labs/logging/.gitignore
@@ -1,0 +1,2 @@
+libwallaroo-logging.o
+libwallaroo-logging.a

--- a/lib/wallaroo_labs/logging/Makefile
+++ b/lib/wallaroo_labs/logging/Makefile
@@ -40,21 +40,17 @@ LOGGING_LIB_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 # standard rules generation makefile
 include $(rules_mk_path)
 
-LOGGING_LIB_DIR=$(LOGGING_LIB_PATH)
-LOGGING_LIB_OBJ=$(LOGGING_LIB_DIR)wallaroo-logging.o
-LOGGING_LIB_A=$(LOGGING_LIB_DIR)libwallaroo-logging.a
-
-build-lib-wallaroo_labs-logging: $(LOGGING_LIB_A)
-$(LOGGING_LIB_A): $(LOGGING_LIB_OBJ)
+build-lib-wallaroo_labs-logging: $(logging_lib_a)
+$(logging_lib_a): $(logging_lib_obj)
 	ar rvs $@ $<
-$(LOGGING_LIB_OBJ): $(LOGGING_LIB_DIR)logging-lib.c
+$(logging_lib_obj): $(logging_lib_path)/logging-lib.c
 	cc -g -o $@ -c $<
 
 # The rule below will trigger a "overriding commands" warning when
 # there is a Pony source file in this directory.  Instead, there'source
 # a special "rm -f" command in rules.mk to delete the obj & lib files.
 #clean-lib-wallaroo_labs-logging:
-#	$(QUIET)rm -f $(LOGGING_LIB_DIR)/*.o $(LOGGING_LIB_DIR)/*.a
+#	$(QUIET)rm -f $(logging_lib_path)/*.o $(logging_lib_path)/*.a
 
 # end of prevent rules from being evaluated/included multiple times
 endif

--- a/lib/wallaroo_labs/logging/Makefile
+++ b/lib/wallaroo_labs/logging/Makefile
@@ -1,42 +1,60 @@
+# include root makefile
+ifndef ROOT_MAKEFILE_MK
+include ../../../Makefile
+endif
+
 # prevent rules from being evaluated/included multiple times
 ifndef $(abspath $(lastword $(MAKEFILE_LIST)))_MK
 $(abspath $(lastword $(MAKEFILE_LIST)))_MK := 1
 
-ROOT_MAKEFILE_MK := 1
-ROOT_MAKEFILE := $(lastword $(MAKEFILE_LIST))
-ROOT_MAKEFILE_PATH := $(dir $(ROOT_MAKEFILE))
-rules_mk_path := $(ROOT_MAKEFILE_PATH)/rules.mk
 
 # The following are control variables that determine what logic from `rules.mk` is enabled
 
 # `true`/`false` to enable/disable the actual unit test command so it can be overridden (the targets are still created)
 # applies to both the pony and elixir test targets
-$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
-$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := false
 
 # `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
 # it can be overridden manually
-$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := false
 
 # `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
 # otherwise targets only get created if there are elixir sources (*.exs) in this directory.
-$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_EXS_TARGET := false
 
 # `true`/`false` to enable/disable generate docker related targets (build/push) for a Dockerfile in this directory
 # otherwise targets only get created if there is a Dockerfile in this directory
-$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := false
 
 # `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
 # (and by recursion every makefile in the tree that is referenced)
-$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := false
+
+
+LOGGING_LIB_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 # standard rules generation makefile
 include $(rules_mk_path)
 
+LOGGING_LIB_DIR=$(LOGGING_LIB_PATH)
+LOGGING_LIB_OBJ=$(LOGGING_LIB_DIR)wallaroo-logging.o
+LOGGING_LIB_A=$(LOGGING_LIB_DIR)libwallaroo-logging.a
+
+build-lib-wallaroo_labs-logging: $(LOGGING_LIB_A)
+$(LOGGING_LIB_A): $(LOGGING_LIB_OBJ)
+	ar rvs $@ $<
+$(LOGGING_LIB_OBJ): $(LOGGING_LIB_DIR)logging-lib.c
+	cc -g -o $@ -c $<
+
+# The rule below will trigger a "overriding commands" warning when
+# there is a Pony source file in this directory.  Instead, there'source
+# a special "rm -f" command in rules.mk to delete the obj & lib files.
+#clean-lib-wallaroo_labs-logging:
+#	$(QUIET)rm -f $(LOGGING_LIB_DIR)/*.o $(LOGGING_LIB_DIR)/*.a
+
 # end of prevent rules from being evaluated/included multiple times
 endif
-
-

--- a/lib/wallaroo_labs/logging/README.md
+++ b/lib/wallaroo_labs/logging/README.md
@@ -1,0 +1,92 @@
+
+# Using the Log logging library
+
+## Prerequisites
+
+```
+// For each source file that uses the `Log` primitive
+use "wallaroo_labs/logging"
+
+// If no Pony source files contain a
+//     use "wallaroo_labs/logging"
+// statement, then add the following to access the C FFI
+// functions in the "libwallaroo-logging.a" library.
+use "lib:wallaroo-logging"
+
+```
+
+## Setup
+
+Early in your Wallaroo app, call `Log.set_defaults()` prior to calling any
+of the public API function described below.
+
+## Using the logging C FFI functions
+
+The top of `wallaroo-logging.pony` has several FFI type specs to
+cut-and-paste into your Pony source, as needed
+
+```
+use @l_enabled[Bool](severity: LogSeverity, category: LogCategory)
+use @ll_enabled[Bool](sev_cat: U16)
+use @l[I32](severity: LogSeverity, category: LogCategory, fmt: Pointer[U8] tag, ...)
+use @ll[I32](sev_cat: U16, fmt: Pointer[U8] tag, ...)
+```
+
+The log messages created by the `@l()` and `@ll()` functions are formatted
+using `sprintf(3)`-style formatting conventions.  The one difference
+is that this library will add a trailing newline/'\n' character to the
+format string.
+
+Log a message at `info` severity for the `checkpoint` category in the
+two argument style:
+
+```
+@l(Log.info(), Log.checkpoint(), "Hello, lucky %d".cstring(), 7)
+```
+
+Log a message at `info` severity for the `checkpoint` category in the
+one argument style
+
+```
+// without var
+@ll(Log.make_sev_crit(Log.info(), Log.checkpoint()), "Hello, lucky %d".cstring(), 7)
+
+// with var
+let info = Log.make_sev_crit(Log.info(), Log.checkpoint())
+@ll(info, "Hello, lucky %d".cstring(), 7)
+```
+
+If message formatting is expensive, then Pony code may wish to check
+if a severity + category is enabled prior to formatting.  Use
+`@l_enabled()` or `@ll_enabled()`:
+
+```
+if (@l_enabled(Log.info(), Log.checkpoint())) then ... end
+
+let info = Log.make_sev_crit(Log.info(), Log.checkpoint())
+if (@ll_enabled(info)) then ... end
+```
+
+## Setting label and severity thresholds
+
+To set new labels for severity & categories:
+
+```
+@w_set_severity_label(LogSeverity(8), "Special Debug label".cstring())
+@w_set_category_label(LogCategory(33), "easter egg".cstring())
+```
+
+To set a severity threshold for all categories or for a specific
+category, respectively:
+
+```
+@w_set_severity_threshold(LogSeverity(8))
+@w_set_severity_cat_threshold(LogSeverity(8), LogCategory(33))
+```
+
+To parse the `WALLAROO_THRESHOLDS` environment variable for overriding
+the thresholds set by `Log.set_defaults()`:
+
+```
+@w_process_category_overrides()
+```

--- a/lib/wallaroo_labs/logging/README.md
+++ b/lib/wallaroo_labs/logging/README.md
@@ -45,7 +45,7 @@ two argument style:
 ```
 
 Log a message at `info` severity for the `checkpoint` category in the
-one argument style
+one argument style:
 
 ```
 // without var
@@ -54,6 +54,17 @@ one argument style
 // with var
 let info = Log.make_sev_crit(Log.info(), Log.checkpoint())
 @ll(info, "Hello, lucky %d".cstring(), 7)
+```
+
+Log a message at `info` severity without a category in the
+one argument style:
+
+```
+@ll(Log.info(), "Hello, lucky %d".cstring(), 7)
+
+// Equivalent to
+@ll(Log.make_sev_crit(Log.info(), Log.none()), "Hello, lucky %d".cstring(), 7)
+
 ```
 
 If message formatting is expensive, then Pony code may wish to check

--- a/lib/wallaroo_labs/logging/_test.pony
+++ b/lib/wallaroo_labs/logging/_test.pony
@@ -41,10 +41,10 @@ class iso _TestFFI is UnitTest
     Log.set_defaults()
 
     // Make it obvious if the log level changes
-    h.assert_eq[U8](Log.info(), Log.default_severity())
+    h.assert_eq[U16](Log.info(), Log.default_severity())
 
     // Check for enabled sev+cat
-    for sev in Range[U8](0, Log.info()) do
+    for sev in Range[U16](0, Log.info()) do
       for cat in Range[U8](0, Log.max_category()) do
         h.assert_eq[Bool](true, @l_enabled(sev, cat))
         h.assert_eq[Bool](true, @ll_enabled(Log.make_sev_cat(sev, cat)))
@@ -52,7 +52,7 @@ class iso _TestFFI is UnitTest
     end
 
     // Check for disabled sev+cat
-    for sev in Range[U8](Log.info() + 1, Log.max_severity() + 1) do
+    for sev in Range[U16](Log.info() + 1, Log.max_severity() + 1) do
       for cat in Range[U8](0, Log.max_category()) do
         h.assert_eq[Bool](false, @l_enabled(sev, cat))
         h.assert_eq[Bool](false, @ll_enabled(Log.make_sev_cat(sev, cat)))

--- a/lib/wallaroo_labs/logging/_test.pony
+++ b/lib/wallaroo_labs/logging/_test.pony
@@ -1,0 +1,71 @@
+/*
+
+Copyright 2019 The Wallaroo Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing
+ permissions and limitations under the License.
+
+*/
+
+use "collections"
+use "ponytest"
+// use "wallaroo_labs/logging"
+use "lib:wallaroo-logging"
+
+actor Main is TestList
+  new create(env: Env) => PonyTest(env, this)
+
+  new make() => None
+
+  fun tag tests(test: PonyTest) =>
+    test(_TestFFI)
+
+class iso _TestFFI is UnitTest
+  fun name(): String => "logging/" + __loc.type_name()
+
+  fun apply(h: TestHelper) /*?*/ =>
+    let cat_40 = LogCategory(40)
+    let cat_41 = LogCategory(41)
+    let debug_40 = Log.make_sev_cat(Log.debug(), cat_40)
+    let debug_41 = Log.make_sev_cat(Log.debug(), cat_41)
+
+    Log.set_defaults()
+
+    // Make it obvious if the log level changes
+    h.assert_eq[U8](Log.info(), Log.default_severity())
+
+    // Check for enabled sev+cat
+    for sev in Range[U8](0, Log.info()) do
+      for cat in Range[U8](0, Log.max_category()) do
+        h.assert_eq[Bool](true, @l_enabled(sev, cat))
+        h.assert_eq[Bool](true, @ll_enabled(Log.make_sev_cat(sev, cat)))
+      end
+    end
+
+    // Check for disabled sev+cat
+    for sev in Range[U8](Log.info() + 1, Log.max_severity() + 1) do
+      for cat in Range[U8](0, Log.max_category()) do
+        h.assert_eq[Bool](false, @l_enabled(sev, cat))
+        h.assert_eq[Bool](false, @ll_enabled(Log.make_sev_cat(sev, cat)))
+      end
+    end
+
+    @l(Log.crit(), cat_40, "Hello, %s, 1 of 3".cstring(), "everything".cstring())
+    @ll(Log.make_sev_cat(Log.crit(), cat_40), "Hello, %s, 2 of 3".cstring(), "all".cstring())
+    @ll(debug_40, "Error if this is printed!".cstring())
+
+    // Now change the threshold for cat_40 only
+    @w_set_severity_cat_threshold(Log.debug(), cat_40)
+    @ll(debug_40, "Hello, %s, 3 of 3".cstring(), "all".cstring())
+    @ll(debug_41, "Error if this is printed!".cstring())
+
+    true

--- a/lib/wallaroo_labs/logging/_test.pony
+++ b/lib/wallaroo_labs/logging/_test.pony
@@ -33,10 +33,10 @@ class iso _TestFFI is UnitTest
   fun name(): String => "logging/" + __loc.type_name()
 
   fun apply(h: TestHelper) /*?*/ =>
-    let cat_40 = LogCategory(40)
-    let cat_41 = LogCategory(41)
+    let cat_39 = Log.manual_category(39)
+    let cat_40 = Log.manual_category(40)
+    let debug_39 = Log.make_sev_cat(Log.debug(), cat_39)
     let debug_40 = Log.make_sev_cat(Log.debug(), cat_40)
-    let debug_41 = Log.make_sev_cat(Log.debug(), cat_41)
 
     Log.set_defaults()
 
@@ -45,17 +45,17 @@ class iso _TestFFI is UnitTest
 
     // Check for enabled sev+cat
     for sev in Range[U16](0, Log.info()) do
-      for cat in Range[U8](0, Log.max_category()) do
-        h.assert_eq[Bool](true, @l_enabled(sev, cat))
-        h.assert_eq[Bool](true, @ll_enabled(Log.make_sev_cat(sev, cat)))
+      for cat in Range[U16](0, Log.max_category().shr(8)) do
+        h.assert_eq[Bool](true, @l_enabled(sev, cat.shl(8)))
+        h.assert_eq[Bool](true, @ll_enabled(Log.make_sev_cat(sev, cat.shl(8))))
       end
     end
 
     // Check for disabled sev+cat
     for sev in Range[U16](Log.info() + 1, Log.max_severity() + 1) do
-      for cat in Range[U8](0, Log.max_category()) do
-        h.assert_eq[Bool](false, @l_enabled(sev, cat))
-        h.assert_eq[Bool](false, @ll_enabled(Log.make_sev_cat(sev, cat)))
+      for cat in Range[U16](0, Log.max_category().shr(8)) do
+        h.assert_eq[Bool](false, @l_enabled(sev, cat.shl(8)))
+        h.assert_eq[Bool](false, @ll_enabled(Log.make_sev_cat(sev, cat.shl(8))))
       end
     end
 
@@ -65,7 +65,7 @@ class iso _TestFFI is UnitTest
 
     // Now change the threshold for cat_40 only
     @w_set_severity_cat_threshold(Log.debug(), cat_40)
+    @ll(debug_39, "Error if this is printed!".cstring())
     @ll(debug_40, "Hello, %s, 3 of 3".cstring(), "all".cstring())
-    @ll(debug_41, "Error if this is printed!".cstring())
 
     true

--- a/lib/wallaroo_labs/logging/bench/Makefile
+++ b/lib/wallaroo_labs/logging/bench/Makefile
@@ -1,6 +1,6 @@
 # include root makefile
 ifndef ROOT_MAKEFILE_MK
-include ../../../Makefile
+include ../../../../Makefile
 endif
 
 # prevent rules from being evaluated/included multiple times
@@ -16,11 +16,11 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_UNIT_TEST_COMMAND := false
 
 # `true`/`false` to enable/disable generate pony related targets (build/test/clean) for pony sources in this directory
 # otherwise targets only get created if there are pony sources (*.pony) in this directory.
-$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONY_TARGET := true
 
 # `true`/`false` to enable/disable generate final file build target using ponyc command for the pony build target so
 # it can be overridden manually
-$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := false
+$(abspath $(lastword $(MAKEFILE_LIST)))_PONYC_TARGET := true
 
 # `true`/`false` to enable/disable generate exs related targets (build/test/clean) for elixir sources in this directory
 # otherwise targets only get created if there are elixir sources (*.exs) in this directory.
@@ -32,25 +32,17 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := false
 
 # `true`/`false` to enable/disable recursing into Makefiles of subdirectories if they exist
 # (and by recursion every makefile in the tree that is referenced)
-$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
-
-
-LOGGING_LIB_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+$(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := false
 
 # standard rules generation makefile
 include $(rules_mk_path)
 
-build-lib-wallaroo_labs-logging: $(logging_lib_a)
-$(logging_lib_a): $(logging_lib_obj)
-	ar rvs $@ $<
-$(logging_lib_obj): $(logging_lib_path)/logging-lib.c
-	cc -g -o $@ -c $<
+LOGGING_BENCH_PATH = $(LOGGING_LIB_PATH)/bench/
 
-# The rule below will trigger a "overriding commands" warning when
-# there is a Pony source file in this directory.  Instead, there'source
-# a special "rm -f" command in rules.mk to delete the obj & lib files.
-#clean-lib-wallaroo_labs-logging:
-#	$(QUIET)rm -f $(logging_lib_path)/*.o $(logging_lib_path)/*.a
+build-lib-wallaroo_labs-logging-bench-bench: $(logging_lib_a)
+build-lib-wallaroo_labs-logging-bench-all: build-lib-wallaroo_labs-logging-bench-bench
+build-lib-wallaroo_labs-logging-bench-bench: $(LOGGING_BENCH_PATH)main.pony
+	$(call PONYC,$(abspath $(LOGGING_BENCH_PATH:%/=%)))
 
 # end of prevent rules from being evaluated/included multiple times
 endif

--- a/lib/wallaroo_labs/logging/bench/main.pony
+++ b/lib/wallaroo_labs/logging/bench/main.pony
@@ -1,0 +1,115 @@
+/*
+
+Copyright 2019 The Wallaroo Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing
+ permissions and limitations under the License.
+
+*/
+
+use "ponybench"
+use "../../logging"
+
+use @printf[I32](fmt: Pointer[U8] tag, ...)
+use @l_enabled[Bool](severity: LogSeverity, category: LogCategory)
+use @ll_enabled[Bool](sev_cat: U16)
+use @l[I32](severity: LogSeverity, category: LogCategory, fmt: Pointer[U8] tag, ...)
+use @ll[I32](sev_cat: U16, fmt: Pointer[U8] tag, ...)
+
+actor Main is BenchmarkList
+  new create(env: Env) =>
+    PonyBench(env, this)
+
+  fun tag benchmarks(bench: PonyBench) =>
+    bench(_True)
+    bench(_TrueWithoutDoNotOptimize)
+    bench(_CheckLEnabled)
+    bench(_CheckLEnabled3)
+    bench(_CheckLNotEnabled)
+    bench(_CheckLLEnabled)
+    bench(_CheckLLNotEnabled)
+
+class iso _True is MicroBenchmark
+  fun name(): String =>
+    __loc.type_name()
+
+  fun ref before() =>
+    Log.set_defaults()
+
+  fun ref apply() =>
+    DoNotOptimise[Bool](@_w_true[Bool]())
+
+class iso _TrueWithoutDoNotOptimize is MicroBenchmark
+  fun name(): String =>
+    __loc.type_name()
+
+  fun ref before() =>
+    Log.set_defaults()
+
+  fun ref apply() =>
+    @_w_true[Bool]()
+
+class iso _CheckLEnabled is MicroBenchmark
+  fun name(): String =>
+    __loc.type_name()
+
+  fun ref before() =>
+    Log.set_defaults()
+
+  fun ref apply() =>
+    DoNotOptimise[Bool](@l_enabled(Log.info(), Log.checkpoint()))
+
+class iso _CheckLEnabled3 is MicroBenchmark
+  fun name(): String =>
+    __loc.type_name()
+
+  fun ref before() =>
+    Log.set_defaults()
+
+  fun ref apply() =>
+    DoNotOptimise[Bool](@l_enabled(Log.info(), Log.checkpoint()))
+    DoNotOptimise[Bool](@l_enabled(Log.warn(), Log.checkpoint()))
+    DoNotOptimise[Bool](@l_enabled(Log.crit(), Log.checkpoint()))
+
+class iso _CheckLNotEnabled is MicroBenchmark
+  fun name(): String =>
+    __loc.type_name()
+
+  fun ref before() =>
+    Log.set_defaults()
+
+  fun ref apply() =>
+    DoNotOptimise[Bool](@l_enabled(Log.debug(), Log.checkpoint()))
+
+class iso _CheckLLEnabled is MicroBenchmark
+  let _info_cp: U16 = Log.make_sev_cat(Log.info(), Log.checkpoint())
+
+  fun name(): String =>
+    __loc.type_name()
+
+  fun ref before() =>
+    Log.set_defaults()
+
+  fun ref apply() =>
+    DoNotOptimise[Bool](@ll_enabled(_info_cp))
+
+class iso _CheckLLNotEnabled is MicroBenchmark
+  let _debug_cp: U16 = Log.make_sev_cat(Log.debug(), Log.checkpoint())
+
+  fun name(): String =>
+    __loc.type_name()
+
+  fun ref before() =>
+    Log.set_defaults()
+
+  fun ref apply() =>
+    DoNotOptimise[Bool](@ll_enabled(_debug_cp))

--- a/lib/wallaroo_labs/logging/logging-lib.c
+++ b/lib/wallaroo_labs/logging/logging-lib.c
@@ -335,13 +335,13 @@ void w_set_severity_cat_threshold(unsigned short severity16, unsigned short cate
 ** _cat2sev_thresholds.
 **
 ** The string should contain a list of zero or more
-** category.severity pairs, e.g, "22.5" for category 23 and
-** severity 5 (which corresponds to Log.notice()).  The string
+** category.severity pairs, e.g, "22.6" for category 22 and
+** severity 6 (which corresponds to Log.notice()).  The string
 ** "*" can be used to specify all categories.
 **
 ** Items in the list are separated by commas and are processed
 ** in order.  The "*" for all categories, if used, probably ought
-** to be first in the list.  For example, "*.1,22.5,3.7,4.0".
+** to be first in the list.  For example, "*.1,22.6,3.7,4.0".
 */
 
 void w_process_category_overrides()
@@ -384,8 +384,8 @@ int main(void)
   char *fmt2 = "Hello, world (too big, no timestamp) Hello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, world!\n";
 
   assert(strlen(fmt1) < FMT_BUF_SIZE);
-  printf("Hello, world (with timestamp)!\n");
+  printf(fmt1);
   assert(strlen(fmt2) > FMT_BUF_SIZE);
-  printf("Hello, world (too big, no timestamp) Hello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, world!\n");
+  printf(fmt2);
 }
 #endif

--- a/lib/wallaroo_labs/logging/logging-lib.c
+++ b/lib/wallaroo_labs/logging/logging-lib.c
@@ -165,8 +165,8 @@ unsigned char l_enabled(unsigned char severity, unsigned char category)
 
 unsigned char ll_enabled(unsigned short sev_cat)
 {
-  unsigned char severity = (sev_cat >> 8) & 0xFF;
-  unsigned char category = sev_cat & 0xFF;
+  unsigned char severity = sev_cat & 0xFF;
+  unsigned char category = (sev_cat >> 8) & 0xFF;
 
   if (severity > _cat2sev_threshold[category]) {
     return 0;
@@ -224,8 +224,8 @@ int l(unsigned char severity, unsigned char category, const char *fmt, ...)
 
 int ll(unsigned short sev_cat, const char *fmt, ...)
 {
-  unsigned char severity = (sev_cat >> 8) & 0xFF;
-  unsigned char category = sev_cat & 0xFF;
+  unsigned char severity = sev_cat & 0xFF;
+  unsigned char category = (sev_cat >> 8) & 0xFF;
   va_list ap;
 
   if (severity > _cat2sev_threshold[category]) {

--- a/lib/wallaroo_labs/logging/logging-lib.c
+++ b/lib/wallaroo_labs/logging/logging-lib.c
@@ -101,7 +101,8 @@ static int _w_l(unsigned char severity, unsigned char category,
 {
   char fmt2[FMT_BUF_SIZE];
 
-  if (severity > _cat2sev_threshold[category]) {
+  if (severity > MAX_SEVERITY || category > MAX_CATEGORY ||
+      severity > _cat2sev_threshold[category]) {
     return 0;
   }
   if (! _labels_initialized) {
@@ -140,9 +141,13 @@ int printf(const char *fmt, ...)
 **               otherwise false
 */
 
-unsigned char l_enabled(unsigned char severity, unsigned char category)
+unsigned char l_enabled(unsigned short severity16, unsigned short category16)
 {
-  if (severity > _cat2sev_threshold[category]) {
+  unsigned char severity = severity16 & 0xFF;
+  unsigned char category = (category16 >> 8) & 0xFF;
+
+  if (severity > MAX_SEVERITY || category > MAX_CATEGORY ||
+      severity > _cat2sev_threshold[category]) {
     return 0;
   }
   return 1;
@@ -168,7 +173,8 @@ unsigned char ll_enabled(unsigned short sev_cat)
   unsigned char severity = sev_cat & 0xFF;
   unsigned char category = (sev_cat >> 8) & 0xFF;
 
-  if (severity > _cat2sev_threshold[category]) {
+  if (severity > MAX_SEVERITY || category > MAX_CATEGORY ||
+      severity > _cat2sev_threshold[category]) {
     return 0;
   }
   return 1;
@@ -190,11 +196,14 @@ unsigned char ll_enabled(unsigned short sev_cat)
 ** Return value: # of bytes written
 */
 
-int l(unsigned char severity, unsigned char category, const char *fmt, ...)
+int l(unsigned short severity16, unsigned short category16, const char *fmt, ...)
 {
+  unsigned char severity = severity16 & 0xFF;
+  unsigned char category = (category16 >> 8) & 0xFF;
   va_list ap;
 
-  if (severity > _cat2sev_threshold[category]) {
+  if (severity > MAX_SEVERITY || category > MAX_CATEGORY ||
+      severity > _cat2sev_threshold[category]) {
     return 0;
   }
   if (! _labels_initialized) {
@@ -228,7 +237,8 @@ int ll(unsigned short sev_cat, const char *fmt, ...)
   unsigned char category = (sev_cat >> 8) & 0xFF;
   va_list ap;
 
-  if (severity > _cat2sev_threshold[category]) {
+  if (severity > MAX_SEVERITY || category > MAX_CATEGORY ||
+      severity > _cat2sev_threshold[category]) {
     return 0;
   }
   if (! _labels_initialized) {
@@ -245,8 +255,10 @@ int ll(unsigned short sev_cat, const char *fmt, ...)
 ** severity - numeric severity from 0 to MAX_SEVERITY
 */
 
-void w_set_severity_label(unsigned char severity, char *label)
+void w_set_severity_label(unsigned short severity16, char *label)
 {
+  unsigned char severity = severity16 & 0xFF;
+
   if (! _labels_initialized) {
     _w_initialize_labels();
   }
@@ -261,8 +273,10 @@ void w_set_severity_label(unsigned char severity, char *label)
 ** category - application category number from 0 to MAX_CATEGORY
 */
 
-void w_set_category_label(unsigned char category, char *label)
+void w_set_category_label(unsigned short category16, char *label)
 {
+  unsigned char category = (category16 >> 8) & 0xFF;
+
   if (! _labels_initialized) {
     _w_initialize_labels();
   }
@@ -277,8 +291,9 @@ void w_set_category_label(unsigned char category, char *label)
 ** severity - numeric severity from 0 to MAX_SEVERITY
 */
 
-void w_set_severity_threshold(unsigned char severity)
+void w_set_severity_threshold(unsigned short severity16)
 {
+  unsigned char severity = severity16 & 0xFF;
   int i;
 
   if (! _labels_initialized) {
@@ -298,8 +313,10 @@ void w_set_severity_threshold(unsigned char severity)
 ** category - application category number from 0 to MAX_CATEGORY
 */
 
-void w_set_severity_cat_threshold(unsigned char severity, unsigned char category)
+void w_set_severity_cat_threshold(unsigned short severity16, unsigned short category16)
 {
+  unsigned char severity = severity16 & 0xFF;
+  unsigned char category = (category16 >> 8) & 0xFF;
   int i;
 
   if (! _labels_initialized) {

--- a/lib/wallaroo_labs/logging/logging-lib.c
+++ b/lib/wallaroo_labs/logging/logging-lib.c
@@ -185,7 +185,7 @@ unsigned char ll_enabled(unsigned short sev_cat)
 **
 ** severity - numeric severity from 0 to MAX_SEVERITY
 ** category - application category number from 0 to MAX_CATEGORY
-** fmt - snprintf(3)-style formatting string
+** fmt - snprintf(3)-style formatting string *without* trailing newline
 ** 0 or or arguments - snprintf(3)-style arguments
 **
 ** NOTE: In the interest of maximum speed, we check severity threshold
@@ -220,7 +220,7 @@ int l(unsigned short severity16, unsigned short category16, const char *fmt, ...
 ** sev_cat: a mix of:
 **     severity - numeric severity, bits 8-15
 **     category - application category number, bits 0-7
-** fmt - snprintf(3)-style formatting string
+** fmt - snprintf(3)-style formatting string *without* trailing newline
 ** 0 or or arguments - snprintf(3)-style arguments
 **
 ** NOTE: In the interest of maximum speed, we check severity threshold

--- a/lib/wallaroo_labs/logging/logging-lib.c
+++ b/lib/wallaroo_labs/logging/logging-lib.c
@@ -1,0 +1,347 @@
+/*
+
+Copyright (C) 2016-2019, Wallaroo Labs
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include <ctype.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/time.h>
+
+#define ENV_BUF_SIZE  1024
+#define FMT_BUF_SIZE  1024
+#define MAX_SEVERITY  8
+#define MAX_CATEGORY  64
+
+static int _labels_initialized = 0;
+
+static char *_severity_labels[MAX_SEVERITY+1];
+static char *_category_labels[MAX_CATEGORY+1];
+
+static int _cat2sev_threshold[MAX_CATEGORY+1];
+
+/*****************************/
+/* Internal static functions */
+/*****************************/
+
+static int _w_now(char *dst, int dst_size)
+{
+  struct timeval tv;
+
+  gettimeofday(&tv, NULL);
+#ifdef  __APPLE__  
+  return snprintf(dst, dst_size, "%ld.%06d", tv.tv_sec, tv.tv_usec);
+#else
+  return snprintf(dst, dst_size, "%ld.%06lu", tv.tv_sec, tv.tv_usec);
+#endif
+}
+
+static int _w_vprintf(const char *fmt, va_list ap)
+{
+  char fmt2[FMT_BUF_SIZE];
+  int fmt2_len;
+  int ret;
+
+  fmt2_len = _w_now(fmt2, sizeof(fmt2));
+  if (strlen(fmt) > (sizeof(fmt2) - fmt2_len - 2 /* , & NUL */)) {
+    /* Our static buffer isn't big enough, so call vprintf() as is. */
+    ret = vprintf(fmt, ap);
+  } else {
+    fmt2[fmt2_len] = ',';
+    memcpy(fmt2 + fmt2_len + 1, fmt, strlen(fmt) + 1);
+    ret = vprintf(fmt2, ap);
+  }
+  va_end(ap);
+  return ret;
+}
+
+static void _w_initialize_labels()
+{
+  int i;
+  char buf[16];
+
+  for (i = 0; i < MAX_SEVERITY+1; i++) {
+    snprintf(buf, sizeof(buf), "sev-%d", i);
+    _severity_labels[i] = strdup(buf);
+  }
+  for (i = 0; i < MAX_CATEGORY+1; i++) {
+    snprintf(buf, sizeof(buf), "cat-%d", i);
+    _category_labels[i] = strdup(buf);
+    _cat2sev_threshold[i] = MAX_SEVERITY;
+  }
+  _labels_initialized = 1;
+}
+
+static int _w_l(unsigned char severity, unsigned char category,
+  const char *fmt, va_list ap)
+{
+  char fmt2[FMT_BUF_SIZE];
+
+  if (severity > _cat2sev_threshold[category]) {
+    return 0;
+  }
+  if (! _labels_initialized) {
+    _w_initialize_labels();
+  }
+
+  snprintf(fmt2, sizeof(fmt2), "%s,%s,%s\n",
+    _severity_labels[severity], _category_labels[category], fmt);
+  return _w_vprintf(fmt2, ap);
+}
+
+/********************/
+/* Public functions */
+/********************/
+
+int printf(const char *fmt, ...)
+{
+  va_list ap;
+
+  va_start(ap, fmt);
+  return _w_vprintf(fmt, ap);
+  // va_end() already done
+}
+
+/*
+** log_enabled(), is logging enabled for a (severity, category) tuple
+**
+** severity - numeric severity from 0 to MAX_SEVERITY
+** category - application category number from 0 to MAX_CATEGORY
+**
+** Return value: true if logging is enabled for this tuple,
+**               otherwise false
+*/
+
+unsigned char log_enabled(unsigned char severity, unsigned char category)
+{
+  if (severity > _cat2sev_threshold[category]) {
+    return 0;
+  }
+  return 1;
+}
+
+/*
+** ll_enabled(), is logging enabled for an unsigned short severity+category
+**
+** sev_cat: a mix of:
+**     severity - numeric severity, bits 8-15
+**     category - application category number, bits 0-7
+**
+** Return value: true if logging is enabled for this tuple,
+**               otherwise false
+*/
+
+unsigned char ll_enabled(unsigned short sev_cat)
+{
+  unsigned char severity = sev_cat & 0xFF;
+  unsigned char category = (sev_cat >> 8) & 0xFF;
+
+  if (severity > _cat2sev_threshold[category]) {
+    return 0;
+  }
+  return 1;
+}
+
+/*
+** l(), the severity + category + format + variable-args logging function.
+**
+** severity - numeric severity from 0 to MAX_SEVERITY
+** category - application category number from 0 to MAX_CATEGORY
+** fmt - snprintf(3)-style formatting string
+** 0 or or arguments - snprintf(3)-style arguments
+**
+** Return value: # of bytes written
+*/
+
+int l(unsigned char severity, unsigned char category, const char *fmt, ...)
+{
+  va_list ap;
+
+  if (severity > _cat2sev_threshold[category]) {
+    return 0;
+  }
+  if (! _labels_initialized) {
+    _w_initialize_labels();
+  }
+
+  va_start(ap, fmt);
+  return _w_l(severity, category, fmt, ap);
+}
+
+/*
+** ll(), the severity + category + format + variable-args logging function.
+**
+** sev_cat: a mix of:
+**     severity - numeric severity, bits 8-15
+**     category - application category number, bits 0-7
+** fmt - snprintf(3)-style formatting string
+** 0 or or arguments - snprintf(3)-style arguments
+**
+** Return value: # of bytes written
+*/
+
+int ll(unsigned short sev_cat, const char *fmt, ...)
+{
+  unsigned char severity = sev_cat & 0xFF;
+  unsigned char category = (sev_cat >> 8) & 0xFF;
+  va_list ap;
+
+  if (severity > _cat2sev_threshold[category]) {
+    return 0;
+  }
+  if (! _labels_initialized) {
+    _w_initialize_labels();
+  }
+
+  va_start(ap, fmt);
+  return _w_l(severity, category, fmt, ap);
+}
+
+/*
+** w_set_severity_label(), set the formatted label for a severity number
+**
+** severity - numeric severity from 0 to MAX_SEVERITY
+*/
+
+void w_set_severity_label(unsigned char severity, char *label)
+{
+  if (! _labels_initialized) {
+    _w_initialize_labels();
+  }
+  if (severity < MAX_SEVERITY+1) {
+    _severity_labels[severity] = strdup(label);
+  }
+}
+
+/*
+** w_set_category_label(), set the formatted label for a category number
+**
+** category - application category number from 0 to MAX_CATEGORY
+*/
+
+void w_set_category_label(unsigned char category, char *label)
+{
+  if (! _labels_initialized) {
+    _w_initialize_labels();
+  }
+  if (category < MAX_CATEGORY+1) {
+    _category_labels[category] = strdup(label);
+  }
+}
+
+/*
+** w_set_severity_threshold(), set the severity threshold for all categories
+**
+** severity - numeric severity from 0 to MAX_SEVERITY
+*/
+
+void w_set_severity_threshold(unsigned char severity)
+{
+  int i;
+
+  if (severity < MAX_SEVERITY+1) {
+    for (i = 0; i < MAX_CATEGORY+1; i++) {
+      _cat2sev_threshold[i] = severity;
+    }
+  }
+}
+
+/*
+** w_set_severity_cat_threshold(), set the severity threshold for a category
+**
+** severity - numeric severity from 0 to MAX_SEVERITY
+** category - application category number from 0 to MAX_CATEGORY
+*/
+
+void w_set_severity_cat_threshold(unsigned char severity, unsigned char category)
+{
+  int i;
+
+  if (severity < MAX_SEVERITY+1 && category < MAX_CATEGORY+1) {
+    _cat2sev_threshold[category] = severity;
+  }
+}
+
+/*
+** w_process_category_overrides, process any env var overrides
+**
+** If the environment variable WALLAROO_THRESHOLDS exists, then
+** parse that string and apply a set of overrides to the
+** _cat2sev_thresholds.
+**
+** The string should contain a list of zero or more
+** category.severity pairs, e.g, "22.5" for category 23 and
+** severity 5 (which corresponds to Log.notice()).  The string
+** "*" can be used to specify all categories.
+**
+** Items in the list are separated by commas and are processed
+** in order.  The "*" for all categories, if used, probably ought
+** to be first in the list.  For example, "*.1,22.5,3.7,4.0".
+*/
+
+void w_process_category_overrides()
+{
+  char *env = getenv("WALLAROO_THRESHOLDS");
+  char buf[ENV_BUF_SIZE];
+  char *p = buf, *start, *saveptr, *dot;
+  unsigned char severity, category;
+  int i;
+
+  if (env != NULL) {
+    if (strlen(env) < sizeof(buf) - 1) {
+      strcpy(buf, env);
+
+      for (start = strtok_r(buf, ",", &saveptr);
+           start != NULL;
+           start = strtok_r(NULL, ",", &saveptr)) {
+        if ((dot = strchr(start, '.')) != NULL) {
+          *dot = '\0';
+          severity = atoi(dot + 1);
+          if (*start == '*') {
+            w_set_severity_threshold(severity);
+          } else if ((category = atoi(start)) > 0) {
+            w_set_severity_cat_threshold(severity, category);
+          }
+        }
+      }
+    }
+  }
+}
+
+#ifdef MAIN
+#include <assert.h>
+int main(void)
+{
+  char *fmt1 = "Hello, world (with timestamp)!\n";
+  char *fmt2 = "Hello, world (too big, no timestamp) Hello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, world!\n";
+
+  assert(strlen(fmt1) < FMT_BUF_SIZE);
+  printf("Hello, world (with timestamp)!\n");
+  assert(strlen(fmt2) > FMT_BUF_SIZE);
+  printf("Hello, world (too big, no timestamp) Hello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, worldHello, world!\n");
+}
+#endif

--- a/lib/wallaroo_labs/logging/logging-lib.c
+++ b/lib/wallaroo_labs/logging/logging-lib.c
@@ -114,6 +114,11 @@ static int _w_l(unsigned char severity, unsigned char category,
   return _w_vprintf(fmt2, ap);
 }
 
+unsigned char _w_true()
+{
+  return 1;
+}
+
 /********************/
 /* Public functions */
 /********************/

--- a/lib/wallaroo_labs/logging/wallaroo-logging.pony
+++ b/lib/wallaroo_labs/logging/wallaroo-logging.pony
@@ -93,21 +93,52 @@ primitive Log
     ] // END category_map
 
   fun set_defaults() =>
+    """
+    Set default severity labels, category labels, and default
+    severity threshold for use in all Wallaroo apps.  This function
+    should be called very early in a Wallaroo application's code,
+    before the first call to @l() or @ll().
+
+    """
     set_severity_labels()
     set_category_labels()
     set_thresholds()
 
   fun set_severity_labels() =>
+    """
+    Set syslog-style printable labels for all severity values.
+    """
     for (severity, label) in severity_map().values() do
       @w_set_severity_label(severity, label.cstring())
     end
 
   fun set_category_labels() =>
+    """
+    Set Wallaroo app subsystem labels for commonly-used categories.
+    """
     for (severity, category, label) in category_map().values() do
       @w_set_category_label(category, label.cstring())
     end
 
   fun set_thresholds(do_defaults: Bool = true, do_overrides: Bool = true) =>
+    """
+    Set the default and/or override logging severity thresholds for
+    Wallaroo app logging categories.  Default thresholds are specified
+    by the category_map() function.  Override thresholds are specified
+    by the environment variable WALLAROO_THRESHOLDS and parsed & set
+    by C FFI function @w_process_category_overrides().
+
+    WALLAROO_THRESHOLDS formatting:
+
+    ** The string should contain a list of zero or more
+    ** category.severity pairs, e.g, "22.6" for category 22 and
+    ** severity 6 (which corresponds to Log.notice()).  The string
+    ** "*" can be used to specify all categories.
+    **
+    ** Items in the list are separated by commas and are processed
+    ** in order.  The "*" for all categories, if used, probably ought
+    ** to be first in the list.  For example, "*.1,22.6,3.7,4.0".
+    """
     if do_defaults then
       @w_set_severity_threshold(default_severity())
       for (severity, category, label) in category_map().values() do
@@ -120,7 +151,13 @@ primitive Log
     end
 
   fun make_sev_cat(severity: LogSeverity, category: LogCategory): U16 =>
-    // Assume that users may not want to specify a category, so we put
-    // the more important severity in bits 0-7 and put the category in
-    // bits 8-15.
+    """
+    Merge together a severity and category into a single U16 for
+    use with the @ll() function.  (NOTE: The @l() function uses two
+    separate arguments to specify severity and category.)
+
+    Assume that users may not want to specify a category, so we put
+    the more important severity in bits 0-7 and put the category in
+    bits 8-15.
+    """
     category + severity

--- a/lib/wallaroo_labs/logging/wallaroo-logging.pony
+++ b/lib/wallaroo_labs/logging/wallaroo-logging.pony
@@ -32,8 +32,8 @@ use @w_set_severity_threshold[None](severity: LogSeverity)
 use @w_set_severity_cat_threshold[None](severity: LogSeverity, category: LogCategory)
 use @w_process_category_overrides[None]()
 
+type LogSeverity is U16
 type LogCategory is U8
-type LogSeverity is U8
 
 primitive Log
   // severity levels

--- a/lib/wallaroo_labs/logging/wallaroo-logging.pony
+++ b/lib/wallaroo_labs/logging/wallaroo-logging.pony
@@ -22,7 +22,7 @@ use "lib:wallaroo-logging"
 
 // C FFI prototypes for cut-and-paste into your Pony source, as needed
 use @printf[I32](fmt: Pointer[U8] tag, ...)
-use @log_enabled[Bool](severity: LogSeverity, category: LogCategory)
+use @l_enabled[Bool](severity: LogSeverity, category: LogCategory)
 use @ll_enabled[Bool](sev_cat: U16)
 use @l[I32](severity: LogSeverity, category: LogCategory, fmt: Pointer[U8] tag, ...)
 use @ll[I32](sev_cat: U16, fmt: Pointer[U8] tag, ...)
@@ -50,7 +50,7 @@ primitive Log
   fun default_severity(): LogSeverity => info()
 
   // categories
-  fun no_cat(): LogCategory             => LogCategory(0)
+  fun no_cat(): LogCategory           => LogCategory(0)
   fun checkpoint(): LogCategory       => LogCategory(1)
   fun source_migration(): LogCategory => LogCategory(2)
   fun twopc(): LogCategory            => LogCategory(3)
@@ -59,6 +59,7 @@ primitive Log
   fun conn_sink(): LogCategory        => LogCategory(6)
   fun tcp_source(): LogCategory       => LogCategory(7)
   fun conn_source(): LogCategory      => LogCategory(8)
+  fun max_category(): LogCategory     => LogCategory(40)
 
   fun severity_map(): Array[(LogSeverity, String)] =>
     [ // BEGIN severity_map

--- a/lib/wallaroo_labs/logging/wallaroo-logging.pony
+++ b/lib/wallaroo_labs/logging/wallaroo-logging.pony
@@ -1,0 +1,117 @@
+/*
+
+Copyright 2019 The Wallaroo Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing
+ permissions and limitations under the License.
+
+*/
+
+// Tell ponyc that we're going to use the external C functions
+// in the libwallaroo-logging.a library.
+use "lib:wallaroo-logging"
+
+// C FFI prototypes for cut-and-paste into your Pony source, as needed
+use @printf[I32](fmt: Pointer[U8] tag, ...)
+use @log_enabled[Bool](severity: LogSeverity, category: LogCategory)
+use @ll_enabled[Bool](sev_cat: U16)
+use @l[I32](severity: LogSeverity, category: LogCategory, fmt: Pointer[U8] tag, ...)
+use @ll[I32](sev_cat: U16, fmt: Pointer[U8] tag, ...)
+use @w_set_severity_label[None](severity: LogSeverity, label: Pointer[U8] tag)
+use @w_set_category_label[None](category: LogCategory, label: Pointer[U8] tag)
+use @w_set_severity_threshold[None](severity: LogSeverity)
+use @w_set_severity_cat_threshold[None](severity: LogSeverity, category: LogCategory)
+use @w_process_category_overrides[None]()
+
+type LogCategory is U8
+type LogSeverity is U8
+
+primitive Log
+  // severity levels
+  fun no_sev(): LogSeverity   => LogSeverity(0)
+  fun emerg(): LogSeverity  => LogSeverity(1)
+  fun alert(): LogSeverity  => LogSeverity(2)
+  fun crit(): LogSeverity   => LogSeverity(3)
+  fun err(): LogSeverity    => LogSeverity(4)
+  fun warn(): LogSeverity   => LogSeverity(5)
+  fun notice(): LogSeverity => LogSeverity(6)
+  fun info(): LogSeverity   => LogSeverity(7)
+  fun debug(): LogSeverity  => LogSeverity(8)
+  fun max_severity(): LogSeverity => debug()
+  fun default_severity(): LogSeverity => info()
+
+  // categories
+  fun no_cat(): LogCategory             => LogCategory(0)
+  fun checkpoint(): LogCategory       => LogCategory(1)
+  fun source_migration(): LogCategory => LogCategory(2)
+  fun twopc(): LogCategory            => LogCategory(3)
+  fun dos_client(): LogCategory       => LogCategory(4)
+  fun tcp_sink(): LogCategory         => LogCategory(5)
+  fun conn_sink(): LogCategory        => LogCategory(6)
+  fun tcp_source(): LogCategory       => LogCategory(7)
+  fun conn_source(): LogCategory      => LogCategory(8)
+
+  fun severity_map(): Array[(LogSeverity, String)] =>
+    [ // BEGIN severity_map
+      (no_sev(), "NONE")
+      (emerg(),  "EMERGENCY")
+      (alert(),  "ALERT")
+      (crit(),   "CRITICAL")
+      (err(),    "ERROR")
+      (warn(),   "WARNING")
+      (notice(), "NOTICE")
+      (info(),   "INFO")
+      (debug(),  "DEBUG")
+    ] // END severity_map
+
+  fun category_map(): Array[(LogSeverity, LogCategory, String)] =>
+    [ // BEGIN category_map
+      (default_severity(), no_cat(),           "none")
+      (default_severity(), checkpoint(),       "checkpoint")
+      (default_severity(), source_migration(), "source-migration")
+      (default_severity(), twopc(),            "2PC")
+      (default_severity(), dos_client(),       "DOSClient")
+      (default_severity(), tcp_sink(),         "TCPSink")
+      (default_severity(), conn_sink(),        "ConnectorSink")
+      (default_severity(), tcp_source(),         "TCPSource")
+      (default_severity(), conn_source(),        "ConnectorSource")
+    ] // END category_map
+
+  fun set_defaults() =>
+    set_severity_labels()
+    set_category_labels()
+    set_thresholds()
+
+  fun set_severity_labels() =>
+    for (severity, label) in severity_map().values() do
+      @w_set_severity_label(severity, label.cstring())
+    end
+
+  fun set_category_labels() =>
+    for (severity, category, label) in category_map().values() do
+      @w_set_category_label(category, label.cstring())
+    end
+
+  fun set_thresholds(do_defaults: Bool = true, do_overrides: Bool = true) =>
+    if do_defaults then
+      @w_set_severity_threshold(default_severity())
+      for (severity, category, label) in category_map().values() do
+        @w_set_severity_cat_threshold(severity, category)
+      end
+    end
+
+    if do_overrides then
+      @w_process_category_overrides[None]()
+    end
+
+  fun make_sev_cat(severity: LogSeverity, category: LogCategory): U16 =>
+    severity.u16().shl(8) + category.u16()

--- a/lib/wallaroo_labs/logging/wallaroo-logging.pony
+++ b/lib/wallaroo_labs/logging/wallaroo-logging.pony
@@ -32,8 +32,12 @@ use @w_set_severity_threshold[None](severity: LogSeverity)
 use @w_set_severity_cat_threshold[None](severity: LogSeverity, category: LogCategory)
 use @w_process_category_overrides[None]()
 
+// LogSeverity is a U16 which is the same size as the
+// combined severity + category, which is weird but
+// intentional.  For more details, see comments in
+// make_sev_cat() or the PR that added this file.
 type LogSeverity is U16
-type LogCategory is U8
+type LogCategory is U16
 
 primitive Log
   // severity levels
@@ -50,16 +54,17 @@ primitive Log
   fun default_severity(): LogSeverity => info()
 
   // categories
-  fun no_cat(): LogCategory           => LogCategory(0)
-  fun checkpoint(): LogCategory       => LogCategory(1)
-  fun source_migration(): LogCategory => LogCategory(2)
-  fun twopc(): LogCategory            => LogCategory(3)
-  fun dos_client(): LogCategory       => LogCategory(4)
-  fun tcp_sink(): LogCategory         => LogCategory(5)
-  fun conn_sink(): LogCategory        => LogCategory(6)
-  fun tcp_source(): LogCategory       => LogCategory(7)
-  fun conn_source(): LogCategory      => LogCategory(8)
-  fun max_category(): LogCategory     => LogCategory(40)
+  fun no_cat(): LogCategory           => LogCategory(0).shl(8)
+  fun checkpoint(): LogCategory       => LogCategory(1).shl(8)
+  fun source_migration(): LogCategory => LogCategory(2).shl(8)
+  fun twopc(): LogCategory            => LogCategory(3).shl(8)
+  fun dos_client(): LogCategory       => LogCategory(4).shl(8)
+  fun tcp_sink(): LogCategory         => LogCategory(5).shl(8)
+  fun conn_sink(): LogCategory        => LogCategory(6).shl(8)
+  fun tcp_source(): LogCategory       => LogCategory(7).shl(8)
+  fun conn_source(): LogCategory      => LogCategory(8).shl(8)
+  fun max_category(): LogCategory     => LogCategory(40).shl(8)
+  fun manual_category(n: U16): LogCategory  => LogCategory(n).shl(8)
 
   fun severity_map(): Array[(LogSeverity, String)] =>
     [ // BEGIN severity_map
@@ -118,4 +123,4 @@ primitive Log
     // Assume that users may not want to specify a category, so we put
     // the more important severity in bits 0-7 and put the category in
     // bits 8-15.
-    category.u16().shl(8) + severity.u16()
+    category + severity

--- a/lib/wallaroo_labs/logging/wallaroo-logging.pony
+++ b/lib/wallaroo_labs/logging/wallaroo-logging.pony
@@ -83,8 +83,8 @@ primitive Log
       (default_severity(), dos_client(),       "DOSClient")
       (default_severity(), tcp_sink(),         "TCPSink")
       (default_severity(), conn_sink(),        "ConnectorSink")
-      (default_severity(), tcp_source(),         "TCPSource")
-      (default_severity(), conn_source(),        "ConnectorSource")
+      (default_severity(), tcp_source(),       "TCPSource")
+      (default_severity(), conn_source(),      "ConnectorSource")
     ] // END category_map
 
   fun set_defaults() =>
@@ -115,4 +115,7 @@ primitive Log
     end
 
   fun make_sev_cat(severity: LogSeverity, category: LogCategory): U16 =>
-    severity.u16().shl(8) + category.u16()
+    // Assume that users may not want to specify a category, so we put
+    // the more important severity in bits 0-7 and put the category in
+    // bits 8-15.
+    category.u16().shl(8) + severity.u16()

--- a/machida/Makefile
+++ b/machida/Makefile
@@ -74,7 +74,7 @@ machida_build: $(MACHIDA_BUILD)/machida
 
 -include $(MACHIDA_PATH)/machida.d
 $(MACHIDA_BUILD)/machida: EXTRA_PONYCFLAGS= --output=$(MACHIDA_BUILD) --path=$(MACHIDA_BUILD)
-$(MACHIDA_BUILD)/machida: $(MACHIDA_BUILD)/libpython-wallaroo.a
+$(MACHIDA_BUILD)/machida: $(MACHIDA_BUILD)/libpython-wallaroo.a $(logging_lib_a)
 	$(call PONYC,$(abspath $(MACHIDA_PATH:%/=%)))
 
 $(MACHIDA_BUILD)/libpython-wallaroo.a: $(MACHIDA_BUILD)/python-wallaroo.o

--- a/machida/main.pony
+++ b/machida/main.pony
@@ -17,6 +17,7 @@ Copyright 2017 The Wallaroo Authors.
 */
 
 use "collections"
+use "wallaroo_labs/logging"
 use "wallaroo_labs/mort"
 use "wallaroo_labs/options"
 use "wallaroo_labs/thread_count"
@@ -30,6 +31,8 @@ use "lib:python-wallaroo"
 
 actor Main
   new create(env: Env) =>
+    Log.set_defaults()
+
     let pony_thread_count = ThreadCount()
 
     if pony_thread_count != 1 then

--- a/machida3/Makefile
+++ b/machida3/Makefile
@@ -78,7 +78,7 @@ $(MACHIDA3_BUILD)/machida3: EXTRA_PONYCFLAGS= --output=$(MACHIDA3_BUILD) --path=
 else
 $(MACHIDA3_BUILD)/machida3: EXTRA_PONYCFLAGS= --output=$(MACHIDA3_BUILD) --path=$(MACHIDA3_BUILD) --linker '$(CC) $(PYTHON3_LIBS)'
 endif
-$(MACHIDA3_BUILD)/machida3: $(MACHIDA3_BUILD)/libpython-wallaroo.a
+$(MACHIDA3_BUILD)/machida3: $(MACHIDA3_BUILD)/libpython-wallaroo.a $(logging_lib_a)
 	$(call PONYC,$(abspath $(MACHIDA3_PATH:%/=%)))
 
 $(MACHIDA3_BUILD)/libpython-wallaroo.a: $(MACHIDA3_BUILD)/python-wallaroo.o

--- a/machida3/main.pony
+++ b/machida3/main.pony
@@ -17,6 +17,7 @@ Copyright 2017 The Wallaroo Authors.
 */
 
 use "collections"
+use "wallaroo_labs/logging"
 use "wallaroo_labs/mort"
 use "wallaroo_labs/options"
 use "wallaroo_labs/thread_count"
@@ -29,6 +30,8 @@ use "lib:python-wallaroo"
 
 actor Main
   new create(env: Env) =>
+    Log.set_defaults()
+
     let pony_thread_count = ThreadCount()
 
     if pony_thread_count != 1 then

--- a/rules.mk
+++ b/rules.mk
@@ -48,6 +48,9 @@ wallaroo_python_path := $(wallaroo_path)/machida/lib
 machida_bin_path := $(wallaroo_path)/machida/build
 machida3_bin_path := $(wallaroo_path)/machida3/build
 external_sender_bin_path := $(integration_path)/external_sender
+logging_lib_path := $(wallaroo_lib)/wallaroo_labs/logging
+logging_lib_obj := $(logging_lib_path)/wallaroo-logging.o
+logging_lib_a := $(logging_lib_path)/libwallaroo-logging.a
 
 EMPTY :=
 SPACE := $(EMPTY) $(EMPTY)
@@ -266,7 +269,7 @@ ifneq ($(arch),native)
 endif
 
 # function call for compiling with ponyc and generating dependency info
-PONYC_LOGGING_LIB_FLAGS = --path $(LOGGING_LIB_DIR)
+PONYC_LOGGING_LIB_FLAGS = --path $(logging_lib_path)
 define PONYC
   $(QUIET)cd $(1) && $(ponyc_docker_args) $(PONYSTABLE) fetch \
     $(if $(filter $(ponyc_docker_args),docker),$(quote))
@@ -335,7 +338,7 @@ endef
 define ponyc-goal
 # include dependencies for already compiled executables
 -include $(abspath $(1:%/=%))/$(notdir $(abspath $(1:%/=%))).d
-$(abspath $(1:%/=%))/$(notdir $(abspath $(1:%/=%))):
+$(abspath $(1:%/=%))/$(notdir $(abspath $(1:%/=%))): $(logging_lib_a)
 	$$(call PONYC,$(abspath $(1:%/=%)))
 endef
 
@@ -748,7 +751,7 @@ clean: clean-$(ROOT_TARGET_SUFFIX) ## Clean all projects (pony & monhub) and cle
 	$(QUIET)rm -f $(abs_wallaroo_dir)/AppRun $(abs_wallaroo_dir)/metrics_ui.desktop $(abs_wallaroo_dir)/metrics_ui.png
 	$(QUIET)rm -f lib/wallaroo/wallaroo lib/wallaroo/wallaroo.o
 	$(QUIET)rm -f sent.txt received.txt
-	$(QUIET)rm -f $(LOGGING_LIB_OBJ) $(LOGGING_LIB_A)
+	$(QUIET)rm -f $(logging_lib_obj) $(logging_lib_a)
 	$(QUIET)echo 'Done cleaning.'
 
 list: ## List all targets (including automagically generated ones)

--- a/rules.mk
+++ b/rules.mk
@@ -266,12 +266,13 @@ ifneq ($(arch),native)
 endif
 
 # function call for compiling with ponyc and generating dependency info
+PONYC_LOGGING_LIB_FLAGS = --path $(LOGGING_LIB_DIR)
 define PONYC
   $(QUIET)cd $(1) && $(ponyc_docker_args) $(PONYSTABLE) fetch \
     $(if $(filter $(ponyc_docker_args),docker),$(quote))
   $(QUIET)cd $(1) && $(ponyc_docker_args) $(PONYSTABLE) env $(PONYCC) $(ponyc_arch_args) \
     $(debug_arg) $(spike_arg) $(trace_arg) $(autoscale_arg) $(clustering_arg) $(resilience_arg) \
-    $(PONYCFLAGS) $(EXTRA_PONYCFLAGS) $(target_cpu_arg) --features=-avx512f . $(if $(filter $(ponyc_docker_args),docker),$(quote))
+    $(PONYCFLAGS) $(EXTRA_PONYCFLAGS) $(PONYC_LOGGING_LIB_FLAGS) $(target_cpu_arg) --features=-avx512f . $(if $(filter $(ponyc_docker_args),docker),$(quote))
   $(QUIET)cd $(1) && echo "$@: $(wildcard $(abspath $(1))/bundle.json)" | tr '\n' ' ' > $(notdir $(abspath $(1:%/=%))).d
   $(QUIET)cd $(1) && $(ponyc_docker_args) $(PONYSTABLE) env $(PONYCC) $(ponyc_arch_args) \
     $(debug_arg) $(spike_arg) $(trace_arg) $(autoscale_arg) $(clustering_arg) $(resilience_arg) \
@@ -376,6 +377,7 @@ clean-pony-all: clean-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
 clean-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))-all += clean-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1)))
 clean-$(subst /,-,$(subst $(abs_wallaroo_dir)/,,$(abspath $1))):
 	$(QUIET)rm -f $(abspath $1)/$(notdir $(abspath $(1:%/=%))) $(abspath $1)/$(notdir $(abspath $(1:%/=%))).o
+	$(QUIET)rm -f $(abspath $1)/$(notdir $(abspath $(1:%/=%))) $(abspath $1)/$(notdir $(abspath $(1:%/=%))).a
 	$(QUIET)rm -f $(abspath $1)/$(notdir $(abspath $(1:%/=%))).d
 	$(QUIET)rm -rf $(abspath $1)/.deps
 	$(QUIET)rm -rf $(abspath $1)/$(notdir $(abspath $(1:%/=%))).dSYM
@@ -746,6 +748,7 @@ clean: clean-$(ROOT_TARGET_SUFFIX) ## Clean all projects (pony & monhub) and cle
 	$(QUIET)rm -f $(abs_wallaroo_dir)/AppRun $(abs_wallaroo_dir)/metrics_ui.desktop $(abs_wallaroo_dir)/metrics_ui.png
 	$(QUIET)rm -f lib/wallaroo/wallaroo lib/wallaroo/wallaroo.o
 	$(QUIET)rm -f sent.txt received.txt
+	$(QUIET)rm -f $(LOGGING_LIB_OBJ) $(LOGGING_LIB_A)
 	$(QUIET)echo 'Done cleaning.'
 
 list: ## List all targets (including automagically generated ones)

--- a/testing/correctness/apps/decoder_filter/decoder_filter.pony
+++ b/testing/correctness/apps/decoder_filter/decoder_filter.pony
@@ -20,6 +20,7 @@ use "buffered"
 use "wallaroo_labs/bytes"
 use "wallaroo"
 use "wallaroo/core/common"
+use "wallaroo_labs/logging"
 use "wallaroo_labs/mort"
 use "wallaroo_labs/time"
 use "wallaroo/core/sink/tcp_sink"
@@ -30,6 +31,7 @@ use "wallaroo/core/topology"
 
 actor Main
   new create(env: Env) =>
+    Log.set_defaults()
     try
       let pipeline = recover val
         Wallaroo.source[U64]("Filter Test",

--- a/testing/correctness/apps/local_sequence_detector/local_sequence_detector.pony
+++ b/testing/correctness/apps/local_sequence_detector/local_sequence_detector.pony
@@ -26,11 +26,13 @@ use "wallaroo/core/source/gen_source"
 use "wallaroo/core/state"
 use "wallaroo/core/topology"
 use "wallaroo_labs/bytes"
+use "wallaroo_labs/logging"
 use "wallaroo_labs/mort"
 
 
 actor Main
   new create(env: Env) =>
+    Log.set_defaults()
     try
       var seq_offset: USize = 0
 

--- a/testing/correctness/apps/multi_aggregation/multi_aggregation.pony
+++ b/testing/correctness/apps/multi_aggregation/multi_aggregation.pony
@@ -23,6 +23,7 @@ use "wallaroo/core/source/tcp_source"
 use "wallaroo/core/state"
 use "wallaroo/core/topology"
 use "wallaroo/core/windows"
+use "wallaroo_labs/logging"
 use "wallaroo_labs/mort"
 use "wallaroo_labs/time"
 
@@ -31,6 +32,7 @@ type NanosecondsSinceEpoch is U64
 
 actor Main
   new create(env: Env) =>
+    Log.set_defaults()
     try
       let pipeline = recover val
         let events = Wallaroo.source[Event]("Multi_Aggregations",

--- a/testing/correctness/apps/multi_partition_detector/multi_partition_detector.pony
+++ b/testing/correctness/apps/multi_partition_detector/multi_partition_detector.pony
@@ -39,6 +39,7 @@ use "time"
 use "wallaroo_labs/bytes"
 use "wallaroo"
 use "wallaroo/core/common"
+use "wallaroo_labs/logging"
 use "wallaroo_labs/mort"
 use "wallaroo_labs/time"
 use "wallaroo/core/sink/tcp_sink"
@@ -51,6 +52,7 @@ use "wallaroo/core/topology"
 
 actor Main
   new create(env: Env) =>
+    Log.set_defaults()
 
     try
       // Add options:

--- a/testing/correctness/apps/multi_pipeline/multi_pipeline.pony
+++ b/testing/correctness/apps/multi_pipeline/multi_pipeline.pony
@@ -20,6 +20,7 @@ use "buffered"
 use "serialise"
 use "wallaroo_labs/bytes"
 use "wallaroo"
+use "wallaroo_labs/logging"
 use "wallaroo_labs/mort"
 use "wallaroo_labs/time"
 use "wallaroo/core/sink/tcp_sink"
@@ -29,6 +30,7 @@ use "wallaroo/core/topology"
 
 actor Main
   new create(env: Env) =>
+    Log.set_defaults()
     try
       let pipeline = recover val
         let inputs1 = Wallaroo.source[(U32, U32)]("Pipeline1",

--- a/testing/correctness/apps/multi_sink/multi_sink.pony
+++ b/testing/correctness/apps/multi_sink/multi_sink.pony
@@ -20,6 +20,7 @@ use "buffered"
 use "serialise"
 use "wallaroo_labs/bytes"
 use "wallaroo"
+use "wallaroo_labs/logging"
 use "wallaroo_labs/mort"
 use "wallaroo_labs/time"
 use "wallaroo/core/sink/tcp_sink"
@@ -29,6 +30,7 @@ use "wallaroo/core/topology"
 
 actor Main
   new create(env: Env) =>
+    Log.set_defaults()
     try
       let pipeline = recover val
         let values = Wallaroo.source[F32]("Celsius Conversion",

--- a/testing/correctness/apps/ping_pong/ping_pong.pony
+++ b/testing/correctness/apps/ping_pong/ping_pong.pony
@@ -35,6 +35,7 @@ use "options"
 use "serialise"
 use "wallaroo_labs/bytes"
 use "wallaroo"
+use "wallaroo_labs/logging"
 use "wallaroo_labs/mort"
 use "wallaroo_labs/time"
 use "wallaroo/core/sink/tcp_sink"
@@ -47,6 +48,7 @@ primitive Pong
 
 actor Main
   new create(env: Env) =>
+    Log.set_defaults()
     var app_type: (Ping | Pong | None) = None
     var options = Options(env.args, false)
 

--- a/testing/correctness/apps/window_detector/window_detector.pony
+++ b/testing/correctness/apps/window_detector/window_detector.pony
@@ -39,6 +39,7 @@ use "wallaroo/core/windows"
 
 // wallaroo/lib/wallaroo_labs
 use "wallaroo_labs/bytes"
+use "wallaroo_labs/logging"
 use "wallaroo_labs/mort"
 use "wallaroo_labs/time"
 
@@ -65,6 +66,7 @@ type WindowPolicy is (Drop | FirePerMessage | PlaceInOldestWindow)
 
 actor Main
   new create(env: Env) =>
+    Log.set_defaults()
 
     try
       // Add options:

--- a/testing/performance/apps/market-spread/market-spread.pony
+++ b/testing/performance/apps/market-spread/market-spread.pony
@@ -78,6 +78,7 @@ use "wallaroo_labs/new_fix"
 use "wallaroo_labs/options"
 use "wallaroo_labs/time"
 use "wallaroo"
+use "wallaroo_labs/logging"
 use "wallaroo_labs/mort"
 use "wallaroo/core/common"
 use "wallaroo/core/metrics"
@@ -89,6 +90,7 @@ use "wallaroo/core/topology"
 
 actor Main
   new create(env: Env) =>
+    Log.set_defaults()
     try
       let pipeline = recover val
         let orders = Wallaroo.source[FixOrderMessage val]("Orders",

--- a/testing/performance/apps/word_count/word_count.pony
+++ b/testing/performance/apps/word_count/word_count.pony
@@ -26,6 +26,7 @@ use "net"
 use "serialise"
 use "wallaroo_labs/bytes"
 use "wallaroo"
+use "wallaroo_labs/logging"
 use "wallaroo_labs/mort"
 use "wallaroo_labs/time"
 use "wallaroo/core/common"
@@ -38,6 +39,7 @@ use "wallaroo/core/topology"
 
 actor Main
   new create(env: Env) =>
+    Log.set_defaults()
     try
       let pipeline = recover val
         let lines = Wallaroo.source[String]("Word Count",

--- a/utils/data_receiver/Makefile
+++ b/utils/data_receiver/Makefile
@@ -34,10 +34,6 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
 # (and by recursion every makefile in the tree that is referenced)
 $(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
 
-# Boilerplate for Pony source: use "lib:wallaroo-logging"
-# This dep must appear prior to include $(rules_mk_path)
-build-utils-data_receiver: $(LOGGING_LIB_A)
-
 # standard rules generation makefile
 include $(rules_mk_path)
 

--- a/utils/data_receiver/Makefile
+++ b/utils/data_receiver/Makefile
@@ -34,6 +34,9 @@ $(abspath $(lastword $(MAKEFILE_LIST)))_DOCKER_TARGET := true
 # (and by recursion every makefile in the tree that is referenced)
 $(abspath $(lastword $(MAKEFILE_LIST)))_RECURSE_SUBMAKEFILES := true
 
+# Boilerplate for Pony source: use "lib:wallaroo-logging"
+# This dep must appear prior to include $(rules_mk_path)
+build-utils-data_receiver: $(LOGGING_LIB_A)
 
 # standard rules generation makefile
 include $(rules_mk_path)

--- a/utils/data_receiver/data_receiver.pony
+++ b/utils/data_receiver/data_receiver.pony
@@ -18,13 +18,7 @@ Copyright 2017 The Wallaroo Authors.
 
 use "net"
 use "wallaroo_labs/bytes"
-use "wallaroo_labs/logging"
 use "wallaroo_labs/options"
-
-use @log_enabled[Bool](severity: LogSeverity, category: LogCategory)
-use @ll_enabled[Bool](sev_cat: U16)
-use @l[I32](severity: LogSeverity, category: LogCategory, fmt: Pointer[U8] tag, ...)
-use @ll[I32](sev_cat: U16, fmt: Pointer[U8] tag, ...)
 
 actor Main
   new create(env: Env) =>
@@ -32,46 +26,6 @@ actor Main
     var l_arg: (Array[String] | None) = None
     var output_mode: OutputMode = Write
     var input_mode: InputMode = Streaming
-
-    // let Log.emerg = U8(0)
-    // let Log.alert = U8(1)
-    // let Log.crit = U8(2)
-    // let Log.err = U8(3)
-    let cat_mumble = U8(40)
-
-    @printf[I32]("SLF: Hello, world!\n".cstring()) // For demo purposes only
-    @l(Log.crit(), cat_mumble, "SLF: Hello, %s\n".cstring(), "everything".cstring()) // For demo purposes only
-    @w_set_severity_label[None](Log.crit(), "2-severity-yo".cstring())
-    @w_set_category_label[None](cat_mumble, "my-mumble-cat".cstring())
-    @l(Log.crit(), cat_mumble, "SLF: Hello, %s!".cstring(), "everything".cstring()) // For demo purposes only
-
-    @w_set_severity_threshold[None](Log.alert())
-    @l(Log.emerg(), cat_mumble, "SLF: visible!".cstring()) // For demo purposes only
-    @l(Log.alert(), cat_mumble, "SLF: visible!".cstring()) // For demo purposes only
-    @l(Log.crit(), cat_mumble, "SLF: this one should be filtered out".cstring()) // For demo purposes only
-
-    @printf[I32]("SLF: emergency enabled = true? res = %s\n".cstring(),
-      @log_enabled(Log.emerg(), cat_mumble).string().cstring())
-    @printf[I32]("SLF: alert enabled = true? res = %s\n".cstring(),
-      @log_enabled(Log.alert(), cat_mumble).string().cstring())
-    @printf[I32]("SLF: critical enabled = false? res = %s\n".cstring(),
-      @log_enabled(Log.crit(), cat_mumble).string().cstring())
-
-    Log.set_category_labels()
-    @l(Log.emerg(), Log.source_migration(), "Visible migration event".cstring())
-    let emerg_s_mig = Log.make_sev_cat(Log.emerg(), Log.source_migration())
-    @ll(emerg_s_mig, "ll-visible migration event".cstring())
-
-    // @l(Log.source_migration_info(), "Visible migration event".cstring())
-    // @l(Log.emerg(), Log.source_migration(), "Visible migration event".cstring())
-
-
-    Log.set_thresholds(false, true)
-    let aa: Array[(U8, U8)] = [ (7,20); (2,20); (7, 21); (2, 21)]
-    for (sev, cat) in aa.values() do
-      @printf[I32]("SLF: enabled sev=%d,cat=%d? res = %s\n".cstring(),
-        sev, cat, @log_enabled(sev, cat).string().cstring())
-    end
 
     try
       var options = Options(env.args)

--- a/utils/data_receiver/data_receiver.pony
+++ b/utils/data_receiver/data_receiver.pony
@@ -18,7 +18,13 @@ Copyright 2017 The Wallaroo Authors.
 
 use "net"
 use "wallaroo_labs/bytes"
+use "wallaroo_labs/logging"
 use "wallaroo_labs/options"
+
+use @log_enabled[Bool](severity: LogSeverity, category: LogCategory)
+use @ll_enabled[Bool](sev_cat: U16)
+use @l[I32](severity: LogSeverity, category: LogCategory, fmt: Pointer[U8] tag, ...)
+use @ll[I32](sev_cat: U16, fmt: Pointer[U8] tag, ...)
 
 actor Main
   new create(env: Env) =>
@@ -26,6 +32,46 @@ actor Main
     var l_arg: (Array[String] | None) = None
     var output_mode: OutputMode = Write
     var input_mode: InputMode = Streaming
+
+    // let Log.emerg = U8(0)
+    // let Log.alert = U8(1)
+    // let Log.crit = U8(2)
+    // let Log.err = U8(3)
+    let cat_mumble = U8(40)
+
+    @printf[I32]("SLF: Hello, world!\n".cstring()) // For demo purposes only
+    @l(Log.crit(), cat_mumble, "SLF: Hello, %s\n".cstring(), "everything".cstring()) // For demo purposes only
+    @w_set_severity_label[None](Log.crit(), "2-severity-yo".cstring())
+    @w_set_category_label[None](cat_mumble, "my-mumble-cat".cstring())
+    @l(Log.crit(), cat_mumble, "SLF: Hello, %s!".cstring(), "everything".cstring()) // For demo purposes only
+
+    @w_set_severity_threshold[None](Log.alert())
+    @l(Log.emerg(), cat_mumble, "SLF: visible!".cstring()) // For demo purposes only
+    @l(Log.alert(), cat_mumble, "SLF: visible!".cstring()) // For demo purposes only
+    @l(Log.crit(), cat_mumble, "SLF: this one should be filtered out".cstring()) // For demo purposes only
+
+    @printf[I32]("SLF: emergency enabled = true? res = %s\n".cstring(),
+      @log_enabled(Log.emerg(), cat_mumble).string().cstring())
+    @printf[I32]("SLF: alert enabled = true? res = %s\n".cstring(),
+      @log_enabled(Log.alert(), cat_mumble).string().cstring())
+    @printf[I32]("SLF: critical enabled = false? res = %s\n".cstring(),
+      @log_enabled(Log.crit(), cat_mumble).string().cstring())
+
+    Log.set_category_labels()
+    @l(Log.emerg(), Log.source_migration(), "Visible migration event".cstring())
+    let emerg_s_mig = Log.make_sev_cat(Log.emerg(), Log.source_migration())
+    @ll(emerg_s_mig, "ll-visible migration event".cstring())
+
+    // @l(Log.source_migration_info(), "Visible migration event".cstring())
+    // @l(Log.emerg(), Log.source_migration(), "Visible migration event".cstring())
+
+
+    Log.set_thresholds(false, true)
+    let aa: Array[(U8, U8)] = [ (7,20); (2,20); (7, 21); (2, 21)]
+    for (sev, cat) in aa.values() do
+      @printf[I32]("SLF: enabled sev=%d,cat=%d? res = %s\n".cstring(),
+        sev, cat, @log_enabled(sev, cat).string().cstring())
+    end
 
     try
       var options = Options(env.args)


### PR DESCRIPTION
Supercedes PRs #2947 and #2949 

The new logging API is introduced to all Wallaroo apps in the repo (I hope) and has severity+category logging statements for all the `@printf` FFI calls in the sources and sinks (excluding the Kafka sources & sinks).  Additional migration to the severity+category scheme can follow later. 

Closes #2942 