### PR TITLE
Add `--window-late-policy` flag to machida & machida3

### DIFF
--- a/machida/machida.pony
+++ b/machida/machida.pony
@@ -1264,9 +1264,23 @@ class val PyPipelineTree
       let raw_aggregation = @PyTuple_GetItem(stage, 4)
       let aggregation = PyAggregation(raw_aggregation)
       Machida.inc_ref(raw_aggregation)
+      let ldp = recover val
+        String.copy_cstring(@PyString_AsString(@PyTuple_GetItem(stage, 5)))
+      end
+      let late_data_policy = match ldp
+        | "drop"                   => LateDataPolicy.drop()
+        | "fire-per-message"       => LateDataPolicy.fire_per_message()
+        | "place-in-oldest-window" => LateDataPolicy.place_in_oldest_window()
+        else
+          @printf[I32]("Invalid value for late-data-policy: %s\n".cstring(),
+            ldp.cstring())
+          Fail()
+          LateDataPolicy.drop()
+        end
       let windows = Wallaroo.range_windows(range)
                               .with_slide(slide)
                               .with_delay(delay)
+                              .with_late_data_policy(late_data_policy)
                               .over[PyData val, PyData val, PyState](
                                 aggregation)
       pipeline = pipeline.to[PyData val](windows)

--- a/testing/correctness/apps/window_detector/Makefile
+++ b/testing/correctness/apps/window_detector/Makefile
@@ -92,7 +92,7 @@ window_detector_tumbling_test_pony:
 		--sequence-sender '(0,100]' Detector '>I' key_0 \
 		--sequence-sender '(0,100]' Detector '>I' key_1 \
 		--log-level $(LOGLEVEL) \
-		--command './window_detector --window-type tumbling $(RUN_WITH_RESILIENCE)' \
+		--command './window_detector --window-type tumbling --window-late-policy fire-per-message $(RUN_WITH_RESILIENCE)' \
 		--validation-cmd 'python _validate.py --window-type tumbling --output' \
 		--output 'received.txt' \
 		--batch-size 50 \
@@ -120,7 +120,7 @@ window_detector_sliding_test_pony:
 		--sequence-sender '(0,100]' Detector '>I' key_0 \
 		--sequence-sender '(0,100]' Detector '>I' key_1 \
 		--log-level $(LOGLEVEL) \
-		--command './window_detector --window-type sliding $(RUN_WITH_RESILIENCE)' \
+		--command './window_detector --window-type sliding --window-late-policy fire-per-message $(RUN_WITH_RESILIENCE)' \
 		--validation-cmd 'python _validate.py --window-type sliding --output' \
 		--output 'received.txt' \
 		--batch-size 50 \
@@ -137,7 +137,7 @@ window_detector_tumbling_alo_source_test_python:
 		--alo-sequence-sender key_0 '(100,200]' Detector \
 		--alo-sequence-sender key_1 '(100,200]' Detector \
 		--log-level $(LOGLEVEL) \
-		--command 'machida --application-module window_detector --source alo --window-type tumbling $(RUN_WITH_RESILIENCE)' \
+		--command 'machida --application-module window_detector --source alo --window-type tumbling --window-late-policy fire-per-message $(RUN_WITH_RESILIENCE)' \
 		--validation-cmd 'python _validate.py --window-type tumbling --output' \
 		--output 'received.txt' \
 		--batch-size 50 \
@@ -153,7 +153,7 @@ window_detector_sliding_alo_source_test_python:
 		--alo-sequence-sender key_0 '(100,200]' Detector \
 		--alo-sequence-sender key_1 '(100,200]' Detector \
 		--log-level $(LOGLEVEL) \
-		--command 'machida --application-module window_detector --source alo --window-type sliding $(RUN_WITH_RESILIENCE)' \
+		--command 'machida --application-module window_detector --source alo --window-type sliding --window-late-policy fire-per-message $(RUN_WITH_RESILIENCE)' \
 		--validation-cmd 'python _validate.py --window-type sliding --output' \
 		--output 'received.txt' \
 		--batch-size 50 \
@@ -183,7 +183,7 @@ window_detector_tumbling_test_python:
 		--sequence-sender '(0,100]' Detector '>I' key_0 \
 		--sequence-sender '(0,100]' Detector '>I' key_1 \
 		--log-level $(LOGLEVEL) \
-		--command 'machida --application-module window_detector --window-type tumbling $(RUN_WITH_RESILIENCE)' \
+		--command 'machida --application-module window_detector --window-type tumbling --window-late-policy fire-per-message $(RUN_WITH_RESILIENCE)' \
 		--validation-cmd 'python _validate.py --window-type tumbling --output' \
 		--output 'received.txt' \
 		--batch-size 50 \
@@ -211,7 +211,7 @@ window_detector_sliding_test_python:
 		--sequence-sender '(0,100]' Detector '>I' key_0 \
 		--sequence-sender '(0,100]' Detector '>I' key_1 \
 		--log-level $(LOGLEVEL) \
-		--command 'machida --application-module window_detector --window-type sliding $(RUN_WITH_RESILIENCE)' \
+		--command 'machida --application-module window_detector --window-type sliding --window-late-policy fire-per-message $(RUN_WITH_RESILIENCE)' \
 		--validation-cmd 'python _validate.py --window-type sliding --output' \
 		--output 'received.txt' \
 		--batch-size 50 \
@@ -223,7 +223,7 @@ window_detector_tumbling_gensource_test_python:
 	cd $(WINDOW_DETECTOR_PATH) && \
 	integration_test \
 		--log-level $(LOGLEVEL) \
-		--command 'machida --application-module window_detector --source gensource --window-type tumbling $(RUN_WITH_RESILIENCE)' \
+		--command 'machida --application-module window_detector --source gensource --window-type tumbling --window-late-policy fire-per-message $(RUN_WITH_RESILIENCE)' \
 		--validation-cmd 'python _validate.py --window-type tumbling --output' \
 		--output 'received.txt' \
 		--batch-size 50 \
@@ -247,7 +247,7 @@ window_detector_sliding_gensource_test_python:
 	cd $(WINDOW_DETECTOR_PATH) && \
 	integration_test \
 		--log-level $(LOGLEVEL) \
-		--command 'machida --application-module window_detector --source gensource --window-type sliding $(RUN_WITH_RESILIENCE)' \
+		--command 'machida --application-module window_detector --source gensource --window-type sliding --window-late-policy fire-per-message $(RUN_WITH_RESILIENCE)' \
 		--validation-cmd 'python _validate.py --window-type sliding --output' \
 		--output 'received.txt' \
 		--batch-size 50 \
@@ -264,7 +264,7 @@ window_detector_tumbling_alo_source_test_python3:
 		--alo-sequence-sender key_0 '(100, 200]' Detector \
 		--alo-sequence-sender key_1 '(100, 200]' Detector \
 		--log-level $(LOGLEVEL) \
-		--command 'machida3 --application-module window_detector --source alo --window-type tumbling $(RUN_WITH_RESILIENCE)' \
+		--command 'machida3 --application-module window_detector --source alo --window-type tumbling --window-late-policy fire-per-message $(RUN_WITH_RESILIENCE)' \
 		--validation-cmd 'python _validate.py --window-type tumbling --output' \
 		--output 'received.txt' \
 		--batch-size 50 \
@@ -280,7 +280,7 @@ window_detector_sliding_alo_source_test_python3:
 		--alo-sequence-sender key_0 '(100, 200]' Detector \
 		--alo-sequence-sender key_1 '(100, 200]' Detector \
 		--log-level $(LOGLEVEL) \
-		--command 'machida3 --application-module window_detector --source alo --window-type sliding $(RUN_WITH_RESILIENCE)' \
+		--command 'machida3 --application-module window_detector --source alo --window-type sliding --window-late-policy fire-per-message $(RUN_WITH_RESILIENCE)' \
 		--validation-cmd 'python _validate.py --window-type sliding --output' \
 		--output 'received.txt' \
 		--batch-size 50 \
@@ -310,7 +310,7 @@ window_detector_tumbling_test_python3:
 		--sequence-sender '(0,100]' Detector '>I' key_0 \
 		--sequence-sender '(0,100]' Detector '>I' key_1 \
 		--log-level $(LOGLEVEL) \
-		--command 'machida3 --application-module window_detector --window-type tumbling $(RUN_WITH_RESILIENCE)' \
+		--command 'machida3 --application-module window_detector --window-type tumbling --window-late-policy fire-per-message $(RUN_WITH_RESILIENCE)' \
 		--validation-cmd 'python3 _validate.py --window-type tumbling --output' \
 		--output 'received.txt' \
 		--batch-size 50 \
@@ -338,7 +338,7 @@ window_detector_sliding_test_python3:
 		--sequence-sender '(0,100]' Detector '>I' key_0 \
 		--sequence-sender '(0,100]' Detector '>I' key_1 \
 		--log-level $(LOGLEVEL) \
-		--command 'machida3 --application-module window_detector --window-type sliding $(RUN_WITH_RESILIENCE)' \
+		--command 'machida3 --application-module window_detector --window-type sliding --window-late-policy fire-per-message $(RUN_WITH_RESILIENCE)' \
 		--validation-cmd 'python3 _validate.py --window-type sliding --output' \
 		--output 'received.txt' \
 		--batch-size 50 \
@@ -350,7 +350,7 @@ window_detector_tumbling_gensource_test_python3:
 	cd $(WINDOW_DETECTOR_PATH) && \
 	integration_test \
 		--log-level $(LOGLEVEL) \
-		--command 'machida3 --application-module window_detector --source gensource --window-type tumbling $(RUN_WITH_RESILIENCE)' \
+		--command 'machida3 --application-module window_detector --source gensource --window-type tumbling --window-late-policy fire-per-message $(RUN_WITH_RESILIENCE)' \
 		--validation-cmd 'python3 _validate.py --window-type tumbling --output' \
 		--output 'received.txt' \
 		--batch-size 50 \
@@ -374,7 +374,7 @@ window_detector_sliding_gensource_test_python3:
 	cd $(WINDOW_DETECTOR_PATH) && \
 	integration_test \
 		--log-level $(LOGLEVEL) \
-		--command 'machida3 --application-module window_detector --source gensource --window-type sliding $(RUN_WITH_RESILIENCE)' \
+		--command 'machida3 --application-module window_detector --source gensource --window-type sliding --window-late-policy fire-per-message $(RUN_WITH_RESILIENCE)' \
 		--validation-cmd 'python3 _validate.py --window-type sliding --output' \
 		--output 'received.txt' \
 		--batch-size 50 \

--- a/testing/correctness/apps/window_detector/window_detector.py
+++ b/testing/correctness/apps/window_detector/window_detector.py
@@ -38,8 +38,8 @@ def application_setup(args):
     parser.add_argument("--window-slide", type=int, default=25,
                         help=("Window slide size, in milliseconds. "
                               "(Default: 25)"))
-    parser.add_argument("--window-policy", default="drop",
-                        choices=["drop", "fire-per-message"])
+    parser.add_argument("--window-late-policy", default="drop",
+                        choices=["drop", "fire-per-message", "place-in-oldest-window"])
     parser.add_argument("--source", choices=['tcp', 'gensource', 'alo'],
                          default='tcp',
                          help=("Choose source type for resilience tests. "
@@ -93,6 +93,14 @@ def application_setup(args):
         if pargs.window_type == 'sliding':
             print("Using window_slide: {} ms".format(pargs.window_slide))
             window = window.with_slide(wallaroo.milliseconds(pargs.window_slide))
+        if pargs.window_late_policy:
+            ## NOTE: The Wallaroo default policy for late window data is "drop".
+            ##       However, it's quite likely that that policy can cause
+            ##       intermittent test failures.
+            if pargs.window_late_policy == "drop":
+                print("\n\nWARNING: drop policy can cause intermittent test failures!\n\n")
+            print("Using window_late_policy: {}".format(pargs.window_late_policy))
+            window = window.with_late_data_policy(pargs.window_late_policy)
     # add the window to the topology
     p = p.to(window.over(Collect))
 


### PR DESCRIPTION
Add the new flag `--window-late-policy` and also thread it through the
Python & Pony sides of the application.

Add `--window-late-policy fire-per-message` flags to relevant tests
in the `testing/correctness/apps/window_detector/Makefile` test collection.

Fixes #2978, and hopefully some tickets related to 2978.

Rationale: The validator of the `testing/correctness/apps/window_detector` tests will detect the omission of any one or more messages are missing.  The default windowing behavior for late data, `drop`, will surely cause a test to fail if a test case execution has a message which is sufficiently late for any given window.  I've observed delays by both the TCP ALO source as well as the `GenSource` where messages are delayed by over 250 msec, both on 1 CPU and 2 CPU virtual machines.

This PR changes the tests to add `--window-late-policy fire-per-message` arguments to each machida/machida3 test invocation to avoid message loss due to unfortunate timing by the OS and/or (simulated) hardware.