### PR TITLE
Fix @printf() arg list error that may cause SIGSEGV crash

### DIFF
--- a/lib/wallaroo/core/recovery/backend.pony
+++ b/lib/wallaroo/core/recovery/backend.pony
@@ -147,7 +147,7 @@ class FileBackend is Backend
   fun bytes_written(): USize =>
     _bytes_written
 
-  fun get_path(): String => // SLF TODO used??
+  fun get_path(): String =>
     _filepath.path
 
   fun ref start_rollback(checkpoint_id: CheckpointId): USize =>
@@ -158,7 +158,8 @@ class FileBackend is Backend
     end
     if _file.size() == 0 then
       @printf[I32](("Trying to rollback to checkpoint %s from empty " +
-        "recovery file %s\n").cstring(), checkpoint_id.string().cstring())
+        "recovery file %s\n").cstring(), checkpoint_id.string().cstring(),
+        get_path().cstring())
       Fail()
     end
 


### PR DESCRIPTION
Add a missing argument to `@printf()` call in backend.pony that can cause a SIGSEGV crash.