### PR TITLE
Fix race between 1st checkpoint token, 2PC intro done, barrier complete

### DIFF
--- a/lib/wallaroo/core/sink/connector_sink/connector_sink.pony
+++ b/lib/wallaroo/core/sink/connector_sink/connector_sink.pony
@@ -428,7 +428,7 @@ actor ConnectorSink is Sink
     This is a callback used by the ConnectorSinkNotify class to Inform
     us that it received a 2PC phase 1 reply.
     """
-    match _twopc.twopc_phase1_reply(txn_id, commit)
+    match _twopc.twopc_phase1_reply(this, txn_id, commit)
     | true =>
       if _twopc.barrier_token != _twopc.barrier_token_initial then
         _barrier_coordinator.ack_barrier(this, _twopc.barrier_token)


### PR DESCRIPTION
See comment added to ConnectorSink2PC.barrier_complete() for
the details of the race between getting the 1st checkpoint token,
reconnecting to the external connector sink, and getting the
last checkpoint token and then calling barrier_complete().

When we hit this rare race, then we send a Phase1 message
if needed and then (when the Phase1 reply arrives), force
a Phase2 abort.

Fixes #3073
