### PR TITLE
Fix data race in handle_restarted()

### DIFF
--- a/machida/lib/wallaroo/experimental/__init__.py
+++ b/machida/lib/wallaroo/experimental/__init__.py
@@ -654,7 +654,11 @@ class AtLeastOnceSourceConnector(asynchat.async_chat, BaseConnector, BaseMeta):
         # close connection
         self._stop_asyncore_loop()
         logging.debug("Removing socket from asyncore map")
-        self._socket_map.pop(self._conn.fileno(), None)
+        if self._async_init:
+            self.del_channel(self._socket_map) # remove the connection from asyncore loop
+        ## For future asynchat/asyncore threads, use a different work map
+        self._socket_map = {}
+
         logging.debug("Closing socket {}".format(self._conn.fileno()))
         self._conn.close()
         self._conn = None


### PR DESCRIPTION
Fixes #2965

The `asynchat` processor was using the same `map` thingie for the two sockets, before and after the `Restart` message.  By using a separate work map, the old thread can (I believe) shut itself down.

I've run the fix in a loop for 3 hours without a test failure.  Without the bug, there's a test error usually within 25 minutes.

I'm not 100% sure there isn't a Pthread leak here.  A couple of experiments say there isn't, but it isn't good proof.  I don't believe this patch increases the chance of a Pthread leak.