### PR TITLE
Add multi-key input and output checking to master-crasher.sh

### DIFF
--- a/testing/correctness/scripts/effectively-once/1-to-1-passthrough-verify.sh
+++ b/testing/correctness/scripts/effectively-once/1-to-1-passthrough-verify.sh
@@ -9,8 +9,14 @@
 #    writes these 1-line messages as-is and then commits via 2PC
 #    groups of 0 or more entire & intact lines.
 #
-# 3. The input file has all lines beginning with the same character,
-#    e.g., ASCII "T".
+# 3. The input file SHOULD have all lines beginning with the same character,
+#    e.g., ASCII "A".  That same character is given to us on the
+#    command line as argument $1.  We use KEY=$1 to filter lines
+#    that begin with that letter because the 1st char in the line is
+#    Wallaroo's routing key, and Wallaroo has limits order guarantees
+#    only on single routing keys.
+#    If the file contains more than one routing key, then this script
+#    should be run multiple times: once for each unique routing key.
 #
 # 5. We follow the TCP port and file input/output naming conventions
 #    of the scripts in this directory.
@@ -28,7 +34,9 @@
 #
 # 9. This script will be for point-in-time verification use.
 
-INPUT=$1
+KEY=$1
+INPUT=$2
+MULTI_KEY_TMP_FILE=$3
 OUTPUT_DIR=/tmp/sink-out
 OUTPUT=$OUTPUT_DIR/output.concatenated
 
@@ -43,8 +51,19 @@ if [ ! -f $INPUT ]; then
     exit 1
 fi
 
-./concat-sink-output.py $OUTPUT_DIR/*.txnlog > $OUTPUT 2> $OUTPUT.mapping
+if [ -z "$MULTI_KEY_TMP_FILE" ]; then
+    (./concat-sink-output.py $OUTPUT_DIR/*.txnlog | \
+        egrep "^$KEY") 1> $OUTPUT 2> $OUTPUT.mapping
+else
+    if [ ! -f $MULTI_KEY_TMP_FILE ]; then
+        ##/bin/echo -n CONCAT > /dev/tty
+        ./concat-sink-output.py $OUTPUT_DIR/*.txnlog \
+            1> $MULTI_KEY_TMP_FILE 2> $MULTI_KEY_TMP_FILE.mapping
+    fi
+    egrep "^$KEY" < $MULTI_KEY_TMP_FILE > $OUTPUT 2> $OUTPUT.mapping
+fi
 output_size=`ls -l $OUTPUT | awk '{print $5}'`
+##/bin/echo -n v$KEY,$output_size, > /dev/tty
 
 cmp -n $output_size $INPUT $OUTPUT
 if [ $? -eq 0 ]; then

--- a/testing/correctness/scripts/effectively-once/create-input-files.sh
+++ b/testing/correctness/scripts/effectively-once/create-input-files.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+for i in $MULTIPLE_KEYS_LIST; do
+	if [ "$WALLAROO_TCP_SOURCE_SINK" = yes ]; then
+		dd if=$WALLAROO_TOP/testing/data/market_spread/nbbo/r3k-symbols_nbbo-fixish.msg bs=1000000 count=1 | od -x | sed s/^/$i/ | sed -n '1,/^.3641060/p' | perl -ne 'print "\0\0\0"; print "1"; print' > /tmp/input-file.$i.txt
+	else
+		dd if=$WALLAROO_TOP/testing/data/market_spread/nbbo/r3k-symbols_nbbo-fixish.msg bs=1000000 count=4 | od -x | sed s/^/$i/ > /tmp/input-file.$i.txt
+	fi
+done

--- a/testing/correctness/scripts/effectively-once/delete-input-files.sh
+++ b/testing/correctness/scripts/effectively-once/delete-input-files.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+rm -f /tmp/input-file.*

--- a/testing/correctness/scripts/effectively-once/master-crasher.sh
+++ b/testing/correctness/scripts/effectively-once/master-crasher.sh
@@ -109,20 +109,27 @@ start_all_workers () {
     poll_ready -a -v -w 5 || exit 1
 }
 
-start_sender () {
-    rm -f $SENDER_OUTFILE
-    while [ 1 ]; do
-        if [ "$WALLAROO_TCP_SOURCE_SINK" = "true" ]; then
-            $WALLAROO_TOP/testing/tools/fixed_length_message_blaster/fixed_length_message_blaster \
-            --host localhost:$WALLAROO_IN_BASE --file /tmp/input-file.txt \
-            --msg-size 53 --batch-size 6 \
-            --msec-interval 5 --report-interval 1000000 --ponythreads=1 \
-            >> $SENDER_OUTFILE 2>&1
-        else
-            env ERROR_9_SHOULD_EXIT=true $WALLAROO_TOP/testing/correctness/scripts/effectively-once/at_least_once_line_file_feed /tmp/input-file.txt 66000 >> $SENDER_OUTFILE 2>&1
-        fi
-        sleep 0.1
+start_senders () {
+    rm -f $SENDER_OUTFILE.*
+    if [ -z "$MULTIPLE_KEYS_LIST" ]; then
+        echo ERROR: The variable \$MULTIPLE_KEYS_LIST is empty, exiting!
+        exit 1
+    fi
+    for i in $MULTIPLE_KEYS_LIST; do
+        while [ 1 ]; do
+            if [ "$WALLAROO_TCP_SOURCE_SINK" = "true" ]; then
+                $WALLAROO_TOP/testing/tools/fixed_length_message_blaster/fixed_length_message_blaster \
+                --host localhost:$WALLAROO_IN_BASE --file /tmp/input-file.$i.txt \
+                --msg-size 53 --batch-size 6 \
+                --msec-interval 5 --report-interval 1000000 --ponythreads=1 \
+                >> $SENDER_OUTFILE.$i 2>&1
+            else
+                env ERROR_9_SHOULD_EXIT=true $WALLAROO_TOP/testing/correctness/scripts/effectively-once/at_least_once_line_file_feed /tmp/input-file.$i.txt 66000 >> $SENDER_OUTFILE.$i 2>&1
+            fi
+            sleep 0.1
+        done &
     done
+    wait
 }
 
 stop_sender () {
@@ -187,20 +194,35 @@ run_crash_sink_loop () {
 
 run_crash_worker_loop () {
     worker="$1"
+    suffix="$2"
+
     if [ -z "$worker" ]; then
         echo ERROR: $0: worker number not given
         print_duration
         exit 1
     fi
     sleep 2 # Don't start crashing until checkpoint #1 is complete.
+    counter=0
     while [ 1 ]; do
+        counter=`expr $counter + 1`
         if [ -f $STATUS_CRASH_WORKER ]; then
-            sleep `random_float 4.5 0`
+            case "$suffix" in
+                *slow*)
+                    ## Space apart the crashes very roughly 120+fudge seconds apart
+                    if [ $counter -lt 120 ]; then
+                        sleep 1
+                        sleep `random_float 0.2`
+                        continue
+                    fi
+                    counter=0
+                ;;
+            esac
+            sleep `random_float 4.5`
             /bin/echo -n "c$worker"
             crash_out=`crash_worker $worker`
             mv /tmp/wallaroo.$worker /tmp/wallaroo.$worker.`date +%s` && gzip /tmp/wallaroo.$worker.`date +%s` > /dev/null 2>&1 &
             if [ -z "$crash_out" ]; then
-                sleep `random_float 2.5 0`
+                sleep `random_float 2.5`
                 if [ $worker -eq 0 ]; then
                     start_initializer
                 else
@@ -254,16 +276,34 @@ run_sanity_loop () {
             echo SANITY
             break
         fi
-        ./1-to-1-passthrough-verify.sh /tmp/input-file.txt > $outfile 2>&1
-        if [ $? -ne 0 ]; then
-            head $outfile
+        multi_key_tmp_file=/tmp/concat-multikey-tmp-file
+        rm -f $multi_key_tmp_file
+        errors=0
+        for i in $MULTIPLE_KEYS_LIST; do
+            ./1-to-1-passthrough-verify.sh $i /tmp/input-file.$i.txt $multi_key_tmp_file > $outfile 2>&1
+            if [ $? -ne 0 ]; then
+                echo ""
+                head $outfile
+                rm $outfile
+                echo SANITY2
+                errors=1
+            fi
             rm $outfile
-            echo BREAK2
-            break
+        done
+        if [ $errors -ne 0 ]; then
+            print_duration
+            pause_the_world
         fi
-        rm $outfile
-        res=`logtail $SENDER_OUTFILE | egrep 'MultiSourceConnector closed Stream.*, point_of_ref=12368928, is_open=False'`
-        if [ ! -z "$res" ]; then
+        total=0
+        found=0
+        for i in $MULTIPLE_KEYS_LIST; do
+            total=`expr $total + 1`
+            res=`logtail $SENDER_OUTFILE.$i | egrep 'MultiSourceConnector closed Stream.*, point_of_ref=12368928, is_open=False'`
+            if [ ! -z "$res" ]; then
+                found=`expr $found + 1`
+            fi
+        done
+        if [ $found -eq $total ]; then
             echo "SANITY LOOP SUCCESS: EOF found!"
             echo "SANITY LOOP SUCCESS: EOF found!" >> /tmp/res
             print_duration
@@ -567,12 +607,49 @@ run_custom_crashsink_crash0_overlap () {
     fi
 }
 
+run_custom_20191210a () {
+    ## Assume that we are run with `./master-crasher.sh 2 run_custom_20191210a`
+
+    while [ 1 ]; do
+        (
+            sleep 4.9
+            /bin/echo -n c0
+            crash_worker 0
+            mv /tmp/wallaroo.0 /tmp/wallaroo.0.`date +%s` && gzip /tmp/wallaroo.0.`date +%s` > /dev/null 2>&1 &
+            sleep 0.9
+            /bin/echo -n r0
+            start_initializer
+        ) &
+        (
+            sleep 3.7
+            /bin/echo -n cS
+            crash_sink
+            sleep 1.0
+            /bin/echo -n rS
+            start_sink
+        ) &
+        wait
+        /bin/echo -n echo both-done.
+        poll_out=`poll_ready -w 4 2>&1`
+        if [ $? -ne 0 -o ! -z "$poll_out" ]; then
+            echo "BUMMER A: pause the world: $poll_out"
+            poll_out=`poll_ready -w 4 2>&1`
+            if [ $? -ne 0 -o ! -z "$poll_out" ]; then
+                echo "BUMMER B: pause the world: $poll_out"
+                pause_the_world
+                break
+            fi
+        fi
+        sleep 10
+    done
+}
+
 touch $STATUS_CRASH_WORKER
 touch $STATUS_CRASH_SINK
 reset
 start_sink ; sleep 1
 start_all_workers
-start_sender &
+start_senders &
 
 run_sanity=true
 for arg in $*; do
@@ -586,8 +663,14 @@ for arg in $*; do
             run_sanity=false
             ;;
         crash[0-9]*)
-            worker=`echo $arg | sed 's/crash//'`
-            cmd="run_crash_worker_loop $worker"
+            worker=`echo $arg | sed -e 's/crash//' -e 's/\..*//'`
+            suffix=""
+            case $arg in
+                *.*)
+                    suffix=`echo $arg | sed 's/crash[0-9]*\.//'`
+                ;;
+            esac
+            cmd="run_crash_worker_loop $worker $suffix"
             echo RUN: $cmd
             $cmd &
             ;;

--- a/testing/correctness/scripts/effectively-once/sample-env-vars.sh
+++ b/testing/correctness/scripts/effectively-once/sample-env-vars.sh
@@ -33,7 +33,10 @@ export WALLAROO_ARG_DATA="${WALLAROO_INIT_HOST}:${WALLAROO_DATA_BASE}"
 export WALLAROO_ARG_RESILIENCE="--run-with-resilience"
 export WALLAROO_ARG_PONY="--ponynoblock --ponythreads=1 --ponyminthreads=9999"
 
-export WALLAROO_ARG_PT="--verbose --parallelism 2 --source connector --step asis-state --sink connector"
+export WALLAROO_ARG_PT="--verbose --parallelism 20 --source connector --parallelism 10 --key-by first-byte --step asis-state --sink connector"
 
 export WALLAROO_BASE_ARGS="$WALLAROO_ARG_PT --out $WALLAROO_ARG_OUT --metrics $WALLAROO_ARG_METRICS --control $WALLAROO_ARG_CONTROL $WALLAROO_ARG_RESILIENCE"
 
+if [ -z "$MULTIPLE_KEYS_LIST" ]; then
+	export MULTIPLE_KEYS_LIST="A B C D E F G H I J"
+fi

--- a/testing/correctness/scripts/effectively-once/sample-env-vars.sh.tcp-source+sink
+++ b/testing/correctness/scripts/effectively-once/sample-env-vars.sh.tcp-source+sink
@@ -33,7 +33,10 @@ export WALLAROO_ARG_DATA="${WALLAROO_INIT_HOST}:${WALLAROO_DATA_BASE}"
 export WALLAROO_ARG_RESILIENCE="--run-with-resilience"
 export WALLAROO_ARG_PONY="--ponynoblock --ponythreads=1 --ponyminthreads=9999"
 
-export WALLAROO_ARG_PT="--verbose --parallelism 2 --source tcp --step asis-state --sink tcp"
+export WALLAROO_ARG_PT="--verbose --parallelism 20 --source tcp --parallelism 10 --key-by first-byte --step asis-state --sink tcp"
 
 export WALLAROO_BASE_ARGS="$WALLAROO_ARG_PT --out $WALLAROO_ARG_OUT --metrics $WALLAROO_ARG_METRICS --control $WALLAROO_ARG_CONTROL $WALLAROO_ARG_RESILIENCE"
 
+if [ -z "$MULTIPLE_KEYS_LIST" ]; then
+	export MULTIPLE_KEYS_LIST="A B C D E F G H I J"
+fi

--- a/testing/correctness/tests/aloc_sink/Makefile
+++ b/testing/correctness/tests/aloc_sink/Makefile
@@ -49,7 +49,7 @@ aloc_sink_tests:
 	-rm -fv /tmp/Celsius* /tmp/aloc*
 	#### -cd $(HOME)/s/src/other-repo && make start-s3-container
 	-cd $(ALOC_SINK_PATH) && ./run_aloc_sink_test > /tmp/run_aloc_sink_test.out 2>&1
-	cd $(ALOC_SINK_PATH) && ./run_aloc_sink_test.validate.sh || cat /tmp/run_aloc_sink_test.out
+	cd $(ALOC_SINK_PATH) && ./run_aloc_sink_test.validate.sh || sh -c 'echo FAILED ; cat /tmp/run_aloc_sink_test.out; exit 1'
 else
 aloc_sink_tests:
 	$(QUIET)printf "aloc_sink tests not run.\nRun make with 'resilience=on' to run this test.\n"

--- a/testing/correctness/tests/aloc_sink/run_aloc_sink_test.validate.sh
+++ b/testing/correctness/tests/aloc_sink/run_aloc_sink_test.validate.sh
@@ -13,13 +13,13 @@ cat $IN1 | sed 's/worker-initializer-id-[0-9]*://' > $IN
 
 # We expect rollbacks to happen for these checkpoint_ids
 for c in 3 6 9 15; do
-	pat="c_id=$c.,"
-	egrep $pat $IN | grep '2-ok' > /dev/null 2>&1
+	pat="'Celsius[^']*c_id=$c.,"
+	egrep "$pat" $IN | grep '2-ok' > /dev/null 2>&1
 	if [ $? -eq 0 ]; then
 		echo Error: unexpected phase 2-ok for checkpoint $c
 		cat $IN; exit 1
 	fi
-	egrep $pat $IN | grep '2-rollback' > /dev/null 2>&1
+	egrep "$pat" $IN | grep '2-rollback' > /dev/null 2>&1
 	if [ $? -ne 0 ]; then
 		echo Error: phase 2-rollback not found for checkpoint $c
 		cat $IN; exit 1
@@ -31,14 +31,20 @@ done
 # because test timing can affect how many checkpoints may follow.
 # Also, 18 is the last checkpoint that aloc_sink.abort-rules
 # will affect.
-for c in 1 2 4 5 7 8 11 12 13 14 16 17 18; do
-	pat="c_id=$c.,"
-	egrep $pat $IN | grep '2-rollback' > /dev/null 2>&1
+# We skip 19 because a race condition that we can't control
+# may/may not cause a gap in Wallaroo's output and thus a
+# Phase 1 abort vote by the sink.
+# We check 20 because checkpointing should continue
+# after 18 (some bugs related to 18's scenario can prevent
+# future checkpoints).
+for c in 1 2 4 5 7 8 11 12 13 14 16 17 18 20; do
+	pat="'Celsius[^']*c_id=$c.,"
+	egrep "$pat" $IN | grep '2-rollback' > /dev/null 2>&1
 	if [ $? -eq 0 ]; then
 		echo Error: unexpected phase 2-rollback for checkpoint $c
 		cat $IN; exit 1
 	fi
-	egrep $pat $IN | grep '2-ok' > /dev/null 2>&1
+	egrep "$pat" $IN | grep '2-ok' > /dev/null 2>&1
 	if [ $? -ne 0 ]; then
 		echo Error: phase 2-ok not found for checkpoint $c
 		cat $IN; exit 1


### PR DESCRIPTION
See the sample-env-vars.sh* files for suggested default values:
10 independent keys, A-J, enumerated by the MULTIPLE_KEYS_LIST
environment variable.  The sanity loop of master-crasher.sh will
concatenate all sink outputs into a single ordered file, then
extract only a single key, then verify that the output order for
that key is exactly equal to a strict prefix of the input file.

Also:

* Add '.slow' suffix option for 'crashN' arguments, which will crash
  the Nth worker only every 2 minutes (approximately).  This is useful
  if an external script/proc is attempting to manage disk space by
  rotating out old log data.

* Add run_custom_20191210a arg for convenience in testing the
  scenario 'crash0 crash-sink' in a more repeatable way.

* Various bug & typo fixes

* Fix error handling bug in .../aloc_sink/Makefile
