### PR TITLE
Add time.sleep() to Cluster.rotate_logs() to work around #2957

### DIFF
--- a/testing/conformance/tests/cli.py
+++ b/testing/conformance/tests/cli.py
@@ -28,8 +28,8 @@ from conformance.applications.cli import (CLITesterPython2,
 
 class Query(object):
     def __init__(self, cluster, query_type):
-        cmd = "external_sender --json --external {} --type {}"
-        self.cmds = {w.name: cmd.format(w.external, query_type) for w
+        self.cmd = "external_sender --json --external {} --type {}"
+        self.cmds = {w.name: self.cmd.format(w.external, query_type) for w
                      in cluster.workers}
 
     def result(self):
@@ -42,7 +42,7 @@ class Query(object):
                                 format(res.output))
         else:
             raise Exception("Failed running cmd: {!r} with {!r}".
-                            format(self._cmd, res.output))
+                            format(self.cmd, res.output))
 
 
 

--- a/testing/tools/integration/cluster.py
+++ b/testing/tools/integration/cluster.py
@@ -631,6 +631,7 @@ class Cluster(object):
         # send a log rotate command directly to each worker's external channel
         for w in to_rotate:
             send_rotate_command(w.external, w.name)
+            time.sleep(2.0) ## work-around for GH 2957
 
         # Wait for log rotation watcher to return
         wflr.join()


### PR DESCRIPTION
Work-around #2957 until that ticket's race is fixed.