### PR TITLE
Increase integration & conformance test timeouts 3x

### DIFF
--- a/testing/conformance/conformance/applications/cli.py
+++ b/testing/conformance/conformance/applications/cli.py
@@ -49,7 +49,7 @@ class CLITesterBase(Application):
     def send_data(self):
         self.send(self.values)
         self.completes_when(data_in_sink_contains(self.await_values),
-                            timeout=30)
+                            timeout=90)
 
 
 class CLITesterPython2(CLITesterBase):

--- a/testing/conformance/conformance/applications/system_events.py
+++ b/testing/conformance/conformance/applications/system_events.py
@@ -136,7 +136,7 @@ class ResilienceOperation(object):
 
 
 class Grow(ResilienceOperation):
-    def __init__(self, size, timeout=30, with_test=True):
+    def __init__(self, size, timeout=90, with_test=True):
         super(Grow, self).__init__(size)
         self.timeout = timeout
         self.with_test = with_test
@@ -150,7 +150,7 @@ class Grow(ResilienceOperation):
 
 
 class Shrink(ResilienceOperation):
-    def __init__(self, workers, timeout=30, with_test=True):
+    def __init__(self, workers, timeout=90, with_test=True):
         self.workers = workers
         self.timeout = timeout
         self.with_test = with_test
@@ -191,7 +191,7 @@ class Crash(ResilienceOperation):
 
 
 class Recover(ResilienceOperation):
-    def __init__(self, size=None, timeout=30, with_test=True, resume=True):
+    def __init__(self, size=None, timeout=90, with_test=True, resume=True):
         """
         :size may be a positive int or None
         if int, it denotes the number of workers to recover from the tail end

--- a/testing/conformance/conformance/applications/topology.py
+++ b/testing/conformance/conformance/applications/topology.py
@@ -136,7 +136,7 @@ class TopologyTesterBaseApp(Application):
         logging.info("Awaiting on sink")
         self.completes_when(data_in_sink_count_is(
             expected=(len(self.source_gens) * self.expect),
-            timeout=30,
+            timeout=90,
             sink=-1,
             allow_more=False))
 

--- a/testing/conformance/conformance/base.py
+++ b/testing/conformance/conformance/base.py
@@ -88,7 +88,7 @@ class Application:
         logging.debug("end of send_tcp")
         return sender
 
-    def completes_when(self, test_func, timeout=30):
+    def completes_when(self, test_func, timeout=90):
         notifier = CompletesWhenNotifier(self, test_func,
             timeout, period=0.1)
         notifier.start()
@@ -105,13 +105,13 @@ class Application:
     def parse_output(self, v):
         return v.decode()
 
-    def sink_await(self, values, timeout=30, func=lambda x: x, sink=-1):
+    def sink_await(self, values, timeout=90, func=lambda x: x, sink=-1):
         if not self.cluster:
             raise TestHarnessException("Can't sink_await before creating "
                     "a cluster!")
         self.cluster.sink_await(values, timeout, func, sink)
 
-    def sink_expect(self, expected, timeout=30, sink=-1, allow_more=False):
+    def sink_expect(self, expected, timeout=90, sink=-1, allow_more=False):
         if not self.cluster:
             raise TestHarnessException("Can't sink_expect before creating "
                     "a cluster!")

--- a/testing/conformance/conformance/completes_when.py
+++ b/testing/conformance/conformance/completes_when.py
@@ -15,7 +15,7 @@
 
 from integration.errors import TimeoutError
 
-def data_in_sink_contains(data, timeout=30, sink=-1):
+def data_in_sink_contains(data, timeout=90, sink=-1):
     def data_in_sink_contains_func(context):
         context.sink_await(data, timeout=timeout, func=context.parse_output,
                            sink=sink)
@@ -23,7 +23,7 @@ def data_in_sink_contains(data, timeout=30, sink=-1):
     return data_in_sink_contains_func
 
 
-def data_in_sink_count_is(expected, timeout=30, sink=-1, allow_more=False):
+def data_in_sink_count_is(expected, timeout=90, sink=-1, allow_more=False):
     def data_in_sink_count_is_func(context):
         context.sink_expect(expected, timeout=timeout, sink=sink,
                             allow_more=allow_more)

--- a/testing/conformance/conformance/control.py
+++ b/testing/conformance/conformance/control.py
@@ -50,7 +50,7 @@ class CompletesWhenNotifier(StoppableThread):
     """
     Run a notifier loop with a query function and a check condition function
     """
-    def __init__(self, context, test_func, timeout=30, period=1):
+    def __init__(self, context, test_func, timeout=90, period=1):
         super().__init__()
         self.context = context
         self.test_func = test_func

--- a/testing/conformance/tests/window_policy.py
+++ b/testing/conformance/tests/window_policy.py
@@ -50,7 +50,7 @@ def test_drop_policy():
 
         # Specify end condition (as function over sink)
         test.completes_when(data_in_sink_contains(out_of_order_ts_drop),
-            timeout=30)
+            timeout=90)
 
         # Test validation logic
         output = test.collect()
@@ -71,7 +71,7 @@ def test_firepermessage_policy():
         # Specify end condition (as function over sink)
         test.completes_when(
             data_in_sink_contains(out_of_order_ts_firepermessage),
-            timeout=30)
+            timeout=90)
 
         # Test validation logic
         output = test.collect()

--- a/testing/tools/integration/cluster.py
+++ b/testing/tools/integration/cluster.py
@@ -498,7 +498,7 @@ class Cluster(object):
 
     def __init__(self, command, host='127.0.0.1', sources=[], workers=1,
             sinks=1, sink_mode='framed', split_streams=False,
-            worker_join_timeout=30,
+            worker_join_timeout=90,
             is_ready_timeout=60, res_dir=None, log_rotation=False,
             persistent_data={}):
         # Create attributes
@@ -654,7 +654,7 @@ class Cluster(object):
     #############
     # Autoscale #
     #############
-    def grow(self, by=1, timeout=30, with_test=True):
+    def grow(self, by=1, timeout=90, with_test=True):
         logging.log(1, "grow(by={}, timeout={}, with_test={})".format(
             by, timeout, with_test))
         pre_partitions = self.get_partition_data() if with_test else None
@@ -698,7 +698,7 @@ class Cluster(object):
             self.confirm_migration(pre_partitions, workers, timeout=timeout)
         return runners
 
-    def shrink(self, workers=1, timeout=30, with_test=True):
+    def shrink(self, workers=1, timeout=90, with_test=True):
         logging.log(1, "shrink(workers={}, with_test={})".format(
             workers, with_test))
         # pick a worker that's not being shrunk
@@ -877,7 +877,7 @@ class Cluster(object):
         for s in self.sinks:
             s.stop()
 
-    def sink_await(self, values, timeout=30, func=lambda x: x, sink=-1):
+    def sink_await(self, values, timeout=90, func=lambda x: x, sink=-1):
         logging.log(1, "sink_await(values={}, timeout={}, func: {}, sink={})"
             .format(values, timeout, func, sink))
         if isinstance(sink, Sink):
@@ -894,7 +894,7 @@ class Cluster(object):
         logging.debug("sink_await completed successfully")
         return sink
 
-    def sink_expect(self, expected, timeout=30, sink=-1, allow_more=False):
+    def sink_expect(self, expected, timeout=90, sink=-1, allow_more=False):
         logging.log(1, "sink_expect(expected={}, timeout={}, sink={})".format(
             expected, timeout, sink))
         if isinstance(sink, Sink):
@@ -920,7 +920,7 @@ class Cluster(object):
         if start:
             sender.start()
 
-    def wait_for_sender(self, sender=-1, timeout=30):
+    def wait_for_sender(self, sender=-1, timeout=90):
         logging.log(1, "wait_for_sender(sender={}, timeout={})"
             .format(sender, timeout))
         if isinstance(sender, (ALOSender, Sender)):
@@ -947,7 +947,7 @@ class Cluster(object):
             s.pause()
         self.wait_for_senders_to_flush()
 
-    def wait_for_senders_to_flush(self, timeout=30):
+    def wait_for_senders_to_flush(self, timeout=90):
         logging.log(1, "wait_for_senders_to_flush({})".format(timeout))
         awaiters = []
         for s in self.senders:
@@ -973,7 +973,7 @@ class Cluster(object):
     ###########
     # Cluster #
     ###########
-    def wait_to_resume_processing(self, timeout=30):
+    def wait_to_resume_processing(self, timeout=90):
         logging.log(1, "wait_to_resume_processing(timeout={})"
             .format(timeout))
         w = WaitForClusterToResumeProcessing(self.workers, timeout=timeout)
@@ -993,7 +993,7 @@ class Cluster(object):
     #########################
     # Observability queries #
     #########################
-    def query_observability(self, query, args, tests, timeout=30, period=2):
+    def query_observability(self, query, args, tests, timeout=90, period=2):
         logging.log(1, "query_observability(query={}, args={}, tests={}, "
             "timeout={}, period={})".format(
                 query, args, tests, timeout, period))

--- a/testing/tools/integration/control.py
+++ b/testing/tools/integration/control.py
@@ -29,7 +29,7 @@ from .validations import is_processing
 
 
 class WaitForClusterToResumeProcessing(StoppableThread):
-    def __init__(self, runners, timeout=30, interval=0.05):
+    def __init__(self, runners, timeout=90, interval=0.05):
         super(WaitForClusterToResumeProcessing, self).__init__()
         self.name = 'WaitForClusterToResumeProcessing'
         # Wait until all workers have resumed processing
@@ -82,7 +82,7 @@ class SinkExpect(StoppableThread):
     """
     __base_name__ = 'SinkExpect'
 
-    def __init__(self, sink, expected, timeout=30, allow_more=False):
+    def __init__(self, sink, expected, timeout=90, allow_more=False):
         super(SinkExpect, self).__init__()
         self.sink = sink
         self.expected = expected
@@ -125,7 +125,7 @@ class SinkAwaitValue(StoppableThread):
     """
     __base_name__ = 'SinkAwaitValue'
 
-    def __init__(self, sink, values, timeout=30, func=lambda x: x):
+    def __init__(self, sink, values, timeout=90, func=lambda x: x):
         super(SinkAwaitValue, self).__init__()
         self.sink = sink
         if isinstance(values, (list, tuple)):
@@ -172,7 +172,7 @@ class SinkAwaitValue(StoppableThread):
 
 
 class TryUntilTimeout(StoppableThread):
-    def __init__(self, test, pre_process=None, timeout=30, interval=0.1):
+    def __init__(self, test, pre_process=None, timeout=90, interval=0.1):
         """
         Try a test until it passes or the time runs out
 
@@ -255,7 +255,7 @@ class WaitForLogRotation(StoppableThread):
     __base_name__ = 'WaitForLogRottion'
 
     def __init__(self, cluster, base_path, prefixes=[], log_suffix='.evlog',
-                 timeout=30):
+                 timeout=90):
         super(WaitForLogRotation, self).__init__()
         logging.debug("{}({}, {}, {}, {})".format(self.__base_name__,
             base_path, prefixes, log_suffix, timeout))

--- a/testing/tools/integration/integration.py
+++ b/testing/tools/integration/integration.py
@@ -43,8 +43,8 @@ except NameError:
     basestring = (str, bytes)
 
 
-DEFAULT_SINK_STOP_TIMEOUT = 30
-DEFAULT_RUNNER_JOIN_TIMEOUT = 30
+DEFAULT_SINK_STOP_TIMEOUT = 90
+DEFAULT_RUNNER_JOIN_TIMEOUT = 90
 
 
 FROM_TAIL = int(os.environ.get("FROM_TAIL", 10))
@@ -73,10 +73,10 @@ def pipeline_test(sources, expected, command, workers=1,
                   batch_size=1, sender_interval=0.001,
                   sink_expect=None, sink_expect_allow_more=False,
                   sink_stop_timeout=DEFAULT_SINK_STOP_TIMEOUT,
-                  sink_await=None, sink_await_keys=None, delay=30,
+                  sink_await=None, sink_await_keys=None, delay=90,
                   output_file=None, validation_cmd=None,
                   host='127.0.0.1', listen_attempts=1,
-                  ready_timeout=30,
+                  ready_timeout=90,
                   runner_join_timeout=DEFAULT_RUNNER_JOIN_TIMEOUT,
                   resilience_dir=None,
                   spikes={},
@@ -122,10 +122,10 @@ def pipeline_test(sources, expected, command, workers=1,
         be stopped.
     - `sink_stop_timeout`: the timeout in seconds to use when awaiting an
         expected number of messages at the sink. Raise an error if timeout
-        elapses. Default: 30
+        elapses. Default: 90
         Can be a number or a list of numbers of `len(sinks)`.
     - `delay`: Wait for `delay` seconds before stopping the cluster.
-      Default 30 seconds. Only used if `sink_expect` and `sink_await`
+      Default 90 seconds. Only used if `sink_expect` and `sink_await`
       are both `None`.
     - `host`: the network host address to use in workers, senders, and
         receivers. Default '127.0.0.1'
@@ -135,7 +135,7 @@ def pipeline_test(sources, expected, command, workers=1,
         errors, this value should be set higher than 1.
         Default 1.
     - `ready_timeout`: number of seconds before an error is raised if the
-        application does not report as ready. Default 30
+        application does not report as ready. Default 90
     - `runner_join_timeout`: the timeout in seconds to use when waiting for
       the runners to exit cleanly. If the timeout is exceeded, the runners
       are killed and an error is raised.

--- a/testing/tools/integration/observability.py
+++ b/testing/tools/integration/observability.py
@@ -190,7 +190,7 @@ class ObservabilityNotifier(StoppableThread):
     """
     __base_name__ = 'ObservabilityNotifier'
 
-    def __init__(self, query_func, query_args, tests, timeout=30, period=2):
+    def __init__(self, query_func, query_args, tests, timeout=90, period=2):
         """
         - `query_func` is an argument-free function to query an observability
         status. You can use `functools.partial` to create it.
@@ -201,7 +201,7 @@ class ObservabilityNotifier(StoppableThread):
         by raising an error, and pass by returning True.
         - `timeout` is the period in seconds the notifier should wait before
         exiting with an error status if any of the tests is still failing.
-        The default is 30 seconds.
+        The default is 90 seconds.
         - `period` is the time in seconds to wait between queries. The default
         is 2 seconds.
         """
@@ -310,7 +310,7 @@ class RunnerReadyChecker(StoppableThread):
     __base_name__ = 'RunnerReadyChecker'
     pattern = re.compile('Application has successfully initialized')
 
-    def __init__(self, runners, timeout=30):
+    def __init__(self, runners, timeout=90):
         super(RunnerReadyChecker, self).__init__()
         self.runners = runners
         self.name = self.__base_name__
@@ -345,7 +345,7 @@ class RunnerReadyChecker(StoppableThread):
 class RunnerChecker(StoppableThread):
     __base_name__ = 'RunnerChecker'
 
-    def __init__(self, runner, patterns, timeout=30, start_from=0):
+    def __init__(self, runner, patterns, timeout=90, start_from=0):
         super(RunnerChecker, self).__init__()
         self.name = self.__base_name__
         self.runner = runner

--- a/testing/tools/integration_test
+++ b/testing/tools/integration_test
@@ -469,7 +469,7 @@ def CLI():
     stopper.add_argument('--sink-await-keys', action=SinkAwaitKeysAction,
                          nargs='+', metavar=('key', 'value'),
                          help=("Key and Value to match on, as strings"))
-    expect.add_argument('--sink-stop-timeout', type=float, default=30,
+    expect.add_argument('--sink-stop-timeout', type=float, default=90,
                         help=("Timeout in seconds before raising a "
                               "TimeoutError"))
     stopper.add_argument('--delay', type=float, default=None,
@@ -494,7 +494,7 @@ def CLI():
                            action="store_true")
 
     term_group = parser.add_argument_group('Termination')
-    term_group.add_argument('--runner-join_timeout', type=float, default=30,
+    term_group.add_argument('--runner-join_timeout', type=float, default=90,
                             help=("Timeout in seconds before killing any "
                                   "remaining live workers and raising an "
                                   "error."))


### PR DESCRIPTION
Change test timeouts from 30 seconds to 90 seconds, in order to
avoid certain test failures that happen only in 1 CPU environments
by timing out only because there isn't enough CPU resource to
process all test keys, e.g., `--source gensource` tests that also
have a large number of keys, e.g., `--sink-expect 10000`.

This change shouldn't slow down a passing test: in merely raises
the ceiling that we're willing to wait for a test failure.
