### PR TITLE
Refine TCPConnection expect calls in TCPConnectionNotifys

### DIFF
--- a/lib/wallaroo/core/network/control_channel_tcp.pony
+++ b/lib/wallaroo/core/network/control_channel_tcp.pony
@@ -186,8 +186,14 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
     if _header then
       try
         let expect = Bytes.to_u32(data(0)?, data(1)?, data(2)?, data(3)?).usize()
-        conn.expect(expect)?
-        _header = false
+        try
+          conn.expect(expect)?
+          _header = false
+        else
+          @printf[I32](("Received expect larger than 16kb on Control " +
+            "Channel\n").cstring())
+          Fail()
+        end
       else
         @printf[I32]("Error reading header on control channel\n".cstring())
       end
@@ -703,8 +709,14 @@ class JoiningControlSenderConnectNotifier is TCPConnectionNotify
     if _header then
       try
         let expect = Bytes.to_u32(data(0)?, data(1)?, data(2)?, data(3)?).usize()
-        conn.expect(expect)?
-        _header = false
+        try
+          conn.expect(expect)?
+          _header = false
+        else
+          @printf[I32](("Received expect larger than 16kb on Control " +
+            "Channel\n").cstring())
+          Fail()
+        end
       else
         @printf[I32]("Error reading header on control channel\n".cstring())
       end

--- a/lib/wallaroo/core/network/external_channel_tcp.pony
+++ b/lib/wallaroo/core/network/external_channel_tcp.pony
@@ -108,8 +108,14 @@ class ExternalChannelConnectNotifier is TCPConnectionNotify
         let expect = Bytes.to_u32(data(0)?, data(1)?, data(2)?, data(3)?)
           .usize()
         if expect > 0 then
-          conn.expect(expect)?
-          _header = false
+          try
+            conn.expect(expect)?
+            _header = false
+          else
+            conn.dispose()
+            @printf[I32](("Received expect greater than 16kb on External " +
+              "Channel\n").cstring())
+          end
         else
           conn.expect(4)?
           _header = true

--- a/testing/tools/merrick/merrick.pony
+++ b/testing/tools/merrick/merrick.pony
@@ -179,8 +179,14 @@ class FromWallarooNotify is TCPConnectionNotify
       try
 
         let expect = Bytes.to_u32(data(0)?, data(1)?, data(2)?, data(3)?).usize()
-        conn.expect(expect)?
-        _header = false
+        try
+          conn.expect(expect)?
+          _header = false
+        else
+          @printf[I32](("Received expect larger than 16kb, closing " +
+            "connection.\n").cstring())
+          conn.dispose()
+        end
       else
         @printf[I32]("Blew up reading header from Wallaroo\n".cstring())
         Fail()

--- a/utils/data_receiver/data_receiver.pony
+++ b/utils/data_receiver/data_receiver.pony
@@ -141,7 +141,8 @@ class ConnectionNotify is TCPConnectionNotify
           try
             c.expect(expect)?
           else
-            Fail()
+            _stderr.print("Received an expect larger than 16kb. Exiting.")
+            c.close()
           end
           _read_header = false
         else


### PR DESCRIPTION
**External Channel TCP**
given that we have defined the ExternalChannel messages, we can safely assume that no expect should exceed 16kb. Therefore, I felt it was safe to simply close the connection and print an error. 

We would want to revisit handling of larger than 16kb expects if we had a message type that can exceed that size.


**Control Channel TCP**

given that we define and send the messages via the Control Channel, I've opted to `Fail()` in the scenario where an expect exceeds 16kb given that none exceed that size currently.

We would want to revisit handling of larger than 16kb expects if we had a message type that can exceed that size.

**Data Receiver**

I've currently opted to print an error message and close the connection when an expect larger than 16kb is set.

This is the one scenario where I think we _may_ want to add the capability to handle expects larger than 16kb. Thoughts @jtfmumm? If we think this is a place where we should expect to handle expects larger than 16kb than I'll consult with @SeanTAllen to determine the best approach given his involvement in the Pony PRs.

**Merrick**

I've currently opted to print an error message and close the connection when an expect larger than 16kb is set. I think this is the smallest of our problems with this tool and I vote for removing it from the codebase. Thoughts @jtfmumm ?

ref #2964 