### PR TITLE
Make SourceTCPHandler max_received_count configurable

### DIFF
--- a/lib/wallaroo/core/source/connector_source/connector_source.pony
+++ b/lib/wallaroo/core/source/connector_source/connector_source.pony
@@ -168,7 +168,9 @@ actor ConnectorSource[In: Any val] is (Source & TCPActor)
         _source_id.string().cstring())
     end
 
-  be accept(fd: U32, init_size: USize = 64, max_size: USize = 16384) =>
+  be accept(fd: U32, init_size: USize = 64, max_size: USize = 16384,
+    max_received_count: USize = 50)
+  =>
     """
     A new connection accepted on a server.
     """
@@ -178,7 +180,7 @@ actor ConnectorSource[In: Any val] is (Source & TCPActor)
       // Get new session id for new connection
       _session_id = _routing_id_gen()
       _tcp_handler = _tcp_handler_builder.for_connection(fd, init_size,
-        max_size, this, _muted)
+        max_size, max_received_count, this, _muted)
       _tcp_handler.accept()
     end
 

--- a/lib/wallaroo/core/source/connector_source/connector_source_coordinator.pony
+++ b/lib/wallaroo/core/source/connector_source/connector_source_coordinator.pony
@@ -100,6 +100,7 @@ actor ConnectorSourceCoordinator[In: Any val] is
   var _closed: Bool = false
   var _init_size: USize
   var _max_size: USize
+  var _max_received_count: USize
 
   let _connected_sources: SetIs[(RoutingId, ConnectorSource[In])] =
     _connected_sources.create()
@@ -132,7 +133,8 @@ actor ConnectorSourceCoordinator[In: Any val] is
     handler: FramedSourceHandler[In] val,
     host: String, service: String, cookie: String,
     max_credits: U32, refill_credits: U32,
-    init_size: USize = 64, max_size: USize = 16384)
+    init_size: USize = 64, max_size: USize = 16384,
+    max_received_count: USize = 50)
   =>
     """
     Listens for both IPv4 and IPv6 connections.
@@ -166,6 +168,7 @@ actor ConnectorSourceCoordinator[In: Any val] is
     _limit = parallelism
     _init_size = init_size
     _max_size = max_size
+    _max_received_count = max_received_count
 
     // Pass LocalConnectorStreamRegistry the parameters it needs to create
     // its own instance of the GlobalConnectorStreamRegistry
@@ -386,7 +389,7 @@ actor ConnectorSourceCoordinator[In: Any val] is
     """
     try
       (let source_id, let source) = _available_sources.pop()?
-      source.accept(ns, _init_size, _max_size)
+      source.accept(ns, _init_size, _max_size, _max_received_count)
       _connected_sources.set((source_id, source))
       _count = _count + 1
     else

--- a/lib/wallaroo/core/source/tcp_source/tcp_source.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source.pony
@@ -164,13 +164,15 @@ actor TCPSource[In: Any val] is (Source & TCPActor)
         _source_id.string().cstring())
     end
 
-  be accept(fd: U32, init_size: USize = 64, max_size: USize = 16384) =>
+  be accept(fd: U32, init_size: USize = 64, max_size: USize = 16384,
+    max_received_count: USize = 50)
+  =>
     """
     A new connection accepted on a server.
     """
     if not _disposed then
       _tcp_handler = _tcp_handler_builder.for_connection(fd, init_size,
-        max_size, this, _muted)
+        max_size, max_received_count, this, _muted)
       _tcp_handler.accept()
     end
 

--- a/lib/wallaroo/core/source/tcp_source/tcp_source_config.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source_config.pony
@@ -85,25 +85,29 @@ class val TCPSourceConfig[In: Any val] is SourceConfig
   let handler: FramedSourceHandler[In] val
   let parallelism: USize
   let max_size: USize
+  let max_received_count: USize
   let _worker_source_config: WorkerTCPSourceConfig
 
   new val create(source_name': SourceName,
     handler': FramedSourceHandler[In] val, host': String, service': String,
-    valid': Bool, parallelism': USize = 10, max_size': USize = 16384)
+    valid': Bool, parallelism': USize = 10, max_size': USize = 16384,
+    max_received_count': USize = 50)
   =>
     handler = handler'
     parallelism = parallelism'
     max_size = max_size'
+    max_received_count = max_received_count'
     _worker_source_config = WorkerTCPSourceConfig(source_name', host',
       service', valid')
 
   new val from_options(handler': FramedSourceHandler[In] val,
     opts: TCPSourceConfigOptions, parallelism': USize = 10,
-    max_size': USize = 16384)
+    max_size': USize = 16384, max_received_count': USize = 50)
   =>
     handler = handler'
     parallelism = parallelism'
     max_size = max_size'
+    max_received_count = max_received_count'
     _worker_source_config = WorkerTCPSourceConfig(opts.source_name, opts.host,
       opts.service, opts.valid)
 

--- a/lib/wallaroo/core/source/tcp_source/tcp_source_coordinator.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source_coordinator.pony
@@ -93,6 +93,7 @@ actor TCPSourceCoordinator[In: Any val] is SourceCoordinator
   var _closed: Bool = false
   var _init_size: USize = 0
   var _max_size: USize = 0
+  var _max_received_count: USize = 50
 
   let _connected_sources: SetIs[TCPSource[In]] = _connected_sources.create()
   let _available_sources: Array[TCPSource[In]] = _available_sources.create()
@@ -112,7 +113,8 @@ actor TCPSourceCoordinator[In: Any val] is SourceCoordinator
     recovering: Bool, target_router: Router = EmptyRouter,
     parallelism: USize, handler: FramedSourceHandler[In] val,
     host: String, service: String, valid: Bool,
-    init_size: USize = 64, max_size: USize = 16384)
+    init_size: USize = 64, max_size: USize = 16384,
+    max_received_count: USize = 50)
   =>
     """
     Listens for both IPv4 and IPv6 connections.
@@ -143,6 +145,7 @@ actor TCPSourceCoordinator[In: Any val] is SourceCoordinator
     _limit = parallelism
     _init_size = init_size
     _max_size = max_size
+    _max_received_count = max_received_count
 
     match router
     | let pr: StatePartitionRouter =>
@@ -331,7 +334,7 @@ actor TCPSourceCoordinator[In: Any val] is SourceCoordinator
     """
     try
       let source = _available_sources.pop()?
-      source.accept(ns, _init_size, _max_size)
+      source.accept(ns, _init_size, _max_size, _max_received_count)
       _connected_sources.set(source)
       _count = _count + 1
     else

--- a/lib/wallaroo/core/source/tcp_source/tcp_source_coordinator_builder.pony
+++ b/lib/wallaroo/core/source/tcp_source/tcp_source_coordinator_builder.pony
@@ -47,6 +47,7 @@ class val TCPSourceCoordinatorBuilder[In: Any val] is SourceCoordinatorBuilder
   let _target_router: Router
   let _parallelism: USize
   let _max_size: USize
+  let _max_received_count: USize
   let _handler: FramedSourceHandler[In] val
   let _host: String
   let _service: String
@@ -60,7 +61,8 @@ class val TCPSourceCoordinatorBuilder[In: Any val] is SourceCoordinatorBuilder
     event_log: EventLog, auth: AmbientAuth,
     layout_initializer: LayoutInitializer,
     recovering: Bool, target_router: Router = EmptyRouter,
-    parallelism: USize, max_size: USize, handler: FramedSourceHandler[In] val,
+    parallelism: USize, max_size: USize, max_received_count: USize,
+    handler: FramedSourceHandler[In] val,
     host: String, service: String, valid: Bool)
   =>
     _worker_name = worker_name
@@ -79,6 +81,7 @@ class val TCPSourceCoordinatorBuilder[In: Any val] is SourceCoordinatorBuilder
     _target_router = target_router
     _parallelism = parallelism
     _max_size = max_size
+    _max_received_count = max_received_count
     _handler = handler
     _host = host
     _service = service
@@ -90,7 +93,8 @@ class val TCPSourceCoordinatorBuilder[In: Any val] is SourceCoordinatorBuilder
       _metrics_reporter.clone(), _router_registry,
       _outgoing_boundary_builders, _event_log, _auth, _layout_initializer,
       _recovering, _target_router, _parallelism, _handler,
-      _host, _service, _valid where max_size = _max_size)
+      _host, _service, _valid where max_size = _max_size,
+      max_received_count = _max_received_count)
 
 class val TCPSourceCoordinatorBuilderBuilder[In: Any val] is
   SourceCoordinatorBuilderBuilder
@@ -122,7 +126,8 @@ class val TCPSourceCoordinatorBuilderBuilder[In: Any val] is
         consume metrics_reporter, router_registry, outgoing_boundary_builders,
         event_log, auth, layout_initializer, recovering, target_router,
         _source_config.parallelism, _source_config.max_size,
-        _source_config.handler, config.host, config.service, config.valid)
+        _source_config.max_received_count, _source_config.handler, config.host,
+        config.service, config.valid)
     else
       Unreachable()
       TCPSourceCoordinatorBuilder[In](worker_name, pipeline_name,
@@ -130,5 +135,6 @@ class val TCPSourceCoordinatorBuilderBuilder[In: Any val] is
         consume metrics_reporter, router_registry, outgoing_boundary_builders,
         event_log, auth, layout_initializer, recovering, target_router,
         _source_config.parallelism, _source_config.max_size,
-        _source_config.handler, "0", "0", false)
+        _source_config.max_received_count, _source_config.handler, "0", "0",
+        false)
     end

--- a/lib/wallaroo/core/tcp_actor/source_tcp_handler.pony
+++ b/lib/wallaroo/core/tcp_actor/source_tcp_handler.pony
@@ -11,9 +11,11 @@ class val SourceTCPHandlerBuilder
     SourceTCPHandler(tcp_actor)
 
   fun for_connection(fd: U32, init_size: USize = 64, max_size: USize = 16384,
-    tcp_actor: TCPActor ref, muted: Bool): TestableTCPHandler
+    max_received_count: USize = 50, tcp_actor: TCPActor ref, muted: Bool):
+    TestableTCPHandler
   =>
-    SourceTCPHandler(tcp_actor, fd, init_size, max_size, muted)
+    SourceTCPHandler(tcp_actor, fd, init_size, max_size, max_received_count,
+      muted)
 
 class SourceTCPHandler is TestableTCPHandler
   let _tcp_actor: TCPActor ref
@@ -46,7 +48,8 @@ class SourceTCPHandler is TestableTCPHandler
   var _throttled: Bool = false
 
   new create(tcp_actor: TCPActor ref, fd: U32 = -1, init_size: USize = 64,
-    max_size: USize = 16384, muted: Bool = false)
+    max_size: USize = 16384, max_received_count: USize = 50,
+    muted: Bool = false)
   =>
     """
     A new connection accepted on a server.
@@ -66,6 +69,7 @@ class SourceTCPHandler is TestableTCPHandler
     _read_buf_offset = 0
     _init_size = init_size
     _max_size = max_size
+    _max_received_count = max_received_count
 
     _readable = true
     _closed = false

--- a/lib/wallaroo/core/tcp_actor/tcp_handler.pony
+++ b/lib/wallaroo/core/tcp_actor/tcp_handler.pony
@@ -38,7 +38,8 @@ interface val TestableTCPHandlerBuilder
   fun apply(tcp_actor: TCPActor ref): TestableTCPHandler
 
   fun for_connection(fd: U32, init_size: USize = 64, max_size: USize = 16384,
-    tcp_actor: TCPActor ref, muted: Bool): TestableTCPHandler
+    max_received_count: USize = 50, tcp_actor: TCPActor ref, muted: Bool):
+    TestableTCPHandler
   =>
     //!@ Temporary fix because of Pony wallaroo_labs/mort import bug
     tcp_actor.fail()

--- a/machida/lib/wallaroo/__init__.py
+++ b/machida/lib/wallaroo/__init__.py
@@ -510,7 +510,7 @@ def encoder(func):
 
 
 class TCPSourceConfig(object):
-    def __init__(self, name, host, port, decoder, valid=True, parallelism=10, max_size=16384):
+    def __init__(self, name, host, port, decoder, valid=True, parallelism=10, max_size=16384, max_received_count=50):
         self._host = host
         self._port = port
         self._name = name
@@ -518,10 +518,11 @@ class TCPSourceConfig(object):
         self._valid = valid
         self._parallelism = parallelism
         self._max_size = max_size
+        self._max_received_count = max_received_count
 
     def to_tuple(self):
         return ("tcp", self._name, self._host, self._port, self._decoder,
-                self._valid, self._parallelism, self._max_size)
+                self._valid, self._parallelism, self._max_size, self._max_received_count)
 
 
 class GenSourceConfig(object):

--- a/machida/machida.pony
+++ b/machida/machida.pony
@@ -931,8 +931,12 @@ primitive _SourceConfig
         USize.from[I64](@PyLong_AsLong(@PyTuple_GetItem(source_config_tuple, 7)))
       end
 
+      let max_received_count: USize = recover val
+        USize.from[I64](@PyLong_AsLong(@PyTuple_GetItem(source_config_tuple, 8)))
+      end
+
       TCPSourceConfig[(PyData val | None)](source_name, decoder, host, port,
-        valid, parallelism, max_size)
+        valid, parallelism, max_size, max_received_count)
     | "kafka-internal" =>
       let ksclip = KafkaSourceConfigCLIParser(env.out, source_name)
       let ksco = ksclip.parse_options(env.args)?

--- a/machida3/machida.pony
+++ b/machida3/machida.pony
@@ -955,8 +955,12 @@ primitive _SourceConfig
         USize.from[I64](@PyLong_AsLong(@PyTuple_GetItem(source_config_tuple, 7)))
       end
 
+      let max_received_count: USize = recover val
+        USize.from[I64](@PyLong_AsLong(@PyTuple_GetItem(source_config_tuple, 8)))
+      end
+
       TCPSourceConfig[(PyData val | None)](source_name, decoder, host, port,
-        valid, parallelism, max_size)
+        valid, parallelism, max_size, max_received_count)
     | "kafka-internal" =>
       let ksclip = KafkaSourceConfigCLIParser(env.out, source_name)
       let ksco = ksclip.parse_options(env.args)?


### PR DESCRIPTION
  - gives us the ability to configure the SourceTCPHandler's  max_received_count
    variable via the TCPSourceConfig

<!--
Make sure you've read the [Contributors Guide](https://github.com/WallarooLabs/wallaroo/blob/master/CONTRIBUTING.md). You'll need to sign our CLA before your issue can be accepted.

Reference the issue your code change relates to if possible
-->
ref #

<!--
Include any other necessary information below. If you have any questions don't hesitate to reach out on the mailing list.
-->
