### PR TITLE
ALO Python client: Reset self._conn = None on socket connect/write errors

### DIFF
--- a/machida/lib/wallaroo/experimental/__init__.py
+++ b/machida/lib/wallaroo/experimental/__init__.py
@@ -734,6 +734,7 @@ class AtLeastOnceSourceConnector(asynchat.async_chat, BaseConnector, BaseMeta):
                 self.handle_restarted(self._streams)
                 break
             except socket.error as err:
+                self._conn = None
                 if err.errno in retry_errno:
                     logging.debug("_reconnect_common: {}".format(err))
                     time.sleep(1.0)


### PR DESCRIPTION
Fixes intermittent conformance test failures such as https://circleci.com/gh/WallarooLabs/wallaroo/28929 and https://circleci.com/gh/WallarooLabs/wallaroo/28941 by allowing retry loop to actually retry connecting the socket.