### PR TITLE
ConnectorSink 2PC overhaul

### DIFF
--- a/lib/wallaroo/core/sink/sink.pony
+++ b/lib/wallaroo/core/sink/sink.pony
@@ -39,7 +39,7 @@ trait tag Sink is (Consumer & DisposableActor & BarrierProcessor)
     None
   fun ref use_normal_processor() =>
     None
-  fun ref resume_processing_messages_queued() =>
+  fun ref resume_processing_messages_queued(discard_message_type: Bool) =>
     None
 
 interface val SinkConfig[Out: Any val]

--- a/lib/wallaroo/core/sink/sink_phase.pony
+++ b/lib/wallaroo/core/sink/sink_phase.pony
@@ -57,7 +57,7 @@ trait SinkPhase
   fun ref maybe_use_normal_processor() =>
     None
 
-  fun ref resume_processing_messages() =>
+  fun ref resume_processing_messages(discard_message_type: Bool) =>
     _invalid_call(__loc.method_name()); Fail()
 
   fun _invalid_call(method_name: String) =>
@@ -81,7 +81,7 @@ class EarlySinkPhase is SinkPhase
     // But we need the normal processor phase *now*.
     _sink.use_normal_processor()
 
-  fun ref resume_processing_messages() =>
+  fun ref resume_processing_messages(discard_message_type: Bool) =>
     // If we're @ InitialSinkPhase, and we've restarted after a crash,
     // it's possible to hit checkpoint_complete() extremely early in
     // our restart process.  There's nothing to do here.
@@ -119,8 +119,8 @@ class NormalSinkPhase is SinkPhase
   fun ref queued(): Array[SinkPhaseQueued] =>
     Array[SinkPhaseQueued]
 
-  fun ref resume_processing_messages() =>
-    _sink.resume_processing_messages_queued()
+  fun ref resume_processing_messages(discard_message_type: Bool) =>
+    _sink.resume_processing_messages_queued(discard_message_type)
 
 type SinkPhaseQueued is (QueuedMessage | QueuedBarrier)
 
@@ -224,8 +224,8 @@ class BarrierSinkPhase is SinkPhase
   fun ref swap_barrier_to_queued(sink: ConnectorSink ref) =>
     sink.swap_barrier_to_queued(_queued)
 
-  fun ref resume_processing_messages() =>
-    _sink.resume_processing_messages_queued()
+  fun ref resume_processing_messages(discard_message_type: Bool) =>
+    _sink.resume_processing_messages_queued(discard_message_type)
 
 class QueuingSinkPhase is SinkPhase
   let _sink_id: RoutingId
@@ -270,5 +270,5 @@ class QueuingSinkPhase is SinkPhase
     end
     qd
 
-  fun ref resume_processing_messages() =>
-    _sink.resume_processing_messages_queued()
+  fun ref resume_processing_messages(discard_message_type: Bool) =>
+    _sink.resume_processing_messages_queued(discard_message_type)


### PR DESCRIPTION
Based on work from the `master-crasher-multi-key2` working branch.
A fix for bug #3086 by itself wasn't bad, but it then exposed
numerous problems elsewhere in ConnectorSink state management.

* Adjust rollback logic when rollback isn't related to a local sink's failure.

* Clear phase1 token only if phase1 reply is not stale

* Fix errors in sink state management on checkpoint_complete and rollback

* Re-send Phase2 commit just in case, change processing order for rollback

* Re-order when process_uncommitted_list is called

* Add rollback ID to process_uncommitted_list's consideration

* checkpoint_complete: only send phase2 + resume processing if connected

Fixes #3086
