### PR TITLE
Add connection rounds to boundary connections

### DIFF
--- a/lib/wallaroo/core/boundary/boundary.pony
+++ b/lib/wallaroo/core/boundary/boundary.pony
@@ -24,6 +24,7 @@ use "time"
 use "wallaroo/core/barrier"
 use "wallaroo/core/checkpoint"
 use "wallaroo/core/common"
+use "wallaroo/core/data_receiver"
 use "wallaroo/core/initialization"
 use "wallaroo/core/invariant"
 use "wallaroo/core/messages"
@@ -136,6 +137,8 @@ actor OutgoingBoundary is (Consumer & TCPActor)
   let _reconnect_failed_delay: U64
   var _initial_connection_was_established: Bool = false
 
+  var _connection_round: ConnectionRound = 0
+
   new create(auth: AmbientAuth, worker_name: String, target_worker: String,
     tcp_handler_builder: TestableTCPHandlerBuilder,
     metrics_reporter: MetricsReporter iso, host: String, service: String,
@@ -177,9 +180,8 @@ actor OutgoingBoundary is (Consumer & TCPActor)
       if _routing_id == 0 then
         Fail()
       end
-
       let connect_msg = ChannelMsgEncoder.data_connect(_worker_name,
-        _routing_id, seq_id, _auth)?
+        _routing_id, seq_id, _connection_round, _auth)?
       _tcp_handler.writev(connect_msg)
     else
       Fail()
@@ -210,7 +212,7 @@ actor OutgoingBoundary is (Consumer & TCPActor)
         end
 
         let connect_msg = ChannelMsgEncoder.data_connect(_worker_name,
-          _routing_id, seq_id, _auth)?
+          _routing_id, seq_id, _connection_round, _auth)?
         _tcp_handler.writev(connect_msg)
       else
         Fail()
@@ -220,7 +222,8 @@ actor OutgoingBoundary is (Consumer & TCPActor)
   be ack_immediately(p: Promise[OutgoingBoundary]) =>
     _pending_immediate_ack_promise = p
     try
-      let msg = ChannelMsgEncoder.data_receiver_ack_immediately(_auth)?
+      let msg = ChannelMsgEncoder.data_receiver_ack_immediately(
+        _connection_round, _auth)?
 
       _tcp_handler.writev(msg)
     else
@@ -254,7 +257,7 @@ actor OutgoingBoundary is (Consumer & TCPActor)
   =>
     try
       let outgoing_msg = ChannelMsgEncoder.migrate_key(step_group, key,
-        checkpoint_id, state, _worker_name, _auth)?
+        checkpoint_id, state, _worker_name, _connection_round, _auth)?
       _tcp_handler.writev(outgoing_msg)
     else
       Fail()
@@ -263,7 +266,8 @@ actor OutgoingBoundary is (Consumer & TCPActor)
   be send_migration_batch_complete() =>
     try
       let migration_batch_complete_msg =
-        ChannelMsgEncoder.migration_batch_complete(_worker_name, _auth)?
+        ChannelMsgEncoder.migration_batch_complete(_worker_name,
+          _connection_round, _auth)?
       _tcp_handler.writev(migration_batch_complete_msg)
     else
       Fail()
@@ -328,7 +332,7 @@ actor OutgoingBoundary is (Consumer & TCPActor)
         i_producer_id,
         pipeline_time_spent + (WallClock.nanoseconds() - worker_ingress_ts),
         seq_id, _wb, _auth, WallClock.nanoseconds(),
-        new_metrics_id, metric_name)?
+        new_metrics_id, metric_name, _connection_round)?
       _add_to_upstream_backup(outgoing_msg)
 
       if _connection_initialized then
@@ -375,7 +379,10 @@ actor OutgoingBoundary is (Consumer & TCPActor)
     _maybe_mute_or_unmute_upstreams()
     _lowest_queue_id = _lowest_queue_id + flush_count.u64()
 
-  fun ref receive_connect_ack(last_id_seen: SeqId) =>
+  fun ref receive_connect_ack(last_id_seen: SeqId,
+    connection_round: ConnectionRound)
+  =>
+    _connection_round = connection_round
     _replay_from(last_id_seen)
 
   fun ref start_normal_sending() =>
@@ -458,7 +465,7 @@ actor OutgoingBoundary is (Consumer & TCPActor)
     _registered_producers.register_producer(source_id, producer, target_id)
     try
       let msg = ChannelMsgEncoder.register_producer(_worker_name,
-        source_id, target_id, _auth)?
+        source_id, target_id, _connection_round, _auth)?
       _tcp_handler.writev(msg)
     else
       Fail()
@@ -471,7 +478,7 @@ actor OutgoingBoundary is (Consumer & TCPActor)
     _registered_producers.unregister_producer(source_id, producer, target_id)
     try
       let msg = ChannelMsgEncoder.unregister_producer(_worker_name,
-        source_id, target_id, _auth)?
+        source_id, target_id, _connection_round, _auth)?
       _tcp_handler.writev(msg)
     else
       Fail()
@@ -510,7 +517,7 @@ actor OutgoingBoundary is (Consumer & TCPActor)
       seq_id = seq_id + 1
 
       let msg = ChannelMsgEncoder.forward_barrier(target_routing_id,
-        origin_routing_id, barrier_token, seq_id, _auth)?
+        origin_routing_id, barrier_token, seq_id, _connection_round, _auth)?
       if _connection_initialized then
         _tcp_handler.writev(msg)
       else
@@ -659,11 +666,6 @@ actor OutgoingBoundary is (Consumer & TCPActor)
         @printf[I32]("Rcvd msg at OutgoingBoundary\n".cstring())
       end
       match ChannelMsgDecoder(consume data, _auth)
-      | let ac: AckDataConnectMsg =>
-        ifdef "trace" then
-          @printf[I32]("Received AckDataConnectMsg at Boundary\n".cstring())
-        end
-        receive_connect_ack(ac.last_id_seen)
       | let dd: DataDisconnectMsg =>
         dispose()
       | let sn: StartNormalDataSendingMsg =>
@@ -672,7 +674,7 @@ actor OutgoingBoundary is (Consumer & TCPActor)
             .cstring())
         end
         @l(Log.debug(), Log.boundary(), "received: worker %s target_worker %s sn.last_id_seen %lu\n".cstring(), _worker_name.cstring(), _target_worker.cstring(), sn.last_id_seen)
-        receive_connect_ack(sn.last_id_seen)
+        receive_connect_ack(sn.last_id_seen, sn.connection_round)
         start_normal_sending()
       | let aw: AckDataReceivedMsg =>
         ifdef "trace" then
@@ -682,7 +684,7 @@ actor OutgoingBoundary is (Consumer & TCPActor)
       | let ra: RequestBoundaryPunctuationAckMsg =>
         try
           let ack_msg = ChannelMsgEncoder
-            .receive_boundary_punctuation_ack(_auth)?
+            .receive_boundary_punctuation_ack(_connection_round, _auth)?
           _tcp_handler.writev(ack_msg)
         else
           Fail()
@@ -720,7 +722,7 @@ actor OutgoingBoundary is (Consumer & TCPActor)
       // This is not the initial time we connected, so we're reconnecting.
       try
         let connect_msg = ChannelMsgEncoder.data_connect(_worker_name,
-          _routing_id, seq_id, _auth)?
+          _routing_id, seq_id, _connection_round, _auth)?
         _tcp_handler.writev(connect_msg)
       else
         @printf[I32]("error creating data connect message on reconnect\n"

--- a/lib/wallaroo/core/data_channel/data_channel.pony
+++ b/lib/wallaroo/core/data_channel/data_channel.pony
@@ -267,12 +267,12 @@ class _DataReceiver is _DataReceiverWrapper
       _data_receiver.received(data_msg.delivery_msg, data_msg.producer_id,
           data_msg.pipeline_time_spent + (ingest_ts - data_msg.latest_ts),
           data_msg.seq_id, my_latest_ts, data_msg.metrics_id + 1,
-          my_latest_ts)
+          my_latest_ts, data_msg.connection_round)
     | let dc: DataConnectMsg =>
       @printf[I32](("Received DataConnectMsg on DataChannel, but we already " +
         "have a DataReceiver for this connection.\n").cstring())
     | let ia: DataReceiverAckImmediatelyMsg =>
-      _data_receiver.data_receiver_ack_immediately()
+      _data_receiver.data_receiver_ack_immediately(ia.connection_round)
     | let km: KeyMigrationMsg =>
       ifdef "trace" then
         @printf[I32]("Received KeyMigrationMsg on Data Channel\n".cstring())
@@ -290,17 +290,19 @@ class _DataReceiver is _DataReceiverWrapper
       end
       Fail()
     | let m: ReceiveBoundaryPunctuationAckMsg =>
-      _data_receiver.receive_boundary_punctuation_ack()
+      _data_receiver.receive_boundary_punctuation_ack(m.connection_round)
     | let m: SpinUpLocalTopologyMsg =>
       @printf[I32]("Received spin up local topology message!\n".cstring())
     | let m: ReportStatusMsg =>
       _data_receiver.report_status(m.code)
     | let m: RegisterProducerMsg =>
-      _data_receiver.register_producer(m.source_id, m.target_id)
+      _data_receiver.register_producer(m.source_id, m.target_id,
+        m.connection_round)
     | let m: UnregisterProducerMsg =>
-      _data_receiver.unregister_producer(m.source_id, m.target_id)
+      _data_receiver.unregister_producer(m.source_id, m.target_id,
+        m.connection_round)
     | let m: ForwardBarrierMsg =>
-      _data_receiver.forward_barrier(m.target_id, m.origin_id, m.token, m.seq_id)
+      _data_receiver.forward_barrier(m.target_id, m.origin_id, m.token, m.seq_id, m.connection_round)
     | let m: UnknownChannelMsg =>
       @printf[I32]("Unknown Wallaroo data message type: UnknownChannelMsg.\n"
         .cstring())

--- a/testing/conformance/tests/system_events.py
+++ b/testing/conformance/tests/system_events.py
@@ -131,7 +131,7 @@ for app in APPS:
             if o1 == o2:
                 ops = [o1]
             else:
-                ops = [o1, Wait(2), o2]
+                ops = [o1, Wait(4), o2]
             for src_type in SOURCE_TYPES:
                 for src_num in SOURCE_NUMBERS:
                     test_name = (


### PR DESCRIPTION
When we lose connection due to worker failure, we need to reestablish
a connection the same DataReceiver per OutgoingBoundary. We now
increment the connection round for that connection which allows us to
ignore outdated messages at the DataReceiver. This also allows us to
enforce seq_id resets.

This address the problem discovered with #3066, where messages backed up at an outdated DataChannel are received after a crash recovery event, carrying with them seq_ids from the old connection. This overrode the handshake seq_id reset. With these changes, messages from prior rounds like this are simply discarded.

Fixes #3066 