### PR TITLE
Support for multiple sinks per pipeline per worker

### DIFF
--- a/examples/pony/alerts_windowed/README.md
+++ b/examples/pony/alerts_windowed/README.md
@@ -88,7 +88,7 @@ data_receiver --ponythreads=1 --ponynoblock --listen 127.0.0.1:7002
 Run `machida` with `--application-module alerts`:
 
 ```bash
-alerts_stateless --out 127.0.0.1:7002 \
+alerts_windowed --out 127.0.0.1:7002 \
   --metrics 127.0.0.1:5001 --control 127.0.0.1:6000 --data 127.0.0.1:6001 \
   --name worker-name --external 127.0.0.1:5050 --cluster-initializer \
   --ponynoblock

--- a/lib/wallaroo/core/aggregations/aggregations.pony
+++ b/lib/wallaroo/core/aggregations/aggregations.pony
@@ -41,11 +41,11 @@ interface val Aggregation[In: Any val, Out: Any val, Acc: State ref] is
   ////////////////////////////
   // Not implemented by user
   ////////////////////////////
-  fun val runner_builder(step_group_id: RoutingId, parallelization: USize,
+  fun val runner_builder(step_group_id: RoutingId, parallelism: USize,
     local_routing: Bool): RunnerBuilder
   =>
     let global_window_initializer = GlobalWindowStateInitializer[In, Out, Acc](
       this)
     StateRunnerBuilder[In, Out, Acc](global_window_initializer, step_group_id,
-      parallelization, local_routing)
+      parallelism, local_routing)
 

--- a/lib/wallaroo/core/common/failing_consumer_sender.pony
+++ b/lib/wallaroo/core/common/failing_consumer_sender.pony
@@ -32,8 +32,8 @@ use "wallaroo_labs/mort"
 class FailingConsumerSender is TestableConsumerSender
   let _id: RoutingId
 
-  new create(producer_id: RoutingId) =>
-    _id = producer_id
+  new create(producer_id': RoutingId) =>
+    _id = producer_id'
 
   fun _invalid_call() =>
     @printf[I32]("FailingConsumerSender: Invalid call on Producer %s\n"
@@ -62,3 +62,6 @@ class FailingConsumerSender is TestableConsumerSender
   fun ref update_output_watermark(w: U64): (U64, U64) =>
     _invalid_call(); Fail()
     (0, 0)
+
+  fun producer_id(): RoutingId =>
+    _id

--- a/lib/wallaroo/core/common/producer_consumer.pony
+++ b/lib/wallaroo/core/common/producer_consumer.pony
@@ -77,6 +77,8 @@ trait TestableConsumerSender
 
   fun ref update_output_watermark(w: U64): (U64, U64)
 
+  fun producer_id(): RoutingId
+
 trait tag Runnable
   be run[D: Any val](metric_name: String, pipeline_time_spent: U64, data: D,
     key: Key, event_ts: U64, watermark_ts: U64, i_producer_id: RoutingId,

--- a/lib/wallaroo/core/initialization/application_distributor.pony
+++ b/lib/wallaroo/core/initialization/application_distributor.pony
@@ -112,8 +112,16 @@ actor ApplicationDistributor is Distributor
       for sink_node in logical_graph.sinks() do
         match sink_node.value
         | let sb: SinkBuilder =>
-          let egress_builder = EgressBuilder(_app_name, sink_node.id, sb)
-          interm_graph.add_node(egress_builder, sink_node.id)
+          let parallelism = sb.parallelism()
+
+          if parallelism > 1 then
+            let redundant_sink_builder = RedundantSinkBuilder(_app_name,
+              sink_node.id, sb, parallelism)
+            interm_graph.add_node(redundant_sink_builder, sink_node.id)
+          else
+            let egress_builder = EgressBuilder(_app_name, sink_node.id, sb)
+            interm_graph.add_node(egress_builder, sink_node.id)
+          end
         | let sbs: Array[SinkBuilder] val =>
           let multi_sink_builder = MultiSinkBuilder(_app_name, sink_node.id,
             sbs)

--- a/lib/wallaroo/core/initialization/local_topology.pony
+++ b/lib/wallaroo/core/initialization/local_topology.pony
@@ -848,7 +848,8 @@ actor LocalTopologyInitializer is LayoutInitializer
                   let routers = recover iso Array[Router] end
                   for id in out_ids.values() do
                     try
-                      routers.push(built_routers(id)?)
+                      routers.push(built_routers(id)?
+                        .select_based_on_producer_id(next_id))
                     else
                       @printf[I32]("No router found to target\n".cstring())
                       error
@@ -1042,8 +1043,8 @@ actor LocalTopologyInitializer is LayoutInitializer
   =>
     let steps = Map[RoutingId, Step]
     for r_id in routing_ids.values() do
-      let next_step = builder(r_id, _worker_name,
-        output_router.select_based_on_producer_id(r_id),
+      let next_router = output_router.select_based_on_producer_id(r_id)
+      let next_step = builder(r_id, _worker_name, next_router,
         _metrics_conn, _event_log, _recovery_replayer, _auth, _router_registry,
         _outgoing_boundaries where is_recovering = is_recovering)
 

--- a/lib/wallaroo/core/sink/kafka_sink/kafka_sink_config.pony
+++ b/lib/wallaroo/core/sink/kafka_sink/kafka_sink_config.pony
@@ -51,21 +51,24 @@ class val KafkaSinkConfig[Out: Any val] is SinkConfig[Out]
     _ksco = consume ksco
     _auth = auth
 
-  fun apply(): SinkBuilder =>
-    KafkaSinkBuilder(TypedKafkaEncoderWrapper[Out](_encoder), _ksco, _auth)
+  fun apply(parallelism: USize): SinkBuilder =>
+    KafkaSinkBuilder(TypedKafkaEncoderWrapper[Out](_encoder), _ksco, _auth,
+      parallelism)
 
 class val KafkaSinkBuilder
   let _encoder_wrapper: KafkaEncoderWrapper
   let _ksco: KafkaConfigOptions val
   let _auth: TCPConnectionAuth
+  let _parallelism: USize
 
   new val create(encoder_wrapper: KafkaEncoderWrapper,
     ksco: KafkaConfigOptions val,
-    auth: TCPConnectionAuth)
+    auth: TCPConnectionAuth, parallelism': USize)
   =>
     _encoder_wrapper = encoder_wrapper
     _ksco = ksco
     _auth = auth
+    _parallelism = parallelism'
 
   fun apply(sink_name: String, event_log: EventLog,
     reporter: MetricsReporter iso, env: Env,
@@ -90,3 +93,6 @@ class val KafkaSinkBuilder
       Fail()
       EmptySink
     end
+
+  fun parallelism(): USize =>
+    _parallelism

--- a/lib/wallaroo/core/sink/sink.pony
+++ b/lib/wallaroo/core/sink/sink.pony
@@ -39,7 +39,7 @@ trait tag Sink is (Consumer & DisposableActor & BarrierProcessor)
     None
 
 interface val SinkConfig[Out: Any val]
-  fun apply(): SinkBuilder
+  fun apply(parallelism: USize): SinkBuilder
 
 interface val SinkBuilder
   fun apply(sink_name: String, event_log: EventLog,
@@ -47,3 +47,5 @@ interface val SinkBuilder
     barrier_coordinator: BarrierCoordinator,
     checkpoint_initiator: CheckpointInitiator, recovering: Bool,
     worker_name: WorkerName, auth: AmbientAuth): Sink
+
+  fun parallelism(): USize

--- a/lib/wallaroo/core/sink/tcp_sink/tcp_sink_builder.pony
+++ b/lib/wallaroo/core/sink/tcp_sink/tcp_sink_builder.pony
@@ -91,23 +91,26 @@ class val TCPSinkConfig[Out: Any val] is SinkConfig[Out]
     _service = opts.service
 
 
-  fun apply(): SinkBuilder =>
+  fun apply(parallelism: USize): SinkBuilder =>
     TCPSinkBuilder(TypedTCPEncoderWrapper[Out](_encoder), _host, _service,
-      _initial_msgs)
+      _initial_msgs, parallelism)
 
 class val TCPSinkBuilder
   let _encoder_wrapper: TCPEncoderWrapper
   let _host: String
   let _service: String
   let _initial_msgs: Array[Array[ByteSeq] val] val
+  let _parallelism: USize
 
   new val create(encoder_wrapper: TCPEncoderWrapper, host: String,
-    service: String, initial_msgs: Array[Array[ByteSeq] val] val)
+    service: String, initial_msgs: Array[Array[ByteSeq] val] val,
+    parallelism': USize)
   =>
     _encoder_wrapper = encoder_wrapper
     _host = host
     _service = service
     _initial_msgs = initial_msgs
+    _parallelism = parallelism'
 
   fun apply(sink_name: String, event_log: EventLog,
     reporter: MetricsReporter iso, env: Env,
@@ -122,3 +125,7 @@ class val TCPSinkBuilder
     TCPSink(id, sink_name, event_log, recovering, env, _encoder_wrapper,
       consume reporter, barrier_coordinator, checkpoint_initiator, _host, _service,
       _initial_msgs)
+
+  fun parallelism(): USize =>
+    _parallelism
+

--- a/lib/wallaroo/core/topology/computations.pony
+++ b/lib/wallaroo/core/topology/computations.pony
@@ -32,18 +32,18 @@ type ComputationResult[Out: Any val] is
 
 interface val Computation[In: Any val, Out: Any val]
   fun name(): String
-  fun val runner_builder(step_group_id: RoutingId, parallelization: USize,
+  fun val runner_builder(step_group_id: RoutingId, parallelism: USize,
     local_routing: Bool): RunnerBuilder
 
 trait val StatelessComputation[In: Any val, Out: Any val] is
   Computation[In, Out]
   fun apply(input: In): ComputationResult[Out]
 
-  fun val runner_builder(step_group_id: RoutingId, parallelization: USize,
+  fun val runner_builder(step_group_id: RoutingId, parallelism: USize,
     local_routing: Bool): RunnerBuilder
   =>
     StatelessComputationRunnerBuilder[In, Out](this, step_group_id,
-      parallelization, local_routing)
+      parallelism, local_routing)
 
 trait val StateComputation[In: Any val, Out: Any val, S: State ref] is
   (Computation[In, Out] & StateInitializer[In, Out, S])
@@ -60,10 +60,10 @@ trait val StateComputation[In: Any val, Out: Any val, S: State ref] is
   ////////////////////////////
   // Not implemented by user
   ////////////////////////////
-  fun val runner_builder(step_group_id: RoutingId, parallelization: USize,
+  fun val runner_builder(step_group_id: RoutingId, parallelism: USize,
     local_routing: Bool): RunnerBuilder
   =>
-    StateRunnerBuilder[In, Out, S](this, step_group_id, parallelization,
+    StateRunnerBuilder[In, Out, S](this, step_group_id, parallelism,
       local_routing)
 
   fun val state_wrapper(key: Key, rand: Random): StateWrapper[In, Out, S]

--- a/lib/wallaroo/core/topology/consumer_sender.pony
+++ b/lib/wallaroo/core/topology/consumer_sender.pony
@@ -32,10 +32,10 @@ class ConsumerSender is TestableConsumerSender
   let _producer: Producer ref
   let _metrics_reporter: MetricsReporter
 
-  new create(producer_id: RoutingId, producer: Producer ref,
+  new create(producer_id': RoutingId, producer: Producer ref,
     metrics_reporter: MetricsReporter iso)
   =>
-    _producer_id = producer_id
+    _producer_id = producer_id'
     _producer = producer
     _metrics_reporter = consume metrics_reporter
 
@@ -107,3 +107,5 @@ class ConsumerSender is TestableConsumerSender
   fun ref update_output_watermark(w: U64): (U64, U64) =>
     _producer.update_output_watermark(w)
 
+  fun producer_id(): RoutingId =>
+    _producer_id

--- a/lib/wallaroo/core/topology/router.pony
+++ b/lib/wallaroo/core/topology/router.pony
@@ -46,6 +46,8 @@ trait val Router is (Hashable & Equatable[Router])
     latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64): (Bool, U64)
   fun routes(): Map[RoutingId, Consumer] val
   fun routes_not_in(router: Router): Map[RoutingId, Consumer] val
+  //!@
+  fun val select_based_on_producer_id(producer_id: RoutingId): Router => this
 
 primitive EmptyRouter is Router
   fun route[D: Any val](metric_name: String, pipeline_time_spent: U64, data: D,
@@ -224,6 +226,80 @@ class val MultiRouter is Router
       h
     else
       0
+    end
+
+//!@
+class val RedundantMultiRouter is Router
+  let _routers: Array[Router] val
+
+  new val create(routers: Array[Router] val) =>
+    _routers = routers
+    ifdef debug then
+      for r in _routers.values() do
+        Invariant(
+          match r
+          | let mr: MultiRouter => false
+          else true end
+        )
+      end
+    end
+
+  fun route[D: Any val](metric_name: String, pipeline_time_spent: U64, data: D,
+    key: Key, event_ts: U64, watermark_ts: U64,
+    consumer_sender: TestableConsumerSender,
+    i_msg_uid: MsgId, frac_ids: FractionalMessageId,
+    latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64): (Bool, U64)
+  =>
+    Fail()
+    (false, 0)
+
+  fun routes(): Map[RoutingId, Consumer] val =>
+    Fail()
+    recover Map[RoutingId, Consumer] end
+
+  fun routes_not_in(router: Router): Map[RoutingId, Consumer] val =>
+    Fail()
+    recover Map[RoutingId, Consumer] end
+
+  fun eq(that: box->Router): Bool =>
+    match that
+    | let mr: RedundantMultiRouter =>
+      try
+        let theirs = mr._routers
+        if _routers.size() != theirs.size() then return false end
+        var is_equal = true
+        for i in Range(0, _routers.size()) do
+          if _routers(i)? != theirs(i)? then is_equal = false end
+        end
+        is_equal
+      else
+        false
+      end
+    else
+      false
+    end
+
+  fun hash(): USize =>
+    try
+      var h = _routers(0)?.hash()
+      if _routers.size() > 1 then
+        for i in Range(1, _routers.size()) do
+          h = h xor _routers(i)?.hash()
+        end
+      end
+      h
+    else
+      0
+    end
+
+  fun val select_based_on_producer_id(producer_id: RoutingId): Router =>
+    let idx = producer_id.usize() % _routers.size()
+    @printf[I32]("!@ select_based_on_producer_id: got p_id %s, chose idx %s\n".cstring(), producer_id.string().cstring(), idx.string().cstring())
+    try
+      _routers(idx)?
+    else
+      Fail()
+      this
     end
 
 class val ProxyRouter is Router

--- a/lib/wallaroo/core/topology/router.pony
+++ b/lib/wallaroo/core/topology/router.pony
@@ -46,7 +46,6 @@ trait val Router is (Hashable & Equatable[Router])
     latest_ts: U64, metrics_id: U16, worker_ingress_ts: U64): (Bool, U64)
   fun routes(): Map[RoutingId, Consumer] val
   fun routes_not_in(router: Router): Map[RoutingId, Consumer] val
-  //!@
   fun val select_based_on_producer_id(producer_id: RoutingId): Router => this
 
 primitive EmptyRouter is Router
@@ -228,8 +227,15 @@ class val MultiRouter is Router
       0
     end
 
-//!@
 class val RedundantMultiRouter is Router
+  """
+  A router that holds an array of routers to instances representing the same
+  stage that only exist to increase parallelism. This is currently used for a
+  single case: when there are more than one sink for a pipeline on a given
+  worker. We use this router to assign different redundant sinks to the
+  steps in the immediate upstream stage by calling
+  `select_based_on_producer_id()`.
+  """
   let _routers: Array[Router] val
 
   new val create(routers: Array[Router] val) =>

--- a/lib/wallaroo/core/topology/router.pony
+++ b/lib/wallaroo/core/topology/router.pony
@@ -294,7 +294,6 @@ class val RedundantMultiRouter is Router
 
   fun val select_based_on_producer_id(producer_id: RoutingId): Router =>
     let idx = producer_id.usize() % _routers.size()
-    @printf[I32]("!@ select_based_on_producer_id: got p_id %s, chose idx %s\n".cstring(), producer_id.string().cstring(), idx.string().cstring())
     try
       _routers(idx)?
     else

--- a/lib/wallaroo/core/windows/windows.pony
+++ b/lib/wallaroo/core/windows/windows.pony
@@ -169,10 +169,10 @@ class val GlobalWindowStateInitializer[In: Any val, Out: Any val,
   fun state_wrapper(key: Key, rand: Random): StateWrapper[In, Out, Acc] =>
     GlobalWindow[In, Out, Acc](key, _agg)
 
-  fun val runner_builder(step_group_id: RoutingId, parallelization: USize,
+  fun val runner_builder(step_group_id: RoutingId, parallelism: USize,
     local_routing: Bool): RunnerBuilder
   =>
-    StateRunnerBuilder[In, Out, Acc](this, step_group_id, parallelization,
+    StateRunnerBuilder[In, Out, Acc](this, step_group_id, parallelism,
       local_routing)
 
   fun timeout_interval(): U64 =>
@@ -273,10 +273,10 @@ class val RangeWindowsStateInitializer[In: Any val, Out: Any val,
       key, _agg, _range, _slide, _delay, rand', _late_data_policy)
     InitializableWindows[In, Out, Acc](windows_wrapper_builder)
 
-  fun val runner_builder(step_group_id: RoutingId, parallelization: USize,
+  fun val runner_builder(step_group_id: RoutingId, parallelism: USize,
     local_routing: Bool): RunnerBuilder
   =>
-    StateRunnerBuilder[In, Out, Acc](this, step_group_id, parallelization,
+    StateRunnerBuilder[In, Out, Acc](this, step_group_id, parallelism,
       local_routing)
 
   fun timeout_interval(): U64 =>
@@ -393,10 +393,10 @@ class val EphemeralWindowsStateInitializer[In: Any val, Out: Any val,
       _late_data_policy)
     InitializableWindows[In, Out, Acc](window_wrapper_builder)
 
-  fun val runner_builder(step_group_id: RoutingId, parallelization: USize,
+  fun val runner_builder(step_group_id: RoutingId, parallelism: USize,
     local_routing: Bool): RunnerBuilder
   =>
-    StateRunnerBuilder[In, Out, Acc](this, step_group_id, parallelization,
+    StateRunnerBuilder[In, Out, Acc](this, step_group_id, parallelism,
       local_routing)
 
   fun timeout_interval(): U64 =>
@@ -437,10 +437,10 @@ class val TumblingCountWindowsStateInitializer[In: Any val, Out: Any val,
   fun state_wrapper(key: Key, rand: Random): StateWrapper[In, Out, Acc] =>
     TumblingCountWindows[In, Out, Acc](key, _agg, _count)
 
-  fun val runner_builder(step_group_id: RoutingId, parallelization: USize,
+  fun val runner_builder(step_group_id: RoutingId, parallelism: USize,
     local_routing: Bool): RunnerBuilder
   =>
-    StateRunnerBuilder[In, Out, Acc](this, step_group_id, parallelization,
+    StateRunnerBuilder[In, Out, Acc](this, step_group_id, parallelism,
       local_routing)
 
   fun timeout_interval(): U64 =>

--- a/lib/wallaroo/test_components/mock_consumer_sender.pony
+++ b/lib/wallaroo/test_components/mock_consumer_sender.pony
@@ -41,3 +41,6 @@ class MockConsumerSender[V: Any val] is TestableConsumerSender
 
   fun ref update_output_watermark(w: U64): (U64, U64) =>
     (0, 0)
+
+  fun producer_id(): RoutingId =>
+    0

--- a/lib/wallaroo/test_components/mock_state_wrapper.pony
+++ b/lib/wallaroo/test_components/mock_state_wrapper.pony
@@ -44,7 +44,7 @@ class val MockStateInitializer[InOut: Any val] is
     // !TODO! We need a real decoded thing here probably
     MockStateWrapper[InOut](_h, _lifetime)
 
-  fun val runner_builder(step_group_id: RoutingId, parallelization: USize,
+  fun val runner_builder(step_group_id: RoutingId, parallelism: USize,
     local_routing: Bool): RunnerBuilder
   =>
     StateRunnerBuilder[InOut, InOut, ArrayState[InOut]](this, _step_group,

--- a/lib/wallaroo_labs/dag/dag.pony
+++ b/lib/wallaroo_labs/dag/dag.pony
@@ -188,6 +188,9 @@ class DagNode[V: Any val]
   fun ins(): Iterator[this->DagNode[V]] => _ins.values()
   fun outs(): Iterator[this->DagNode[V]] => _outs.values()
 
+  fun ins_count(): USize => _ins.size()
+  fun outs_count(): USize => _outs.size()
+
   fun is_source(): Bool => _ins.size() == 0
   fun is_sink(): Bool => _outs.size() == 0
 


### PR DESCRIPTION
If a parallelism greater than 1 is selected for a sink stage, then
we create as many sink instances for that pipeline per worker. We
then assign each of these instances to a deterministically selected
subset of the upstream actors.

Closes #2962.