### PR TITLE
Allow duplicate deactivate_stream ops for a stream ID in GlobalStreamRegistry

### DIFF
--- a/lib/wallaroo/core/source/connector_source/connector_source.pony
+++ b/lib/wallaroo/core/source/connector_source/connector_source.pony
@@ -469,7 +469,7 @@ actor ConnectorSource[In: Any val] is (Source & TCPActor)
     _prepare_for_rollback()
 
   fun ref _prepare_for_rollback() =>
-    _notify.prepare_for_rollback()
+    _notify.prepare_for_rollback(this)
 
   be rollback(payload: ByteSeq val, event_log: EventLog,
     checkpoint_id: CheckpointId)


### PR DESCRIPTION
It's possible that the GlobalStreamRegistry can get two deactivate_stream ops
for a single stream ID in a short period of time (i.e., without an
activate/use in between):

1. During rollback, the registry's checkpoint payload restores an invalid
   point_of_reference for a stream ID.
2. Also during rollback, a ConnectorSource's checkpoint payload specifies
   the correct point_of_reference for that stream ID.

We need to keep information in the 2nd's deactive_stream.  Prior to this
commit, the 2nd'd deactivate_stream op would be ignored.

There is a larger question which remains open in my mind: how is the
global ordering of #1 and #2 operations preserved so that the registry's
rollback payload is always used first?

<!--
Make sure you've read the [Contributors Guide](https://github.com/WallarooLabs/wallaroo/blob/master/CONTRIBUTING.md). You'll need to sign our CLA before your issue can be accepted.

Fixes #3084 
Fixes #3011 
