### PR TITLE
Docs: connector cleanups

### DIFF
--- a/testing/correctness/scripts/effectively-once/README.md
+++ b/testing/correctness/scripts/effectively-once/README.md
@@ -239,7 +239,16 @@ sleep 1
 
 ## `master-crasher.sh`
 
-TODO
+The environment variables found in the [sample-env-vars.sh](sample-env-vars.sh) control many aspects of the total system under test.  This section will mention a few useful variables to experiment with.
+
+The `master-crasher.sh` script is a one-size-fits-many orchestration script that takes care of the following general steps on a single machine.  No special container orchestration or OS features are required.  All processes are assigned non-conflicting TCP ports for use on a single host/virtual machine.
+
+1. Kill all Python processes related to sources & sinks, Wallaroo processes, etc. and delete their related files in `/tmp`.
+
+2. Start the sink, Wallaroo, and source/sender processes to create a Wallaroo cluster of a desired size.
+    * TODO SLF LEFT OFF HERE
+
+TODO write up bug where source isn't started @ first step -> Wallaroo Fail().
 
 
 ## Testing Recipes

--- a/testing/correctness/scripts/effectively-once/README.md
+++ b/testing/correctness/scripts/effectively-once/README.md
@@ -376,17 +376,22 @@ Duration: 373000
 $ 
 ```
 
-### TODO debugging tips
+### Debugging tips
 
-TODO # of routing keys/env var
-TODO compiling with debug
-TODO compiling with debug + lots of other verbose spam
+1. NOTE: The `master-crasher.sh` script always starts processes in a specific (and almost always deterministic) manner.  As a result, it cannot hit bugs such as [Bug 3123](https://github.com/WallarooLabs/wallaroo/issues/3123), which only happens when Wallaroo is started before the connector sink is ready to accept TCP connections.
 
+1. To reduce workload, or to reduce the number of routing keys in the system by reducing the number of `at_least_once_line_file_feed` sender processes, change the value of the `MULTIPLE_KEYS_LIST` environment variable.
+    * For example, `MULTIPLE_KEYS_LIST='A B C D'` or `MULTIPLE_KEYS_LIST='A'`
 
-###### TODO write up bug where source isn't started @ first step -> Wallaroo Fail().
+2. Compile with `debug=true`.
+
+3. Compile with `PONYCFLAGS="--debug -Dcheckpoint_trace -Didentify_routing_ids"`
+    * Also add `-Dverbose_debug` for additional verbose printing of connector source & sink payloads.
 
 
 ## Testing Recipes
+
+If you cannot use `master-crasher.sh` for a particular task, or if you wish to explore using some of the utility scripts that `master-crasher.sh` uses, then read on!
 
 ### Prerequisites
 

--- a/testing/correctness/scripts/effectively-once/README.md
+++ b/testing/correctness/scripts/effectively-once/README.md
@@ -287,7 +287,7 @@ Optional arguments:
 * `no-sanity` : Do not run the `run_sanity_loop` subprocess.
 * `no-clean-old-gzip-files` : Do not run the `run_clean_old_gzip_files` subprocess.
 * `crashN` where N=integer : Run a `run_crash_worker_loop` subprocess, which periodically crashes & restarts a worker process.
-    * `0` = the `initialier` worker, `1` or larger is the `workerN` worker, e.g., `worker3`.
+    * `0` = the `initializer` worker, `1` or larger is the `workerN` worker, e.g., `worker3`.
 * `grow` : Run the `run_grow_shrink_loop` subprocess with the argument `grow`
 * `shrink` : Run the `run_grow_shrink_loop` subprocess with the argument `shrink`
     * An argument like `grow-and-shrink` can be used to run a single `run_grow_shrink_loop` subprocess that will randomly choose to either grow or shrink the cluster.
@@ -300,7 +300,7 @@ Optional arguments:
 * `:s` : Skip an iteration of crashing/restarting the sink.
     * This action is taken only when Wallaroo's `poll_ready` status is false for long periods of time.
 * `cN` and `rN` where N=integer : Crash/restart worker N.
-    * `0` = the `initialier` worker, `1` or larger is the `workerN` worker, e.g., `worker3`.
+    * `0` = the `initializer` worker, `1` or larger is the `workerN` worker, e.g., `worker3`.
 * `:cN` : Skip an iteration of crashing/restarting worker N
     * This action is taken only when Wallaroo's `poll_ready` status is false for long periods of time.
 * `{AP}` : An iteration of the `run_ack_progress_loop` is running.  This loop checks for at least one successful ack, as reported by the `at_least_once_line_file_feed` sender processes.  If a checkpoint has not happened within 5 minutes, then `pause_the_world` is run: we assume that Wallaroo has deadlocked or livelocked.
@@ -316,7 +316,7 @@ Optional arguments:
 
 Output paths for files created by various parts of the system are:
 * `/tmp/wallaroo.N` : output by Wallaroo worker process N.
-    * `0` = the `initialier` worker, `1` or larger is the `workerN` worker, e.g., `worker3`.
+    * `0` = the `initializer` worker, `1` or larger is the `workerN` worker, e.g., `worker3`.
 * `/tmp/wallaroo.N.T` : output by Wallaroo worker process N that was crashed at UNIX epoch time T.  These files are very useful for certain debugging tasks.  For example, sometimes you need to know what happened while a now-dead Wallaroo worker was doing 40 seconds before a problem was detected now.
 * `/tmp/sender.out.X` : Output from the `at_least_once_line_file_feed` process for routing key X.
 * `/tmp/input-file.X.txt` : Input for `at_least_once_line_file_feed` for routing key X
@@ -380,12 +380,12 @@ $
 
 1. NOTE: The `master-crasher.sh` script always starts processes in a specific (and almost always deterministic) manner.  As a result, it cannot hit bugs such as [Bug 3123](https://github.com/WallarooLabs/wallaroo/issues/3123), which only happens when Wallaroo is started before the connector sink is ready to accept TCP connections.
 
-1. To reduce workload, or to reduce the number of routing keys in the system by reducing the number of `at_least_once_line_file_feed` sender processes, change the value of the `MULTIPLE_KEYS_LIST` environment variable.
+2. To reduce workload, or to reduce the number of routing keys in the system by reducing the number of `at_least_once_line_file_feed` sender processes, change the value of the `MULTIPLE_KEYS_LIST` environment variable.
     * For example, `MULTIPLE_KEYS_LIST='A B C D'` or `MULTIPLE_KEYS_LIST='A'`
 
-2. Compile with `debug=true`.
+3. Compile with `debug=true`.
 
-3. Compile with `PONYCFLAGS="--debug -Dcheckpoint_trace -Didentify_routing_ids"`
+4. Compile with `PONYCFLAGS="--debug -Dcheckpoint_trace -Didentify_routing_ids"`
     * Also add `-Dverbose_debug` for additional verbose printing of connector source & sink payloads.
 
 

--- a/testing/correctness/scripts/effectively-once/master-crasher.sh
+++ b/testing/correctness/scripts/effectively-once/master-crasher.sh
@@ -1,5 +1,18 @@
 #!/bin/sh
 
+reset () {
+    reset.sh
+    ps axww | grep master-crasher.sh | grep -v $$ | awk '{print $1}' | xargs kill -9 > /dev/null 2>&1
+    stop_sink > /dev/null 2>&1
+    stop_sender > /dev/null 2>&1
+}
+
+if [ "$1" = "reset-only" ]; then
+    reset
+    echo "Halting after reset"
+    exit 0
+fi
+
 DESIRED=$1
 if [ -z "$DESIRED" ]; then
     usage=yes
@@ -29,13 +42,6 @@ export WALLAROO_THRESHOLDS='*.8'
 
 export SENDER_OUTFILE=/tmp/sender.out
 export STABILIZE_PREFIX=/tmp/stabilize.doit
-
-reset () {
-    reset.sh
-    ps axww | grep master-crasher.sh | grep -v $$ | awk '{print $1}' | xargs kill -9 > /dev/null 2>&1
-    stop_sink > /dev/null 2>&1
-    stop_sender > /dev/null 2>&1
-}
 
 start_sink () {
     if [ "$WALLAROO_TCP_SOURCE_SINK" = "true" ]; then
@@ -378,6 +384,16 @@ run_sanity_loop () {
     echo "SANITY LOOP FAILURE: pause the world"
     print_duration
     pause_the_world
+}
+
+run_clean_old_gzip_files () {
+    while [ 1 ]; do
+        workers=`ls /tmp/wallaroo.*.*gz 2>&1 | grep -v 'cannot access' | sed -e 's/[^.]*\.//' -e 's/\..*//' | uniq`
+        for w in $workers "dummy-no-such-worker"; do
+            ls -t /tmp/wallaroo.$w.*gz 2>&1 | sed '1,5d' | xargs rm -f
+        done
+        sleep 10
+    done &
 }
 
 get_worker_names () {
@@ -771,6 +787,7 @@ start_senders &
 run_ack_progress_loop=true
 run_registry_progress_loop=true
 run_sanity=true
+run_clean_old_gzip_files=true
 for arg in $*; do
     case $arg in
         crash-sink)
@@ -788,6 +805,10 @@ for arg in $*; do
         no-sanity)
             echo NO RUN: run_sanity_loop
             run_sanity=false
+            ;;
+        no-clean-old-gzip-files)
+            echo NO RUN: run_clean_old_gzip_files
+            run_clean_old_gzip_files=false
             ;;
         crash[0-9]*)
             worker=`echo $arg | sed -e 's/crash//' -e 's/\..*//'`
@@ -827,6 +848,9 @@ if [ $run_registry_progress_loop = true ]; then
 fi
 if [ $run_sanity = true ]; then
     run_sanity_loop &
+fi
+if [ $run_clean_old_gzip_files = true ]; then
+    run_clean_old_gzip_files &
 fi
 
 echo Start time: $START_TIME

--- a/testing/correctness/scripts/effectively-once/master-crasher.sh
+++ b/testing/correctness/scripts/effectively-once/master-crasher.sh
@@ -87,6 +87,7 @@ print_duration () {
 }
 
 pause_the_world () {
+    echo 'Pause the world!'
     killall -STOP passthrough
     if [ `uname -s` = Linux ]; then
         print_duration

--- a/testing/correctness/tests/aloc_sink/README.md
+++ b/testing/correctness/tests/aloc_sink/README.md
@@ -1,0 +1,23 @@
+
+# CircleCI testing for aloc_sink and Wallaroo sink 2PC protocol
+
+The aloc_sink tests in this directory test both `aloc_sink`'s and Wallaroo's reactions to 2PC protocol failures and also TCP connection failures that are injected artificially during test runs.
+
+See the file [README.abort-rules.md](README.abort-rules.md) for details on how `aloc_sink` can be configured for fault injection.
+
+## Separate tests vs. a single test with multiple components
+
+The 2PC round number is embedded in the 2PC transaction ID string.  `aloc_sink` knows about the string's formatting convention and can extract the 2PC round number out of the txn ID string.
+
+Early aloc_sink tests would use a single test to detect problems with multiple 2PC failures (via fault injection by `aloc_sink`).  As the 2PC implementation of Wallaroo had evolved in late 2019-early 2020, it became impossible for the test to determine exactly which 2PC round numbers would be issued by Wallaroo.
+
+The single large test was split into several smaller tests that are run serially by the `Makefile`.  Currently, it is 6 tests.  Each test uses a different abort rule config file (see [README.abort-rules.md](README.abort-rules.md) for more detail), and each test invocation expects either a 2PC COMMIT or ABORT in response to a specific fault.  Each test has only a single fault injected.
+
+# Manual testing for aloc_sink and overall end-to-end 2PC correctness
+
+End-to-end testing means:
+
+    connector source process -> Wallaroo -> `aloc_sink` connector sink process
+
+This test is not yet automated.  See the [testing/correctness/scripts/effectively-once](../../scripts/effectively-once) directory for details on manual testing of end-to-end 2PC correctness.
+

--- a/testing/correctness/tests/aloc_sink/aloc_sink_impl.py
+++ b/testing/correctness/tests/aloc_sink/aloc_sink_impl.py
@@ -704,7 +704,7 @@ class AsyncServer(asynchat.async_chat, object):
 
     def close(self, delete_from_active_workers = True):
         logging.info("Closing the connection for {}, delete_from_active_workers = {}".format(self._worker_name, delete_from_active_workers))
-        logging.info("last received id by stream for {}:\n\t{}".format(
+        logging.info("last received id by stream for {}:  {}".format(
             self._worker_name, self._streams))
         super(AsyncServer, self).close()
         try:

--- a/testing/correctness/tests/aloc_sink/run_aloc_sink_test
+++ b/testing/correctness/tests/aloc_sink/run_aloc_sink_test
@@ -44,10 +44,9 @@ def send_feed():
     while value < 7500:
         packet = struct.pack(">f", value)
         sock.sendto(packet, ('127.0.0.1', 8801))
-        if value == 11:
-            time.sleep(2.2)
         value += 1
-        time.sleep(0.001)
+        # Send a stream of packets at a slow-but-measured rate
+        time.sleep(0.125)
 
 
 def recv_conv():


### PR DESCRIPTION
Fix up various docs related to connector sources & sinks.

* connector-protocol-v3.md: fix misc errors and typos, clarify how a connector sink must respond to 2PC operations
* effectively-once/README.md: fix bitrot in use examples, add major section on `master-crasher.sh` script use, 
* master-crasher.sh: small changes to adapt to new docs
* aloc_sink/README.md: new file
* aloc_sink scripts: minor changes
