### PR TITLE
Add support for source connections to multi sink per pipeline

### DIFF
--- a/lib/wallaroo/core/initialization/local_topology.pony
+++ b/lib/wallaroo/core/initialization/local_topology.pony
@@ -848,8 +848,7 @@ actor LocalTopologyInitializer is LayoutInitializer
                   let routers = recover iso Array[Router] end
                   for id in out_ids.values() do
                     try
-                      routers.push(built_routers(id)?
-                        .select_based_on_producer_id(next_id))
+                      routers.push(built_routers(id)?)
                     else
                       @printf[I32]("No router found to target\n".cstring())
                       error

--- a/lib/wallaroo/core/source/connector_source/connector_source_coordinator.pony
+++ b/lib/wallaroo/core/source/connector_source/connector_source_coordinator.pony
@@ -196,8 +196,11 @@ actor ConnectorSourceCoordinator[In: Any val] is
         partitioner_builder = _partitioner_builder)
       let notify = ConnectorSourceNotify[In](source_id, consume runner,
         notify_parameters, this, _is_recovering)
+      // It's possible that there are more than one sink per worker for this
+      // pipeline. We select our router based on our source id.
+      let selected_router = _router.select_based_on_producer_id(source_id)
       let source = ConnectorSource[In](source_id, _auth, this,
-        consume notify, _event_log, _router, SourceTCPHandlerBuilder,
+        consume notify, _event_log, selected_router, SourceTCPHandlerBuilder,
         _outgoing_boundary_builders, _layout_initializer,
         _metrics_reporter.clone(), _router_registry, _router_registry)
       source.mute(this)

--- a/lib/wallaroo/core/source/gen_source/gen_source_coordinator.pony
+++ b/lib/wallaroo/core/source/gen_source/gen_source_coordinator.pony
@@ -133,8 +133,11 @@ actor GenSourceCoordinator[In: Any val] is SourceCoordinator
     let runner = _runner_builder(_router_registry, _event_log, _auth,
       _metrics_reporter.clone(), None, _target_router, _partitioner_builder)
 
+    // It's possible that there are more than one sink per worker for this
+    // pipeline. We select our router based on our source id.
+    let selected_router = _router.select_based_on_producer_id(source_id)
     let source = GenSource[In](source_id, _auth, _pipeline_name,
-      consume runner, _router, _generator, _event_log,
+      consume runner, selected_router, _generator, _event_log,
       _outgoing_boundary_builders, _layout_initializer,
       _metrics_reporter.clone(), _router_registry, _router_registry)
 

--- a/lib/wallaroo/core/source/kafka_source/kafka_source_coordinator.pony
+++ b/lib/wallaroo/core/source/kafka_source/kafka_source_coordinator.pony
@@ -288,9 +288,13 @@ actor KafkaSourceCoordinator[In: Any val] is (SourceCoordinator & KafkaClientMan
 
             let source_id = try _rb.u128_le()? else Fail(); 0 end
 
+            // It's possible that there are more than one sink per worker for
+            // this pipeline. We select our router based on our source id.
+            let selected_router = _router.select_based_on_producer_id(
+              source_id)
             let source = KafkaSource[In](source_id, _auth, name, this,
               _notify.build_source(source_id, _env), _event_log,
-              _router, _outgoing_boundary_builders,
+              selected_router, _outgoing_boundary_builders,
               _layout_initializer, _metrics_reporter.clone(), topic, part_id,
               kc, _router_registry, _recovering)
             partitions_sources(part_id) = source

--- a/lib/wallaroo/core/source/tcp_source/tcp_source_coordinator.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source_coordinator.pony
@@ -167,8 +167,11 @@ actor TCPSourceCoordinator[In: Any val] is SourceCoordinator
         partitioner_builder = _partitioner_builder)
       let notify = TCPSourceNotify[In](source_id, _pipeline_name, _env,
         _auth, _handler, consume runner, _router, _metrics_reporter.clone())
+      // It's possible that there are more than one sink per worker for this
+      // pipeline. We select our router based on our source id.
+      let selected_router = _router.select_based_on_producer_id(source_id)
       let source = TCPSource[In](source_id, _auth, this,
-        consume notify, _event_log, _router,
+        consume notify, _event_log, selected_router,
         SourceTCPHandlerBuilder,
         _outgoing_boundary_builders, _layout_initializer,
         _metrics_reporter.clone(), _router_registry, _router_registry)


### PR DESCRIPTION
If an application has a parallelism > 1 for sinks in a particular
pipeline and there is a direct connection from source actors to
sink actors, then these changes ensure that the load is distributed
across available sinks.

Closes #2990 