### PR TITLE
Change some messaging in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center"><a href="https://www.wallaroolabs.com/"><img src="wallaroo-logo.png" alt="WallarooLabs logo" width="400"/></a></p>
-<h2 align="center">Build and scale real-time applications as easily as writing a script</h2>
+<h2 align="center">Build and scale real-time applications</h2>
 
 ---
 [![CircleCI](https://circleci.com/gh/WallarooLabs/wallaroo.svg?style=shield)](https://circleci.com/gh/WallarooLabs/wallaroo)
@@ -22,22 +22,6 @@ When we set out to build Wallaroo, we had several high-level goals in mind:
 - Allow applications to scale as needed, even when they are live and up-and-running
 
 You can learn more about [Wallaroo][home-page] from our ["Hello Wallaroo!" blog post][hello-wallaroo-post] and the [Wallaroo overview video][overview-video].
-
-### What makes Wallaroo unique
-
-Wallaroo is a little different than most stream processing tools. While most require the JVM, Wallaroo can be deployed as a separate binary. This means no more jar files. Wallaroo also isn't locked to just using [Kafka](kafka-link) as a source, use any source you like. Application logic can be written in Python 2, Python 3, or Pony.
-
-## Getting Started
-
-Wallaroo can either be installed via [Docker, Vagrant][docker-link] or (on Linux) via our handy [Wallaroo Up command][wally-up].
-
-As easy as:
-
-```sh
-docker pull wallaroo-labs-docker-wallaroolabs.bintray.io/release/wallaroo:latest
-```
-
-Check out our [installation options][installation-options] page to learn more.
 
 ## Usage
 
@@ -62,7 +46,7 @@ def application_setup(args):
         .to(split)
         .key_by(extract_word)
         .to(count_word)
-        .to_sink(wallaroo.TCPSinkConfig(out_host, out_port, 
+        .to_sink(wallaroo.TCPSinkConfig(out_host, out_port,
             encode_word_count)))
 
     return wallaroo.build_application("Word Count Application", pipeline)
@@ -118,14 +102,10 @@ More information is also on our [blog][blog-link]. There you can find more insig
 
 ## Need Help?
 
-Trying to figure out how to get started?
+Trying to figure out how to get started? Drop us a line:
 
- - Check out the [FAQ][faq]
-
- - Drop us a line:
-    - [IRC][irc-link]
-    - [Mailing List][group-link]
-    - [Commercial Support][commercial-support-email]
+- [Mailing List][group-link]
+- [Commercial Support][commercial-support-email]
 
 ## Contributing
 
@@ -143,22 +123,14 @@ Wallaroo is licensed under the [Apache version 2][apache-2-license] license.
 [cla]: https://gist.github.com/WallarooLabsTeam/e06d4fed709e0e7035fdaa7249bf88fb
 [commercial-support-email]: mailto:sales@wallaroolabs.com
 [contribution-guide]: CONTRIBUTING.md
-[docker-link]: https://docs.wallaroolabs.com/python-installation/
 [documentation]: https://docs.wallaroolabs.com/
 [group-badge]: https://img.shields.io/badge/mailing%20list-join%20%E2%86%92-%23551A8B.svg
 [group-link]: https://groups.io/g/wallaroo
 [hello-wallaroo-post]: https://blog.wallaroolabs.com/2017/03/hello-wallaroo/
 [home-page]: https://www.wallaroolabs.com/
-[installation-options]: https://docs.wallaroolabs.com/python-installation/
-[irc-badge]: https://img.shields.io/badge/IRC-join%20chat%20%E2%86%92-blue.svg
-[irc-link]: https://webchat.freenode.net/?channels=#wallaroo
-[kafka-link]: https://kafka.apache.org/
 [word_count]: examples/python/word_count/
 [market-spread]: examples/python/market_spread/
 [overview-video]: https://vimeo.com/234753585
 [python-examples]: examples/python/
 [reverse]: examples/python/reverse/
-[survey-link]: https://wallaroolabs.typeform.com/to/HS6azY?source=wallaroo_readme
 [wallaroo-license-readme]: #license
-[wally-up]: https://docs.wallaroolabs.com/python-installation/python-wallaroo-up-installation-guide/
-[faq]: https://www.wallaroolabs.com/faq


### PR DESCRIPTION
Moving away from python in messaging and towards high-performance.
This commit is a few non-controversial ones that John and I came up with.

Includes:

GH:  remove overview video link
GH: remove what makes wallaroo unique
GH: temporarily remove getting started from GH readme
GH: remove IRC from support options
GH: temporarily remove FAQ link

<!--
Make sure you've read the [Contributors Guide](https://github.com/WallarooLabs/wallaroo/blob/master/CONTRIBUTING.md). You'll need to sign our CLA before your issue can be accepted.

Reference the issue your code change relates to if possible
-->
ref #

<!--
Include any other necessary information below. If you have any questions don't hesitate to reach out on the mailing list or on IRC.
-->
