### PR TITLE
Ensure all producers from other workers have registered during recovery

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,21 +11,18 @@ jobs:
     executor: pony-changelog
     steps:
       - checkout
-      - run: .circleci/clone_tracker.sh
       - run: changelog-tool verify
 
   unit-tests:
     executor: wallaroo-ci
     steps:
       - checkout
-      - run: .circleci/clone_tracker.sh
       - run: make unit-tests debug=true
 
   integration-tests:
     executor: wallaroo-ci
     steps:
       - checkout
-      - run: .circleci/clone_tracker.sh
       - run: make integration-tests-lib-all debug=true
       - run: make integration-tests-demos-all debug=true
       - run: make integration-tests-examples-all debug=true
@@ -41,7 +38,6 @@ jobs:
     executor: wallaroo-ci
     steps:
       - checkout
-      - run: .circleci/clone_tracker.sh
       - run: make integration-tests-demos-all debug=true resilience=on
       - run: make integration-tests-examples-all debug=true resilience=on
       - store_artifacts:
@@ -51,7 +47,6 @@ jobs:
     executor: wallaroo-ci
     steps:
       - checkout
-      - run: .circleci/clone_tracker.sh
       - run: make integration-tests-testing-correctness-apps-all debug=true
       - store_artifacts:
           path: /tmp/wallaroo_test_errors
@@ -60,7 +55,6 @@ jobs:
     executor: wallaroo-ci
     steps:
       - checkout
-      - run: .circleci/clone_tracker.sh
       - run: make integration-tests-testing-correctness-apps-all debug=true resilience=on
       - store_artifacts:
           path: /tmp/wallaroo_test_errors
@@ -69,7 +63,6 @@ jobs:
     executor: wallaroo-ci
     steps:
       - checkout
-      - run: .circleci/clone_tracker.sh
       - run: make integration-tests-testing-correctness-tests-aloc_sink debug=true resilience=on
       - store_artifacts:
           path: /tmp/wallaroo_test_errors
@@ -78,7 +71,6 @@ jobs:
     executor: wallaroo-ci
     steps:
       - checkout
-      - run: .circleci/clone_tracker.sh
       - run: |
           ulimit -c unlimited
           ulimit -a
@@ -90,7 +82,6 @@ jobs:
     executor: wallaroo-ci
     steps:
       - checkout
-      - run: .circleci/clone_tracker.sh
       - run: |
           ulimit -c unlimited
           ulimit -a
@@ -102,7 +93,6 @@ jobs:
     executor: wallaroo-ci
     steps:
       - checkout
-      - run: .circleci/clone_tracker.sh
       - run: |
           ulimit -c unlimited
           ulimit -a
@@ -114,7 +104,6 @@ jobs:
     executor: wallaroo-ci
     steps:
       - checkout
-      - run: .circleci/clone_tracker.sh
       - run: |
           ulimit -c unlimited
           ulimit -a
@@ -126,7 +115,6 @@ jobs:
     executor: wallaroo-ci
     steps:
       - checkout
-      - run: .circleci/clone_tracker.sh
       - run: |
           ulimit -c unlimited
           ulimit -a
@@ -138,7 +126,6 @@ jobs:
     executor: wallaroo-ci
     steps:
       - checkout
-      - run: .circleci/clone_tracker.sh
       - run: |
           ulimit -c unlimited
           ulimit -a
@@ -150,7 +137,6 @@ jobs:
     executor: wallaroo-ci
     steps:
       - checkout
-      - run: .circleci/clone_tracker.sh
       - run: |
           ulimit -c unlimited
           ulimit -a
@@ -162,7 +148,6 @@ jobs:
     executor: wallaroo-ci
     steps:
       - checkout
-      - run: .circleci/clone_tracker.sh
       - run: |
           ulimit -c unlimited
           ulimit -a
@@ -174,7 +159,6 @@ jobs:
     executor: wallaroo-ci
     steps:
       - checkout
-      - run: .circleci/clone_tracker.sh
       - run: |
           ulimit -c unlimited
           ulimit -a
@@ -186,7 +170,6 @@ jobs:
     executor: wallaroo-ci
     steps:
       - checkout
-      - run: .circleci/clone_tracker.sh
       - run: |
           ulimit -c unlimited
           ulimit -a
@@ -198,7 +181,6 @@ jobs:
     executor: wallaroo-ci
     steps:
       - checkout
-      - run: .circleci/clone_tracker.sh
       - run: |
           ulimit -c unlimited
           ulimit -a
@@ -210,7 +192,6 @@ jobs:
     executor: wallaroo-ci
     steps:
       - checkout
-      - run: .circleci/clone_tracker.sh
       - run: |
           ulimit -c unlimited
           ulimit -a
@@ -222,7 +203,6 @@ jobs:
     executor: wallaroo-ci
     steps:
       - checkout
-      - run: .circleci/clone_tracker.sh
       - run: |
           ulimit -c unlimited
           ulimit -a
@@ -234,7 +214,6 @@ jobs:
     executor: wallaroo-ci
     steps:
       - checkout
-      - run: .circleci/clone_tracker.sh
       - run: |
           ulimit -c unlimited
           ulimit -a
@@ -246,7 +225,6 @@ jobs:
     executor: wallaroo-ci
     steps:
       - checkout
-      - run: .circleci/clone_tracker.sh
       - run: |
           ulimit -c unlimited
           ulimit -a
@@ -258,7 +236,6 @@ jobs:
     executor: wallaroo-ci
     steps:
       - checkout
-      - run: .circleci/clone_tracker.sh
       - run: |
           ulimit -c unlimited
           ulimit -a
@@ -270,7 +247,6 @@ jobs:
     executor: wallaroo-ci
     steps:
       - checkout
-      - run: .circleci/clone_tracker.sh
       - run: |
           ulimit -c unlimited
           ulimit -a

--- a/lib/wallaroo/core/boundary/boundary.pony
+++ b/lib/wallaroo/core/boundary/boundary.pony
@@ -667,6 +667,14 @@ actor OutgoingBoundary is (Consumer & TCPActor)
           @printf[I32]("Received AckDataReceivedMsg at Boundary\n".cstring())
         end
         receive_ack(aw.seq_id)
+      | let ra: RequestBoundaryPunctuationAckMsg =>
+        try
+          let ack_msg = ChannelMsgEncoder
+            .receive_boundary_punctuation_ack(_auth)?
+          _tcp_handler.writev(ack_msg)
+        else
+          Fail()
+        end
       | let ia: ImmediateAckMsg =>
         receive_immediate_ack()
       else

--- a/lib/wallaroo/core/checkpoint/checkpoint_initiator.pony
+++ b/lib/wallaroo/core/checkpoint/checkpoint_initiator.pony
@@ -414,7 +414,7 @@ actor CheckpointInitiator is Initializable
         else
           r.update_checkpoint_id(_last_complete_checkpoint_id)
         end
-        r.start_recovery(consume ws where with_reconnect = false)
+        r.start_recovery(consume ws, RecoveryReasons.abort_checkpoint())
       else
         Fail()
       end

--- a/lib/wallaroo/core/data_channel/data_channel.pony
+++ b/lib/wallaroo/core/data_channel/data_channel.pony
@@ -289,6 +289,8 @@ class _DataReceiver is _DataReceiverWrapper
           .cstring())
       end
       Fail()
+    | let m: ReceiveBoundaryPunctuationAckMsg =>
+      _data_receiver.receive_boundary_punctuation_ack()
     | let m: SpinUpLocalTopologyMsg =>
       @printf[I32]("Received spin up local topology message!\n".cstring())
     | let m: ReportStatusMsg =>

--- a/lib/wallaroo/core/data_receiver/data_receivers.pony
+++ b/lib/wallaroo/core/data_receiver/data_receivers.pony
@@ -17,6 +17,7 @@ Copyright 2018 The Wallaroo Authors.
 */
 
 use "collections"
+use "promises"
 use "wallaroo/core/common"
 use "wallaroo/core/data_channel"
 use "wallaroo/core/metrics"
@@ -124,6 +125,16 @@ actor DataReceivers
         Fail()
       end
     end
+
+  be request_boundary_punctuation_acks(promise: Promise[None]) =>
+    let ps = Array[Promise[None]]
+    for dr in _data_receivers.values() do
+      let p = Promise[None]
+      ps.push(p)
+      dr.request_boundary_punctuation_ack(p)
+    end
+    let promises = Promises[None].join(ps.values())
+    promises.next[None]({(_: None) => promise(None)})
 
   be rollback_barrier_complete(recovery: Recovery) =>
     _recovery_complete()

--- a/lib/wallaroo/core/initialization/local_topology.pony
+++ b/lib/wallaroo/core/initialization/local_topology.pony
@@ -1131,7 +1131,8 @@ actor LocalTopologyInitializer is LayoutInitializer
     match _topology
     | let t: LocalTopology =>
       if _is_recovering then
-        _recovery.start_recovery(t.worker_names)
+        _recovery.start_recovery(t.worker_names,
+          RecoveryReasons.crash_recovery())
       else
         _phase.report_recovery_ready_to_work()
         _event_log.quick_initialize(this)

--- a/lib/wallaroo/core/messages/channel_messages.pony
+++ b/lib/wallaroo/core/messages/channel_messages.pony
@@ -27,6 +27,7 @@ use "wallaroo/core/checkpoint"
 use "wallaroo/core/common"
 use "wallaroo/core/data_receiver"
 use "wallaroo/core/initialization"
+use "wallaroo/core/recovery"
 use "wallaroo/core/registries"
 use "wallaroo/core/routing"
 use "wallaroo/core/source/connector_source"
@@ -529,13 +530,14 @@ primitive ChannelMsgEncoder
     _encode(AnnounceRollbackIdMsg(rollback_id), auth)?
 
   fun recovery_initiated(rollback_id: RollbackId,
-    sender: WorkerName, auth: AmbientAuth): Array[ByteSeq] val ?
+    sender: WorkerName, reason: RecoveryReason, auth: AmbientAuth):
+    Array[ByteSeq] val ?
   =>
     """
     Sent to all workers in cluster when a recovering worker has connected so
     that currently recovering workers can cede control.
     """
-    _encode(RecoveryInitiatedMsg(rollback_id, sender), auth)?
+    _encode(RecoveryInitiatedMsg(rollback_id, sender, reason), auth)?
 
   fun ack_recovery_initiated(sender: WorkerName, auth: AmbientAuth):
     Array[ByteSeq] val ?
@@ -1821,11 +1823,15 @@ class val AnnounceRollbackIdMsg is ChannelMsg
 class val RecoveryInitiatedMsg is ChannelMsg
   let rollback_id: RollbackId
   let sender: WorkerName
+  let reason: RecoveryReason
 
   fun val string(): String => __loc.type_name()
-  new val create(rollback_id': RollbackId, sender': WorkerName) =>
+  new val create(rollback_id': RollbackId, sender': WorkerName,
+    reason': RecoveryReason)
+  =>
     rollback_id = rollback_id'
     sender = sender'
+    reason = reason'
 
 class val AckRecoveryInitiatedMsg is ChannelMsg
   let sender: WorkerName

--- a/lib/wallaroo/core/messages/channel_messages.pony
+++ b/lib/wallaroo/core/messages/channel_messages.pony
@@ -223,6 +223,19 @@ primitive ChannelMsgEncoder
   =>
     _encode(AckDataReceivedMsg(sender_name, sender_step_id, seq_id), auth)?
 
+  fun request_boundary_punctuation_ack(auth: AmbientAuth): Array[ByteSeq] val ?
+  =>
+    """
+    A punctuation ack is used to guarantee that all pending messages after
+    a certain received message at DataReceiver were sent by the boundary before
+    we proceed.
+    """
+    _encode(RequestBoundaryPunctuationAckMsg, auth)?
+
+  fun receive_boundary_punctuation_ack(auth: AmbientAuth): Array[ByteSeq] val ?
+  =>
+    _encode(ReceiveBoundaryPunctuationAckMsg, auth)?
+
   fun data_receiver_ack_immediately(auth: AmbientAuth): Array[ByteSeq] val ? =>
     _encode(DataReceiverAckImmediatelyMsg, auth)?
 
@@ -1217,6 +1230,12 @@ class val AckDataReceivedMsg is ChannelMsg
     sender_name = sender_name'
     sender_step_id = sender_step_id'
     seq_id = seq_id'
+
+primitive RequestBoundaryPunctuationAckMsg is ChannelMsg
+  fun val string(): String => __loc.type_name()
+
+primitive ReceiveBoundaryPunctuationAckMsg is ChannelMsg
+  fun val string(): String => __loc.type_name()
 
 class val DataMsg is ChannelMsg
   let pipeline_time_spent: U64

--- a/lib/wallaroo/core/network/control_channel_tcp.pony
+++ b/lib/wallaroo/core/network/control_channel_tcp.pony
@@ -598,7 +598,8 @@ class ControlChannelConnectNotifier is TCPConnectionNotify
         _checkpoint_initiator.commit_checkpoint_id(m.checkpoint_id,
           m.rollback_id, m.sender)
       | let m: RecoveryInitiatedMsg =>
-        _recovery.recovery_initiated_at_worker(m.sender, m.rollback_id)
+        _recovery.recovery_initiated_at_worker(m.sender, m.rollback_id,
+          m.reason)
       | let m: AckRecoveryInitiatedMsg =>
         _recovery.ack_recovery_initiated(m.sender)
       | let m: InitiateRollbackBarrierMsg =>

--- a/lib/wallaroo/core/recovery/recovery_phase.pony
+++ b/lib/wallaroo/core/recovery/recovery_phase.pony
@@ -524,6 +524,16 @@ class _RecoveryOverrideAccepted is _RecoveryPhase
   =>
     None
 
+  fun ref inform_of_boundaries_map(obs: Map[WorkerName, OutgoingBoundary] val)
+  =>
+    None
+
+  fun ref boundary_acked_registering(b: OutgoingBoundary) =>
+    None
+
+  fun ref data_receivers_acked_registering() =>
+    None
+
   fun ref rollback_barrier_complete(token: CheckpointRollbackBarrierToken) =>
     None
 

--- a/lib/wallaroo/core/recovery/step_rollbacker.pony
+++ b/lib/wallaroo/core/recovery/step_rollbacker.pony
@@ -26,6 +26,10 @@ primitive StepRollbacker
   fun apply(payload: ByteSeq val, runner: Runner, step: Step ref,
     rb: Reader = Reader)
   =>
+    match runner
+    | let r: RollbackableRunner =>
+      r.clear_state()
+    end
     rb.append(payload)
     try
       let w_bytes_size = rb.u32_be()?.usize()

--- a/lib/wallaroo/core/registries/router_registry.pony
+++ b/lib/wallaroo/core/registries/router_registry.pony
@@ -905,7 +905,9 @@ actor RouterRegistry is (KeyRegistry & SourceRegistry & DisposableRegistry &
     end
 
   be inform_worker_of_boundary_count(target_worker: WorkerName) =>
-    // There is one boundary per source plus the canonical boundary
+    // There is one boundary per source plus the canonical boundary.
+    // BarrierSource, a special case, is not counted here because it uses the
+    // canonical boundary and doesn't register as a normal source.
     let count = _sources.size() + 1
     _connections.inform_worker_of_boundary_count(target_worker, count)
 

--- a/lib/wallaroo/core/source/barrier_source/barrier_source.pony
+++ b/lib/wallaroo/core/source/barrier_source/barrier_source.pony
@@ -87,7 +87,13 @@ actor BarrierSource is Source
       @printf[I32]("===BarrierSource %s created===\n".cstring(),
         _source_id.string().cstring())
     end
-    _router_registry.register_source(this, _source_id)
+
+    // NOTE: We don't register BarrierSource as a source with RouterRegistry
+    // because it is only a source for the purposes of the barrier
+    // protocol. As a result, unlike other sources, it does not use its
+    // own OutgoingBoundaries, but instead uses the canonical ones. This is
+    // because it only rarely sends messages (those related to barriers
+    // and to register/unregister itself as a Producer).
 
   fun ref metrics_reporter(): MetricsReporter =>
     _metrics_reporter

--- a/lib/wallaroo/core/source/barrier_source/barrier_source.pony
+++ b/lib/wallaroo/core/source/barrier_source/barrier_source.pony
@@ -87,6 +87,7 @@ actor BarrierSource is Source
       @printf[I32]("===BarrierSource %s created===\n".cstring(),
         _source_id.string().cstring())
     end
+    _router_registry.register_source(this, _source_id)
 
   fun ref metrics_reporter(): MetricsReporter =>
     _metrics_reporter

--- a/lib/wallaroo/core/step/step.pony
+++ b/lib/wallaroo/core/step/step.pony
@@ -491,8 +491,8 @@ actor Step is (Producer & Consumer & BarrierProcessor)
 
   fun ref barrier_complete(barrier_token: BarrierToken) =>
     ifdef "checkpoint_trace" then
-      @printf[I32]("Barrier complete at Step %s\n".cstring(),
-        _id.string().cstring())
+      @printf[I32]("Barrier %s complete at Step %s\n".cstring(),
+        barrier_token.string().cstring(), _id.string().cstring())
     end
     match barrier_token
     | let cbt: CheckpointBarrierToken =>

--- a/lib/wallaroo/core/topology/runner.pony
+++ b/lib/wallaroo/core/topology/runner.pony
@@ -63,6 +63,7 @@ trait SerializableStateRunner
 
 trait RollbackableRunner
   fun ref rollback(state_bytes: ByteSeq val)
+  fun ref clear_state()
   fun ref set_step_id(id: U128)
 
 trait val RunnerBuilder
@@ -675,6 +676,12 @@ class StateRunner[In: Any val, Out: Any val, S: State ref] is (Runner &
     else
       Fail()
     end
+
+  fun ref clear_state() =>
+    """
+    Called to purge all keys when we are rolling back.
+    """
+    _state_map.clear()
 
 interface Stringablike
   fun string(): String

--- a/testing/conformance/tests/system_events.py
+++ b/testing/conformance/tests/system_events.py
@@ -41,7 +41,7 @@ from integration import clear_current_test
 #     # ResilienceTestBaseApplications provide their own test runner
 #     # So we only need to give it a config and a sequence of operations
 #     with MultiPartitionDetector(config=conf) as test:
-#         test.run_test_sequence([Wait(1), Grow(1), Wait(1), Shrink(1), Wait(1)])
+#         test.run_test_sequence([Wait(3), Grow(1), Wait(1), Shrink(1), Wait(1)])
 
 ####################
 # Generative Tests #
@@ -75,20 +75,20 @@ SOURCE_NUMBERS = [1]
 
 RESILIENCE_SEQS = [
     # wait, grow1, wait, shrink1, wait, crash2, wait, recover
-    [Wait(2), Grow(1), Wait(2), Shrink(1), Wait(2), Crash(2),
-     Wait(2), Recover(2), Wait(5)],
+    [Wait(3), Grow(1), Wait(2), Shrink(1), Wait(2), Crash(2),
+     Wait(3), Recover(2), Wait(5)],
 
     # crash1, recover1
-    [Wait(2), Crash(1), Wait(2), Recover(1), Wait(5)],
+    [Wait(3), Crash(1), Wait(2), Recover(1), Wait(5)],
 
     # crash2, recover2
-    [Wait(2), Crash(2), Wait(2), Recover(2), Wait(5)],
+    [Wait(3), Crash(2), Wait(2), Recover(2), Wait(5)],
 
     # Log rotate
-    [Wait(2), Rotate(), Wait(2)],
+    [Wait(3), Rotate(), Wait(2)],
 
     # Log rotate and crash
-    [Wait(2), Rotate(), Wait(2), Crash(1), Wait(2), Recover(1), Wait(2)],
+    [Wait(3), Rotate(), Wait(2), Crash(1), Wait(2), Recover(1), Wait(2)],
     ]
 
 

--- a/testing/correctness/scripts/effectively-once/README.md
+++ b/testing/correctness/scripts/effectively-once/README.md
@@ -81,6 +81,12 @@ Finally, all of the Bourne/Bash shell variables in the
 Their values may be tweaked to fit your use case, hence the prefix
 "sample" in the file name.
 
+You can also pass in your Wallaroo top directory directly, e.g. 
+```
+. ./sample-env-vars.sh path/to/wallaroo
+. ./sample-env-vars.sh.tcp-source+sink path/to/wallaroo
+```
+
 ### Stop all Wallaroo-related processes and delete all state files
 
 ```

--- a/testing/correctness/scripts/effectively-once/master-crasher.sh
+++ b/testing/correctness/scripts/effectively-once/master-crasher.sh
@@ -464,7 +464,7 @@ run_custom3006 () {
 
 run_custom_tcp_crash0 () {
     ## Assume that we are run with `./master-crasher.sh 2 run_custom_tcp_crash0
-    sleep 2
+    sleep 4
 
     /bin/echo -n c0
     ./crash-worker.sh 0
@@ -475,7 +475,13 @@ run_custom_tcp_crash0 () {
     ./start-initializer.sh
     poll_out=`poll_ready -w 4 2>&1`
     if [ $? -ne 0 -o ! -z "$poll_out" ]; then
-        echo "custom3006 cmd $cmd: $poll_out"
+        echo ""
+        echo "\nQuery initializer\n"
+        ../../../../testing/tools/external_sender/external_sender -e 127.0.0.1:7103 -t cluster-status-query
+        echo "\nQuery worker1\n"
+        ../../../../testing/tools/external_sender/external_sender -e 127.0.0.1:7113 -t cluster-status-query
+        echo "\nQuery initializer again\n"
+        ../../../../testing/tools/external_sender/external_sender -e 127.0.0.1:7103 -t cluster-status-query
         pause_the_world
         exit 1
     fi

--- a/testing/correctness/scripts/effectively-once/sample-env-vars.sh
+++ b/testing/correctness/scripts/effectively-once/sample-env-vars.sh
@@ -1,5 +1,11 @@
 ## When using sh/bash, use via: . /path/to/this/file
 
+if [ -z "$1" ]; then
+	echo ""
+else
+	export WALLAROO_TOP=$1
+fi
+
 if [ -z "$WALLAROO_TOP" ]; then
     export WALLAROO_TOP=$HOME/wallaroo
 fi

--- a/testing/correctness/scripts/effectively-once/sample-env-vars.sh.tcp-source+sink
+++ b/testing/correctness/scripts/effectively-once/sample-env-vars.sh.tcp-source+sink
@@ -1,5 +1,11 @@
 ## When using sh/bash, use via: . /path/to/this/file
 
+if [ -z "$1" ]; then
+	echo ""
+else
+	export WALLAROO_TOP=$1
+fi
+
 if [ -z "$WALLAROO_TOP" ]; then
     export WALLAROO_TOP=$HOME/wallaroo
 fi


### PR DESCRIPTION
This adds two new phases to the recovery protocol to guarantee that
all Producers on other workers have registered with a recovering
worker before we proceed to initiate the rollback barrier.

Fixes #3018.
