### PR TITLE
Use `bash` instead of `sh` in ansible generate_inventory.sh

### DIFF
--- a/orchestration/pulumi/generate_inventory.sh
+++ b/orchestration/pulumi/generate_inventory.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #set -x
 vmss_name=$1
 resource_group_name=$2


### PR DESCRIPTION
The script uses Bash features. It was using `/bin/sh`, as the
interpreter, which works on systems like Mac OS that use `/bin/bash`
when you call for `/bin/sh`, but fails on systems that do not do this.

This change will make the script work correctly on all systems.

closes #3142