### PR TITLE
Expand checkpoint id logging

### DIFF
--- a/lib/wallaroo/startup.pony
+++ b/lib/wallaroo/startup.pony
@@ -180,9 +180,10 @@ actor Startup
         _disposables.set(joining_listener)
       elseif _is_recovering then
         ifdef "resilience" then
-          (let checkpoint_id, let rollback_id) =
+          (let current_checkpoint_id, let last_complete_checkpoint_id,
+            let rollback_id) =
             LatestCheckpointId.read(auth, _checkpoint_ids_file)
-          _initialize(checkpoint_id)
+          _initialize(last_complete_checkpoint_id)
         else
           _initialize()
         end


### PR DESCRIPTION
Prior to this commit, we would only store 2 pieces of info for local checkpoint state:
1. last committed checkpoint #
2. rollback checkpoint #

This commit adds a 3rd integer: current checkpoint #. Its purpose is to avoid reusing checkpoint #s, despite possible crashes by the initializer worker.

Fixes #3032 
