### PR TITLE
Retry immediate acks with timer

### DIFF
--- a/lib/wallaroo/core/data_channel/data_channel.pony
+++ b/lib/wallaroo/core/data_channel/data_channel.pony
@@ -275,7 +275,8 @@ class _DataReceiver is _DataReceiverWrapper
       @printf[I32](("Received DataReceiverAckImmediatelyMsg from boundary " +
         "with routing id %s\n").cstring(),
         ia.boundary_routing_id.string().cstring())
-      _data_receiver.data_receiver_ack_immediately(ia.connection_round)
+      _data_receiver.data_receiver_ack_immediately(ia.ack_id,
+        ia.connection_round)
     | let km: KeyMigrationMsg =>
       ifdef "trace" then
         @printf[I32]("Received KeyMigrationMsg on Data Channel\n".cstring())

--- a/lib/wallaroo/core/data_receiver/data_receiver.pony
+++ b/lib/wallaroo/core/data_receiver/data_receiver.pony
@@ -20,6 +20,7 @@ use "collections"
 use "net"
 use "promises"
 use "time"
+use "wallaroo/core/boundary"
 use "wallaroo/core/common"
 use "wallaroo/core/data_channel"
 use "wallaroo/core/invariant"
@@ -249,9 +250,11 @@ actor DataReceiver is Producer
       @printf[I32]("Error creating ack data received message\n".cstring())
     end
 
-  be data_receiver_ack_immediately(connection_round: ConnectionRound) =>
+  be data_receiver_ack_immediately(ack_id: AckId,
+    connection_round: ConnectionRound)
+  =>
     try
-      let ack_msg = ChannelMsgEncoder.immediate_ack(_auth)?
+      let ack_msg = ChannelMsgEncoder.immediate_ack(ack_id, _auth)?
       _write_on_conn(ack_msg)
     else
       Fail()

--- a/lib/wallaroo/core/messages/channel_messages.pony
+++ b/lib/wallaroo/core/messages/channel_messages.pony
@@ -236,14 +236,15 @@ primitive ChannelMsgEncoder
   =>
     _encode(ReceiveBoundaryPunctuationAckMsg(connection_round), auth)?
 
-  fun data_receiver_ack_immediately(connection_round: ConnectionRound,
-    boundary_routing_id: RoutingId, auth: AmbientAuth): Array[ByteSeq] val ?
+  fun data_receiver_ack_immediately(ack_id: AckId,
+    connection_round: ConnectionRound, boundary_routing_id: RoutingId,
+    auth: AmbientAuth): Array[ByteSeq] val ?
   =>
-    _encode(DataReceiverAckImmediatelyMsg(connection_round,
+    _encode(DataReceiverAckImmediatelyMsg(ack_id, connection_round,
       boundary_routing_id), auth)?
 
-  fun immediate_ack(auth: AmbientAuth): Array[ByteSeq] val ? =>
-    _encode(ImmediateAckMsg, auth)?
+  fun immediate_ack(ack_id: AckId, auth: AmbientAuth): Array[ByteSeq] val ? =>
+    _encode(ImmediateAckMsg(ack_id), auth)?
 
   fun request_recovery_info(worker_name: WorkerName, auth: AmbientAuth):
     Array[ByteSeq] val ?
@@ -1087,18 +1088,25 @@ class val StartNormalDataSendingMsg is ChannelMsg
     connection_round = connection_round'
 
 class val DataReceiverAckImmediatelyMsg is ChannelMsg
+  let ack_id: AckId
   let connection_round: ConnectionRound
   let boundary_routing_id: RoutingId
 
-  new val create(connection_round': ConnectionRound,
+  new val create(ack_id': AckId, connection_round': ConnectionRound,
     boundary_routing_id': RoutingId)
   =>
+    ack_id = ack_id'
     connection_round = connection_round'
     boundary_routing_id = boundary_routing_id'
 
   fun val string(): String => __loc.type_name()
 
-primitive ImmediateAckMsg is ChannelMsg
+class val ImmediateAckMsg is ChannelMsg
+  let ack_id: AckId
+
+  new val create(ack_id': AckId) =>
+    ack_id = ack_id'
+
   fun val string(): String => __loc.type_name()
 
 class val RequestBoundaryCountMsg is ChannelMsg


### PR DESCRIPTION
We need to make sure that immediate ack requests are acknowledged by
the corresponding DataReceiver. By using a timer, we can retry
until we've succeeded (or until the boundary is disposed).
