### PR TITLE
Add external Pony Connector sink

### DIFF
--- a/connectors/pony_connector_sink/.gitignore
+++ b/connectors/pony_connector_sink/.gitignore
@@ -1,0 +1,1 @@
+pony_connector_sink

--- a/connectors/pony_connector_sink/Makefile
+++ b/connectors/pony_connector_sink/Makefile
@@ -1,0 +1,2 @@
+sink: sink.pony
+	ponyc --debug --path '../../lib'

--- a/connectors/pony_connector_sink/README.md
+++ b/connectors/pony_connector_sink/README.md
@@ -1,0 +1,85 @@
+# Pony Connector Sink
+
+This is a Pony implementation of a sink that uses the Wallaroo Connector Protocol. It is based on the [Python At Least Once Sink](https://github.com/WallarooLabs/wallaroo/blob/master/testing/correctness/tests/aloc_sink).
+
+## Current Limitations
+
+This implementation is incomplete.
+
+* Testing has been limited, there may be errors.
+* Error handling is very limited. There are places where it should probably exit.
+* Reporting is done through the `Debug` package.
+* It does not implement persistence, so it cannot be restarted.
+
+## Overall Design
+
+The sink listens for HTTP connections from Wallaroo workers and communciates with them using the Connector protocol. Each connection maintains a state machine that ensures proper Connector message handling and provides a mechanism for sharing information with other actors.
+
+The Connector protocol is based on a two-phase commit protocol.
+
+* There is an initial handshake where a connecting Wallaroo worker sends information about itself to the sink. If the sink is not currently processing information from another worker with the same name then it can begin accepting application messages.
+* The sink receives application messages and processes them.
+* The worker can send a phase 1 message indicating that it is ready to start the two-phase commit. If the information that the worker sends matches the information that the sink sees, then the sink will reply with a "success" message, otherwise it will reply with a "rollback" message.
+* If the sink sent a "success" message then the worker can reply with either a "commit" message or a "rollback" message. If the message is a "commit" message then all of the messages received before the phase 1 message are committed, otherwise they are rolled back.
+
+If a Wallaroo worker dies and restarts then the worker can reconnect and the sink will continue processing it's messages. This requires that the sink maintain a list of connected workers and data associated with those workers that can be passed to a new state machine when the worker reconnects.
+
+### Global Data
+
+#### Active Workers
+
+A set of workers that are currently connected to the sink. This allows the sink to make sure that it is only processing one connection for a given worker. If a second connection from a worker with the same name is attempted, it will fail.
+
+#### Streams
+
+Stream data for each worker that connects to a sink is stored. This allows a worker to reconnect to a sink and have the sink continue to process messages from that worker using the data it received up until the point where it was disconnected.
+
+### Local State (per state machine)
+
+State that is local to a state machine is stored in a `StateContext` object. The major points of interest are the local information about the streams for the worker associated with this state machine, the transaction state, and the two-phase commit output.
+
+#### Streams
+
+This maps a stream ID to a stream name and the point of reference for the stream. If the worker has connected to the sink before then the state machine receives the information about this worker when the worker reconnects, otherwise this map starts out empty.
+
+#### Transaction State
+
+This stores the transaction state associated a phase 1 messages.
+
+#### Two-Phase Commit Output
+
+This stores information about information that is committed during the two-phase commit process.
+
+NOTE: This is currently only stored to memory, in a working system it would be committed to disk.
+
+### States
+
+States handle different kinds of messages, either in the form of Connector protocol messages, or internal sink messages. These descriptions list the primary responsiblities for each state. In addition to the messages listed, the `AwaitMessageOr2PCPhaseX` states also handle Error, Notify, EOS, Worker Left, and ListUncommitted messages.
+
+#### `InitialState`
+
+This state waits for a `Hello` message from the Wallaroo worker. When the message is received it is checked to make sure that the worker is using the correct protocol version and cookie. If so, it tries to see if the worker name is already active by sending a message to the actor that stores the information about active and previously connected workers, and moves into the `AwaitApproveOrDenyWorker` state.
+
+#### `AwaitApproveOrDenyWorker`
+
+This state waits for a message from the actor that tracks active workers about whether or not the connecting worker is already active. While the state machine is in this state, all other incoming messages are queued. If it is active then it receives a message denying the new connection, otherwise it receives a message approving the new worker, along with the streams data for that worker if it is reconnecting. If the worker is approved then the state machine goes into the `AwaitMessageOr2PCPhase1State` and synchronously processes all of the queued messages.
+
+#### `AwaitMessageOr2PCPhase1State`
+
+This state waits for application messages or a phase 1 message.
+
+#### `AwaitMessageOr2PCPhase2State`
+
+This state waits for application messages or a phase 2 message.
+
+### Considerations When Building Another Connector-Based Source or Sink
+
+When I was talking to Scott he said that the most difficult part of writing the Python ALOC Sink was getting all the edge cases right. I spent a lot of time trying to reverse engineer what he had done with respect to keeping track of points of reference and I'm still not sure I got it right. I'd like to believe what I did in Pony might be a little more readable because I'm using a typed language and so there's a bit more clarity about what is going into different data structures, but I'm also not completely confident that I got everything right so the Python ALOC Sink should still probably be considered the source of truth with respect to the logic of the system. If we plan to continue to use the Connector protocol we should look at how to hide some of this complexity from the user.
+
+The Pony library for connectors provides encoding and decoding support for the protocol messges, but we should probably also provide some classes that represent the transaction log data, along with encoders and decoders. As with all the point-of-reference related code, there's probably a way that we can provide one implementation that will work for most use-cases, rather than being forced to rewrite them from scratch every time we build a new source or sink.
+
+I spent a lot more time than I wanted to trying to figure out how to translate between `Array[U8]`s, `String`s, `ByteSeq`s, and `ByteSeqIter`s. I understand why this flexibility exists in Pony but from an application programmer standpoint (or at least from my standpoint) it's a lot of overhead to work with. I think we should creating APIs that, for example, only accept at return an `Array[U8]`.
+
+Providing a reusable state machine implementation for the protocol would be extremely useful if we need to create lots of Connector sources and sinks in the future. Otherwise the programmer will be forced to do it over and over again, and there really shouldn't be too many variations on how it is done.
+
+In general, if we plan to continue to use the Connector protocol internally or let other parties develop their own Connector sources and sinks, we need to figure out how to abstract away as much of this complexity as possible. I believe there are enough common pieces we could incrementally get pieces in place that would greatly reduce developement time.

--- a/connectors/pony_connector_sink/active_workers.pony
+++ b/connectors/pony_connector_sink/active_workers.pony
@@ -1,0 +1,38 @@
+use "collections"
+
+use cwm = "wallaroo_labs/connector_wire_messages"
+
+actor ActiveWorkers
+  let _worker_names: Set[cwm.WorkerName]
+
+  let _worker_streams: Map[cwm.WorkerName, Map[cwm.StreamId, (cwm.StreamId, cwm.StreamName, cwm.PointOfRef)] val]
+
+  new create() =>
+    _worker_names = _worker_names.create()
+    _worker_streams = _worker_streams.create()
+
+  be add_new_worker(worker_name: cwm.WorkerName, sm: SinkStateMachine, hello: cwm.HelloMsg val) =>
+    if _worker_names.contains(worker_name) then
+      sm.deny_new_worker(hello)
+    else
+      _worker_names.set(worker_name)
+
+      let worker_streams =
+        _worker_streams.get_or_else(worker_name, recover val Map[cwm.StreamId, (cwm.StreamId, cwm.StreamName, cwm.PointOfRef)] end)
+
+      sm.approve_new_worker(hello, worker_streams)
+    end
+
+  be remove_worker(worker_name: cwm.WorkerName, streams: Map[cwm.StreamId, (cwm.StreamId, cwm.StreamName, cwm.PointOfRef)] val) =>
+    _worker_names.unset(worker_name)
+    _worker_streams(worker_name) = streams
+
+  be workers_left(worker_names: Array[cwm.WorkerName] val) =>
+    for wn in worker_names.values() do
+      try
+        // Every connectoin will receive the same message and try to remove
+        // these entries, so the first one to get here will succeed and the rest
+        // will fail, which is fine.
+        _worker_streams.remove(wn)?
+      end
+    end

--- a/connectors/pony_connector_sink/message_handler.pony
+++ b/connectors/pony_connector_sink/message_handler.pony
@@ -1,0 +1,270 @@
+use "buffered"
+use "debug"
+
+use cwm = "wallaroo_labs/connector_wire_messages"
+
+primitive HandleNotifyMsg
+  fun apply(ctx: StateContext, notify: cwm.NotifyMsg): (SinkState | None) =>
+    if notify.stream_id != 1 then
+      Debug("Unsupported stream id " + notify.stream_id.string())
+      let err = cwm.ErrorMsg("Unsupported stream id " + notify.stream_id.string())
+      ctx.writev(err.encode().done())
+      return InvalidState
+    end
+
+    let point_of_ref = try
+      ctx.lookup_stream(notify.stream_id)?._3
+    else
+      0
+    end
+
+    ctx.set_stream(notify.stream_id, notify.stream_name, point_of_ref)
+
+    let notify_ack = cwm.NotifyAckMsg(true, notify.stream_id, point_of_ref)
+    ctx.writev(notify_ack.encode().done())
+
+    None
+
+primitive HandleErrorMsg
+  fun apply(ctx: StateContext, err: cwm.ErrorMsg) =>
+    Debug("Recieved an error message, closing the connection")
+    ctx.close()
+
+    ctx.active_workers.remove_worker(ctx.get_worker_name(), ctx.get_sendable_streams())
+
+primitive HandleMessageMsg
+  fun apply(ctx: StateContext, message: cwm.MessageMsg) =>
+    (let bytes_size: USize, let message_message: Array[U8] val) = match message.message
+    | let mbs: cwm.MessageBytes =>
+      mbs.size()
+      let s = match mbs
+      | let ms: String =>
+        ms.array()
+      | let ma: Array[U8] val =>
+        ma
+      end
+      (mbs.size(), s)
+    | let bsi: ByteSeqIter =>
+      var size: USize = 0
+      for bs in bsi.values() do
+        size = size + bs.size()
+      end
+      (size, recover Array[U8] end)
+    | None =>
+      (0, recover Array[U8] end)
+    end
+
+    if message.message_id isnt None then
+      match ctx.compare_output_offset_to(message.message_id)
+      | Equal =>
+        Debug("offset == message_id")
+        try
+          (let ret1, let new_offset) = ctx.two_pc_out.append_output(message_message)?
+          ctx.set_output_offset(new_offset)
+          ctx.set_stream_output_offset(message.stream_id, new_offset)?
+        else
+          ctx.set_txn_commit_next(false)
+        end
+      | Less =>
+        Debug(" ".join([as Stringable: "offset"; ctx.get_output_offset(); "< message_id"; message.message_id.string()].values()))
+        Debug("message: '" + String.from_array(message_message) + "'")
+        ctx.set_txn_commit_next(false)
+        if not ctx.get_next_txn_force_abort_written() then
+          ctx.set_next_txn_force_abort_written(true)
+          ctx.log_it(NextTxnForceAbort("MISSING DATA: offset < message_id " + message.message_id.string() + " worker " + ctx.get_worker_name()))
+        end
+
+        if ctx.get_last_message() is None then
+          Debug("got message after a gap")
+        elseif not ctx.get_next_txn_force_abort_written() then
+          Debug("this is bad")
+          // TODO: More logging here?
+          // TODO: exit here, or go to invalid state?
+        end
+      | Greater =>
+        Debug("offset > message_id")
+        ctx.set_txn_commit_next(false)
+        ctx.two_pc_out.flush_fsync_all()
+        // TODO: exit here, or go to invalid state?
+      end
+    else
+      Debug("message has no message_id")
+      // TODO: exit here, or go to invalid state?
+    end
+
+    ctx.set_last_message(message)
+
+primitive HandleEosMsg
+  fun apply(ctx: StateContext, eos: cwm.EosMessageMsg) =>
+    Debug("acking eos")
+    try
+      (_, _, let point_of_ref) = ctx.lookup_stream(eos.stream_id)?
+      ctx.writev(cwm.AckMsg(1, [(eos.stream_id, point_of_ref)]).encode().done())
+    else
+      Debug("Could not find stream id=" + eos.stream_id.string() + " for EOS message")
+    end
+
+primitive Handle2PCPhase1Msg
+  fun apply(ctx: StateContext, message: cwm.TwoPCPhase1Msg): SinkState =>
+    if ctx.compare_output_offset_to(ctx.two_pc_out.out_tell()) isnt Equal then
+      ctx.set_txn_commit_next(false)
+      Debug("2PC: sanity: offset != tell")
+      return InvalidState
+    end
+
+    for (stream_id, start_point_of_ref, end_point_of_ref) in message.where_list.values() do
+      if stream_id != 1 then
+        ctx.set_txn_commit_next(false)
+        Debug("2PC: Phase 1 invalid stream_id")
+      end
+
+      if ctx.compare_last_committed_offset_to(start_point_of_ref) isnt Equal then
+        ctx.set_txn_commit_next(false)
+        Debug("2PC: Phase 1 invalid start point of reference")
+      end
+
+      if start_point_of_ref > end_point_of_ref then
+        ctx.set_txn_commit_next(false)
+        Debug("2PC: Phase 1 start point of reference > end point of reference")
+      end
+
+      if ctx.compare_output_offset_to(end_point_of_ref) isnt Less then
+        ctx.set_txn_commit_next(false)
+        let m = "2PC: Phase 1 end point of reference > end point of reference"
+        if ctx.compare_output_offset_to(start_point_of_ref) is Equal then
+          Debug(m)
+        else
+          Debug(m + "THIS IS BAD")
+          ctx.log_it(NextTxnForceAbort(m))
+          return ErrorState
+        end
+      end
+    end
+
+    let wl_i: cwm.WhereList iso = (recover iso cwm.WhereList.create() end)
+    let wl: cwm.WhereList val  = consume wl_i
+
+    let success = if ctx.get_txn_commit_next() then
+      Phase1Success
+    else
+      Phase1Fail
+    end
+
+    ctx.set_txn_state(message.txn_id, (success, message.where_list))
+
+    match success
+    | Phase1Success =>
+      ctx.log_it(PhaseOneOk(message.txn_id, wl))
+    else
+      ctx.log_it(PhaseOneRollback(message.txn_id, wl))
+    end
+
+    let reply = cwm.TwoPCReplyMsg(message.txn_id, success.bool())
+    let reply_bytes = cwm.TwoPCFrame.encode(reply)
+    ctx.writev(cwm.MessageMsg(0, 0, 0, None, reply_bytes).encode().done())
+
+    AwaitMessageOr2PCPhase2State
+
+primitive Handle2PCPhase2Msg
+  fun apply(ctx: StateContext, message: cwm.TwoPCPhase2Msg): SinkState =>
+    match ctx.lookup_txn_state(message.txn_id)
+    | (let phase1_status: Phase1Status, let where_list: cwm.WhereList) =>
+      Debug("got 2PC phase 2 message")
+      if not message.commit then
+        for (stream_id, start_point_of_ref, end_point_of_ref) in where_list.values() do
+          Debug("going through where_list")
+          if stream_id != 1 then
+            Debug("Phase 2 abort: bad stream_id")
+            return ErrorState
+          end
+
+          ctx.two_pc_out.flush_fsync_out()
+          // TODO: copy output log for diagnostics
+
+          ctx.two_pc_out.flush_fsync_out()
+          let t_point_of_ref = ctx.two_pc_out.truncate_and_seek_to(start_point_of_ref)
+
+          if t_point_of_ref != start_point_of_ref then
+            Debug("truncate got " + t_point_of_ref.string() + " expected " + start_point_of_ref.string())
+            return ErrorState
+          end
+
+          ctx.set_output_offset(start_point_of_ref)
+
+          try
+            // In case of disconnect, reconnect, and ReplyUncommitted's list of
+            // txns is not empty, then when the phase 2 abort arrives, we have
+            // not seen a Notify message for the stream id, this attempt to
+            // update the offset will raise an error, which is ok here.
+            ctx.set_stream_output_offset(stream_id, start_point_of_ref)?
+          end
+        end
+      end
+
+      if (phase1_status isnt Phase1Success) and message.commit then
+        // TODO: Log and exit or something?
+        Debug("2PC: Protocol error: phase 1 status was rollback but phase 2 says commit")
+        return ErrorState
+      end
+
+      let log_item = if message.commit then
+        try
+          let offset = where_list(0)?._3
+
+          ctx.set_last_committed_offset(offset)
+
+          PhaseTwoOk(message.txn_id, offset)
+        else
+          Debug("2PC: empty where_list in commit")
+          return ErrorState
+        end
+      else
+        try
+          let offset = where_list(0)?._2
+
+          if ctx.compare_output_offset_to(offset) isnt Equal then
+            Debug("2PC: phase 2 offset != output_offset")
+          end
+
+          ctx.set_last_committed_offset(offset)
+
+          PhaseTwoRollback(message.txn_id, offset)
+        else
+          Debug("2PC: empty where_list in rollback")
+          return ErrorState
+        end
+      end
+
+      ctx.log_it(log_item)
+
+      try
+        ctx.remove_txn_state(message.txn_id)?
+      else
+        Debug("could not remove txn " + message.txn_id.string() + " from txn_state")
+      end
+    else
+      Debug("2PC: Phase 2 got unknown txn_id " + message.txn_id + " commit " + message.commit.string())
+      ctx.log_it(PhaseTwoError(message.txn_id, "unknown txn_id, commit " + message.commit.string()))
+    end
+
+    AwaitMessageOr2PCPhase1State
+
+primitive HandleListUncommittedMsg
+  fun apply(ctx: StateContext, message: cwm.ListUncommittedMsg) =>
+    Debug("List uncommitted messages")
+
+    let uncommitted = recover iso Array[String] end
+
+    for txn_id in ctx.txn_state_keys() do
+      uncommitted.push(txn_id)
+    end
+
+    let reply = cwm.ReplyUncommittedMsg(message.rtag, consume uncommitted)
+    let reply_bytes = cwm.TwoPCFrame.encode(reply)
+    ctx.writev(cwm.MessageMsg(0, 0, 0, None, reply_bytes).encode().done())
+
+primitive HandleWorkersLeftMsg
+  fun apply(ctx: StateContext, message: cwm.WorkersLeftMsg) =>
+    let lw: Array[cwm.WorkerName] val = (recover iso Array[cwm.WorkerName] end) .> append(message.leaving_workers)
+    ctx.active_workers.workers_left(lw)
+    ctx.two_pc_out.leaving_workers(lw)

--- a/connectors/pony_connector_sink/sink.pony
+++ b/connectors/pony_connector_sink/sink.pony
@@ -1,0 +1,132 @@
+use "buffered"
+use "collections"
+use "debug"
+use "net"
+
+use cwm = "wallaroo_labs/connector_wire_messages"
+
+primitive MessageMessageToArray
+  fun apply(mm: (cwm.MessageBytes | ByteSeqIter | None)): Array[U8] val =>
+    recover
+      match mm
+      | None =>
+        []
+      | let mm': String =>
+        Array[U8] .> concat(mm'.values())
+      | let mm': Array[U8] val =>
+        Array[U8] .> concat(mm'.values())
+      | let mm': ByteSeqIter =>
+        let data' = Array[U8]
+        for v in mm'.values() do
+          match v
+          | let s: String =>
+            data'.concat(s.values())
+          | let a: Array[U8] val =>
+            data'.concat(a.values())
+          end
+        end
+        data'
+      end
+    end
+
+class SinkTCPConnectionNotify is TCPConnectionNotify
+  let _out: OutStream
+  let _active_workers: ActiveWorkers
+  var _sm: SinkStateMachine
+  var _awaiting_size: Bool
+
+  new iso create(out: OutStream, active_workers: ActiveWorkers) =>
+    _out = out
+    _active_workers = active_workers
+    _sm = UnconnectedSinkStateMachine
+    _awaiting_size = true
+    Debug("waiting for messages now")
+
+  fun ref accepted(conn: TCPConnection ref) =>
+    Debug("Connecting notifier connected")
+
+    _sm = ConnectedSinkStateMachine(conn, _active_workers, InitialState)
+
+    try
+      conn.expect(4)?
+    else
+      Debug("error setting expect to size size")
+    end
+
+  fun ref received(
+    conn: TCPConnection ref,
+    data: Array[U8] iso,
+    times: USize)
+    : Bool
+  =>
+    Debug("received")
+    if _awaiting_size then
+      let rb = Reader .> append(consume data)
+      let size = try
+        rb.u32_be()?
+      else
+        conn.close()
+        Debug("error reading size, closing connection")
+        return true
+      end
+
+      Debug("size is " + size.string())
+
+      try
+        conn.expect(size.usize())?
+      else
+        Debug("error setting expect to message size")
+      end
+
+      _awaiting_size = false
+    else
+      Debug("received some data")
+      let msg = try
+        recover iso
+          cwm.Frame.decode(consume data)?
+        end
+      else
+        conn.close()
+        Debug("error decoding frame, closing connection")
+        return true
+      end
+
+      _sm(consume msg)
+
+      try
+        conn.expect(4)?
+      else
+        Debug("error setting expect to message size")
+      end
+
+      _awaiting_size = true
+    end
+
+    true
+
+  fun ref connect_failed(conn: TCPConnection ref) =>
+    None
+
+class SinkTCPListenNotify is TCPListenNotify
+  let _out: OutStream
+  let _active_workers: ActiveWorkers
+
+  new iso create(out: OutStream, active_workers: ActiveWorkers) =>
+    _out = out
+    _active_workers = active_workers
+
+  fun ref connected(listen: TCPListener ref): TCPConnectionNotify iso^ =>
+    Debug("connected")
+    SinkTCPConnectionNotify(_out, _active_workers)
+
+  fun ref not_listening(listen: TCPListener ref) =>
+    None
+
+actor Main
+  new create(env: Env) =>
+    let active_workers = ActiveWorkers
+
+    try
+      TCPListener(env.root as AmbientAuth,
+        SinkTCPListenNotify(env.out, active_workers), "", "8989")
+    end

--- a/connectors/pony_connector_sink/state.pony
+++ b/connectors/pony_connector_sink/state.pony
@@ -1,0 +1,281 @@
+use "collections"
+use "debug"
+
+use cwm = "wallaroo_labs/connector_wire_messages"
+
+trait val SinkState
+  fun handle_hello(ctx: StateContext, hello: cwm.HelloMsg): SinkState => InvalidState
+  fun handle_ok(ctx: StateContext, ok: cwm.OkMsg): SinkState => InvalidState
+  fun handle_error(ctx: StateContext, err: cwm.ErrorMsg): SinkState => InvalidState
+  fun handle_notify(ctx: StateContext, notify: cwm.NotifyMsg): SinkState => InvalidState
+  fun handle_notify_ack(ctx: StateContext, notify_ack: cwm.NotifyAckMsg): SinkState => InvalidState
+  fun handle_message(ctx: StateContext, message: cwm.MessageMsg): SinkState => InvalidState
+  fun handle_eos(ctx: StateContext, eos: cwm.EosMessageMsg): SinkState => InvalidState
+  fun handle_ack(ctx: StateContext, ack: cwm.AckMsg): SinkState => InvalidState
+  fun handle_restart(ctx: StateContext, restart: cwm.RestartMsg): SinkState => InvalidState
+  fun handle_workers_left(ctx: StateContext, workers_left: cwm.WorkersLeftMsg): SinkState => InvalidState
+
+  fun handle_approve_new_worker(ctx: StateContext,
+    hello: cwm.HelloMsg val,
+    streams: Map[cwm.StreamId, (cwm.StreamId, cwm.StreamName, cwm.PointOfRef)] val): SinkState
+  =>
+    InvalidState
+
+  fun handle_deny_new_worker(ctx: StateContext, hello: cwm.HelloMsg val): SinkState => InvalidState
+
+  fun string(): String iso^
+
+primitive DebugState is SinkState
+  """
+  This state just tries to return an appropriate message based on the message it received.
+  """
+  fun handle_hello(ctx: StateContext, hello: cwm.HelloMsg): SinkState =>
+    Debug("Got HELLO")
+    let msg = cwm.OkMsg(500)
+    ctx.writev(msg.encode().done())
+    DebugState
+
+  fun handle_ok(ctx: StateContext, ok: cwm.OkMsg): SinkState =>
+    Debug("Got OK")
+    DebugState
+
+  fun handle_error(ctx: StateContext, err: cwm.ErrorMsg): SinkState =>
+    Debug("Got ERROR")
+    DebugState
+
+  fun handle_notify(ctx: StateContext, notify: cwm.NotifyMsg): SinkState =>
+    Debug("Got NOTIFY")
+    DebugState
+
+  fun handle_notify_ack(ctx: StateContext, notify_ack: cwm.NotifyAckMsg): SinkState =>
+    Debug("Got NOTIFY_ACK")
+    DebugState
+
+  fun handle_message(ctx: StateContext, message: cwm.MessageMsg): SinkState =>
+    Debug("Got MESSAGE")
+    DebugState
+
+  fun handle_eos(ctx: StateContext, eos: cwm.EosMessageMsg): SinkState =>
+    Debug("Got EOS")
+    DebugState
+
+  fun handle_ack(ctx: StateContext, ack: cwm.AckMsg): SinkState =>
+    Debug("Got ACK")
+    DebugState
+
+  fun handle_restart(ctx: StateContext, restart: cwm.RestartMsg): SinkState =>
+    Debug("Got RESTART")
+    DebugState
+
+  fun handle_workers_left(ctx: StateContext, workers_left: cwm.WorkersLeftMsg): SinkState =>
+    Debug("Got WORKERS_LEFT")
+    DebugState
+
+  fun string(): String iso^ => "DebugState".clone()
+
+primitive InvalidState is SinkState
+  fun string(): String iso^ => "InvalidState".clone()
+
+primitive InitialState is SinkState
+  fun handle_hello(ctx: StateContext, hello: cwm.HelloMsg): SinkState =>
+    if hello.version != "v0.0.1" then
+      Debug("bad protocol version" + hello.version)
+      return InvalidState
+    end
+
+    if hello.cookie != "Dragons-Love-Tacos" then
+      Debug("bad cookie: " + hello.cookie)
+      return InvalidState
+    end
+
+    Debug("Hello message from worker " + hello.instance_name)
+
+    let version = hello.version
+    let cookie = hello.cookie
+    let program_name = hello.program_name
+    let instance_name = hello.instance_name
+
+    let hello_val = recover val cwm.HelloMsg(version, cookie, program_name, instance_name) end
+
+    ctx.active_workers.add_new_worker(hello.instance_name, ctx.state_machine, hello_val)
+
+    AwaitApproveOrDenyWorkerState
+
+  fun handle_error(ctx: StateContext, err: cwm.ErrorMsg): SinkState =>
+    HandleErrorMsg(ctx, err)
+    ErrorState
+
+  fun string(): String iso^ => "InitialState".clone()
+
+primitive AwaitApproveOrDenyWorkerState is SinkState
+  fun handle_approve_new_worker(ctx: StateContext,
+    hello: cwm.HelloMsg val,
+    streams: Map[cwm.StreamId,
+    (cwm.StreamId, cwm.StreamName, cwm.PointOfRef)] val): SinkState
+  =>
+    let ok = cwm.OkMsg(500)
+
+    ctx.writev(ok.encode().done())
+
+    ctx.set_worker_name(hello.instance_name)
+
+    ctx.set_output_offset(ctx.two_pc_out.open(hello.instance_name))
+
+    ctx.set_streams(streams)
+
+    let transaction_log_lines = ctx.two_pc_out.read_txn_log_lines()
+
+    try
+      ctx.update_from_transaction_log_lines(transaction_log_lines)?
+    else
+      return ErrorState
+    end
+
+    // TODO: include orphaned list? doesn't makes sense if we aren't using S3 right now.
+
+    AwaitMessageOr2PCPhase1State
+
+  fun handle_deny_new_worker(ctx: StateContext, hello: cwm.HelloMsg val): SinkState =>
+    let err = cwm.ErrorMsg("Hello message from worker " + hello.instance_name + ": already active")
+
+    ctx.writev(err.encode().done())
+
+    ctx.close()
+
+    ErrorState
+
+  fun handle_ok(ctx: StateContext, ok: cwm.OkMsg): SinkState =>
+    ctx.queue_message(ok)
+    this
+
+  fun handle_error(ctx: StateContext, err: cwm.ErrorMsg): SinkState =>
+    ctx.queue_message(err)
+    this
+
+  fun handle_notify(ctx: StateContext, notify: cwm.NotifyMsg): SinkState =>
+    ctx.queue_message(notify)
+    this
+
+  fun handle_notify_ack(ctx: StateContext, notify_ack: cwm.NotifyAckMsg): SinkState =>
+    ctx.queue_message(notify_ack)
+    this
+
+  fun handle_message(ctx: StateContext, message: cwm.MessageMsg): SinkState =>
+    ctx.queue_message(message)
+    this
+
+  fun handle_eos(ctx: StateContext, eos: cwm.EosMessageMsg): SinkState =>
+    ctx.queue_message(eos)
+    this
+
+  fun handle_ack(ctx: StateContext, ack: cwm.AckMsg): SinkState =>
+    ctx.queue_message(ack)
+    this
+
+  fun handle_restart(ctx: StateContext, restart: cwm.RestartMsg): SinkState =>
+    ctx.queue_message(restart)
+    this
+
+  fun handle_workers_left(ctx: StateContext, workers_left: cwm.WorkersLeftMsg): SinkState =>
+    ctx.queue_message(workers_left)
+    this
+
+  fun string(): String iso^ => "AwaitApproveOrDenyWorkerState".clone()
+
+primitive ErrorState is SinkState
+  fun handle_hello(ctx: StateContext, hello: cwm.HelloMsg): SinkState => ErrorState
+  fun handle_ok(ctx: StateContext, ok: cwm.OkMsg): SinkState => ErrorState
+  fun handle_error(ctx: StateContext, err: cwm.ErrorMsg): SinkState => ErrorState
+  fun handle_notify(ctx: StateContext, notify: cwm.NotifyMsg): SinkState => ErrorState
+  fun handle_notify_ack(ctx: StateContext, notify_ack: cwm.NotifyAckMsg): SinkState => ErrorState
+  fun handle_message(ctx: StateContext, message: cwm.MessageMsg): SinkState => ErrorState
+  fun handle_eos(ctx: StateContext, eos: cwm.EosMessageMsg): SinkState => ErrorState
+  fun handle_ack(ctx: StateContext, ack: cwm.AckMsg): SinkState => ErrorState
+  fun handle_restart(ctx: StateContext, restart: cwm.RestartMsg): SinkState => ErrorState
+  fun handle_workers_left(ctx: StateContext, workers_left: cwm.WorkersLeftMsg): SinkState => ErrorState
+
+  fun string(): String iso^ =>
+    "ErrorState".clone()
+
+primitive AwaitMessageOr2PCPhase1State is SinkState
+  fun handle_error(ctx: StateContext, err: cwm.ErrorMsg): SinkState =>
+    HandleErrorMsg(ctx, err)
+    ErrorState
+
+  fun handle_notify(ctx: StateContext, notify: cwm.NotifyMsg): SinkState =>
+    match HandleNotifyMsg(ctx, notify)
+    | let ss: SinkState =>
+      ss
+    else
+      AwaitMessageOr2PCPhase1State
+    end
+
+  fun handle_message(ctx: StateContext, message: cwm.MessageMsg): SinkState =>
+    match message.stream_id
+    | 0 =>
+      let two_pc_bytes = MessageMessageToArray(message.message)
+
+      try
+        let two_pc_msg = cwm.TwoPCFrame.decode(two_pc_bytes)?
+
+        match two_pc_msg
+        | let m: cwm.ListUncommittedMsg =>
+          HandleListUncommittedMsg(ctx, m)
+          this
+        | let m: cwm.TwoPCPhase1Msg =>
+          Handle2PCPhase1Msg(ctx, m)
+        else
+          InvalidState
+        end
+      else
+        Debug("error decoding 2PC message")
+        AwaitMessageOr2PCPhase1State
+      end
+    else
+      HandleMessageMsg(ctx, message)
+      AwaitMessageOr2PCPhase1State
+    end
+
+  fun string(): String iso^ => "AwaitMessageOr2PCPhase1State".clone()
+
+primitive AwaitMessageOr2PCPhase2State is SinkState
+  fun handle_error(ctx: StateContext, err: cwm.ErrorMsg): SinkState =>
+    HandleErrorMsg(ctx, err)
+    ErrorState
+
+  fun handle_notify(ctx: StateContext, notify: cwm.NotifyMsg): SinkState =>
+    match HandleNotifyMsg(ctx, notify)
+    | let ss: SinkState =>
+      ss
+    else
+      AwaitMessageOr2PCPhase2State
+    end
+
+  fun handle_message(ctx: StateContext, message: cwm.MessageMsg): SinkState =>
+    match message.stream_id
+    | 0 =>
+      let two_pc_bytes = MessageMessageToArray(message.message)
+
+      try
+        let two_pc_msg = cwm.TwoPCFrame.decode(two_pc_bytes)?
+
+        match two_pc_msg
+        | let m: cwm.ListUncommittedMsg =>
+          HandleListUncommittedMsg(ctx, m)
+          this
+        | let m: cwm.TwoPCPhase2Msg =>
+          Handle2PCPhase2Msg(ctx, m)
+        else
+          InvalidState
+        end
+        this
+      else
+        Debug("error decoding 2PC message")
+        AwaitMessageOr2PCPhase2State
+      end
+    else
+      HandleMessageMsg(ctx, message)
+      AwaitMessageOr2PCPhase2State
+    end
+
+  fun string(): String iso^ => "AwaitMessageOr2PCPhase2State".clone()

--- a/connectors/pony_connector_sink/state_context.pony
+++ b/connectors/pony_connector_sink/state_context.pony
@@ -1,0 +1,220 @@
+use "debug"
+use "collections"
+use "net"
+use "time"
+
+use cwm = "wallaroo_labs/connector_wire_messages"
+
+primitive Phase1Success
+  fun bool(): Bool => true
+
+primitive Phase1Fail
+  fun bool(): Bool => false
+
+type Phase1Status is (Phase1Success | Phase1Fail)
+
+class StateContext
+  let state_machine: SinkStateMachine
+  let _conn: TCPConnection
+  let active_workers: ActiveWorkers
+  let _streams: Map[cwm.StreamId, (cwm.StreamId, cwm.StreamName, cwm.PointOfRef)]
+  let _txn_state: Map[String, (Phase1Status, cwm.WhereList)]
+  var _worker_name: cwm.WorkerName
+  var _output_offset: cwm.PointOfRef
+  var _last_committed_offset: cwm.PointOfRef
+  var _txn_commit_next: Bool
+  var _last_message: (None | cwm.MessageMsg)
+  var _next_txn_force_abort_written: Bool
+  let _queued_messages: Array[cwm.Message]
+  let two_pc_out: TwoPCOutput
+
+  new create(state_machine': SinkStateMachine, conn: TCPConnection, active_workers': ActiveWorkers) =>
+    state_machine = state_machine'
+    _conn = conn
+    active_workers = active_workers'
+    _streams = _streams.create()
+    _txn_state = _txn_state.create()
+    _worker_name = ""
+    _output_offset = 0
+    _last_committed_offset = 0
+    _txn_commit_next = true
+    _last_message = None
+    _next_txn_force_abort_written = false
+    _queued_messages = _queued_messages.create()
+    two_pc_out = TwoPCOutputInMemory("")
+
+  fun ref log_it(txn_log_item: TxnLogItem) =>
+    let timestamp = Time.seconds().u64()
+    two_pc_out.append_txn_log((timestamp, txn_log_item))
+
+  fun ref close() =>
+    _conn.dispose()
+
+  fun writev(data: Array[(String val | Array[U8 val] val)] val) =>
+    _conn.writev(data)
+
+  fun get_worker_name(): cwm.WorkerName =>
+    _worker_name
+
+  fun ref set_worker_name(worker_name: cwm.WorkerName) =>
+    _worker_name = worker_name
+
+  fun lookup_stream(stream_id: cwm.StreamId): (cwm.StreamId, cwm.StreamName,
+    cwm.PointOfRef) ?
+  =>
+    _streams(stream_id)?
+
+  fun ref set_stream(stream_id: cwm.StreamId, stream_name: cwm.StreamName,
+    point_of_ref: cwm.PointOfRef)
+  =>
+    _streams(stream_id) = (stream_id, stream_name, point_of_ref)
+
+  fun ref set_streams(streams: Map[cwm.StreamId, (cwm.StreamId, cwm.StreamName, cwm.PointOfRef)] val) =>
+    _streams.concat(streams.pairs())
+
+  fun get_sendable_streams(): Map[cwm.StreamId, (cwm.StreamId, cwm.StreamName, cwm.PointOfRef)] iso^ =>
+    let sendable_streams = recover iso  Map[cwm.StreamId, (cwm.StreamId, cwm.StreamName, cwm.PointOfRef)] end
+
+    for (k, v) in _streams.pairs() do
+      sendable_streams(k) = v
+    end
+
+    consume sendable_streams
+
+  fun get_output_offset(): cwm.PointOfRef =>
+    _output_offset
+
+  fun ref set_output_offset(point_of_ref: cwm.PointOfRef) =>
+    _output_offset = point_of_ref
+
+  fun ref set_stream_output_offset(stream_id: cwm.StreamId, point_of_ref: cwm.PointOfRef) ? =>
+    (_, let stream_name, _) = _streams(stream_id)?
+    _streams(stream_id) = (stream_id, stream_name, point_of_ref)
+
+  fun compare_output_offset_to(point_of_ref: cwm.PointOfRef): Compare =>
+    if _output_offset == point_of_ref then
+      Equal
+    elseif _output_offset > point_of_ref then
+      Greater
+    else
+      Less
+    end
+
+  fun ref set_last_committed_offset(point_of_ref: cwm.PointOfRef) =>
+    _last_committed_offset = point_of_ref
+
+  fun ref _set_last_committed_offset_from_transaction_log_lines(transaction_log_lines: Array[TxnLogItem] box) =>
+    // TODO: implement this
+    None
+
+  fun compare_last_committed_offset_to(point_of_ref: cwm.PointOfRef): Compare =>
+    if _last_committed_offset == point_of_ref then
+      Equal
+    elseif _last_committed_offset > point_of_ref then
+      Greater
+    else
+      Less
+    end
+
+  fun ref set_txn_state(txn_id: String, state: (Phase1Status, cwm.WhereList)) =>
+    _txn_state(txn_id) = state
+
+  fun ref remove_txn_state(txn_id: String) ? =>
+    _txn_state.remove(txn_id)?
+
+  fun ref _reload_phase1_txn_state(transaction_log_lines: Array[TxnLogItem] box) =>
+    // TODO: implement this
+    None
+
+  fun txn_state_keys(): Iterator[String] =>
+    _txn_state.keys()
+
+  fun txn_state_contains(txn_id: String): Bool =>
+    _txn_state.contains(txn_id)
+
+  fun ref lookup_txn_state(txn_id: String): (None | (Phase1Status, cwm.WhereList)) =>
+    try
+      _txn_state(txn_id)?
+    else
+      None
+    end
+
+  fun get_txn_commit_next(): Bool =>
+    _txn_commit_next
+
+  fun ref set_txn_commit_next(s: Bool) =>
+    _txn_commit_next = false
+
+  fun ref _set_txn_commit_next_from_transaction_log_lines(txn_log: Array[TxnLogItem] box) =>
+    // TODO: implement this
+    None
+
+  fun ref get_last_message(): (None | cwm.MessageMsg) =>
+    _last_message
+
+  fun ref set_last_message(message: cwm.MessageMsg) =>
+    _last_message = message
+
+  fun get_next_txn_force_abort_written(): Bool =>
+    _next_txn_force_abort_written
+
+  fun ref set_next_txn_force_abort_written(b: Bool) =>
+    _next_txn_force_abort_written = b
+
+  fun ref queue_message(m: cwm.Message) =>
+    _queued_messages.push(m)
+
+  fun get_queued_messages_values(): Iterator[this->cwm.Message] =>
+    _queued_messages.values()
+
+  fun ref clear_queued_messages() =>
+    _queued_messages.clear()
+
+  fun ref _set_output_offset_and_truncate_from_transaction_log_lines(txn_log_lines: Array[TxnLogItem] box) ? =>
+    var truncate_offset: cwm.PointOfRef = 0
+
+    if _txn_state.size() > 1 then
+      Debug("_txn_state.size() > 1")
+      error
+    end
+
+    if _txn_state.size() == 1 then
+      // this will not fail because we have already confirmed that _txn_state.size() == 1
+      (let phase1_status, let where_list: cwm.WhereList) = try _txn_state.values().next()? else (Phase1Success, []) end
+
+      if where_list.size() != 1 then
+        Debug("bad where_list")
+        error
+      end
+
+      (let stream_id, let start_por, let end_por) = try where_list(0)? else (0, 0, 0) end
+
+      if stream_id != 1 then
+        Debug("Bad where_list")
+        error
+      end
+
+      if phase1_status is Phase1Success then
+        truncate_offset = end_por
+      else
+        truncate_offset = _last_committed_offset
+      end
+
+    elseif _txn_state.size() == 0 then
+      truncate_offset = _last_committed_offset
+    end
+
+    let truncate_point_of_ref = two_pc_out.truncate_and_seek_to(truncate_offset)
+
+    if truncate_point_of_ref != truncate_offset then
+      Debug("truncate got " + truncate_point_of_ref.string() + " expected " + truncate_offset.string())
+      error
+    end
+
+    _output_offset = truncate_offset
+
+  fun ref update_from_transaction_log_lines(txn_log_lines: Array[TxnLogItem] box) ? =>
+    _reload_phase1_txn_state(txn_log_lines)
+    _set_txn_commit_next_from_transaction_log_lines(txn_log_lines)
+    _set_last_committed_offset_from_transaction_log_lines(txn_log_lines)
+    _set_output_offset_and_truncate_from_transaction_log_lines(txn_log_lines)?

--- a/connectors/pony_connector_sink/state_machine.pony
+++ b/connectors/pony_connector_sink/state_machine.pony
@@ -1,0 +1,83 @@
+use "collections"
+use "debug"
+use "net"
+
+use cwm = "wallaroo_labs/connector_wire_messages"
+
+trait tag SinkStateMachine
+  be apply(msg: cwm.Message iso)
+  be approve_new_worker(hello: cwm.HelloMsg val, streams: Map[cwm.StreamId, (cwm.StreamId, cwm.StreamName, cwm.PointOfRef)] val)
+  be deny_new_worker(hello: cwm.HelloMsg val)
+
+actor UnconnectedSinkStateMachine is SinkStateMachine
+  be apply(msg: cwm.Message iso) =>
+    None
+  be approve_new_worker(hello: cwm.HelloMsg val, streams: Map[cwm.StreamId, (cwm.StreamId, cwm.StreamName, cwm.PointOfRef)] val) =>
+    None
+  be deny_new_worker(hello: cwm.HelloMsg val) =>
+    None
+
+actor ConnectedSinkStateMachine is SinkStateMachine
+  let _ctx: StateContext
+  var _state: SinkState
+
+  new create(conn: TCPConnection, active_workers: ActiveWorkers, initial_state: SinkState) =>
+    _ctx = StateContext(this, conn, active_workers)
+    _state = initial_state
+
+  be approve_new_worker(hello: cwm.HelloMsg val, streams: Map[cwm.StreamId, (cwm.StreamId, cwm.StreamName, cwm.PointOfRef)] val) =>
+    _state = _state.handle_approve_new_worker(_ctx, hello, streams)
+
+    for m in _ctx.get_queued_messages_values() do
+      _apply(m)
+    end
+
+    _ctx.clear_queued_messages()
+
+  be deny_new_worker(hello: cwm.HelloMsg val) =>
+    _state = _state.handle_deny_new_worker(_ctx, hello)
+
+  be apply(msg_iso: cwm.Message iso) =>
+    _apply(consume msg_iso)
+
+  fun ref _apply(msg: cwm.Message) =>
+    let old_state = _state
+    _state = match msg
+    | let msg': cwm.HelloMsg =>
+      _state.handle_hello(_ctx, msg')
+    | let msg': cwm.OkMsg =>
+      _state.handle_ok(_ctx, msg')
+    | let msg': cwm.ErrorMsg =>
+      _state.handle_error(_ctx, msg')
+    | let msg': cwm.NotifyMsg =>
+      _state.handle_notify(_ctx, msg')
+    | let msg': cwm.NotifyAckMsg =>
+      _state.handle_notify_ack(_ctx, msg')
+    | let msg': cwm.MessageMsg =>
+      _state.handle_message(_ctx, msg')
+    | let msg': cwm.EosMessageMsg =>
+      _state.handle_eos(_ctx, msg')
+    | let msg': cwm.AckMsg =>
+      _state.handle_ack(_ctx, msg')
+    | let msg': cwm.RestartMsg =>
+      _state.handle_restart(_ctx, msg')
+    | let msg': cwm.WorkersLeftMsg =>
+      _state.handle_workers_left(_ctx, msg')
+    end
+
+    ifdef debug then
+      let msg_type = match msg
+      | let msg': cwm.HelloMsg => "HELLO"
+      | let msg': cwm.OkMsg => "OK"
+      | let msg': cwm.ErrorMsg => "ERROR"
+      | let msg': cwm.NotifyMsg => "NOTIFY"
+      | let msg': cwm.NotifyAckMsg => "NOTIFY_ACK"
+      | let msg': cwm.MessageMsg => "MESSAGE"
+      | let msg': cwm.EosMessageMsg => "EOS"
+      | let msg': cwm.AckMsg => "ACK"
+      | let msg': cwm.RestartMsg => "RESTART"
+      | let msg': cwm.WorkersLeftMsg => "WORKERS_LEFT"
+      end
+
+      Debug(" ".join([old_state; " X "; msg_type; " => "; _state].values()))
+    end

--- a/connectors/pony_connector_sink/two_pc_output.pony
+++ b/connectors/pony_connector_sink/two_pc_output.pony
@@ -1,0 +1,79 @@
+use cwm = "wallaroo_labs/connector_wire_messages"
+
+trait TwoPCOutput
+  fun ref open(instance_name: cwm.WorkerName): cwm.PointOfRef
+  fun truncate_and_seek_to(truncate_offset: cwm.PointOfRef): cwm.PointOfRef
+  fun out_tell(): cwm.PointOfRef
+  fun flush_fsync_all()
+  fun flush_fsync_out()
+  fun flush_fsync_txn_log()
+  fun ref append_output(msg: Array[U8] val): (U64, cwm.PointOfRef)?
+  fun append_txn_log(log_entry: (U64, TxnLogItem))
+  fun read_txn_log_lines(): Array[TxnLogItem]
+  fun leaving_workers(leaving_workers': Seq[cwm.WorkerName] box)
+
+class TwoPCOutputInMemory is TwoPCOutput
+  let _out_path: String
+  var _instance_name: cwm.WorkerName
+  let _output: Array[U8]
+  let _txn_log: Array[(U64, TxnLogItem)]
+
+  new create(out_path: String) =>
+    _out_path = out_path
+    _instance_name = ""
+    _output = _output.create()
+    _txn_log = _txn_log.create()
+
+  fun ref open(instance_name: cwm.WorkerName): cwm.PointOfRef =>
+    // TODO: implement this
+    _instance_name = instance_name
+    0
+
+  fun truncate_and_seek_to(truncate_offset: cwm.PointOfRef): cwm.PointOfRef =>
+    // TODO: implement this
+    0
+
+  fun out_tell(): cwm.PointOfRef =>
+    // TODO: implement this
+    0
+
+  fun flush_fsync_all() =>
+    // TODO: implement this
+    None
+
+  fun flush_fsync_out() =>
+    // TODO: implement this
+    None
+
+  fun flush_fsync_txn_log() =>
+    // TODO: implement this
+    None
+
+  fun ref append_output(msg: Array[U8] val): (U64, cwm.PointOfRef) =>
+    _output.concat(msg.values())
+
+    (msg.size().u64(), _output.size().u64())
+
+  fun append_txn_log(log_entry: (U64, TxnLogItem)) =>
+    (let timestamp, let txn_log_item) = log_entry
+
+
+  fun read_txn_log_lines(): Array[TxnLogItem] =>
+    // TODO: implement this
+    []
+
+  fun leaving_workers(leaving_workers': Seq[cwm.WorkerName] box) =>
+    """
+    def leaving_workers(self, leaving_workers):
+        for w in leaving_workers:
+            opath = self._out_path + "." + w
+            mv_path1 = "{}.{}".format(opath, time.time())
+            cmd1 = "mv {} {} > /dev/null 2>&1".format(opath, mv_path1)
+            cmd2 = "mv {}.txnlog {}.txnlog > /dev/null 2>&1".format(opath, mv_path1)
+            logging.info("leaving worker: run: {}".format(cmd1))
+            logging.info("leaving worker: run: {}".format(cmd2))
+            os.system(cmd1)
+            os.system(cmd2)
+    """
+    // TODO: implement this
+    None

--- a/connectors/pony_connector_sink/txn_log.pony
+++ b/connectors/pony_connector_sink/txn_log.pony
@@ -1,0 +1,81 @@
+use cwm = "wallaroo_labs/connector_wire_messages"
+
+trait val TxnLogItem
+
+class Orphaned is TxnLogItem
+  let txn_id: String
+  let start_point_of_ref: cwm.PointOfRef
+  let end_point_of_ref: cwm.PointOfRef
+
+  new val create(txn_id': String, start': cwm.PointOfRef, end': cwm.PointOfRef) =>
+    txn_id = txn_id'
+    start_point_of_ref = start'
+    end_point_of_ref = end'
+
+class ListUncommitted is TxnLogItem
+  let txn_id: String
+  let uncommitted: Array[String] val
+
+  new val create(txn_id': String, uncommitted': Array[String] val) =>
+    txn_id = txn_id'
+    uncommitted = uncommitted'
+
+class NextTxnForceAbort is TxnLogItem
+  let message: String
+
+  new val create(message': String) =>
+    message = message'
+
+class PhaseOneRollback is TxnLogItem
+  let txn_id: String
+  let where_list: cwm.WhereList val
+
+  new val create(txn_id': String, where_list': cwm.WhereList val) =>
+    txn_id = txn_id'
+    where_list = where_list'
+
+class PhaseOneOk is TxnLogItem
+  let txn_id: String
+  let where_list: cwm.WhereList val
+
+  new val create(txn_id': String, where_list': cwm.WhereList val) =>
+    txn_id = txn_id'
+    where_list = where_list'
+
+class PhaseTwoRollback is TxnLogItem
+  let txn_id: String
+  let offset: cwm.PointOfRef
+
+  new val create(txn_id': String, offset': cwm.PointOfRef) =>
+    txn_id = txn_id'
+    offset = offset'
+
+class PhaseTwoOk is TxnLogItem
+  let txn_id: String
+  let offset: cwm.PointOfRef
+
+  new val create(txn_id': String, offset': cwm.PointOfRef) =>
+    txn_id = txn_id'
+    offset = offset'
+
+class PhaseTwoError is TxnLogItem
+  let txn_id: String
+  let message: String
+
+  new val create(txn_id': String, message': String) =>
+    txn_id = txn_id'
+    message = message'
+
+class WorkersLeft is TxnLogItem
+  let txn_id: String
+  let workers: Array[String] val
+
+  new val create(txn_id': String, workers': Array[String] val) =>
+    txn_id = txn_id'
+    workers = workers'
+
+class ConnectoinClosed is TxnLogItem
+  let txn_id: String
+
+  new val create(txn_id': String) =>
+    txn_id = txn_id'


### PR DESCRIPTION
This is an external sink that uses the Connector protocol. It is based
on the Python ALOC Sync in testing/correctness/tests/aloc_sink.

This implementation is partially tested and should only be considered
partially working. It does not persist any data. It was created as an
exercise to see what would be needed to implement an sink in Pony.

There are design notes as well as notes about future work in the
README file.

Closes #3131