### PR TITLE
Add cluster-state-entity-count-query

### DIFF
--- a/lib/wallaroo/core/common/id_generators.pony
+++ b/lib/wallaroo/core/common/id_generators.pony
@@ -32,6 +32,12 @@ class RoutingIdGenerator
   fun ref apply(): RoutingId =>
     _guid.u128()
 
+class RequestIdGenerator
+  let _guid: GuidGenerator = GuidGenerator
+
+  fun ref apply(): RequestId =>
+    _guid.u128()
+
 primitive DeterministicSourceIdGenerator
   fun apply(text: String): RoutingId ? =>
     let temp_id = MD5(text)

--- a/lib/wallaroo/core/common/request_id.pony
+++ b/lib/wallaroo/core/common/request_id.pony
@@ -1,0 +1,19 @@
+/*
+
+Copyright 2019 The Wallaroo Authors.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ implied. See the License for the specific language governing
+ permissions and limitations under the License.
+
+*/
+
+type RequestId is U128

--- a/lib/wallaroo/core/initialization/local_topology.pony
+++ b/lib/wallaroo/core/initialization/local_topology.pony
@@ -1642,6 +1642,14 @@ actor LocalTopologyInitializer is LayoutInitializer
   be state_entity_count_query(conn: TCPConnection) =>
     _router_registry.state_entity_count_query(conn)
 
+  be cluster_state_entity_count_query(conn: TCPConnection) =>
+    match _topology
+    | let t: LocalTopology =>
+      _router_registry.cluster_state_entity_count_query(conn, t.worker_names)
+    else
+      Fail()
+    end
+
   be stateless_partition_count_query(conn: TCPConnection) =>
     _router_registry.stateless_partition_count_query(conn)
 

--- a/lib/wallaroo/core/messages/channel_messages.pony
+++ b/lib/wallaroo/core/messages/channel_messages.pony
@@ -682,6 +682,19 @@ primitive ChannelMsgEncoder
     _encode(ConnectorLeaderNameResponseMsg(leader_name, source_name),
       auth)?
 
+  fun worker_state_entity_count_request(worker_name: WorkerName,
+    requester: WorkerName, request_id: RequestId,
+    auth: AmbientAuth): Array[ByteSeq] val ?
+  =>
+    _encode(WorkerStateEntityCountRequestMsg(requester, request_id),
+      auth)?
+
+  fun worker_state_entity_count_response(worker_name: WorkerName,
+    request_id: RequestId, worker_state_entity_count_json: String,
+    auth: AmbientAuth): Array[ByteSeq] val ?
+  =>
+    _encode(WorkerStateEntityCountResponseMsg(worker_name, request_id,
+      worker_state_entity_count_json), auth)?
 
 primitive ChannelMsgDecoder
   fun apply(data: Array[U8] val, auth: AmbientAuth): ChannelMsg =>
@@ -1771,3 +1784,24 @@ class val ReportStatusMsg is ChannelMsg
 
   new val create(c: ReportStatusCode) =>
     code = c
+
+class val WorkerStateEntityCountRequestMsg is ChannelMsg
+  let requester: WorkerName
+  let request_id: RequestId
+
+  new val create(requester': WorkerName, request_id': RequestId) =>
+    requester = requester'
+    request_id = request_id'
+
+class val WorkerStateEntityCountResponseMsg is ChannelMsg
+  let worker_name: WorkerName
+  let request_id: RequestId
+  let state_entity_count_json: String
+
+  new val create(worker_name': WorkerName, request_id': RequestId,
+    state_entity_count_json': String)
+  =>
+    worker_name = worker_name'
+    request_id = request_id'
+    state_entity_count_json = state_entity_count_json'
+

--- a/lib/wallaroo/core/network/control_channel_tcp.pony
+++ b/lib/wallaroo/core/network/control_channel_tcp.pony
@@ -645,6 +645,10 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
           @printf[I32]("Received SourceCoordinatorMsg.\n".cstring())
         end
         _router_registry.receive_source_coordinator_msg(m)
+      | let m: WorkerStateEntityCountRequestMsg =>
+        _router_registry.receive_worker_state_entity_count_request_msg(m)
+      | let m: WorkerStateEntityCountResponseMsg =>
+        _router_registry.receive_worker_state_entity_count_response_msg(m)
       | let m: UnknownChannelMsg =>
         @printf[I32]("Unknown channel message type.\n".cstring())
       else

--- a/lib/wallaroo/core/network/external_channel_tcp.pony
+++ b/lib/wallaroo/core/network/external_channel_tcp.pony
@@ -218,10 +218,17 @@ class ExternalChannelConnectNotifier is TCPConnectionNotify
 
         | let m: ExternalStateEntityCountQueryMsg =>
           ifdef "trace" then
-            @printf[I32](("Received ExternalStateEntityCountQueryMsg on "
+            @printf[I32](("Received ExternalStateEntityCountQueryMsg on " +
               "External Channel\n").cstring())
           end
           _local_topology_initializer.state_entity_count_query(conn)
+
+        | let m: ExternalClusterStateEntityCountQueryMsg =>
+          ifdef "trace" then
+            @printf[I32](("Received ExternalClusterStateEntityCountQueryMsg " +
+              "on External Channel\n").cstring())
+          end
+          _local_topology_initializer.cluster_state_entity_count_query(conn)
         | let m: ExternalStatelessPartitionCountQueryMsg =>
           ifdef "trace" then
             @printf[I32](("Received ExternalStatelessPartitionCountQueryMsg "

--- a/lib/wallaroo/core/topology/router.pony
+++ b/lib/wallaroo/core/topology/router.pony
@@ -507,6 +507,11 @@ class val StatePartitionRouter is Router
   fun step_group(): RoutingId =>
     _step_group
 
+  fun step_id_for_key(key: Key): RoutingId ? =>
+    let idx = (HashKey(key) % _state_steps.size().u128()).usize()
+    let step = _state_steps(idx)?
+    _consumer_ids(step)?
+
   fun route[D: Any val](metric_name: String, pipeline_time_spent: U64, data: D,
     key: Key, event_ts: U64, watermark_ts: U64,
     consumer_sender: TestableConsumerSender,

--- a/lib/wallaroo_labs/query/query_json.pony
+++ b/lib/wallaroo_labs/query/query_json.pony
@@ -62,6 +62,38 @@ primitive StateEntityCountQueryEncoder
     end
     o.string()
 
+primitive StepStateEntityCountQueryEncoder
+  fun step_state_entity_count(
+    digest: Map[String, Map[String, Array[Key] val] val] val):
+    String
+  =>
+    let o = JsonObject
+    for (step_group, step_keys) in digest.pairs() do
+      let o1 = JsonObject
+      for (k,v) in step_keys.pairs() do
+        // Type hack/workaround
+        let v2: Array[String] trn = recover v2.create() end
+        for key in v.values() do
+          v2.push("")
+        end
+        o1.data(k) = _EncodeArrayLength(consume v2)
+      end
+      o.data(step_group) = o1
+    end
+    o.string()
+
+primitive ClusterStateEntityCountQueryEncoder
+  fun cluster_state_entity_count(
+    cluster_state_entity_counts: Map[WorkerName, String]): String ?
+  =>
+    let o = JsonObject
+    for (worker, state_entity_count) in cluster_state_entity_counts.pairs() do
+      let doc: JsonDoc = JsonDoc
+      doc.parse(state_entity_count)?
+      let state_entity_count_json: JsonObject = doc.data as JsonObject
+      o.data(worker) = state_entity_count_json
+    end
+    o.string()
 
 primitive StatelessPartitionQueryEncoder
   fun stateless_partition_keys(

--- a/testing/tools/external_sender/external_sender.pony
+++ b/testing/tools/external_sender/external_sender.pony
@@ -71,6 +71,7 @@ actor Main
                   partition-count-query | cluster-status-query |
                   source-ids-query | boundary-count-status |
                   state-entity-query | state-entity-count-query |
+                  cluster-state-entity-count-query |
                   stateless-partition-query | stateless-partition-count-query |
                   print
 
@@ -115,6 +116,9 @@ actor Main
         | "state-entity-count-query" =>
           await_response = true
           ExternalMsgEncoder.state_entity_count_query()
+        | "cluster-state-entity-count-query" =>
+          await_response = true
+          ExternalMsgEncoder.cluster_state_entity_count_query()
         | "stateless-partition-count-query" =>
           await_response = true
           ExternalMsgEncoder.stateless_partition_count_query()
@@ -227,6 +231,12 @@ class ExternalSenderConnectNotifier is TCPConnectionNotify
         | let m: ExternalStateEntityCountQueryResponseMsg =>
           if not _json then
             _env.out.print("State Entity Count:")
+          end
+          _env.out.print(m.msg)
+          conn.dispose()
+        | let m: ExternalClusterStateEntityCountQueryResponseMsg =>
+          if not _json then
+            _env.out.print("Cluster State Entity Count:")
           end
           _env.out.print(m.msg)
           conn.dispose()


### PR DESCRIPTION
  - adds query to external sender to retrieve the state entity count
    of the cluster, this information is organized by worker and by
    entity key.

**Testing**

run the following to test:

` testing/tools/external_sender/external_sender -j -e <WORKER_EXTERNAL_ADDRESS> -t cluster-state-entity-count-query`

The above should work in both single and multi-worker instances and should get the result from _any_ worker in the multi-worker case.


<!--
Make sure you've read the [Contributors Guide](https://github.com/WallarooLabs/wallaroo/blob/master/CONTRIBUTING.md). You'll need to sign our CLA before your issue can be accepted.

Reference the issue your code change relates to if possible
-->
closes #2899

<!--
Include any other necessary information below. If you have any questions don't hesitate to reach out on the mailing list or on IRC.
-->
