### PR TITLE
Address connection timing bugs in OutgoingBoundary

### DIFF
--- a/lib/wallaroo/core/data_channel/data_channel.pony
+++ b/lib/wallaroo/core/data_channel/data_channel.pony
@@ -272,6 +272,9 @@ class _DataReceiver is _DataReceiverWrapper
       @printf[I32](("Received DataConnectMsg on DataChannel, but we already " +
         "have a DataReceiver for this connection.\n").cstring())
     | let ia: DataReceiverAckImmediatelyMsg =>
+      @printf[I32](("Received DataReceiverAckImmediatelyMsg from boundary " +
+        "with routing id %s\n").cstring(),
+        ia.boundary_routing_id.string().cstring())
       _data_receiver.data_receiver_ack_immediately(ia.connection_round)
     | let km: KeyMigrationMsg =>
       ifdef "trace" then

--- a/lib/wallaroo/core/messages/channel_messages.pony
+++ b/lib/wallaroo/core/messages/channel_messages.pony
@@ -237,9 +237,10 @@ primitive ChannelMsgEncoder
     _encode(ReceiveBoundaryPunctuationAckMsg(connection_round), auth)?
 
   fun data_receiver_ack_immediately(connection_round: ConnectionRound,
-    auth: AmbientAuth): Array[ByteSeq] val ?
+    boundary_routing_id: RoutingId, auth: AmbientAuth): Array[ByteSeq] val ?
   =>
-    _encode(DataReceiverAckImmediatelyMsg(connection_round), auth)?
+    _encode(DataReceiverAckImmediatelyMsg(connection_round,
+      boundary_routing_id), auth)?
 
   fun immediate_ack(auth: AmbientAuth): Array[ByteSeq] val ? =>
     _encode(ImmediateAckMsg, auth)?
@@ -1087,9 +1088,13 @@ class val StartNormalDataSendingMsg is ChannelMsg
 
 class val DataReceiverAckImmediatelyMsg is ChannelMsg
   let connection_round: ConnectionRound
+  let boundary_routing_id: RoutingId
 
-  new val create(connection_round': ConnectionRound) =>
+  new val create(connection_round': ConnectionRound,
+    boundary_routing_id': RoutingId)
+  =>
     connection_round = connection_round'
+    boundary_routing_id = boundary_routing_id'
 
   fun val string(): String => __loc.type_name()
 

--- a/lib/wallaroo/core/recovery/recovery.pony
+++ b/lib/wallaroo/core/recovery/recovery.pony
@@ -78,7 +78,7 @@ actor Recovery
        and all producers and consumers are ready to rollback state.
     10) _AwaitDataReceiversAck: Put DataReceivers in non-recovery mode.
     11) _Rollback: Rollback all state to last safe checkpoint.
-    12) _FinishedRecovering: Finished recovery
+    12) _NotRecovering: Either finished recovery or was never recovering
     13) _RecoveryOverrideAccepted: If recovery was handed off to another worker
   """
   let _self: Recovery tag = this
@@ -114,7 +114,7 @@ actor Recovery
     if is_recovering then
       _recovery_phase = _AwaitRecovering(RecoveryReasons.crash_recovery())
     else
-      _recovery_phase = _AwaitRecovering(RecoveryReasons.not_recovering())
+      _recovery_phase = _NotRecovering
     end
     _checkpoint_initiator.set_recovery(this)
 
@@ -399,7 +399,7 @@ actor Recovery
     end
     _router_registry.resume_the_world(_worker_name)
     _data_receivers.recovery_complete()
-    _recovery_phase = _FinishedRecovering
+    _recovery_phase = _NotRecovering
     match _initializer
     | let lti: LocalTopologyInitializer =>
       lti.report_recovery_ready_to_work()

--- a/lib/wallaroo/core/recovery/recovery_phase.pony
+++ b/lib/wallaroo/core/recovery/recovery_phase.pony
@@ -133,6 +133,12 @@ trait _RecoveryPhase
     @printf[I32]("UNEXPECTED CALL to %s on recovery phase %s. Ignoring!\n"
       .cstring(), method_name.cstring(), name().cstring())
 
+  fun _print_phase_transition() =>
+    ifdef debug then
+      @printf[I32]("_RecoveryPhase transition to %s\n".cstring(),
+        name().string().cstring())
+    end
+
 class _AwaitRecovering is _RecoveryPhase
   let _initial_recovery_reason: RecoveryReason
   let _recovery_priority_tracker: RecoveryPriorityTracker
@@ -140,6 +146,7 @@ class _AwaitRecovering is _RecoveryPhase
   new create(reason: RecoveryReason) =>
     _initial_recovery_reason = reason
     _recovery_priority_tracker = RecoveryPriorityTracker(reason)
+    _print_phase_transition()
 
   fun name(): String => __loc.type_name()
   fun recovery_reason(): RecoveryReason => _initial_recovery_reason
@@ -184,6 +191,7 @@ class _BoundariesReconnect is _RecoveryPhase
     _workers = workers
     _recovery = recovery
     _recovery_priority_tracker = recovery_priority_tracker
+    _print_phase_transition()
 
   fun name(): String => __loc.type_name()
   fun recovery_reason(): RecoveryReason => _recovery_reason
@@ -221,6 +229,7 @@ class _WaitingForBoundariesMap is _RecoveryPhase
     _recovery_reason = reason
     _recovery = recovery
     _recovery_priority_tracker = recovery_priority_tracker
+    _print_phase_transition()
 
   fun name(): String => __loc.type_name()
   fun recovery_reason(): RecoveryReason => _recovery_reason
@@ -262,6 +271,7 @@ class _WaitingForBoundariesToAckRegistering is _RecoveryPhase
       _boundaries.set(b)
     end
     Invariant(_boundaries.size() > 0)
+    _print_phase_transition()
 
   fun name(): String => __loc.type_name()
   fun recovery_reason(): RecoveryReason => _recovery_reason
@@ -302,6 +312,7 @@ class _PrepareRollback is _RecoveryPhase
   new create(recovery: Recovery ref, reason: RecoveryReason) =>
     _recovery_reason = reason
     _recovery = recovery
+    _print_phase_transition()
 
   fun name(): String => __loc.type_name()
   fun recovery_reason(): RecoveryReason => _recovery_reason
@@ -323,6 +334,7 @@ class _RollbackLocalKeys is _RecoveryPhase
     _recovery = recovery
     _workers = workers
     _checkpoint_id = checkpoint_id
+    _print_phase_transition()
 
   fun name(): String => __loc.type_name()
   fun recovery_reason(): RecoveryReason => _recovery_reason
@@ -366,6 +378,7 @@ class _AwaitRollbackId is _RecoveryPhase
   new create(recovery: Recovery ref, reason: RecoveryReason) =>
     _recovery_reason = reason
     _recovery = recovery
+    _print_phase_transition()
 
   fun name(): String => __loc.type_name()
   fun recovery_reason(): RecoveryReason => _recovery_reason
@@ -396,6 +409,7 @@ class _AwaitRecoveryInitiatedAcks is _RecoveryPhase
     _workers = workers
     _recovery = recovery
     _rollback_id = rollback_id
+    _print_phase_transition()
 
   fun name(): String => __loc.type_name()
   fun recovery_reason(): RecoveryReason => _recovery_reason
@@ -433,6 +447,7 @@ class _RollbackBarrier is _RecoveryPhase
     _recovery_reason = reason
     _recovery = recovery
     _rollback_id = rollback_id
+    _print_phase_transition()
 
   fun name(): String => __loc.type_name()
   fun recovery_reason(): RecoveryReason => _recovery_reason
@@ -463,6 +478,7 @@ class _AwaitDataReceiversAck is _RecoveryPhase
     _recovery_reason = reason
     _recovery = recovery
     _token = token
+    _print_phase_transition()
 
   fun name(): String => __loc.type_name()
   fun recovery_reason(): RecoveryReason => _recovery_reason
@@ -496,6 +512,7 @@ class _Rollback is _RecoveryPhase
     _recovery = recovery
     _token = token
     _workers = workers
+    _print_phase_transition()
 
   fun name(): String => __loc.type_name()
   fun recovery_reason(): RecoveryReason => _recovery_reason
@@ -525,9 +542,12 @@ class _Rollback is _RecoveryPhase
       abort_promise(None)
     end
 
-class _FinishedRecovering is _RecoveryPhase
+class _NotRecovering is _RecoveryPhase
   fun name(): String => __loc.type_name()
   fun recovery_reason(): RecoveryReason => RecoveryReasons.not_recovering()
+
+  new create() =>
+    _print_phase_transition()
 
   fun ref start_recovery(workers: Array[WorkerName] val,
     recovery: Recovery ref, reason: RecoveryReason)
@@ -547,6 +567,9 @@ class _FinishedRecovering is _RecoveryPhase
 class _RecoveryOverrideAccepted is _RecoveryPhase
   fun name(): String => __loc.type_name()
   fun recovery_reason(): RecoveryReason => RecoveryReasons.not_recovering()
+
+  new create() =>
+    _print_phase_transition()
 
   fun ref start_recovery(workers: Array[WorkerName] val,
     recovery: Recovery ref, reason: RecoveryReason)


### PR DESCRIPTION
This commit addresses two bugs related to connection timing:

1) If we successfully connect before receiving a request to report
ready to work, then we use a flag so that when we receive that
request, we know to immediately report.

2) We make sure that we in the case of a boundary reconnect, we
resend any messages that were unsent simply because we didn't have
a connection open.

