### PR TITLE
Add RecoveryPriorityTracker to determine when to cede recovery control

### DIFF
--- a/lib/wallaroo/core/boundary/boundary.pony
+++ b/lib/wallaroo/core/boundary/boundary.pony
@@ -93,6 +93,7 @@ actor OutgoingBoundary is (Consumer & TCPActor)
   var _initializer: (LayoutInitializer | None) = None
   var _reported_initialized: Bool = false
   var _reported_ready_to_work: Bool = false
+  var _ready_to_work_requested: Bool = false
 
   // Consumer
   var _registered_producers: RegisteredProducers =
@@ -180,6 +181,7 @@ actor OutgoingBoundary is (Consumer & TCPActor)
       if _routing_id == 0 then
         Fail()
       end
+      _ready_to_work_requested = true
       let connect_msg = ChannelMsgEncoder.data_connect(_worker_name,
         _routing_id, seq_id, _connection_round, _auth)?
       _tcp_handler.writev(connect_msg)
@@ -386,7 +388,7 @@ actor OutgoingBoundary is (Consumer & TCPActor)
     _replay_from(last_id_seen)
 
   fun ref start_normal_sending() =>
-    if not _reported_ready_to_work then
+    if not _reported_ready_to_work and _ready_to_work_requested then
       match _initializer
       | let li: LayoutInitializer =>
         li.report_ready_to_work(this)

--- a/lib/wallaroo/core/data_receiver/data_receiver.pony
+++ b/lib/wallaroo/core/data_receiver/data_receiver.pony
@@ -396,7 +396,7 @@ actor DataReceiver is Producer
     if seq_id > _last_id_seen then
       match barrier_token
       // !TODO!: This isn't good enough. We need to ensure that we've been
-      // overriden to make this change back from recovery phase. As it stands,
+      // overridden to make this change back from recovery phase. As it stands,
       // this introduces a race condition if we receive an old resume token in
       // flight before we recovered.
       | let crrt: CheckpointRollbackResumeBarrierToken =>

--- a/lib/wallaroo/core/initialization/local_topology.pony
+++ b/lib/wallaroo/core/initialization/local_topology.pony
@@ -247,7 +247,7 @@ actor LocalTopologyInitializer is LayoutInitializer
   var _recovered_worker_names: Array[WorkerName] val =
     recover val Array[WorkerName] end
   var _is_recovering: Bool = false
-  var _recovery_overriden: Bool = false
+  var _recovery_overridden: Bool = false
   let _is_joining: Bool
 
   let _routing_id_gen: RoutingIdGenerator = RoutingIdGenerator
@@ -379,7 +379,7 @@ actor LocalTopologyInitializer is LayoutInitializer
       _router_registry)
 
   be abort_recovery_early() =>
-    _recovery_overriden = true
+    _recovery_overridden = true
 
   be initialize(cluster_initializer: (ClusterInitializer | None) = None,
     checkpoint_target: (CheckpointId | None) = None,
@@ -1134,7 +1134,7 @@ actor LocalTopologyInitializer is LayoutInitializer
 
     match _topology
     | let t: LocalTopology =>
-      if _is_recovering and not _recovery_overriden then
+      if _is_recovering and not _recovery_overridden then
         _recovery.start_recovery(t.worker_names,
           RecoveryReasons.crash_recovery())
       else

--- a/lib/wallaroo/core/recovery/recovery_phase.pony
+++ b/lib/wallaroo/core/recovery/recovery_phase.pony
@@ -199,13 +199,6 @@ class _BoundariesReconnect is _RecoveryPhase
     _recovery_reconnecter.start_recovery_reconnect(_workers, _recovery)
 
   fun ref recovery_reconnect_finished() =>
-    //!@
-    // match _abort_promise
-    // | let p: Promise[None] =>
-    //   p(None)
-    //   _recovery._abort_early(_override_worker)
-    //   return
-    // end
     _recovery.request_boundaries_map(_recovery_reason,
       _recovery_priority_tracker)
 

--- a/lib/wallaroo/core/recovery/recovery_phase.pony
+++ b/lib/wallaroo/core/recovery/recovery_phase.pony
@@ -79,7 +79,7 @@ trait _RecoveryPhase
     _unexpected_call(__loc.method_name())
 
   fun ref rollback_barrier_complete(token: CheckpointRollbackBarrierToken) =>
-    _invalid_call(__loc.method_name()); Fail()
+    _unexpected_call(__loc.method_name())
 
   fun ref data_receivers_ack() =>
     _invalid_call(__loc.method_name()); Fail()

--- a/lib/wallaroo/core/recovery/recovery_priority_tracker.pony
+++ b/lib/wallaroo/core/recovery/recovery_priority_tracker.pony
@@ -1,0 +1,51 @@
+use "promises"
+use "wallaroo/core/boundary"
+use "wallaroo/core/checkpoint"
+use "wallaroo/core/common"
+use "wallaroo_labs/mort"
+
+
+class RecoveryPriorityTracker
+  let _initial_recovery_reason: RecoveryReason
+  var _override_worker: (WorkerName | None) = None
+  var _highest_rival_rollback_id: RollbackId = 0
+  var _abort_promise: (Promise[None] | None) = None
+
+  new create(reason: RecoveryReason) =>
+    _initial_recovery_reason = reason
+
+  fun ref try_override(worker: WorkerName, rollback_id: RollbackId,
+    reason: RecoveryReason, recovery: Recovery ref,
+    abort_promise: Promise[None])
+  =>
+    if RecoveryReasons.has_priority(reason, _initial_recovery_reason) or
+       (not RecoveryReasons.has_priority(_initial_recovery_reason, reason) and
+         (rollback_id > _highest_rival_rollback_id))
+    then
+      @printf[I32](("RECOVERY: Waiting to cede control until " +
+        "boundaries are reconnected and producers are registered.\n")
+        .cstring())
+      _highest_rival_rollback_id = rollback_id
+      _override_worker = worker
+      _abort_promise = abort_promise
+    end
+
+  fun has_override(): Bool =>
+    match _abort_promise
+    | let p: Promise[None] => true
+    else
+      false
+    end
+
+  fun initiate_abort(recovery: Recovery ref) =>
+    match _override_worker
+    | let ow: WorkerName =>
+      match _abort_promise
+      | let p: Promise[None] => p(None)
+      else
+        Fail()
+      end
+      recovery._abort_early(ow)
+    else
+      Fail()
+    end

--- a/lib/wallaroo/core/sink/connector_sink/connector_sink.pony
+++ b/lib/wallaroo/core/sink/connector_sink/connector_sink.pony
@@ -249,6 +249,7 @@ actor ConnectorSink is Sink
       __loc.type_name().cstring(), __loc.method_name().cstring(),
       _sink_id.string().cstring())
     _initial_connect()
+    _notify.ready_to_work_requested(this)
 
   be application_ready_to_work(initializer: LocalTopologyInitializer) =>
     @ll(_conn_info, "Lifecycle: %s.%s at %s".cstring(),

--- a/lib/wallaroo/core/sink/sink_phase.pony
+++ b/lib/wallaroo/core/sink/sink_phase.pony
@@ -159,6 +159,9 @@ class BarrierSinkPhase is SinkPhase
     barrier_token: BarrierToken)
   =>
     if input_blocking(input_id) then
+      ifdef debug then
+        @printf[I32]("SinkPhase %s: receive_barrier: push %s\n".cstring(), name().cstring(), barrier_token.string().cstring())
+      end
       _queued.push(QueuedBarrier(input_id, producer, barrier_token))
     else
       ifdef debug then
@@ -252,6 +255,9 @@ class QueuingSinkPhase is SinkPhase
   fun ref receive_barrier(input_id: RoutingId, producer: Producer,
     barrier_token: BarrierToken)
   =>
+    ifdef debug then
+      @printf[I32]("SinkPhase %s: receive_barrier: push %s\n".cstring(), name().cstring(), barrier_token.string().cstring())
+    end
     _queued.push(QueuedBarrier(input_id, producer, barrier_token))
 
   fun ref prepare_for_rollback(token: BarrierToken) =>


### PR DESCRIPTION
Depending on the reason for recovery, a worker needs to get through
a certain subset of recovery phases before it's in a position to cede
control for recovery. The new RecoveryPriorityTracker is passed through
these phases, keeping track of whether the worker was ever overridden.
This addresses the problems surfaced in #3061.  

This PR also includes fixes to the procedure for reporting ready to work during
worker initialization, since during recovery there was a case where Initializables on
a recovering worker could report before the system had requested that report.

Fixes #3061 
