### PR TITLE
Handle rollbackresume_barrier_complete event in AbortCheckpoint state

### DIFF
--- a/lib/wallaroo/core/sink/connector_sink/connector-sink-2pc-management.dot
+++ b/lib/wallaroo/core/sink/connector_sink/connector-sink-2pc-management.dot
@@ -44,6 +44,7 @@ digraph mashup {
 	WaitingForCheckpoint -> CPStarts [label="cp_barrier_complete"];
 	AbortCheckpoint -> AbortCheckpoint [label="cp_barrier_complete"];
 	AbortCheckpoint -> AbortCheckpoint [label="phase1_abort"];
+	AbortCheckpoint -> AbortCheckpoint [label="rollbackresume_barrier_complete"];
 	AbortCheckpoint -> RollingBack [label="rollback_barrier_complete",fontcolor=red,color=red];
 
 	WaitingForCheckpoint -> PreparedForRollback [label="prepare_for_rollback",fontcolor=red,color=red];


### PR DESCRIPTION
In rare cases, Wallaroo can generate a `rollbackresume_barrier_complete` event when `ConnectorSink` is in the `AbortCheckpoint state`.  Let's handle this event rather than crash.  Also, add more info to an existing debug log statement.