### PR TITLE
Update handling of large expects in SourceTCPHandler

### DIFF
--- a/lib/wallaroo/core/tcp_actor/source_tcp_handler.pony
+++ b/lib/wallaroo/core/tcp_actor/source_tcp_handler.pony
@@ -216,7 +216,10 @@ class SourceTCPHandler is TestableTCPHandler
     if qty <= _max_size then
       _expect = qty
     else
-      Fail()
+      @printf[I32](("SourceTCPHandler: Received unexpected expect of size: " +
+        qty.string() + ", exceeds max: " + _max_size.string() +
+        ". Closed connection.\n").cstring())
+      close()
     end
 
   fun ref set_nodelay(state: Bool) =>
@@ -353,6 +356,10 @@ class SourceTCPHandler is TestableTCPHandler
         // distribute and data we've already read that is in the `read_buf`
         // and able to be distributed
         while (_read_buf_offset >= _expect) and (_read_buf_offset > 0) do
+          if _shutdown_peer then
+            _reading = false
+            return
+          end
           // get data to be distributed and update `_read_buf_offset`
           let data =
             if _expect == 0 then


### PR DESCRIPTION
  - previously, we failed whenever an expect larger than 16kb arrived
    at a source. This isn't ideal due to running workers crashing if
    something other than a source connects. we'll now close the
    connection and log a message letting users know why the connection
    was closed so it doesn't interrupt a running cluster.

<!--
Make sure you've read the [Contributors Guide](https://github.com/WallarooLabs/wallaroo/blob/master/CONTRIBUTING.md). You'll need to sign our CLA before your issue can be accepted.

Reference the issue your code change relates to if possible
-->

<!--
Include any other necessary information below. If you have any questions don't hesitate to reach out on the mailing list or on IRC.
-->
