### PR TITLE
Bugfix for ConnectorSink: fix report_ready_to_work() criteria

### DIFF
--- a/testing/correctness/tests/aloc_sink/Makefile
+++ b/testing/correctness/tests/aloc_sink/Makefile
@@ -49,7 +49,7 @@ aloc_sink_tests:
 	-rm -fv /tmp/Celsius* /tmp/aloc*
 	#### -cd $(HOME)/s/src/other-repo && make start-s3-container
 	-cd $(ALOC_SINK_PATH) && ./run_aloc_sink_test > /tmp/run_aloc_sink_test.out 2>&1
-	cd $(ALOC_SINK_PATH) && ./run_aloc_sink_test.validate.sh
+	cd $(ALOC_SINK_PATH) && ./run_aloc_sink_test.validate.sh || cat /tmp/run_aloc_sink_test.out
 else
 aloc_sink_tests:
 	$(QUIET)printf "aloc_sink tests not run.\nRun make with 'resilience=on' to run this test.\n"


### PR DESCRIPTION
Prior to this patch, a counter of the # of established TCP connections
was used to determine when report_ready_to_work() would be called
by ConnectorSink.  This method is vulnerable to the following race:

1. A Wallaroo worker starts.
2. The worker's ConnectorSink connects successfully to the remote
   peer sink.
3. The worker's TCP connection is closed before ConnectorSink
   receives the 2PC message ReplyUncommitted.
4. The worker's ConnectorSink connects successfully to the remote
   peer sink a second time.
5. The worker's TCP connection remains open, and ConnectorSink
   receives the 2PC message ReplyUncommitted.
6. At this point, the value of _connection_count is > 1, so
   report_ready_to_work() is not called.
7. The Wallaroo worker does not finish its initialization protocol.

Fixes #3037.

<!--
Make sure you've read the [Contributors Guide](https://github.com/WallarooLabs/wallaroo/blob/master/CONTRIBUTING.md). You'll need to sign our CLA before your issue can be accepted.

Reference the issue your code change relates to if possible
-->
ref #

<!--
Include any other necessary information below. If you have any questions don't hesitate to reach out on the mailing list or on IRC.
-->
